### PR TITLE
don't require type meta to merge

### DIFF
--- a/pkg/operator/resource/resourcemerge/generic_config_merger.go
+++ b/pkg/operator/resource/resourcemerge/generic_config_merger.go
@@ -1,14 +1,17 @@
 package resourcemerge
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+
 	"github.com/golang/glog"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	kyaml "k8s.io/apimachinery/pkg/util/yaml"
-
-	"reflect"
 )
 
 // MergeConfigMap takes a configmap, the target key, special overlay funcs a list of config configs to overlay on top of each other
@@ -40,11 +43,10 @@ func MergeProcessConfig(specialCases map[string]MergeFunc, configYAMLs ...[]byte
 			// maybe it's just json
 			prevConfigJSON = currentConfigYAML
 		}
-		prevConfigObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, prevConfigJSON)
-		if err != nil {
+		prevConfig := map[string]interface{}{}
+		if err := json.NewDecoder(bytes.NewBuffer(prevConfigJSON)).Decode(&prevConfig); err != nil {
 			return nil, err
 		}
-		prevConfig := prevConfigObj.(*unstructured.Unstructured)
 
 		if len(currConfigYAML) > 0 {
 			currConfigJSON, err := kyaml.ToJSON(currConfigYAML)
@@ -53,17 +55,28 @@ func MergeProcessConfig(specialCases map[string]MergeFunc, configYAMLs ...[]byte
 				// maybe it's just json
 				currConfigJSON = currConfigYAML
 			}
-			currConfigObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, currConfigJSON)
-			if err != nil {
+			currConfig := map[string]interface{}{}
+			if err := json.NewDecoder(bytes.NewBuffer(currConfigJSON)).Decode(&currConfig); err != nil {
 				return nil, err
 			}
-			currConfig := currConfigObj.(*unstructured.Unstructured)
-			if err := mergeConfig(prevConfig.Object, currConfig.Object, "", specialCases); err != nil {
+
+			// protected against mismatched typemeta
+			prevAPIVersion, _, _ := unstructured.NestedString(prevConfig, "apiVersion")
+			prevKind, _, _ := unstructured.NestedString(prevConfig, "kind")
+			currAPIVersion, _, _ := unstructured.NestedString(currConfig, "apiVersion")
+			currKind, _, _ := unstructured.NestedString(currConfig, "kind")
+			currGVKSet := len(currAPIVersion) > 0 || len(currKind) > 0
+			gvkMismatched := currAPIVersion != prevAPIVersion || currKind != prevKind
+			if currGVKSet && gvkMismatched {
+				return nil, fmt.Errorf("%v/%v does not equal %v/%v", currAPIVersion, currKind, prevAPIVersion, prevKind)
+			}
+
+			if err := mergeConfig(prevConfig, currConfig, "", specialCases); err != nil {
 				return nil, err
 			}
 		}
 
-		currentConfigYAML, err = runtime.Encode(unstructured.UnstructuredJSONScheme, prevConfig)
+		currentConfigYAML, err = runtime.Encode(unstructured.UnstructuredJSONScheme, &unstructured.Unstructured{Object: prevConfig})
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
If we decode into maps we can prevent conflicting object meta, but we don't require it in all cases.  If we want to require it, we can do that too, but we can do it without trying the decoding stack.

/assign @soltysh 