### PR TITLE
refactor staticpod unit tests

### DIFF
--- a/pkg/operator/staticpod/controller/backingresource/backing_resource_controller.go
+++ b/pkg/operator/staticpod/controller/backingresource/backing_resource_controller.go
@@ -144,7 +144,7 @@ func (c BackingResourceController) sync() error {
 			glog.Error(updateError)
 		}
 	}
-	return err
+	return fmt.Errorf("synthetic requeue (errs: %q)", strings.Join(errors, ","))
 
 }
 

--- a/pkg/operator/staticpod/controller/backingresource/backing_resource_controller_test.go
+++ b/pkg/operator/staticpod/controller/backingresource/backing_resource_controller_test.go
@@ -1,101 +1,202 @@
 package backingresource
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	"k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
-	ktesting "k8s.io/client-go/testing"
+	clienttesting "k8s.io/client-go/testing"
 
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 	"github.com/openshift/library-go/pkg/operator/staticpod/controller/common"
 )
 
-func TestNewBackingResourceController(t *testing.T) {
-	kubeClient := fake.NewSimpleClientset()
-	var (
-		serviceAccountCreated     *v1.ServiceAccount
-		clusterRoleBindingCreated *rbacv1.ClusterRoleBinding
-		createCallCount           int
-	)
-	kubeClient.PrependReactor("*", "*", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
-		createAction, ok := action.(ktesting.CreateAction)
-		if ok {
-			if createAction.GetResource().Resource == "serviceaccounts" {
-				createCallCount += 1
-				serviceAccountCreated = createAction.GetObject().(*v1.ServiceAccount)
-			}
-			if createAction.GetResource().Resource == "clusterrolebindings" {
-				createCallCount += 1
-				clusterRoleBindingCreated = createAction.GetObject().(*rbacv1.ClusterRoleBinding)
-			}
+func filterCreateActions(actions []clienttesting.Action) []runtime.Object {
+	var createdObjects []runtime.Object
+	for _, a := range actions {
+		createAction, isCreate := a.(clienttesting.CreateAction)
+		if !isCreate {
+			continue
 		}
-		return false, nil, nil
-	})
-	kubeInformers := informers.NewSharedInformerFactoryWithOptions(kubeClient, 1*time.Minute, informers.WithNamespace("test"))
+		createdObjects = append(createdObjects, createAction.GetObject())
+	}
+	return createdObjects
+}
 
-	fakeStaticPodOperatorClient := common.NewFakeStaticPodOperatorClient(
-		&operatorv1alpha1.OperatorSpec{
-			ManagementState: operatorv1alpha1.Managed,
-			Version:         "3.11.1",
-		},
-		&operatorv1alpha1.OperatorStatus{},
-		&operatorv1alpha1.StaticPodOperatorStatus{
-			LatestAvailableDeploymentGeneration: 1,
-			NodeStatuses: []operatorv1alpha1.NodeStatus{
-				{
-					NodeName:                    "test-node-1",
-					CurrentDeploymentGeneration: 0,
-					TargetDeploymentGeneration:  0,
+type prependReactorSpec struct {
+	verb, resource string
+	reaction       clienttesting.ReactionFunc
+}
+
+func TestBackingResourceController(t *testing.T) {
+	tests := []struct {
+		targetNamespace         string
+		prependReactors         []prependReactorSpec
+		startingObjects         []runtime.Object
+		staticPodOperatorClient common.OperatorClient
+		validateActions         func(t *testing.T, actions []clienttesting.Action)
+		validateStatus          func(t *testing.T, status *operatorv1alpha1.StaticPodOperatorStatus)
+		expectSyncError         string
+	}{
+		{
+			targetNamespace: "successful-create",
+			staticPodOperatorClient: common.NewFakeStaticPodOperatorClient(
+				&operatorv1alpha1.OperatorSpec{
+					ManagementState: operatorv1alpha1.Managed,
 				},
+				&operatorv1alpha1.OperatorStatus{},
+				&operatorv1alpha1.StaticPodOperatorStatus{},
+				nil,
+			),
+			validateActions: func(t *testing.T, actions []clienttesting.Action) {
+				createdObjects := filterCreateActions(actions)
+				if createdObjectCount := len(createdObjects); createdObjectCount != 2 {
+					t.Errorf("expected 2 objects to be created, got %d", createdObjectCount)
+					return
+				}
+				sa, hasServiceAccount := createdObjects[0].(*v1.ServiceAccount)
+				if !hasServiceAccount {
+					t.Errorf("expected service account to be created first, got %+v", createdObjects[0])
+					return
+				}
+				if sa.Namespace != "successful-create" {
+					t.Errorf("expected that service account to have 'tc-successful-create' namespace, got %q", sa.Namespace)
+					return
+				}
+				if sa.Name != "installer-sa" {
+					t.Errorf("expected service account to have name 'installer-sa', got %q", sa.Name)
+				}
+
+				crb, hasClusterRoleBinding := createdObjects[1].(*rbacv1.ClusterRoleBinding)
+				if !hasClusterRoleBinding {
+					t.Errorf("expected cluster role binding as second object, got %+v", createdObjects[1])
+				}
+				if rbNamespace := crb.Subjects[0].Namespace; rbNamespace != "successful-create" {
+					t.Errorf("expected that cluster role binding first subject to have 'tc-successful-create' namespace, got %q", rbNamespace)
+					return
+				}
+				if crb.Name != "system:openshift:operator:successful-create-installer" {
+					t.Errorf("expected that cluster role binding name is 'system:openshift:operator:tc-successful-create-installer', got %q", crb.Name)
+				}
 			},
 		},
-		nil,
-	)
-
-	c := NewBackingResourceController(
-		"test",
-		fakeStaticPodOperatorClient,
-		kubeInformers,
-		kubeClient,
-	)
-
-	if err := c.sync(); err != nil {
-		t.Fatal(err)
+		{
+			targetNamespace: "operator-unmanaged",
+			staticPodOperatorClient: common.NewFakeStaticPodOperatorClient(
+				&operatorv1alpha1.OperatorSpec{
+					ManagementState: operatorv1alpha1.Unmanaged,
+				},
+				&operatorv1alpha1.OperatorStatus{},
+				&operatorv1alpha1.StaticPodOperatorStatus{},
+				nil,
+			),
+			validateActions: func(t *testing.T, actions []clienttesting.Action) {
+				createdObjects := filterCreateActions(actions)
+				if createdObjectCount := len(createdObjects); createdObjectCount != 0 {
+					t.Errorf("expected no objects to be created, got %d", createdObjectCount)
+				}
+			},
+		},
+		{
+			targetNamespace: "service-account-exists",
+			startingObjects: []runtime.Object{
+				&v1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "installer-sa", Namespace: "service-account-exists"}},
+			},
+			staticPodOperatorClient: common.NewFakeStaticPodOperatorClient(
+				&operatorv1alpha1.OperatorSpec{
+					ManagementState: operatorv1alpha1.Managed,
+				},
+				&operatorv1alpha1.OperatorStatus{},
+				&operatorv1alpha1.StaticPodOperatorStatus{},
+				nil,
+			),
+			validateActions: func(t *testing.T, actions []clienttesting.Action) {
+				createdObjects := filterCreateActions(actions)
+				if createdObjectCount := len(createdObjects); createdObjectCount != 1 {
+					t.Errorf("expected only one object to be created, got %d", createdObjectCount)
+				}
+				crb, hasClusterRoleBinding := createdObjects[0].(*rbacv1.ClusterRoleBinding)
+				if !hasClusterRoleBinding {
+					t.Errorf("expected cluster role binding as second object, got %+v", createdObjects[0])
+				}
+				if rbNamespace := crb.Subjects[0].Namespace; rbNamespace != "service-account-exists" {
+					t.Errorf("expected that cluster role binding first subject to have 'tc-successful-create' namespace, got %q", rbNamespace)
+					return
+				}
+				if crb.Name != "system:openshift:operator:service-account-exists-installer" {
+					t.Errorf("expected that cluster role binding name is 'system:openshift:operator:tc-successful-create-installer', got %q", crb.Name)
+				}
+			},
+		},
+		{
+			targetNamespace: "resource-apply-failed",
+			prependReactors: []prependReactorSpec{
+				{
+					verb:     "*",
+					resource: "serviceaccounts",
+					reaction: func(clienttesting.Action) (bool, runtime.Object, error) {
+						return true, nil, fmt.Errorf("test error")
+					},
+				},
+			},
+			staticPodOperatorClient: common.NewFakeStaticPodOperatorClient(
+				&operatorv1alpha1.OperatorSpec{
+					ManagementState: operatorv1alpha1.Managed,
+				},
+				&operatorv1alpha1.OperatorStatus{},
+				&operatorv1alpha1.StaticPodOperatorStatus{},
+				nil,
+			),
+			expectSyncError: `test error`,
+			validateStatus: func(t *testing.T, status *operatorv1alpha1.StaticPodOperatorStatus) {
+				if status.Conditions[0].Type != operatorv1alpha1.OperatorStatusTypeFailing {
+					t.Errorf("expected status condition to be failing, got %v", status.Conditions[0].Type)
+				}
+				if status.Conditions[0].Reason != "CreateBackingResourcesError" {
+					t.Errorf("expected status condition reason to be 'CreateBackingResourcesError', got %v", status.Conditions[0].Reason)
+				}
+				if !strings.Contains(status.Conditions[0].Message, "test error") {
+					t.Errorf("expected status condition message to contain 'test error', got: %s", status.Conditions[0].Message)
+				}
+			},
+		},
 	}
 
-	if createCallCount != 2 {
-		t.Fatalf("expected 2 create calls, got %d", createCallCount)
-	}
-
-	if serviceAccountCreated == nil {
-		t.Fatal("expected service account to be created")
-	}
-	if clusterRoleBindingCreated == nil {
-		t.Fatal("expected cluster role binding to be created")
-	}
-
-	if serviceAccountCreated.Namespace != "test" {
-		t.Fatalf("expected that service account have 'test' namespace, got %q", serviceAccountCreated.Namespace)
-	}
-
-	if clusterRoleBindingCreated.Name != "system:openshift:operator:test-installer" {
-		t.Fatalf("expected that cluster role binding name is 'system:openshift:operator:test-installer', got %q", clusterRoleBindingCreated.Name)
-	}
-
-	if clusterRoleBindingCreated.Subjects[0].Namespace != "test" {
-		t.Fatalf("expected that cluster role binding namespace is 'test', got %q", clusterRoleBindingCreated.Subjects[0].Namespace)
-	}
-
-	if err := c.sync(); err != nil {
-		t.Fatal(err)
-	}
-
-	if createCallCount != 2 {
-		t.Fatalf("expected no create calls after next sync, got %d", createCallCount)
+	for _, tc := range tests {
+		t.Run(tc.targetNamespace, func(t *testing.T) {
+			kubeClient := fake.NewSimpleClientset(tc.startingObjects...)
+			for _, r := range tc.prependReactors {
+				kubeClient.PrependReactor(r.verb, r.resource, r.reaction)
+			}
+			c := NewBackingResourceController(
+				tc.targetNamespace,
+				tc.staticPodOperatorClient,
+				informers.NewSharedInformerFactoryWithOptions(kubeClient, 1*time.Minute, informers.WithNamespace(tc.targetNamespace)),
+				kubeClient,
+			)
+			syncErr := c.sync()
+			if tc.validateStatus != nil {
+				_, status, _, _ := tc.staticPodOperatorClient.Get()
+				tc.validateStatus(t, status)
+			}
+			if syncErr != nil {
+				if !strings.Contains(syncErr.Error(), tc.expectSyncError) {
+					t.Errorf("expected %q string in error %q", tc.expectSyncError, syncErr.Error())
+				}
+				return
+			}
+			if syncErr == nil && len(tc.expectSyncError) != 0 {
+				t.Errorf("expected %v error, got none", tc.expectSyncError)
+				return
+			}
+			tc.validateActions(t, kubeClient.Actions())
+		})
 	}
 }

--- a/pkg/operator/staticpod/controller/deployment/deployment_controller_test.go
+++ b/pkg/operator/staticpod/controller/deployment/deployment_controller_test.go
@@ -1,145 +1,174 @@
 package deployment
 
 import (
+	"strings"
 	"testing"
 	"time"
 
 	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
-	ktesting "k8s.io/client-go/testing"
+	clienttesting "k8s.io/client-go/testing"
 
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 	"github.com/openshift/library-go/pkg/operator/staticpod/controller/common"
 )
 
-func TestDeploymentControllerWithMissingConfigMap(t *testing.T) {
-	kubeClient := fake.NewSimpleClientset()
-	kubeInformers := informers.NewSharedInformerFactoryWithOptions(kubeClient, 1*time.Minute, informers.WithNamespace("test"))
-
-	fakeStaticPodOperatorClient := common.NewFakeStaticPodOperatorClient(
-		&operatorv1alpha1.OperatorSpec{
-			ManagementState: operatorv1alpha1.Managed,
-			Version:         "3.11.1",
-		},
-		&operatorv1alpha1.OperatorStatus{},
-		&operatorv1alpha1.StaticPodOperatorStatus{
-			LatestAvailableDeploymentGeneration: 1,
-			NodeStatuses: []operatorv1alpha1.NodeStatus{
-				{
-					NodeName:                    "test-node-1",
-					CurrentDeploymentGeneration: 0,
-					TargetDeploymentGeneration:  0,
-				},
-			},
-		},
-		nil,
-	)
-
-	c := NewDeploymentController(
-		"test",
-		[]string{"test-config"},
-		[]string{"test-secret"},
-		kubeInformers,
-		fakeStaticPodOperatorClient,
-		kubeClient,
-	)
-
-	if err := c.sync(); err == nil {
-		t.Fatalf("expected synthetic error, got none")
+func filterCreateActions(actions []clienttesting.Action) []runtime.Object {
+	var createdObjects []runtime.Object
+	for _, a := range actions {
+		createAction, isCreate := a.(clienttesting.CreateAction)
+		if !isCreate {
+			continue
+		}
+		createdObjects = append(createdObjects, createAction.GetObject())
 	}
-
-	_, currStatus, _, _ := fakeStaticPodOperatorClient.Get()
-
-	if conditionCount := len(currStatus.Conditions); conditionCount == 0 {
-		t.Fatalf("expected static pod operator status to have one error condition, got %d", conditionCount)
-	}
-
-	condition := currStatus.Conditions[0]
-	if condition.Type != "DeploymentControllerFailing" && condition.Status != "True" {
-		t.Errorf("expected condition type DeploymentControllerFailing to be true, got %#v", condition)
-	}
-
-	if condition.Message != `configmaps "test-config" not found` {
-		t.Errorf("expected condition error message to indicate missing config map, got: %q", condition.Message)
-	}
+	return createdObjects
 }
 
-func TestDeploymentControllerSyncing(t *testing.T) {
-	fakeConfig := &v1.ConfigMap{}
-	fakeConfig.Name = "test-config"
-	fakeConfig.Namespace = "test"
-
-	fakeSecret := &v1.Secret{}
-	fakeSecret.Name = "test-secret"
-	fakeSecret.Namespace = "test"
-
-	kubeClient := fake.NewSimpleClientset(fakeConfig, fakeSecret)
-
-	var secretCreated *v1.Secret
-	var configCreated *v1.ConfigMap
-
-	kubeClient.PrependReactor("*", "*", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
-		createAction, ok := action.(ktesting.CreateAction)
-		if ok {
-			if createAction.GetResource().Resource == "secrets" {
-				secretCreated = createAction.GetObject().(*v1.Secret)
-			}
-			if createAction.GetResource().Resource == "configmaps" {
-				configCreated = createAction.GetObject().(*v1.ConfigMap)
-			}
-		}
-		return false, nil, nil
-	})
-	kubeInformers := informers.NewSharedInformerFactoryWithOptions(kubeClient, 1*time.Minute, informers.WithNamespace("test"))
-
-	fakeStaticPodOperatorClient := common.NewFakeStaticPodOperatorClient(
-		&operatorv1alpha1.OperatorSpec{
-			ManagementState: operatorv1alpha1.Managed,
-			Version:         "3.11.1",
-		},
-		&operatorv1alpha1.OperatorStatus{},
-		&operatorv1alpha1.StaticPodOperatorStatus{
-			LatestAvailableDeploymentGeneration: 1,
-			NodeStatuses: []operatorv1alpha1.NodeStatus{
-				{
-					NodeName:                    "test-node-1",
-					CurrentDeploymentGeneration: 0,
-					TargetDeploymentGeneration:  0,
+func TestDeploymentController(t *testing.T) {
+	tests := []struct {
+		targetNamespace         string
+		testSecrets             []string
+		testConfigs             []string
+		startingObjects         []runtime.Object
+		staticPodOperatorClient common.OperatorClient
+		validateActions         func(t *testing.T, actions []clienttesting.Action)
+		validateStatus          func(t *testing.T, status *operatorv1alpha1.StaticPodOperatorStatus)
+		expectSyncError         string
+	}{
+		{
+			targetNamespace: "operator-unmanaged",
+			staticPodOperatorClient: common.NewFakeStaticPodOperatorClient(
+				&operatorv1alpha1.OperatorSpec{
+					ManagementState: operatorv1alpha1.Unmanaged,
 				},
+				&operatorv1alpha1.OperatorStatus{},
+				&operatorv1alpha1.StaticPodOperatorStatus{},
+				nil,
+			),
+			validateActions: func(t *testing.T, actions []clienttesting.Action) {
+				createdObjects := filterCreateActions(actions)
+				if createdObjectCount := len(createdObjects); createdObjectCount != 0 {
+					t.Errorf("expected no objects to be created, got %d", createdObjectCount)
+				}
 			},
 		},
-		nil,
-	)
-
-	c := NewDeploymentController(
-		"test",
-		[]string{"test-config"},
-		[]string{"test-secret"},
-		kubeInformers,
-		fakeStaticPodOperatorClient,
-		kubeClient,
-	)
-
-	if err := c.sync(); err != nil {
-		t.Fatal(err)
+		{
+			targetNamespace: "missing-source-resources",
+			staticPodOperatorClient: common.NewFakeStaticPodOperatorClient(
+				&operatorv1alpha1.OperatorSpec{
+					ManagementState: operatorv1alpha1.Managed,
+					Version:         "3.11.1",
+				},
+				&operatorv1alpha1.OperatorStatus{},
+				&operatorv1alpha1.StaticPodOperatorStatus{
+					LatestAvailableDeploymentGeneration: 1,
+					NodeStatuses: []operatorv1alpha1.NodeStatus{
+						{
+							NodeName:                    "test-node-1",
+							CurrentDeploymentGeneration: 0,
+							TargetDeploymentGeneration:  0,
+						},
+					},
+				},
+				nil,
+			),
+			testConfigs:     []string{"test-config"},
+			testSecrets:     []string{"test-secret"},
+			expectSyncError: "synthetic requeue request",
+			validateStatus: func(t *testing.T, status *operatorv1alpha1.StaticPodOperatorStatus) {
+				if status.Conditions[0].Type != "DeploymentControllerFailing" {
+					t.Errorf("expected status condition to be 'DeploymentControllerFailing', got %v", status.Conditions[0].Type)
+				}
+				if status.Conditions[0].Reason != "ContentCreationError" {
+					t.Errorf("expected status condition reason to be 'ContentCreationError', got %v", status.Conditions[0].Reason)
+				}
+				if !strings.Contains(status.Conditions[0].Message, `configmaps "test-config" not found`) {
+					t.Errorf("expected status to be 'configmaps test-config not found', got: %s", status.Conditions[0].Message)
+				}
+			},
+		},
+		{
+			targetNamespace: "copy-resources",
+			staticPodOperatorClient: common.NewFakeStaticPodOperatorClient(
+				&operatorv1alpha1.OperatorSpec{
+					ManagementState: operatorv1alpha1.Managed,
+					Version:         "3.11.1",
+				},
+				&operatorv1alpha1.OperatorStatus{},
+				&operatorv1alpha1.StaticPodOperatorStatus{
+					LatestAvailableDeploymentGeneration: 1,
+					NodeStatuses: []operatorv1alpha1.NodeStatus{
+						{
+							NodeName:                    "test-node-1",
+							CurrentDeploymentGeneration: 0,
+							TargetDeploymentGeneration:  0,
+						},
+					},
+				},
+				nil,
+			),
+			startingObjects: []runtime.Object{
+				&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "test-secret", Namespace: "copy-resources"}},
+				&v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "test-config", Namespace: "copy-resources"}},
+			},
+			testConfigs: []string{"test-config"},
+			testSecrets: []string{"test-secret"},
+			validateActions: func(t *testing.T, actions []clienttesting.Action) {
+				createdObjects := filterCreateActions(actions)
+				if createdObjectCount := len(createdObjects); createdObjectCount != 2 {
+					t.Errorf("expected 2 objects to be created, got %d", createdObjectCount)
+					return
+				}
+				config, hasConfig := createdObjects[0].(*v1.ConfigMap)
+				if !hasConfig {
+					t.Errorf("expected config to be created")
+					return
+				}
+				if config.Name != "test-config-1" {
+					t.Errorf("expected config to have name 'test-config-1', got %q", config.Name)
+				}
+				secret, hasSecret := createdObjects[1].(*v1.Secret)
+				if !hasSecret {
+					t.Errorf("expected secret to be created")
+					return
+				}
+				if secret.Name != "test-secret-1" {
+					t.Errorf("expected secret to have name 'test-secret-1', got %q", secret.Name)
+				}
+			},
+		},
 	}
 
-	if configCreated.Name != "test-config-2" {
-		t.Errorf("expected 'test-config-2' as config map name. got %v", configCreated.Name)
-	}
-	if secretCreated.Name != "test-secret-2" {
-		t.Errorf("expected 'test-secret-2' as secret name. got %v", secretCreated.Name)
-	}
-
-	if err := c.sync(); err != nil {
-		t.Fatal(err)
-	}
-	if configCreated.Name != "test-config-2" {
-		t.Errorf("expected 'test-config-2' as config map name after second sync. got %v", configCreated.Name)
-	}
-	if secretCreated.Name != "test-secret-2" {
-		t.Errorf("expected 'test-secret-2' as secret name after second sync. got %v", secretCreated.Name)
+	for _, tc := range tests {
+		t.Run(tc.targetNamespace, func(t *testing.T) {
+			kubeClient := fake.NewSimpleClientset(tc.startingObjects...)
+			c := NewDeploymentController(
+				tc.targetNamespace,
+				tc.testConfigs,
+				tc.testSecrets,
+				informers.NewSharedInformerFactoryWithOptions(kubeClient, 1*time.Minute, informers.WithNamespace(tc.targetNamespace)),
+				tc.staticPodOperatorClient,
+				kubeClient,
+			)
+			syncErr := c.sync()
+			if tc.validateStatus != nil {
+				_, status, _, _ := tc.staticPodOperatorClient.Get()
+				tc.validateStatus(t, status)
+			}
+			if syncErr != nil {
+				if !strings.Contains(syncErr.Error(), tc.expectSyncError) {
+					t.Errorf("expected %q string in error %q", tc.expectSyncError, syncErr.Error())
+				}
+				return
+			}
+			if syncErr == nil && len(tc.expectSyncError) != 0 {
+				t.Errorf("expected %v error, got none", tc.expectSyncError)
+				return
+			}
+		})
 	}
 }


### PR DESCRIPTION
Refactors backing resource and deployment unit tests to evaluate test client actions instead of mocking with test client reactors. 

I left the installer test as it was, since it needs to do more trickery to kubeclient than other tests.

Fixes: https://github.com/openshift/library-go/issues/71

/cc @deads2k 