### PR TITLE
Pass controller context struct to StartFunc

### DIFF
--- a/pkg/controller/controllercmd/cmd.go
+++ b/pkg/controller/controllercmd/cmd.go
@@ -26,16 +26,6 @@ import (
 	_ "github.com/openshift/library-go/pkg/controller/metrics"
 )
 
-var (
-	configScheme = runtime.NewScheme()
-)
-
-func init() {
-	if err := operatorv1alpha1.Install(configScheme); err != nil {
-		panic(err)
-	}
-}
-
 // ControllerCommandConfig holds values required to construct a command to run.
 type ControllerCommandConfig struct {
 	componentName string
@@ -180,5 +170,4 @@ func (c *ControllerCommandConfig) StartController(stopCh <-chan struct{}) error 
 		WithServer(config.ServingInfo, config.Authentication, config.Authorization).
 		WithRestartOnChange(exitOnChangeReactorCh, observedFiles...).
 		Run(unstructuredConfig, stopCh)
-
 }

--- a/pkg/controller/controllercmd/flags.go
+++ b/pkg/controller/controllercmd/flags.go
@@ -2,7 +2,6 @@ package controllercmd
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 
@@ -32,10 +31,7 @@ func NewControllerFlags() *ControllerFlags {
 
 // Validate makes sure the required flags are specified and no illegal combinations are found
 func (o *ControllerFlags) Validate() error {
-	if len(o.ConfigFile) == 0 {
-		return errors.New("--config is required for this command")
-	}
-
+	// everything is optional currently
 	return nil
 }
 


### PR DESCRIPTION
StartFunc was refactored to take a ControllerContext struct.  This prevents the function signature from expanding indefinitely and makes is easier to add new fields without breaking every caller.

Signed-off-by: Monis Khan <mkhan@redhat.com>