### PR TITLE
add skeleton for operator config observation

### DIFF
--- a/pkg/operator/configobserver/config_observer_controller.go
+++ b/pkg/operator/configobserver/config_observer_controller.go
@@ -1,0 +1,197 @@
+package configobserver
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/imdario/mergo"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/apimachinery/pkg/util/rand"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/client-go/util/workqueue"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+const operatorStatusTypeConfigObservationFailing = "ConfigObservationFailing"
+const configObservationErrorConditionReason = "ConfigObservationError"
+const configObserverWorkKey = "key"
+
+type OperatorClient interface {
+	GetOperatorState() (spec *operatorv1.OperatorSpec, status *operatorv1.OperatorStatus, resourceVersion string, err error)
+	UpdateOperatorSpec(string, *operatorv1.OperatorSpec) (spec *operatorv1.OperatorSpec, resourceVersion string, err error)
+	UpdateOperatorStatus(string, *operatorv1.OperatorStatus) (status *operatorv1.OperatorStatus, resourceVersion string, err error)
+}
+
+// Listers is an interface which will be passed to the config observer funcs.  It is expected to be hard-cast to the "correct" type
+type Listers interface {
+	PreRunHasSynced() []cache.InformerSynced
+}
+
+// ObserveConfigFunc observes configuration and returns the observedConfig. This function should not return an
+// observedConfig that would cause the service being managed by the operator to crash. For example, if a required
+// configuration key cannot be observed, consider reusing the configuration key's previous value. Errors that occur
+// while attempting to generate the observedConfig should be returned in the errs slice.
+type ObserveConfigFunc func(listers Listers, existingConfig map[string]interface{}) (observedConfig map[string]interface{}, errs []error)
+
+type ConfigObserver struct {
+	operatorClient OperatorClient
+
+	// queue only ever has one item, but it has nice error handling backoff/retry semantics
+	queue workqueue.RateLimitingInterface
+
+	rateLimiter flowcontrol.RateLimiter
+	// observers are called in an undefined order and their results are merged to
+	// determine the observed configuration.
+	observers []ObserveConfigFunc
+
+	// listers are used by config observers to retrieve necessary resources
+	listers Listers
+}
+
+func NewConfigObserver(
+	operatorClient OperatorClient,
+	listers Listers,
+	observers ...ObserveConfigFunc,
+) *ConfigObserver {
+	return &ConfigObserver{
+		operatorClient: operatorClient,
+
+		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "ConfigObserver"),
+
+		rateLimiter: flowcontrol.NewTokenBucketRateLimiter(0.05 /*3 per minute*/, 4),
+		observers:   observers,
+		listers:     listers,
+	}
+}
+
+// sync reacts to a change in prereqs by finding information that is required to match another value in the cluster. This
+// must be information that is logically "owned" by another component.
+func (c ConfigObserver) sync() error {
+	originalSpec, originalStatus, resourceVersion, err := c.operatorClient.GetOperatorState()
+	if err != nil {
+		return err
+	}
+	spec := originalSpec.DeepCopy()
+	// don't worry about errors.  If we can't decode, we'll simply stomp over the field.
+	existingConfig := map[string]interface{}{}
+	json.NewDecoder(bytes.NewBuffer(spec.ObservedConfig.Raw)).Decode(&existingConfig)
+
+	var errs []error
+	var observedConfigs []map[string]interface{}
+	for _, i := range rand.Perm(len(c.observers)) {
+		var currErrs []error
+		observedConfig, currErrs := c.observers[i](c.listers, existingConfig)
+		observedConfigs = append(observedConfigs, observedConfig)
+		errs = append(errs, currErrs...)
+	}
+
+	mergedObservedConfig := map[string]interface{}{}
+	for _, observedConfig := range observedConfigs {
+		mergo.Merge(&mergedObservedConfig, observedConfig)
+	}
+
+	if !equality.Semantic.DeepEqual(existingConfig, mergedObservedConfig) {
+		glog.Infof("writing updated observedConfig: %v", diff.ObjectDiff(existingConfig, mergedObservedConfig))
+		spec.ObservedConfig = runtime.RawExtension{Object: &unstructured.Unstructured{Object: mergedObservedConfig}}
+		_, resourceVersion, err = c.operatorClient.UpdateOperatorSpec(resourceVersion, spec)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("error writing updated observed config: %v", err))
+		}
+	}
+
+	status := originalStatus.DeepCopy()
+	if len(errs) > 0 {
+		var messages []string
+		for _, currentError := range errs {
+			messages = append(messages, currentError.Error())
+		}
+		v1helpers.SetOperatorCondition(&status.Conditions, operatorv1.OperatorCondition{
+			Type:    operatorStatusTypeConfigObservationFailing,
+			Status:  operatorv1.ConditionTrue,
+			Reason:  configObservationErrorConditionReason,
+			Message: strings.Join(messages, "\n"),
+		})
+
+	} else {
+		v1helpers.SetOperatorCondition(&status.Conditions, operatorv1.OperatorCondition{
+			Type:   operatorStatusTypeConfigObservationFailing,
+			Status: operatorv1.ConditionFalse,
+		})
+	}
+
+	if !equality.Semantic.DeepEqual(originalStatus, status) {
+		_, _, err = c.operatorClient.UpdateOperatorStatus(resourceVersion, status)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *ConfigObserver) Run(workers int, stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	glog.Infof("Starting ConfigObserver")
+	defer glog.Infof("Shutting down ConfigObserver")
+
+	if !cache.WaitForCacheSync(stopCh, c.listers.PreRunHasSynced()...) {
+		utilruntime.HandleError(fmt.Errorf("caches did not sync"))
+		return
+	}
+
+	// doesn't matter what workers say, only start one.
+	go wait.Until(c.runWorker, time.Second, stopCh)
+
+	<-stopCh
+}
+
+func (c *ConfigObserver) runWorker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+func (c *ConfigObserver) processNextWorkItem() bool {
+	dsKey, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(dsKey)
+
+	// before we call sync, we want to wait for token.  We do this to avoid hot looping.
+	c.rateLimiter.Accept()
+
+	err := c.sync()
+	if err == nil {
+		c.queue.Forget(dsKey)
+		return true
+	}
+
+	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", dsKey, err))
+	c.queue.AddRateLimited(dsKey)
+
+	return true
+}
+
+// eventHandler queues the operator to check spec and status
+func (c *ConfigObserver) EventHandler() cache.ResourceEventHandler {
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { c.queue.Add(configObserverWorkKey) },
+		UpdateFunc: func(old, new interface{}) { c.queue.Add(configObserverWorkKey) },
+		DeleteFunc: func(obj interface{}) { c.queue.Add(configObserverWorkKey) },
+	}
+}

