### PR TITLE
configobserver: move install-config CIDR readers here

### DIFF
--- a/pkg/operator/configobserver/network/observe_network.go
+++ b/pkg/operator/configobserver/network/observe_network.go
@@ -1,0 +1,112 @@
+package network
+
+import (
+	"fmt"
+
+	"github.com/ghodss/yaml"
+	"github.com/golang/glog"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/listers/core/v1"
+
+	"github.com/openshift/library-go/pkg/operator/events"
+)
+
+const (
+	clusterConfigNamespace = "kube-system"
+	clusterConfigName      = "cluster-config-v1"
+)
+
+// GetClusterCIDRs reads the cluster CIDRs from the install-config ConfigMap in the cluster.
+func GetClusterCIDRs(lister v1.ConfigMapLister, recorder events.Recorder) ([]string, error) {
+	clusterConfig, err := lister.ConfigMaps(clusterConfigNamespace).Get(clusterConfigName)
+	if errors.IsNotFound(err) {
+		recorder.Warningf("ObserveClusterCIDRFailed", "Required %s/%s config map not found", clusterConfigNamespace, clusterConfigName)
+		glog.Warning("configmap/cluster-config-v1.kube-system: not found")
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	installConfigYaml, ok := clusterConfig.Data["install-config"]
+	if !ok {
+		glog.Warning("configmap/cluster-config-v1.kube-system: install-config not found")
+		recorder.Warningf("ObserveClusterCIDRFailed", "ConfigMap %s/%s does not have required 'install-config'", clusterConfigNamespace, clusterConfigName)
+		return nil, nil
+	}
+	installConfig := map[string]interface{}{}
+	err = yaml.Unmarshal([]byte(installConfigYaml), &installConfig)
+	if err != nil {
+		recorder.Warningf("ObserveRestrictedCIDRFailed", "Unable to decode install config: %v'", err)
+		return nil, fmt.Errorf("unable to parse install-config: %s", err)
+	}
+
+	var clusterCIDRs []string
+	clusterNetworks, _, err := unstructured.NestedSlice(installConfig, "networking", "clusterNetworks")
+	if err != nil {
+		return nil, fmt.Errorf("unabled to parse install-config: %s", err)
+	}
+	for i, n := range clusterNetworks {
+		obj, ok := n.(map[string]interface{})
+		if !ok {
+			recorder.Warningf("ObserveRestrictedCIDRFailed", "Required networking.clusterNetworks field is not set in install-config")
+			return nil, fmt.Errorf("unabled to parse install-config: expected networking.clusterNetworks[%d] to be an object, got: %#v", i, n)
+		}
+		cidr, _, err := unstructured.NestedString(obj, "cidr")
+		if err != nil {
+			return nil, fmt.Errorf("unabled to parse install-config: %v", err)
+		}
+		clusterCIDRs = append(clusterCIDRs, cidr)
+	}
+	// fallback to podCIDR
+	if clusterNetworks == nil {
+		podCIDR, _, err := unstructured.NestedString(installConfig, "networking", "podCIDR")
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse install-config: %v", err)
+		}
+		if len(podCIDR) == 0 {
+			return nil, fmt.Errorf("configmap/cluster-config-v1.kube-system: install-config.networking.clusterNetworks and install-config.networking.podCIDR not found")
+		}
+		clusterCIDRs = append(clusterCIDRs, podCIDR)
+	}
+
+	return clusterCIDRs, nil
+}
+
+// GetServiceCIDR reads the service IP range from the install-config ConfigMap in the cluster.
+func GetServiceCIDR(lister v1.ConfigMapLister, recorder events.Recorder) (string, error) {
+	clusterConfig, err := lister.ConfigMaps(clusterConfigNamespace).Get(clusterConfigName)
+	if errors.IsNotFound(err) {
+		glog.Warning("configmap/cluster-config-v1.kube-system: not found")
+		recorder.Warningf("ObserveServiceClusterIPRangesFailed", "Required %s/%s config map not found", clusterConfigNamespace, clusterConfigName)
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+
+	installConfigYaml, ok := clusterConfig.Data["install-config"]
+	if !ok {
+		glog.Warning("configmap/cluster-config-v1.kube-system: install-config not found")
+		recorder.Warningf("ObserveServiceClusterIPRangesFailed", "ConfigMap %s/%s does not have required 'install-config'", clusterConfigNamespace, clusterConfigName)
+		return "", nil
+	}
+	installConfig := map[string]interface{}{}
+	err = yaml.Unmarshal([]byte(installConfigYaml), &installConfig)
+	if err != nil {
+		return "", fmt.Errorf("unable to parse install-config: %v", err)
+	}
+
+	serviceCIDR, _, err := unstructured.NestedString(installConfig, "networking", "serviceCIDR")
+	if err != nil {
+		return "", fmt.Errorf("unable to parse install-config: %v", err)
+	}
+	if len(serviceCIDR) == 0 {
+		recorder.Warningf("ObserveServiceClusterIPRangesFailed", "Required networking.serviceCIDR field is not set in install-config")
+		return "", fmt.Errorf("configmap/cluster-config-v1.kube-system: install-config.networking.serviceCIDR not found")
+	}
+
+	return serviceCIDR, nil
+}

--- a/pkg/operator/configobserver/network/observe_networking_test.go
+++ b/pkg/operator/configobserver/network/observe_networking_test.go
@@ -1,0 +1,160 @@
+package network
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/ghodss/yaml"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corelistersv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/openshift/library-go/pkg/operator/events"
+)
+
+func TestObserveClusterCIDRs(t *testing.T) {
+	type Test struct {
+		name          string
+		config        *corev1.ConfigMap
+		expected      []string
+		expectedError bool
+	}
+	tests := []Test{
+		{
+			"podCIDR, empty old config",
+			&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster-config-v1",
+					Namespace: "kube-system",
+				},
+				Data: map[string]string{
+					"install-config": "networking:\n  podCIDR: podCIDR",
+				},
+			},
+			[]string{"podCIDR"},
+			false,
+		},
+		{
+			"podCIDR, existing config",
+			&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster-config-v1",
+					Namespace: "kube-system",
+				},
+				Data: map[string]string{
+					"install-config": "networking:\n  podCIDR: podCIDR",
+				},
+			},
+			[]string{"podCIDR"},
+			false,
+		},
+		{
+			"clusterNetworks",
+			&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster-config-v1",
+					Namespace: "kube-system",
+				},
+				Data: map[string]string{
+					"install-config": "networking:\n  clusterNetworks:\n  - cidr: podCIDR1\n  - cidr: podCIDR2",
+				},
+			},
+			[]string{"podCIDR1", "podCIDR2"},
+			false,
+		},
+		{
+			"both podCIDR and clusterNetworks",
+			&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster-config-v1",
+					Namespace: "kube-system",
+				},
+				Data: map[string]string{
+					"install-config": "networking:\n  clusterNetworks:\n  - cidr: podCIDR1\n  - cidr: podCIDR2\n  podCIDR: podCIDR",
+				},
+			},
+			[]string{"podCIDR1", "podCIDR2"},
+			false,
+		},
+		{
+			"none, no old config",
+			&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster-config-v1",
+					Namespace: "kube-system",
+				},
+				Data: map[string]string{
+					"install-config": "networking: {}\n",
+				},
+			},
+			nil,
+			true,
+		},
+		{
+			"none, existing config",
+			&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster-config-v1",
+					Namespace: "kube-system",
+				},
+				Data: map[string]string{
+					"install-config": "networking: {}\n",
+				},
+			},
+			nil,
+			true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			if err := indexer.Add(test.config); err != nil {
+				t.Fatal(err.Error())
+			}
+			result, err := GetClusterCIDRs(corelistersv1.NewConfigMapLister(indexer), events.NewInMemoryRecorder("network"))
+			if err != nil && !test.expectedError {
+				t.Fatal(err)
+			} else if err == nil {
+				if test.expectedError {
+					t.Fatalf("expected error, but got none")
+				}
+				if !reflect.DeepEqual(test.expected, result) {
+					t.Errorf("\n===== observed config expected:\n%v\n===== observed config actual:\n%v", toYAML(test.expected), toYAML(result))
+				}
+			}
+		})
+	}
+}
+
+func TestObserveServiceClusterIPRanges(t *testing.T) {
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	if err := indexer.Add(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-config-v1",
+			Namespace: "kube-system",
+		},
+		Data: map[string]string{
+			"install-config": "networking:\n  serviceCIDR: serviceCIDR",
+		},
+	}); err != nil {
+		t.Fatal(err.Error())
+	}
+	result, err := GetServiceCIDR(corelistersv1.NewConfigMapLister(indexer), events.NewInMemoryRecorder("network"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if expected := "serviceCIDR"; !reflect.DeepEqual(expected, result) {
+		t.Errorf("\n===== observed config expected:\n%v\n===== observed config actual:\n%v", toYAML(expected), toYAML(result))
+	}
+}
+
+func toYAML(o interface{}) string {
+	b, e := yaml.Marshal(o)
+	if e != nil {
+		return e.Error()
+	}
+	return string(b)
+}


### PR DESCRIPTION
This code is used by multiple operators.