### PR TITLE
align client helpers to types

### DIFF
--- a/pkg/config/helpers/client.go
+++ b/pkg/config/helpers/client.go
@@ -12,6 +12,11 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 )
 
+// GetKubeClientConfig loads in-cluster config if kubeConfigFile is empty or the file if not, then applies overrides.
+func GetKubeClientConfig(kubeClientConnection configv1.KubeClientConfig) (*rest.Config, error) {
+	return GetKubeConfigOrInClusterConfig(kubeClientConnection.KubeConfig, kubeClientConnection.ConnectionOverrides)
+}
+
 // GetKubeConfigOrInClusterConfig loads in-cluster config if kubeConfigFile is empty or the file if not,
 // then applies overrides.
 func GetKubeConfigOrInClusterConfig(kubeConfigFile string, overrides configv1.ClientConnectionOverrides) (*rest.Config, error) {

--- a/pkg/config/helpers/config_refs.go
+++ b/pkg/config/helpers/config_refs.go
@@ -84,7 +84,7 @@ func GetAdmissionPluginConfigFileReferences(config *configv1.AdmissionPluginConf
 	return refs
 }
 
-func GetAuditConfigReferences(config *configv1.AuditConfig) []*string {
+func GetAuditConfigFileReferences(config *configv1.AuditConfig) []*string {
 	if config == nil {
 		return []*string{}
 	}
@@ -95,7 +95,7 @@ func GetAuditConfigReferences(config *configv1.AuditConfig) []*string {
 	return refs
 }
 
-func GetKubeClientConfigReferences(config *configv1.KubeClientConfig) []*string {
+func GetKubeClientConfigFileReferences(config *configv1.KubeClientConfig) []*string {
 	if config == nil {
 		return []*string{}
 	}
@@ -113,8 +113,8 @@ func GetGenericAPIServerConfigFileReferences(config *configv1.GenericAPIServerCo
 	refs := []*string{}
 	refs = append(refs, GetHTTPServingInfoFileReferences(&config.ServingInfo)...)
 	refs = append(refs, GetEtcdConnectionInfoFileReferences(&config.StorageConfig.EtcdConnectionInfo)...)
-	refs = append(refs, GetAuditConfigReferences(&config.AuditConfig)...)
-	refs = append(refs, GetKubeClientConfigReferences(&config.KubeClientConfig)...)
+	refs = append(refs, GetAuditConfigFileReferences(&config.AuditConfig)...)
+	refs = append(refs, GetKubeClientConfigFileReferences(&config.KubeClientConfig)...)
 
 	// TODO admission config file resolution is currently broken.
 	//for k := range config.AdmissionPluginConfig {


### PR DESCRIPTION
Adds helper methods direct against api types.  Fixes name consistency

/assign @mfojtik 