### PR TITLE
OWNERS: add myself as approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,8 @@
 reviewers:
   - smarterclayton
   - deads2k
+  - sttts
 approvers:
   - smarterclayton
   - deads2k
+  - sttts


### PR DESCRIPTION
As discussed, any new externally consumable code needs agreement among the approvers. Goal: don't turn this into a sink of trivial helpers.