### PR TITLE
observer: fail when requesting empty filename for observing

### DIFF
--- a/pkg/controller/fileobserver/observer_polling.go
+++ b/pkg/controller/fileobserver/observer_polling.go
@@ -26,6 +26,9 @@ func (o *pollingObserver) AddReactor(reaction reactorFn, files ...string) Observ
 	o.reactorsMutex.Lock()
 	defer o.reactorsMutex.Unlock()
 	for _, f := range files {
+		if len(f) == 0 {
+			panic(fmt.Sprintf("observed file name must not be empty (%#v)", files))
+		}
 		// Do not rehash existing files
 		if _, exists := o.files[f]; exists {
 			continue


### PR DESCRIPTION
The observer should never accept to observe an empty file. If it does, it is a programming error and we should panic.

/cc @sttts 