### PR TITLE
build: fix GO_BUILD_PACKAGES to build binaries

### DIFF
--- a/alpha-build-machinery/make/lib/golang.mk
+++ b/alpha-build-machinery/make/lib/golang.mk
@@ -8,7 +8,7 @@ GO_PACKAGES ?=./...
 GO_PACKAGES_EXPANDED ?=$(GOLIST) $(GO_PACKAGES)
 GO_TEST_PACKAGES ?=$(GO_PACKAGES)
 
-GO_BUILD_PACKAGES ?=./cmd/...
+GO_BUILD_PACKAGES ?=$(shell find ./cmd -mindepth 1 -maxdepth 1 -print)
 GO_BUILD_FLAGS ?=
 GO_TEST_FLAGS ?=-race
 


### PR DESCRIPTION
This fix will build all commands that are represented as directories under `./cmd` instead of doing `./cmd/...` which does not result into any binary.

/cc @tnozicka 
/cc @soltysh 