### PR TITLE
alpha-build-machinery: fix verify-deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ origin.iml
 *.go~
 tags
 .envrc
+.hg_archival.txt

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,5 @@ origin.iml
 .tag*
 .project
 *.go~
-tags
 .envrc
 .hg_archival.txt

--- a/alpha-build-machinery/make/targets/openshift/deps.mk
+++ b/alpha-build-machinery/make/targets/openshift/deps.mk
@@ -13,7 +13,7 @@ define restore-deps
 	ln -s $(abspath ./) "$(1)"/current
 	cp -R -H ./ "$(1)"/updated
 	$(RM) -r "$(1)"/updated/vendor
-	cd "$(1)"/updated && glide install --strip-vendor
+	cd "$(1)"/updated && glide install --strip-vendor && git ls-files --others -i --exclude-standard vendor/ | xargs rm -f
 	cd "$(1)" && $(DIFF) -r -N {current,updated}/vendor/ > updated/glide.diff || true
 endef
 

--- a/vendor/bitbucket.org/ww/goautoneg/.hg_archival.txt
+++ b/vendor/bitbucket.org/ww/goautoneg/.hg_archival.txt
@@ -1,6 +1,0 @@
-repo: 848b351341922ce39becda978778724d5b58dbca
-node: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
-branch: default
-latesttag: null
-latesttagdistance: 5
-changessincelatesttag: 5


### PR DESCRIPTION
- ~~use compatible `cp -R` instead of `cp -r`.~~ merged in @mfojtik's PR.
- gitignore `.hg_archival.txt` files as there content depends on the hg version installed
- make `verify-deps` make target ignore gitignored files