### PR TITLE
events: fix reporting kind from resource apply

### DIFF
--- a/pkg/operator/resource/resourceapply/event_helpers.go
+++ b/pkg/operator/resource/resourceapply/event_helpers.go
@@ -7,42 +7,69 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
+	kubescheme "k8s.io/client-go/kubernetes/scheme"
 
+	openshiftapi "github.com/openshift/api"
 	"github.com/openshift/library-go/pkg/operator/events"
 )
 
+var (
+	openshiftScheme = runtime.NewScheme()
+)
+
+func init() {
+	if err := openshiftapi.Install(openshiftScheme); err != nil {
+		panic(err)
+	}
+}
+
+// guessObjectKind returns a human name for the passed runtime object.
+func guessObjectGroupKind(object runtime.Object) (string, string) {
+	if gvk := object.GetObjectKind().GroupVersionKind(); len(gvk.Kind) > 0 {
+		return gvk.Group, gvk.Kind
+	}
+	if kinds, _, _ := kubescheme.Scheme.ObjectKinds(object); len(kinds) > 0 {
+		return kinds[0].Group, kinds[0].Kind
+	}
+	if kinds, _, _ := openshiftScheme.ObjectKinds(object); len(kinds) > 0 {
+		return kinds[0].Group, kinds[0].Kind
+	}
+	return "unknown", "Object"
+
+}
+
 func reportCreateEvent(recorder events.Recorder, obj runtime.Object, originalErr error) {
-	gvk := obj.GetObjectKind().GroupVersionKind()
+	reportingKind, reportingGroup := guessObjectGroupKind(obj)
 	accessor, err := meta.Accessor(obj)
 	if err != nil {
 		glog.Errorf("Failed to get accessor for %+v", obj)
 		return
 	}
-	objName := fmt.Sprintf("%s/%s", accessor.GetNamespace(), accessor.GetName())
-	if len(accessor.GetNamespace()) == 0 {
-		objName = accessor.GetName()
+	namespace := ""
+	if len(accessor.GetNamespace()) > 0 {
+		namespace = " -n " + accessor.GetNamespace()
 	}
 	if originalErr == nil {
-		recorder.Eventf(fmt.Sprintf("%sCreated", gvk.Kind), "Created %s %q because it was missing", gvk.Kind, objName)
+		recorder.Eventf(fmt.Sprintf("%sCreated", reportingKind), "Created %s.%s/%s%s %q because it was missing", reportingKind, reportingGroup, namespace, accessor.GetName())
 		return
 	}
-	recorder.Warningf(fmt.Sprintf("%sCreateFailed", gvk.Kind), "Failed to create %s %q: %v", gvk.Kind, objName, originalErr)
+	recorder.Warningf(fmt.Sprintf("%sCreateFailed", reportingKind), "Failed to create %s.%s/%s%s %q: %v", reportingKind, reportingGroup, namespace, accessor.GetName(), originalErr)
 }
 
 func reportUpdateEvent(recorder events.Recorder, obj runtime.Object, originalErr error) {
-	gvk := obj.GetObjectKind().GroupVersionKind()
+	reportingKind, reportingGroup := guessObjectGroupKind(obj)
 	accessor, err := meta.Accessor(obj)
 	if err != nil {
 		glog.Errorf("Failed to get accessor for %+v", obj)
 		return
 	}
-	objName := fmt.Sprintf("%s/%s", accessor.GetNamespace(), accessor.GetName())
-	if len(accessor.GetNamespace()) == 0 {
-		objName = accessor.GetName()
+	namespace := ""
+	if len(accessor.GetNamespace()) > 0 {
+		namespace = " -n " + accessor.GetNamespace()
 	}
 	if originalErr == nil {
-		recorder.Eventf(fmt.Sprintf("%sUpdated", gvk.Kind), "Updated %s %q because it changed", gvk.Kind, objName)
+		recorder.Eventf(fmt.Sprintf("%sUpdated", reportingKind), "Updated %s.%s/%s%s %q because it changed", reportingKind, reportingGroup, namespace, accessor.GetName())
 		return
 	}
-	recorder.Warningf(fmt.Sprintf("%sUpdateFailed", gvk.Kind), "Failed to update %s %q: %v", gvk.Kind, objName, originalErr)
+	recorder.Warningf(fmt.Sprintf("%sUpdateFailed", reportingKind), "Failed to update %s.%s/%s%s %q: %v", reportingKind, reportingGroup, namespace, accessor.GetName(), originalErr)
 }


### PR DESCRIPTION
Fixes the output which is currently:

```
2 minutes   ServiceCreated                Created Service "openshift-kube-apiserver/apiserver" because it was missing
2 minutes   ClusterRoleBindingCreated     Created ClusterRoleBinding "system:openshift:operator:openshift-kube-apiserver-installer" because it was missing
2 minutes   ServiceAccountCreated         Created ServiceAccount "openshift-kube-apiserver/installer-sa" because it was missing
2 minutes   Created                       Created  "openshift-kube-apiserver/etcd-serving-ca" because it was missing
3 minutes   Created                       Created  "openshift-kube-apiserver/etcd-client" because it was missing
3 minutes   ConfigMapCreated              Created ConfigMap "openshift-kube-apiserver/deployment-kube-apiserver-config" because it was missing
3 minutes   Created                       Created  "openshift-kube-apiserver/kube-apiserver-pod-1" because it was missing
3 minutes   Created                       Created  "openshift-kube-apiserver/client-ca-1" because it was missing
3 minutes   Created                       Created  "openshift-kube-apiserver/deployment-kube-apiserver-config-1" because it was missing
3 minutes   Created                       Created  "openshift-kube-apiserver/aggregator-client-ca-1" because it was missing
3 minutes   Created                       Created  "openshift-kube-apiserver/etcd-serving-ca-1" because it was missing
3 minutes   Created                       Created  "openshift-kube-apiserver/kubelet-serving-ca-1" because it was missing
3 minutes   Created                       Created  "openshift-kube-apiserver/sa-token-signing-certs-1" because it was missing
```