### PR TITLE
Add simple event recorder

### DIFF
--- a/pkg/operator/events/recorder.go
+++ b/pkg/operator/events/recorder.go
@@ -1,0 +1,78 @@
+package events
+
+import (
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+// Recorder is a simple event recording interface.
+type Recorder interface {
+	Event(reason, message string) error
+	Eventf(reason, messageFmt string, args ...interface{}) error
+	Warning(reason, message string) error
+	Warningf(reason, messageFmt string, args ...interface{}) error
+}
+
+// NewRecorder returns new event recorder.
+func NewRecorder(client corev1client.EventInterface, sourceComponentName string, involvedObjectRef *corev1.ObjectReference) Recorder {
+	return &recorder{
+		eventClient:       client,
+		involvedObjectRef: involvedObjectRef,
+		sourceComponent:   sourceComponentName,
+	}
+}
+
+// recorder is an implementation of Recorder interface.
+type recorder struct {
+	eventClient       corev1client.EventInterface
+	involvedObjectRef *corev1.ObjectReference
+	sourceComponent   string
+}
+
+// Event emits the normal type event and allow formatting of message.
+func (r *recorder) Eventf(reason, messageFmt string, args ...interface{}) error {
+	return r.Event(reason, fmt.Sprintf(messageFmt, args...))
+}
+
+// Warning emits the warning type event and allow formatting of message.
+func (r *recorder) Warningf(reason, messageFmt string, args ...interface{}) error {
+	return r.Warning(reason, fmt.Sprintf(messageFmt, args...))
+}
+
+// Event emits the normal type event.
+func (r *recorder) Event(reason, message string) error {
+	_, err := r.eventClient.Create(r.makeEvent(r.involvedObjectRef, corev1.EventTypeNormal, reason, message))
+	return err
+}
+
+// Warning emits the warning type event.
+func (r *recorder) Warning(reason, message string) error {
+	_, err := r.eventClient.Create(r.makeEvent(r.involvedObjectRef, corev1.EventTypeWarning, reason, message))
+	return err
+}
+
+func (r recorder) makeEvent(involvedObjRef *corev1.ObjectReference, eventType, reason, message string) *corev1.Event {
+	currentTime := metav1.Time{Time: time.Now()}
+	event := &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%v.%x", involvedObjRef.Name, currentTime.UnixNano()),
+			Namespace: involvedObjRef.Namespace,
+		},
+		InvolvedObject: *involvedObjRef,
+		Reason:         reason,
+		Message:        message,
+		Type:           eventType,
+		Count:          1,
+		FirstTimestamp: currentTime,
+		LastTimestamp:  currentTime,
+		EventTime:      metav1.MicroTime{Time: currentTime.Time},
+	}
+	if len(r.sourceComponent) > 0 {
+		event.Source.Component = r.sourceComponent
+	}
+	return event
+}

