### PR TITLE
add helper for processing and writing assets using go templates

### DIFF
--- a/pkg/assets/assets.go
+++ b/pkg/assets/assets.go
@@ -1,0 +1,79 @@
+package assets
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"text/template"
+)
+
+type Permission os.FileMode
+
+const (
+	PermissionDirectoryDefault Permission = 0755
+	PermissionFileDefault      Permission = 0644
+	PermissionFileRestricted   Permission = 0600
+)
+
+// Asset defines a single static asset.
+type Asset struct {
+	Name           string
+	FilePermission Permission
+	Data           []byte
+}
+
+// Assets is a list of assets.
+type Assets []Asset
+
+// WriteFiles writes the assets to specified path.
+func (as Assets) WriteFiles(path string) error {
+	if err := os.MkdirAll(path, os.FileMode(PermissionDirectoryDefault)); err != nil {
+		return err
+	}
+	for _, asset := range as {
+		if _, err := os.Stat(path); os.IsExist(err) {
+			fmt.Printf("WARNING: File %s already exists, content will be replaced\n", path)
+		}
+		if err := asset.WriteFile(path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// WriteFile writes a single asset into specified path.
+func (a Asset) WriteFile(path string) error {
+	f := filepath.Join(path, a.Name)
+	perms := PermissionFileDefault
+	if err := os.MkdirAll(filepath.Dir(f), os.FileMode(PermissionDirectoryDefault)); err != nil {
+		return err
+	}
+	if a.FilePermission != 0 {
+		perms = a.FilePermission
+	}
+	fmt.Printf("Writing asset: %s\n", f)
+	return ioutil.WriteFile(f, a.Data, os.FileMode(perms))
+}
+
+// MustCreateAssetFromTemplate process the given template using and return an asset.
+func MustCreateAssetFromTemplate(name string, template []byte, config interface{}) Asset {
+	asset, err := assetFromTemplate(name, template, config)
+	if err != nil {
+		panic(err)
+	}
+	return asset
+}
+
+func assetFromTemplate(name string, tb []byte, data interface{}) (Asset, error) {
+	tmpl, err := template.New(name).Parse(string(tb))
+	if err != nil {
+		return Asset{}, err
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return Asset{}, err
+	}
+	return Asset{Name: name, Data: buf.Bytes()}, nil
+}

--- a/pkg/assets/assets_test.go
+++ b/pkg/assets/assets_test.go
@@ -1,0 +1,61 @@
+package assets
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAsset_WriteFile(t *testing.T) {
+	sampleAssets := Assets{
+		{
+			Name: "test-default",
+			Data: []byte("test"),
+		},
+		{
+			Name:           "test-restricted",
+			FilePermission: PermissionFileRestricted,
+			Data:           []byte("test"),
+		},
+		{
+			Name:           "test-default-explicit",
+			FilePermission: PermissionFileDefault,
+			Data:           []byte("test"),
+		},
+	}
+
+	assetDir, err := ioutil.TempDir("", "asset-test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer os.RemoveAll(assetDir)
+
+	if err := sampleAssets.WriteFiles(assetDir); err != nil {
+		t.Fatalf("unexpected error when writing files: %v", err)
+	}
+
+	if s, err := os.Stat(filepath.Join(assetDir, sampleAssets[0].Name)); err != nil {
+		t.Fatalf("expected file to exists, got: %v", err)
+	} else {
+		if s.Mode() != os.FileMode(PermissionFileDefault) {
+			t.Errorf("expected file to have %d permissions, got %d", PermissionFileDefault, s.Mode())
+		}
+	}
+
+	if s, err := os.Stat(filepath.Join(assetDir, sampleAssets[1].Name)); err != nil {
+		t.Fatalf("expected file to exists, got: %v", err)
+	} else {
+		if s.Mode() != os.FileMode(sampleAssets[1].FilePermission) {
+			t.Errorf("expected file to have %d permissions, got %d", sampleAssets[1].FilePermission, s.Mode())
+		}
+	}
+
+	if s, err := os.Stat(filepath.Join(assetDir, sampleAssets[2].Name)); err != nil {
+		t.Fatalf("expected file to exists, got: %v", err)
+	} else {
+		if s.Mode() != os.FileMode(sampleAssets[2].FilePermission) {
+			t.Errorf("expected file to have %s permissions, got %s", os.FileMode(sampleAssets[2].FilePermission), s.Mode())
+		}
+	}
+}


### PR DESCRIPTION
We will need this in every master operator repo to render the manifests for bootkube.
Instead of copying this, make it shared.

/cc @deads2k
/cc @sttts