### PR TITLE
events: wire events directly to resourceapply

### DIFF
--- a/pkg/operator/resource/resourceapply/core.go
+++ b/pkg/operator/resource/resourceapply/core.go
@@ -7,14 +7,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	coreclientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 
+	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
 )
 
 // ApplyNamespace merges objectmeta, does not worry about anything else
-func ApplyNamespace(client coreclientv1.NamespacesGetter, required *corev1.Namespace) (*corev1.Namespace, bool, error) {
+func ApplyNamespace(client coreclientv1.NamespacesGetter, recorder events.Recorder, required *corev1.Namespace) (*corev1.Namespace, bool, error) {
 	existing, err := client.Namespaces().Get(required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		actual, err := client.Namespaces().Create(required)
+		reportCreateEvent(recorder, required, err)
 		return actual, true, err
 	}
 	if err != nil {
@@ -28,16 +30,18 @@ func ApplyNamespace(client coreclientv1.NamespacesGetter, required *corev1.Names
 	}
 
 	actual, err := client.Namespaces().Update(existing)
+	reportUpdateEvent(recorder, required, err)
 	return actual, true, err
 }
 
 // ApplyService merges objectmeta and requires
 // TODO, since this cannot determine whether changes are due to legitimate actors (api server) or illegitimate ones (users), we cannot update
 // TODO I've special cased the selector for now
-func ApplyService(client coreclientv1.ServicesGetter, required *corev1.Service) (*corev1.Service, bool, error) {
+func ApplyService(client coreclientv1.ServicesGetter, recorder events.Recorder, required *corev1.Service) (*corev1.Service, bool, error) {
 	existing, err := client.Services(required.Namespace).Get(required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		actual, err := client.Services(required.Namespace).Create(required)
+		reportCreateEvent(recorder, required, err)
 		return actual, true, err
 	}
 	if err != nil {
@@ -58,18 +62,21 @@ func ApplyService(client coreclientv1.ServicesGetter, required *corev1.Service) 
 	if selectorSame && typeSame && !*modified {
 		return nil, false, nil
 	}
+
 	existing.Spec.Selector = required.Spec.Selector
 	existing.Spec.Type = required.Spec.Type // if this is different, the update will fail.  Status will indicate it.
 
 	actual, err := client.Services(required.Namespace).Update(existing)
+	reportUpdateEvent(recorder, required, err)
 	return actual, true, err
 }
 
 // ApplyServiceAccount merges objectmeta, does not worry about anything else
-func ApplyServiceAccount(client coreclientv1.ServiceAccountsGetter, required *corev1.ServiceAccount) (*corev1.ServiceAccount, bool, error) {
+func ApplyServiceAccount(client coreclientv1.ServiceAccountsGetter, recorder events.Recorder, required *corev1.ServiceAccount) (*corev1.ServiceAccount, bool, error) {
 	existing, err := client.ServiceAccounts(required.Namespace).Get(required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		actual, err := client.ServiceAccounts(required.Namespace).Create(required)
+		reportCreateEvent(recorder, required, err)
 		return actual, true, err
 	}
 	if err != nil {
@@ -83,14 +90,16 @@ func ApplyServiceAccount(client coreclientv1.ServiceAccountsGetter, required *co
 	}
 
 	actual, err := client.ServiceAccounts(required.Namespace).Update(existing)
+	reportUpdateEvent(recorder, required, err)
 	return actual, true, err
 }
 
 // ApplyConfigMap merges objectmeta, requires data
-func ApplyConfigMap(client coreclientv1.ConfigMapsGetter, required *corev1.ConfigMap) (*corev1.ConfigMap, bool, error) {
+func ApplyConfigMap(client coreclientv1.ConfigMapsGetter, recorder events.Recorder, required *corev1.ConfigMap) (*corev1.ConfigMap, bool, error) {
 	existing, err := client.ConfigMaps(required.Namespace).Get(required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		actual, err := client.ConfigMaps(required.Namespace).Create(required)
+		reportCreateEvent(recorder, required, err)
 		return actual, true, err
 	}
 	if err != nil {
@@ -106,14 +115,16 @@ func ApplyConfigMap(client coreclientv1.ConfigMapsGetter, required *corev1.Confi
 	existing.Data = required.Data
 
 	actual, err := client.ConfigMaps(required.Namespace).Update(existing)
+	reportUpdateEvent(recorder, required, err)
 	return actual, true, err
 }
 
 // ApplySecret merges objectmeta, requires data
-func ApplySecret(client coreclientv1.SecretsGetter, required *corev1.Secret) (*corev1.Secret, bool, error) {
+func ApplySecret(client coreclientv1.SecretsGetter, recorder events.Recorder, required *corev1.Secret) (*corev1.Secret, bool, error) {
 	existing, err := client.Secrets(required.Namespace).Get(required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		actual, err := client.Secrets(required.Namespace).Create(required)
+		reportCreateEvent(recorder, required, err)
 		return actual, true, err
 	}
 	if err != nil {
@@ -129,10 +140,11 @@ func ApplySecret(client coreclientv1.SecretsGetter, required *corev1.Secret) (*c
 	existing.Data = required.Data
 
 	actual, err := client.Secrets(required.Namespace).Update(existing)
+	reportUpdateEvent(recorder, required, err)
 	return actual, true, err
 }
 
-func SyncConfigMap(client coreclientv1.ConfigMapsGetter, sourceNamespace, sourceName, targetNamespace, targetName string) (*corev1.ConfigMap, bool, error) {
+func SyncConfigMap(client coreclientv1.ConfigMapsGetter, recorder events.Recorder, sourceNamespace, sourceName, targetNamespace, targetName string) (*corev1.ConfigMap, bool, error) {
 	source, err := client.ConfigMaps(sourceNamespace).Get(sourceName, metav1.GetOptions{})
 	switch {
 	case apierrors.IsNotFound(err):
@@ -141,6 +153,7 @@ func SyncConfigMap(client coreclientv1.ConfigMapsGetter, sourceNamespace, source
 			return nil, false, nil
 		}
 		if deleteErr == nil {
+			recorder.Eventf("TargetConfigDeleted", "Deleted target configmap %s/%s because source config does not exist", targetNamespace, targetName)
 			return nil, true, nil
 		}
 		return nil, false, deleteErr
@@ -151,11 +164,11 @@ func SyncConfigMap(client coreclientv1.ConfigMapsGetter, sourceNamespace, source
 		source.Name = targetName
 		source.ResourceVersion = ""
 		source.OwnerReferences = []metav1.OwnerReference{}
-		return ApplyConfigMap(client, source)
+		return ApplyConfigMap(client, recorder, source)
 	}
 }
 
-func SyncSecret(client coreclientv1.SecretsGetter, sourceNamespace, sourceName, targetNamespace, targetName string) (*corev1.Secret, bool, error) {
+func SyncSecret(client coreclientv1.SecretsGetter, recorder events.Recorder, sourceNamespace, sourceName, targetNamespace, targetName string) (*corev1.Secret, bool, error) {
 	source, err := client.Secrets(sourceNamespace).Get(sourceName, metav1.GetOptions{})
 	switch {
 	case apierrors.IsNotFound(err):
@@ -164,6 +177,7 @@ func SyncSecret(client coreclientv1.SecretsGetter, sourceNamespace, sourceName, 
 			return nil, false, nil
 		}
 		if deleteErr == nil {
+			recorder.Eventf("TargetSecretDeleted", "Deleted target secret %s/%s because source config does not exist", targetNamespace, targetName)
 			return nil, true, nil
 		}
 		return nil, false, deleteErr
@@ -174,6 +188,6 @@ func SyncSecret(client coreclientv1.SecretsGetter, sourceNamespace, sourceName, 
 		source.Name = targetName
 		source.ResourceVersion = ""
 		source.OwnerReferences = []metav1.OwnerReference{}
-		return ApplySecret(client, source)
+		return ApplySecret(client, recorder, source)
 	}
 }

--- a/pkg/operator/resource/resourceapply/core_test.go
+++ b/pkg/operator/resource/resourceapply/core_test.go
@@ -12,6 +12,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
+
+	"github.com/openshift/library-go/pkg/operator/events"
 )
 
 func TestApplyConfigMap(t *testing.T) {
@@ -143,7 +145,7 @@ func TestApplyConfigMap(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			client := fake.NewSimpleClientset(test.existing...)
-			_, actualModified, err := ApplyConfigMap(client.CoreV1(), test.input)
+			_, actualModified, err := ApplyConfigMap(client.CoreV1(), events.NewInMemoryRecorder("test"), test.input)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/operator/resource/resourceapply/event_helpers.go
+++ b/pkg/operator/resource/resourceapply/event_helpers.go
@@ -1,0 +1,48 @@
+package resourceapply
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/openshift/library-go/pkg/operator/events"
+)
+
+func reportCreateEvent(recorder events.Recorder, obj runtime.Object, originalErr error) {
+	gvk := obj.GetObjectKind().GroupVersionKind()
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		glog.Errorf("Failed to get accessor for %+v", obj)
+		return
+	}
+	objName := fmt.Sprintf("%s/%s", accessor.GetNamespace(), accessor.GetName())
+	if len(accessor.GetNamespace()) == 0 {
+		objName = accessor.GetName()
+	}
+	if originalErr == nil {
+		recorder.Eventf(fmt.Sprintf("%sCreated", gvk.Kind), "Created %s %q because it was missing", gvk.Kind, objName)
+		return
+	}
+	recorder.Warningf(fmt.Sprintf("%sCreateFailed", gvk.Kind), "Failed to create %s %q: %v", gvk.Kind, objName, originalErr)
+}
+
+func reportUpdateEvent(recorder events.Recorder, obj runtime.Object, originalErr error) {
+	gvk := obj.GetObjectKind().GroupVersionKind()
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		glog.Errorf("Failed to get accessor for %+v", obj)
+		return
+	}
+	objName := fmt.Sprintf("%s/%s", accessor.GetNamespace(), accessor.GetName())
+	if len(accessor.GetNamespace()) == 0 {
+		objName = accessor.GetName()
+	}
+	if originalErr == nil {
+		recorder.Eventf(fmt.Sprintf("%sUpdated", gvk.Kind), "Updated %s %q because it changed", gvk.Kind, objName)
+		return
+	}
+	recorder.Warningf(fmt.Sprintf("%sUpdateFailed", gvk.Kind), "Failed to update %s %q: %v", gvk.Kind, objName, originalErr)
+}

--- a/pkg/operator/resource/resourceapply/generic_test.go
+++ b/pkg/operator/resource/resourceapply/generic_test.go
@@ -42,11 +42,4 @@ metadata:
 	} else if ret[0].Error.Error() != "unhandled type *v1.Pod" {
 		t.Fatal(ret[0].Error)
 	}
-	if len(recorder.Events()) == 0 {
-		t.Fatal("expected events to be recorder")
-	}
-
-	if recorder.Events()[0].Reason != "ResourceApplyFailed" {
-		t.Fatalf("expected reason to be ResourceApplyFailed, got %v", recorder.Events()[0].Reason)
-	}
 }

--- a/pkg/operator/resource/resourceapply/rbac.go
+++ b/pkg/operator/resource/resourceapply/rbac.go
@@ -9,11 +9,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	rbacclientv1 "k8s.io/client-go/kubernetes/typed/rbac/v1"
 
+	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
 )
 
 // ApplyClusterRole merges objectmeta, requires rules, aggregation rules are not allowed for now.
-func ApplyClusterRole(client rbacclientv1.ClusterRolesGetter, required *rbacv1.ClusterRole) (*rbacv1.ClusterRole, bool, error) {
+func ApplyClusterRole(client rbacclientv1.ClusterRolesGetter, recorder events.Recorder, required *rbacv1.ClusterRole) (*rbacv1.ClusterRole, bool, error) {
 	if required.AggregationRule != nil && len(required.AggregationRule.ClusterRoleSelectors) != 0 {
 		return nil, false, fmt.Errorf("cannot create an aggregated cluster role")
 	}
@@ -21,6 +22,7 @@ func ApplyClusterRole(client rbacclientv1.ClusterRolesGetter, required *rbacv1.C
 	existing, err := client.ClusterRoles().Get(required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		actual, err := client.ClusterRoles().Create(required)
+		reportCreateEvent(recorder, required, err)
 		return actual, true, err
 	}
 	if err != nil {
@@ -37,15 +39,17 @@ func ApplyClusterRole(client rbacclientv1.ClusterRolesGetter, required *rbacv1.C
 	existing.AggregationRule = nil
 
 	actual, err := client.ClusterRoles().Update(existing)
+	reportUpdateEvent(recorder, required, err)
 	return actual, true, err
 }
 
 // ApplyClusterRoleBinding merges objectmeta, requires subjects and role refs
 // TODO on non-matching roleref, delete and recreate
-func ApplyClusterRoleBinding(client rbacclientv1.ClusterRoleBindingsGetter, required *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, bool, error) {
+func ApplyClusterRoleBinding(client rbacclientv1.ClusterRoleBindingsGetter, recorder events.Recorder, required *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, bool, error) {
 	existing, err := client.ClusterRoleBindings().Get(required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		actual, err := client.ClusterRoleBindings().Create(required)
+		reportCreateEvent(recorder, required, err)
 		return actual, true, err
 	}
 	if err != nil {
@@ -63,14 +67,16 @@ func ApplyClusterRoleBinding(client rbacclientv1.ClusterRoleBindingsGetter, requ
 	existing.RoleRef = required.RoleRef
 
 	actual, err := client.ClusterRoleBindings().Update(existing)
+	reportUpdateEvent(recorder, required, err)
 	return actual, true, err
 }
 
 // ApplyRole merges objectmeta, requires rules
-func ApplyRole(client rbacclientv1.RolesGetter, required *rbacv1.Role) (*rbacv1.Role, bool, error) {
+func ApplyRole(client rbacclientv1.RolesGetter, recorder events.Recorder, required *rbacv1.Role) (*rbacv1.Role, bool, error) {
 	existing, err := client.Roles(required.Namespace).Get(required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		actual, err := client.Roles(required.Namespace).Create(required)
+		reportCreateEvent(recorder, required, err)
 		return actual, true, err
 	}
 	if err != nil {
@@ -86,15 +92,17 @@ func ApplyRole(client rbacclientv1.RolesGetter, required *rbacv1.Role) (*rbacv1.
 	existing.Rules = required.Rules
 
 	actual, err := client.Roles(required.Namespace).Update(existing)
+	reportUpdateEvent(recorder, required, err)
 	return actual, true, err
 }
 
 // ApplyRoleBinding merges objectmeta, requires subjects and role refs
 // TODO on non-matching roleref, delete and recreate
-func ApplyRoleBinding(client rbacclientv1.RoleBindingsGetter, required *rbacv1.RoleBinding) (*rbacv1.RoleBinding, bool, error) {
+func ApplyRoleBinding(client rbacclientv1.RoleBindingsGetter, recorder events.Recorder, required *rbacv1.RoleBinding) (*rbacv1.RoleBinding, bool, error) {
 	existing, err := client.RoleBindings(required.Namespace).Get(required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		actual, err := client.RoleBindings(required.Namespace).Create(required)
+		reportCreateEvent(recorder, required, err)
 		return actual, true, err
 	}
 	if err != nil {
@@ -112,6 +120,7 @@ func ApplyRoleBinding(client rbacclientv1.RoleBindingsGetter, required *rbacv1.R
 	existing.RoleRef = required.RoleRef
 
 	actual, err := client.RoleBindings(required.Namespace).Update(existing)
+	reportUpdateEvent(recorder, required, err)
 	return actual, true, err
 }
 

--- a/pkg/operator/staticpod/controller/revision/deployment_controller.go
+++ b/pkg/operator/staticpod/controller/revision/deployment_controller.go
@@ -160,7 +160,7 @@ func (c RevisionController) isLatestRevisionCurrent(revision int32) (bool, strin
 
 func (c RevisionController) createNewRevision(revision int32) error {
 	for _, name := range c.configMaps {
-		obj, _, err := resourceapply.SyncConfigMap(c.kubeClient.CoreV1(), c.targetNamespace, name, c.targetNamespace, nameFor(name, revision))
+		obj, _, err := resourceapply.SyncConfigMap(c.kubeClient.CoreV1(), c.eventRecorder, c.targetNamespace, name, c.targetNamespace, nameFor(name, revision))
 		if err != nil {
 			return err
 		}
@@ -169,7 +169,7 @@ func (c RevisionController) createNewRevision(revision int32) error {
 		}
 	}
 	for _, name := range c.secrets {
-		obj, _, err := resourceapply.SyncSecret(c.kubeClient.CoreV1(), c.targetNamespace, name, c.targetNamespace, nameFor(name, revision))
+		obj, _, err := resourceapply.SyncSecret(c.kubeClient.CoreV1(), c.eventRecorder, c.targetNamespace, name, c.targetNamespace, nameFor(name, revision))
 		if err != nil {
 			return err
 		}

--- a/pkg/operator/v1alpha1staticpod/controller/deployment/deployment_controller_test.go
+++ b/pkg/operator/v1alpha1staticpod/controller/deployment/deployment_controller_test.go
@@ -13,6 +13,7 @@ import (
 	clienttesting "k8s.io/client-go/testing"
 
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
+	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/v1alpha1staticpod/controller/common"
 )
 
@@ -153,6 +154,7 @@ func TestDeploymentController(t *testing.T) {
 				informers.NewSharedInformerFactoryWithOptions(kubeClient, 1*time.Minute, informers.WithNamespace(tc.targetNamespace)),
 				tc.staticPodOperatorClient,
 				kubeClient,
+				events.NewInMemoryRecorder("test"),
 			)
 			syncErr := c.sync()
 			if tc.validateStatus != nil {

--- a/pkg/operator/v1alpha1staticpod/controllers.go
+++ b/pkg/operator/v1alpha1staticpod/controllers.go
@@ -1,10 +1,10 @@
 package v1alpha1staticpod
 
 import (
-	"github.com/openshift/library-go/pkg/operator/events"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/v1alpha1staticpod/controller/backingresource"
 	"github.com/openshift/library-go/pkg/operator/v1alpha1staticpod/controller/common"
 	"github.com/openshift/library-go/pkg/operator/v1alpha1staticpod/controller/deployment"
@@ -39,6 +39,7 @@ func NewControllers(targetNamespaceName, staticPodName string, command, deployme
 		kubeInformersNamespaceScoped,
 		staticPodOperatorClient,
 		kubeClient,
+		eventRecorder,
 	)
 
 	controller.installerController = installer.NewInstallerController(


### PR DESCRIPTION
This wire event recorder to all resourceapply functions. Any operator using these should pass an event recorder.