### PR TITLE
Implement operator installer revision history pruning controller

### DIFF
--- a/pkg/operator/staticpod/controller/installer/installer_controller.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/golang/glog"
-	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -25,6 +24,7 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
 	"github.com/openshift/library-go/pkg/operator/staticpod/controller/common"
 	"github.com/openshift/library-go/pkg/operator/staticpod/controller/installer/bindata"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
@@ -38,12 +38,15 @@ const (
 
 	hostResourceDirDir = "/etc/kubernetes/static-pod-resources"
 	hostPodManifestDir = "/etc/kubernetes/manifests"
+
+	revisionLabel       = "revision"
+	statusConfigMapName = "revision-status"
 )
 
 // InstallerController is a controller that watches the currentRevision and targetRevision fields for each node and spawn
 // installer pods to update the static pods on the master nodes.
 type InstallerController struct {
-	targetNamespace, staticPodName string
+	targetNamespace, staticPodName, podResourcePrefix string
 	// configMaps is the list of configmaps that are directly copied.A different actor/controller modifies these.
 	// the first element should be the configmap that contains the static pod manifest
 	configMaps []string
@@ -77,11 +80,9 @@ const (
 	staticPodStateFailed
 )
 
-const revisionLabel = "revision"
-
-// NewBackingResourceController creates a new installer controller.
+// NewInstallerController creates a new installer controller.
 func NewInstallerController(
-	targetNamespace, staticPodName string,
+	targetNamespace, staticPodName, podResourcePrefix string,
 	configMaps []string,
 	secrets []string,
 	command []string,
@@ -91,11 +92,12 @@ func NewInstallerController(
 	eventRecorder events.Recorder,
 ) *InstallerController {
 	c := &InstallerController{
-		targetNamespace: targetNamespace,
-		staticPodName:   staticPodName,
-		configMaps:      configMaps,
-		secrets:         secrets,
-		command:         command,
+		targetNamespace:   targetNamespace,
+		staticPodName:     staticPodName,
+		podResourcePrefix: podResourcePrefix,
+		configMaps:        configMaps,
+		secrets:           secrets,
+		command:           command,
 
 		operatorConfigClient: operatorConfigClient,
 		kubeClient:           kubeClient,
@@ -189,6 +191,23 @@ func (c *InstallerController) manageInstallationPods(operatorSpec *operatorv1.Op
 		return false, nil
 	}
 
+	// Store success/fail status in the status configmap for revision history tracking
+	statusConfigMap, err := c.kubeClient.CoreV1().ConfigMaps(c.targetNamespace).Get(statusConfigMapName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		statusConfigMapObject := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Namespace: c.targetNamespace, Name: statusConfigMapName},
+			Data: map[string]string{
+				"phase": "InProgress",
+			},
+		}
+		statusConfigMap, _, err = resourceapply.ApplyConfigMap(c.kubeClient.CoreV1(), c.eventRecorder, statusConfigMapObject)
+		if err != nil {
+			return true, err
+		}
+	}
+
+	phaseStatus := string(corev1.PodSucceeded)
+
 	// start with node which is in worst state (instead of terminating healthy pods first)
 	startNode, err := nodeToStartRevisionWith(c.getStaticPodState, operatorStatus.NodeStatuses)
 	if err != nil {
@@ -206,6 +225,9 @@ func (c *InstallerController) manageInstallationPods(operatorSpec *operatorv1.Op
 			prevNodeState = &operatorStatus.NodeStatuses[prev]
 		}
 
+		statusConfigMap.Name = statusConfigMapNameForRevision(currNodeState.CurrentRevision)
+		statusConfigMap.Data["revision"] = fmt.Sprintf("%d", currNodeState.CurrentRevision)
+
 		// if we are in a transition, check to see if our installer pod completed
 		if currNodeState.TargetRevision > currNodeState.CurrentRevision {
 			if err := c.ensureInstallerPod(currNodeState.NodeName, operatorSpec, currNodeState.TargetRevision); err != nil {
@@ -218,6 +240,10 @@ func (c *InstallerController) manageInstallationPods(operatorSpec *operatorv1.Op
 			newCurrNodeState, err := c.newNodeStateForInstallInProgress(currNodeState, pendingNewRevision)
 			if err != nil {
 				return true, err
+			}
+
+			if newCurrNodeState.LastFailedRevision != 0 {
+				phaseStatus = string(corev1.PodFailed)
 			}
 
 			// if we make a change to this status, we want to write it out to the API before we commence work on the next node.
@@ -263,6 +289,12 @@ func (c *InstallerController) manageInstallationPods(operatorSpec *operatorv1.Op
 			return false, nil
 		}
 		break
+	}
+
+	statusConfigMap.Data["phase"] = phaseStatus
+	_, _, err = resourceapply.ApplyConfigMap(c.kubeClient.CoreV1(), c.eventRecorder, statusConfigMap)
+	if err != nil {
+		return true, err
 	}
 
 	return false, nil
@@ -549,4 +581,8 @@ func (c *InstallerController) eventHandler() cache.ResourceEventHandler {
 
 func mirrorPodNameForNode(staticPodName, nodeName string) string {
 	return staticPodName + "-" + nodeName
+}
+
+func statusConfigMapNameForRevision(revision int32) string {
+	return fmt.Sprintf("%s-%d", statusConfigMapName, revision)
 }


### PR DESCRIPTION
JIRA: https://jira.coreos.com/browse/MSTR-221

~~Depends on https://github.com/openshift/api/pull/128~~
Now depends on https://github.com/openshift/library-go/pull/141

Prunes installer revision history based on a specified limit in the `OperatorSpec`, with `0` being unlimited.