--- a/pkg/operator/configobserver/config_observer_controller_test.go
+++ b/pkg/operator/configobserver/config_observer_controller_test.go
@@ -1,0 +1,203 @@
+package configobserver
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+
+	"github.com/ghodss/yaml"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/tools/cache"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+func (c *fakeOperatorClient) GetOperatorState() (spec *operatorv1.OperatorSpec, status *operatorv1.OperatorStatus, resourceVersion string, err error) {
+	return c.startingSpec, &operatorv1.OperatorStatus{}, "", nil
+
+}
+func (c *fakeOperatorClient) UpdateOperatorSpec(rv string, in *operatorv1.OperatorSpec) (spec *operatorv1.OperatorSpec, resourceVersion string, err error) {
+	if c.specUpdateFailure != nil {
+		return &operatorv1.OperatorSpec{}, rv, c.specUpdateFailure
+	}
+	c.spec = in
+	return in, rv, c.specUpdateFailure
+}
+func (c *fakeOperatorClient) UpdateOperatorStatus(rv string, in *operatorv1.OperatorStatus) (status *operatorv1.OperatorStatus, resourceVersion string, err error) {
+	c.status = in
+	return in, rv, nil
+}
+
+type fakeOperatorClient struct {
+	startingSpec      *operatorv1.OperatorSpec
+	specUpdateFailure error
+
+	status *operatorv1.OperatorStatus
+	spec   *operatorv1.OperatorSpec
+}
+
+type fakeLister struct{}
+
+func (l *fakeLister) PreRunHasSynced() []cache.InformerSynced {
+	return []cache.InformerSynced{
+		func() bool { return true },
+	}
+}
+
+func TestSyncStatus(t *testing.T) {
+	testCases := []struct {
+		name       string
+		fakeClient func() *fakeOperatorClient
+		observers  []ObserveConfigFunc
+
+		expectError            bool
+		expectedObservedConfig *unstructured.Unstructured
+		expectedCondition      *operatorv1.OperatorCondition
+	}{
+		{
+			name: "HappyPath",
+			fakeClient: func() *fakeOperatorClient {
+				return &fakeOperatorClient{
+					startingSpec: &operatorv1.OperatorSpec{},
+				}
+			},
+			observers: []ObserveConfigFunc{
+				func(listers Listers, existingConfig map[string]interface{}) (observedConfig map[string]interface{}, errs []error) {
+					return map[string]interface{}{"foo": "one"}, nil
+				},
+				func(listers Listers, existingConfig map[string]interface{}) (observedConfig map[string]interface{}, errs []error) {
+					return map[string]interface{}{"bar": "two"}, nil
+				},
+				func(listers Listers, existingConfig map[string]interface{}) (observedConfig map[string]interface{}, errs []error) {
+					return map[string]interface{}{"baz": "three"}, nil
+				},
+			},
+
+			expectError: false,
+			expectedObservedConfig: &unstructured.Unstructured{Object: map[string]interface{}{
+				"foo": "one",
+				"bar": "two",
+				"baz": "three",
+			}},
+			expectedCondition: &operatorv1.OperatorCondition{
+				Type:   operatorStatusTypeConfigObservationFailing,
+				Status: operatorv1.ConditionFalse,
+			},
+		},
+		{
+			name: "MergeTwoOfThreeWithError",
+			fakeClient: func() *fakeOperatorClient {
+				return &fakeOperatorClient{
+					startingSpec: &operatorv1.OperatorSpec{},
+				}
+			},
+			observers: []ObserveConfigFunc{
+				func(listers Listers, existingConfig map[string]interface{}) (observedConfig map[string]interface{}, errs []error) {
+					return map[string]interface{}{"foo": "one"}, nil
+				},
+				func(listers Listers, existingConfig map[string]interface{}) (observedConfig map[string]interface{}, errs []error) {
+					return map[string]interface{}{"bar": "two"}, nil
+				},
+				func(listers Listers, existingConfig map[string]interface{}) (observedConfig map[string]interface{}, errs []error) {
+					errs = append(errs, fmt.Errorf("some failure"))
+					return observedConfig, errs
+				},
+			},
+
+			expectError: false,
+			expectedObservedConfig: &unstructured.Unstructured{Object: map[string]interface{}{
+				"foo": "one",
+				"bar": "two",
+			}},
+			expectedCondition: &operatorv1.OperatorCondition{
+				Type:    operatorStatusTypeConfigObservationFailing,
+				Status:  operatorv1.ConditionTrue,
+				Reason:  configObservationErrorConditionReason,
+				Message: "some failure",
+			},
+		},
+		{
+			name: "TestUpdateFailed",
+			fakeClient: func() *fakeOperatorClient {
+				return &fakeOperatorClient{
+					startingSpec:      &operatorv1.OperatorSpec{},
+					specUpdateFailure: fmt.Errorf("update spec failure"),
+				}
+			},
+			observers: []ObserveConfigFunc{
+				func(listers Listers, existingConfig map[string]interface{}) (observedConfig map[string]interface{}, errs []error) {
+					return map[string]interface{}{"foo": "one"}, nil
+				},
+			},
+
+			expectError:            false,
+			expectedObservedConfig: nil,
+			expectedCondition: &operatorv1.OperatorCondition{
+				Type:    operatorStatusTypeConfigObservationFailing,
+				Status:  operatorv1.ConditionTrue,
+				Reason:  configObservationErrorConditionReason,
+				Message: "error writing updated observed config: update spec failure",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			operatorConfigClient := tc.fakeClient()
+
+			configObserver := ConfigObserver{
+				listers:        &fakeLister{},
+				operatorClient: operatorConfigClient,
+				observers:      tc.observers,
+			}
+			err := configObserver.sync()
+			if tc.expectError && err == nil {
+				t.Fatal("error expected")
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			switch {
+			case tc.expectedObservedConfig != nil && operatorConfigClient.spec == nil:
+				t.Error("missing expected spec")
+			case tc.expectedObservedConfig != nil:
+				if !reflect.DeepEqual(tc.expectedObservedConfig, operatorConfigClient.spec.ObservedConfig.Object) {
+					t.Errorf("\n===== observed config expected:\n%v\n===== observed config actual:\n%v", toYAML(tc.expectedObservedConfig), toYAML(operatorConfigClient.spec.ObservedConfig.Object))
+				}
+			default:
+				if operatorConfigClient.spec != nil {
+					t.Errorf("unexpected %v", spew.Sdump(operatorConfigClient.spec))
+				}
+			}
+
+			switch {
+			case tc.expectedCondition != nil && operatorConfigClient.status == nil:
+				t.Error("missing expected status")
+			case tc.expectedCondition != nil:
+				condition := v1helpers.FindOperatorCondition(operatorConfigClient.status.Conditions, operatorStatusTypeConfigObservationFailing)
+				condition.LastTransitionTime = tc.expectedCondition.LastTransitionTime
+				if !reflect.DeepEqual(tc.expectedCondition, condition) {
+					t.Fatalf("\n===== condition expected:\n%v\n===== condition actual:\n%v", toYAML(tc.expectedCondition), toYAML(condition))
+				}
+			default:
+				if operatorConfigClient.status != nil {
+					t.Errorf("unexpected %v", spew.Sdump(operatorConfigClient.status))
+				}
+			}
+
+		})
+	}
+}
+
+func toYAML(o interface{}) string {
+	b, e := yaml.Marshal(o)
+	if e != nil {
+		return e.Error()
+	}
+	return string(b)
+}


### PR DESCRIPTION
This provides the core of controller loop that operators can use to drive config observation wiring in their process.  It manages retries, merging, error handling, and condition reporting.

/assign @mfojtik 