--- a/pkg/operator/events/recorder_deployment.go
+++ b/pkg/operator/events/recorder_deployment.go
@@ -1,0 +1,34 @@
+package events
+
+import (
+	"fmt"
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	appsv1client "k8s.io/client-go/kubernetes/typed/apps/v1"
+	"k8s.io/client-go/tools/reference"
+)
+
+// eventSourceReplicaSetNameEnv is a name of environment variable inside container that specifies the name of the current replica set.
+// This replica set name is then used as a source/involved object for operator events.
+const eventSourceReplicaSetNameEnv = "EVENT_SOURCE_REPLICASET_NAME"
+
+// eventSourceReplicaSetNameEnvFunc allows to override the way we get the environment variable value (for unit tests).
+var eventSourceReplicaSetNameEnvFunc = func() string {
+	return os.Getenv(eventSourceReplicaSetNameEnv)
+}
+
+// GetReplicaSetOwnerReference returns an object reference for a replica set specified in EVENT_SOURCE_REPLICASET_NAME environment variable.
+// This object reference can be used as involvedObjectRef in event recorder. This method should be called once, in factory.
+func GetReplicaSetOwnerReference(client appsv1client.ReplicaSetInterface) (*corev1.ObjectReference, error) {
+	replicaSetName := eventSourceReplicaSetNameEnvFunc()
+	if len(replicaSetName) == 0 {
+		return nil, fmt.Errorf("unable to setup event recorder as %q env variable is not set", eventSourceReplicaSetNameEnv)
+	}
+	rs, err := client.Get(replicaSetName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return reference.GetReference(nil, rs)
+}

--- a/pkg/operator/events/recorder_deployment_test.go
+++ b/pkg/operator/events/recorder_deployment_test.go
@@ -1,0 +1,38 @@
+package events
+
+import (
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func makeFakeReplicaSet(namespace, name string) *appsv1.ReplicaSet {
+	rs := appsv1.ReplicaSet{}
+	rs.Name = name
+	rs.Namespace = namespace
+	rs.TypeMeta.Kind = "ReplicaSet"
+	rs.TypeMeta.APIVersion = "apps/v1"
+	return &rs
+}
+
+func TestGetReplicaSetOwnerReference(t *testing.T) {
+	client := fake.NewSimpleClientset(makeFakeReplicaSet("test", "foo"))
+
+	eventSourceReplicaSetNameEnvFunc = func() string {
+		return "foo"
+	}
+
+	objectReference, err := GetReplicaSetOwnerReference(client.AppsV1().ReplicaSets("test"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if objectReference.Name != "foo" {
+		t.Errorf("expected objectReference name to be 'foo', got %q", objectReference.Name)
+	}
+
+	if objectReference.GroupVersionKind().String() != "apps/v1, Kind=ReplicaSet" {
+		t.Errorf("expected objectReference to be ReplicaSet, got %q", objectReference.GroupVersionKind().String())
+	}
+}

--- a/pkg/operator/events/recorder_test.go
+++ b/pkg/operator/events/recorder_test.go
@@ -1,0 +1,61 @@
+package events
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	clientgotesting "k8s.io/client-go/testing"
+)
+
+func fakeRecorderSource() *corev1.ObjectReference {
+	rs := makeFakeReplicaSet("test-namespace", "test-replicaset")
+	return &corev1.ObjectReference{
+		APIVersion:      rs.TypeMeta.APIVersion,
+		Kind:            rs.TypeMeta.Kind,
+		Name:            rs.Name,
+		Namespace:       rs.Namespace,
+		ResourceVersion: rs.ResourceVersion,
+		UID:             rs.UID,
+	}
+}
+
+func TestNewRecorder(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	r := NewRecorder(client.CoreV1().Events("test-namespace"), "test-operator", fakeRecorderSource())
+
+	if err := r.Event("TestReason", "foo"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var createdEvent *corev1.Event
+
+	for _, action := range client.Actions() {
+		if action.Matches("create", "events") {
+			createAction := action.(clientgotesting.CreateAction)
+			createdEvent = createAction.GetObject().(*corev1.Event)
+			break
+		}
+	}
+	if createdEvent == nil {
+		t.Fatalf("expected event to be created")
+	}
+	if createdEvent.InvolvedObject.Kind != "ReplicaSet" {
+		t.Errorf("expected involved object kind ReplicaSet, got: %q", createdEvent.InvolvedObject.Kind)
+	}
+	if createdEvent.InvolvedObject.Namespace != "test-namespace" {
+		t.Errorf("expected involved object namespace test-namespace, got: %q", createdEvent.InvolvedObject.Namespace)
+	}
+	if createdEvent.Reason != "TestReason" {
+		t.Errorf("expected event to have TestReason, got %q", createdEvent.Reason)
+	}
+	if createdEvent.Message != "foo" {
+		t.Errorf("expected message to be foo, got %q", createdEvent.Message)
+	}
+	if createdEvent.Type != "Normal" {
+		t.Errorf("expected event type to be Normal, got %q", createdEvent.Type)
+	}
+	if createdEvent.Source.Component != "test-operator" {
+		t.Errorf("expected event source to be test-operator, got %q", createdEvent.Source.Component)
+	}
+}


### PR DESCRIPTION
Adding event recorder interface for recording events from operators. Recorder should be wired to resourceapply package and observer package to. Events published by operator are for historical action debugging.

This implementation require the ObjectReference to be passed to NewRecorder in the factory when the operator is started. It means that the `EVENT_SOURCE_REPLICASET_NAME` will have to be passed via downward API into the container running the operator and the replica set is then used as the object we recording the events against. These events should be also propagated to the owning deployment.

/cc @deads2k 
/cc @sttts 