### PR TITLE
[WIP] let's talk about complexity

### DIFF
--- a/pkg/oauth/helpers.go
+++ b/pkg/oauth/helpers.go
@@ -1,0 +1,7 @@
+package oauth
+
+// ClientAuthorizationName creates the computed name for a given username, clientName tuple
+// This cannot change or client authorizations will be have unpredictably
+func ClientAuthorizationName(userName, clientName string) string {
+	return userName + ":" + clientName
+}


### PR DESCRIPTION
I've pulled this item as a real-life example that is holding up the split of the openshift oauthserver.  There is a helper shared between the openshift-apiserver and the openshift-authserver to determine the name of a client-authorization.  

The complexity here is low and this effectively cannot change or the API callers will not be able to predict how to use the API.  I'd claim that in this case we simply duplicate the functionality in both repos.

@openshift/api-review @openshift/sig-security Disagreement?  I suspect we'll have several like this over time.

/hold