### PR TITLE
Revert "config obverser: do not write invalid configs"

### DIFF
--- a/pkg/operator/configobserver/config_observer_controller.go
+++ b/pkg/operator/configobserver/config_observer_controller.go
@@ -111,7 +111,7 @@ func (c ConfigObserver) sync() error {
 		}
 	}
 
-	if len(errs) == 0 && !equality.Semantic.DeepEqual(existingConfig, mergedObservedConfig) {
+	if !equality.Semantic.DeepEqual(existingConfig, mergedObservedConfig) {
 		glog.Infof("writing updated observedConfig: %v", diff.ObjectDiff(existingConfig, mergedObservedConfig))
 		spec.ObservedConfig = runtime.RawExtension{Object: &unstructured.Unstructured{Object: mergedObservedConfig}}
 		_, resourceVersion, err = c.operatorClient.UpdateOperatorSpec(resourceVersion, spec)

--- a/pkg/operator/configobserver/config_observer_controller_test.go
+++ b/pkg/operator/configobserver/config_observer_controller_test.go
@@ -102,7 +102,9 @@ func TestSyncStatus(t *testing.T) {
 					startingSpec: &operatorv1.OperatorSpec{},
 				}
 			},
-			expectEvents: [][]string{},
+			expectEvents: [][]string{
+				{"ObservedConfigChanged", "Writing updated observed config"},
+			},
 			observers: []ObserveConfigFunc{
 				func(listers Listers, recorder events.Recorder, existingConfig map[string]interface{}) (observedConfig map[string]interface{}, errs []error) {
 					return map[string]interface{}{"foo": "one"}, nil
@@ -116,8 +118,11 @@ func TestSyncStatus(t *testing.T) {
 				},
 			},
 
-			expectError:            false,
-			expectedObservedConfig: nil,
+			expectError: false,
+			expectedObservedConfig: &unstructured.Unstructured{Object: map[string]interface{}{
+				"foo": "one",
+				"bar": "two",
+			}},
 			expectedCondition: &operatorv1.OperatorCondition{
 				Type:    operatorStatusTypeConfigObservationFailing,
 				Status:  operatorv1.ConditionTrue,
@@ -181,19 +186,15 @@ func TestSyncStatus(t *testing.T) {
 				observedEvents = append(observedEvents, []string{event.Reason, event.Message})
 			}
 			for i, event := range tc.expectEvents {
-				if i >= len(observedEvents) {
-					t.Errorf("expected %d event message %q, reason %q, got only %d events", i, event[0], event[1], len(observedEvents))
-					continue
-				}
 				if observedEvents[i][0] != event[0] {
 					t.Errorf("expected %d event reason to be %q, got %q", i, event[0], observedEvents[i][0])
 				}
 				if observedEvents[i][1] != event[1] {
-					t.Errorf("expected %d event message to be %q, got %q", i, event[1], observedEvents[i][1])
+					t.Errorf("expected %d event message to be %q, got %q", i, event[0], observedEvents[i][0])
 				}
 			}
-			if len(tc.expectEvents) < len(observedEvents) {
-				t.Errorf("expected only %d events, got %d (%#v)", len(tc.expectEvents), len(observedEvents), observedEvents[len(tc.expectEvents):])
+			if len(tc.expectEvents) != len(observedEvents) {
+				t.Errorf("expected %d events, got %d (%#v)", len(tc.expectEvents), len(observedEvents), observedEvents)
 			}
 
 			switch {


### PR DESCRIPTION
Reverts openshift/library-go#131

Just because one observer has failed, does not mean that all observed config is invalid.  Since the previous value is available to the config observer, returning a failure *and* the config to merge in a valid choice and we need to be able to observe config generally.