### PR TITLE
fileobserve: handle panic when multiple files are changed

### DIFF
--- a/pkg/controller/controllercmd/builder.go
+++ b/pkg/controller/controllercmd/builder.go
@@ -3,6 +3,7 @@ package controllercmd
 import (
 	"fmt"
 	"io/ioutil"
+	"sync"
 	"time"
 
 	"github.com/golang/glog"
@@ -79,10 +80,13 @@ func (b *ControllerBuilder) WithRestartOnChange(stopCh chan<- struct{}, files ..
 		}
 		b.fileObserver = observer
 	}
+	var once sync.Once
 
 	b.fileObserverReactorFn = func(filename string, action fileobserver.ActionType) error {
-		defer close(stopCh)
-		glog.Warning(fmt.Sprintf("Restart triggered because of %s", action.String(filename)))
+		once.Do(func() {
+			glog.Warning(fmt.Sprintf("Restart triggered because of %s", action.String(filename)))
+			close(stopCh)
+		})
 		return nil
 	}
 


### PR DESCRIPTION
This fixes the panic when operator is shutting down because fileobserver observed a change in local file. If there are multiple files changed, this will call the callback multiple times, leading to panic about closing a closed channel.

This change will cause it to close the channel just once.

/cc @sttts 
/cc @smarterclayton 