### PR TITLE
build: make verify-deps work on osx

### DIFF
--- a/alpha-build-machinery/make/targets/openshift/deps.mk
+++ b/alpha-build-machinery/make/targets/openshift/deps.mk
@@ -11,7 +11,7 @@ update-deps:
 # $1 - temporary directory to restore vendor dependencies from glide.lock
 define restore-deps
 	ln -s $(abspath ./) "$(1)"/current
-	cp -r -H ./ "$(1)"/updated
+	cp -R -H ./ "$(1)"/updated
 	$(RM) -r "$(1)"/updated/vendor
 	cd "$(1)"/updated && glide install --strip-vendor
 	cd "$(1)" && $(DIFF) -r -N {current,updated}/vendor/ > updated/glide.diff || true


### PR DESCRIPTION
```
COMPATIBILITY
     Historic versions of the cp utility had a -r option.  This implementation supports that option; however, its use is strongly discouraged, as it does not cor-
     rectly copy special files, symbolic links, or fifo's.
```

