### PR TITLE
Make mac with prehistoric shell happy by using the old redirection syntax

### DIFF
--- a/alpha-build-machinery/make/targets/help.mk
+++ b/alpha-build-machinery/make/targets/help.mk
@@ -1,6 +1,6 @@
 help:
 	$(info The following make targets are available:)
-	@$(MAKE) -f $(firstword $(MAKEFILE_LIST)) --print-data-base --question no-such-target |& grep -v 'no-such-target' | \
+	@$(MAKE) -f $(firstword $(MAKEFILE_LIST)) --print-data-base --question no-such-target 2>&1 | grep -v 'no-such-target' | \
 	grep -v -e '^no-such-target' -e '^makefile' | \
 	awk '/^[^.%][-A-Za-z0-9_]*:/	{ print substr($$1, 1, length($$1)-1) }' | sort -u
 .PHONY: help


### PR DESCRIPTION
@mfojtik this issue you were having with bash (shell) < 4.x

/assign @sttts 