### PR TITLE
Static pod revision history prune command

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: be554cc57be62b801fadab65f1ebaec34046b7d913e559b61eccf809ca1c9092
-updated: 2018-11-28T12:01:38.243516833-05:00
+updated: 2018-12-06T15:57:15.466410788-05:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -185,7 +185,7 @@ imports:
 - name: github.com/NYTimes/gziphandler
   version: 56545f4a5d46df9a6648819d1664c3a03a13ffdb
 - name: github.com/openshift/api
-  version: e7dc90658844828191986cb07f3e44eeeba0b03a
+  version: 83b2fe56301417028bd52e56edd75768e2ea051c
   subpackages:
   - apps
   - apps/v1
@@ -232,6 +232,12 @@ imports:
   - webconsole/v1
 - name: github.com/openshift/client-go
   version: 960f72aa32a8e9b4dd769b90ff1cb5bd4c898eec
+  subpackages:
+  - config/clientset/versioned
+  - config/clientset/versioned/fake
+  - config/clientset/versioned/scheme
+  - config/clientset/versioned/typed/config/v1
+  - config/clientset/versioned/typed/config/v1/fake
 - name: github.com/pborman/uuid
   version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
 - name: github.com/peterbourgon/diskv
@@ -384,6 +390,8 @@ imports:
   subpackages:
   - pkg/apis/apiextensions
   - pkg/apis/apiextensions/v1beta1
+  - pkg/client/clientset/clientset/scheme
+  - pkg/client/clientset/clientset/typed/apiextensions/v1beta1
 - name: k8s.io/apimachinery
   version: 103fd098999dc9c0c88536f5c9ad2e5da39373ae
   subpackages:
@@ -706,4 +714,8 @@ imports:
   - pkg/handler
   - pkg/util
   - pkg/util/proto
-testImports: []
+testImports:
+- name: vbom.ml/util
+  version: db5cfe13f5cc80a4990d98e2e1b0707a4d1a5394
+  subpackages:
+  - sortorder

--- a/pkg/operator/staticpod/prune/cmd.go
+++ b/pkg/operator/staticpod/prune/cmd.go
@@ -1,0 +1,116 @@
+package prune
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+type PruneOptions struct {
+	MaxEligibleRevisionID int
+	ProtectedRevisionIDs  []int
+
+	ResourceDir   string
+	StaticPodName string
+}
+
+func NewPruneOptions() *PruneOptions {
+	return &PruneOptions{}
+}
+
+func NewPrune() *cobra.Command {
+	o := NewPruneOptions()
+
+	cmd := &cobra.Command{
+		Use:   "prune",
+		Short: "Prune static pod installer revisions",
+		Run: func(cmd *cobra.Command, args []string) {
+			glog.V(1).Info(cmd.Flags())
+			glog.V(1).Info(spew.Sdump(o))
+
+			if err := o.Validate(); err != nil {
+				glog.Fatal(err)
+			}
+			if err := o.Run(); err != nil {
+				glog.Fatal(err)
+			}
+		},
+	}
+
+	o.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+func (o *PruneOptions) AddFlags(fs *pflag.FlagSet) {
+	fs.IntVar(&o.MaxEligibleRevisionID, "max-eligible-id", o.MaxEligibleRevisionID, "highest revision ID to be eligible for pruning")
+	fs.IntSliceVar(&o.ProtectedRevisionIDs, "protected-ids", o.ProtectedRevisionIDs, "list of revision IDs to preserve (not delete)")
+	fs.StringVar(&o.ResourceDir, "resource-dir", o.ResourceDir, "directory for all files supporting the static pod manifest")
+	fs.StringVar(&o.StaticPodName, "static-pod-name", o.StaticPodName, "name of the static pod")
+}
+
+func (o *PruneOptions) Validate() error {
+	if len(o.ResourceDir) == 0 {
+		return fmt.Errorf("--resource-dir is required")
+	}
+	if o.MaxEligibleRevisionID == 0 {
+		return fmt.Errorf("--max-eligible-id is required")
+	}
+	if len(o.StaticPodName) == 0 {
+		return fmt.Errorf("--static-pod-name is required")
+	}
+
+	return nil
+}
+
+func (o *PruneOptions) Run() error {
+	protectedIDs := sets.NewInt(o.ProtectedRevisionIDs...)
+
+	files, err := ioutil.ReadDir(o.ResourceDir)
+	if err != nil {
+		return err
+	}
+
+	for _, file := range files {
+		// If the file is not a resource directory...
+		if !file.IsDir() {
+			continue
+		}
+		// And doesn't match our static pod prefix...
+		if !strings.HasPrefix(file.Name(), o.StaticPodName) {
+			continue
+		}
+
+		// Split file name to get just the integer revision ID
+		fileSplit := strings.Split(file.Name(), o.StaticPodName+"-")
+		revisionID, err := strconv.Atoi(fileSplit[len(fileSplit)-1])
+		if err != nil {
+			return err
+		}
+
+		// And is not protected...
+		if protected := protectedIDs.Has(revisionID); protected {
+			continue
+		}
+		// And is less than or equal to the maxEligibleRevisionID
+		if revisionID > o.MaxEligibleRevisionID {
+			continue
+		}
+
+		err = os.RemoveAll(path.Join(o.ResourceDir, file.Name()))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/operator/staticpod/prune/cmd_test.go
+++ b/pkg/operator/staticpod/prune/cmd_test.go
@@ -1,0 +1,103 @@
+package prune
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"reflect"
+	"sort"
+	"testing"
+
+	"vbom.ml/util/sortorder"
+)
+
+func TestRun(t *testing.T) {
+	tests := []struct {
+		name     string
+		o        PruneOptions
+		files    []string
+		expected []string
+	}{
+		{
+			name: "only deletes non-protected revisions of the specified pod",
+			o: PruneOptions{
+				MaxEligibleRevisionID: 3,
+				ProtectedRevisionIDs:  []int{3, 2},
+				StaticPodName:         "test",
+			},
+			files:    []string{"test-1", "test-2", "test-3", "othertest-4"},
+			expected: []string{"test-2", "test-3", "othertest-4"},
+		},
+		{
+			name: "doesn't delete anything higher than highest eligible revision",
+			o: PruneOptions{
+				MaxEligibleRevisionID: 2,
+				ProtectedRevisionIDs:  []int{2},
+				StaticPodName:         "test",
+			},
+			files:    []string{"test-1", "test-2", "test-3"},
+			expected: []string{"test-2", "test-3"},
+		},
+		{
+			name: "revision numbers do not conflict between pods when detecting protected IDs",
+			o: PruneOptions{
+				MaxEligibleRevisionID: 2,
+				ProtectedRevisionIDs:  []int{2},
+				StaticPodName:         "test",
+			},
+			files:    []string{"test-1", "test-2", "othertest-1", "othertest-2"},
+			expected: []string{"test-2", "othertest-1", "othertest-2"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			testDir, err := ioutil.TempDir("", "prune-revisions-test")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() {
+				os.Remove(testDir)
+			}()
+
+			resourceDir := path.Join(testDir, "resources")
+			err = os.Mkdir(resourceDir, os.ModePerm)
+			if err != nil {
+				t.Error(err)
+			}
+			for _, file := range test.files {
+				err = os.Mkdir(path.Join(resourceDir, file), os.ModePerm)
+				if err != nil {
+					t.Error(err)
+				}
+			}
+
+			o := test.o
+			o.ResourceDir = resourceDir
+
+			err = o.Run()
+			if err != nil {
+				t.Error(err)
+			}
+			checkPruned(t, o.ResourceDir, test.expected)
+		})
+	}
+}
+
+func checkPruned(t *testing.T, resourceDir string, expected []string) {
+	files, err := ioutil.ReadDir(resourceDir)
+	if err != nil {
+		t.Error(err)
+	}
+	actual := make([]string, 0, len(files))
+	for _, file := range files {
+		actual = append(actual, file.Name())
+	}
+
+	sort.Sort(sortorder.Natural(expected))
+	sort.Sort(sortorder.Natural(actual))
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("expected %+v, got %+v", expected, actual)
+	}
+}

--- a/vendor/github.com/openshift/api/config/v1/types.go
+++ b/vendor/github.com/openshift/api/config/v1/types.go
@@ -5,10 +5,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-// ConfigMapReference references the location of a configmap.
+// ConfigMapReference references a configmap in the openshift-config namespace.
 type ConfigMapReference struct {
-	Namespace string `json:"namespace"`
-	Name      string `json:"name"`
+	Name string `json:"name"`
 	// Key allows pointing to a specific key/value inside of the configmap.  This is useful for logical file references.
 	Key string `json:"filename,omitempty"`
 }

--- a/vendor/github.com/openshift/api/config/v1/types_swagger_doc_generated.go
+++ b/vendor/github.com/openshift/api/config/v1/types_swagger_doc_generated.go
@@ -61,7 +61,7 @@ func (ClientConnectionOverrides) SwaggerDoc() map[string]string {
 }
 
 var map_ConfigMapReference = map[string]string{
-	"":         "ConfigMapReference references the location of a configmap.",
+	"":         "ConfigMapReference references a configmap in the openshift-config namespace.",
 	"filename": "Key allows pointing to a specific key/value inside of the configmap.  This is useful for logical file references.",
 }
 

--- a/vendor/vbom.ml/util/.gitignore
+++ b/vendor/vbom.ml/util/.gitignore
@@ -1,0 +1,19 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+# Folders
+_obj
+_test
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+_testmain.go
+*.exe
+*.test
+*.prof

--- a/vendor/vbom.ml/util/LICENSE
+++ b/vendor/vbom.ml/util/LICENSE
@@ -1,0 +1,17 @@
+The MIT License (MIT)
+Copyright (c) 2015 Frits van Bommel
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/vbom.ml/util/README.md
+++ b/vendor/vbom.ml/util/README.md
@@ -1,0 +1,5 @@
+## util [![GoDoc](https://godoc.org/vbom.ml/util?status.svg)](https://godoc.org/vbom.ml/util)
+
+    import "vbom.ml/util"
+
+Go utility packages.

--- a/vendor/vbom.ml/util/cmd/short-regexp/main.go
+++ b/vendor/vbom.ml/util/cmd/short-regexp/main.go
@@ -1,0 +1,26 @@
+// short-regexp is a command-line utility that reads strings from standard input
+// (one per line) and outputs a regexp that matches only those strings.
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"vbom.ml/util"
+)
+
+func main() {
+	data, err := ioutil.ReadAll(os.Stdin)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %s", err)
+		os.Exit(1)
+	}
+	lines := strings.Split(string(data), "\n")
+	// Remove trailing empty line if present
+	if N := len(lines); N > 0 && lines[N-1] == "" {
+		lines = lines[:N-1]
+	}
+	os.Stdout.WriteString(util.ShortRegexpString(lines...))
+}

--- a/vendor/vbom.ml/util/doc.go
+++ b/vendor/vbom.ml/util/doc.go
@@ -1,0 +1,2 @@
+// Package util includes various small pieces of code.
+package util // import "vbom.ml/util"

--- a/vendor/vbom.ml/util/regexp.go
+++ b/vendor/vbom.ml/util/regexp.go
@@ -1,0 +1,509 @@
+package util
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+	"unicode/utf8"
+)
+
+var level = 0
+
+// func init() { log.SetFlags(0) }
+//
+// func debugf(f string, vs ...interface{}) {
+// 	log.Printf(strings.Repeat("  ", level)+f, vs...)
+// }
+
+// ShortRegexpString tries to construct a short regexp that matches exactly the
+// provided strings and nothing else.
+//
+// Warning: the current implementation may use a lot of time of memory.
+func ShortRegexpString(vs ...string) (res string) {
+	cache := make(map[string][]string)
+	return render(shortRegexpString(vs, cache), false)
+}
+
+func shortRegexpString(vs []string, cache map[string][]string) (res []string) {
+	// Canonicalize (might turn the input into one of the trivial cases below)
+	if len(vs) > 1 {
+		sort.Strings(vs)
+		vs = removeDups(vs)
+	}
+
+	// Trivial cases.
+	switch len(vs) {
+	case 0:
+		return nil
+	case 1:
+		return []string{regexp.QuoteMeta(vs[0])} // Nothing else to do.
+	}
+
+	// level++
+	// defer func(s string) {
+	// 	level--
+	// 	debugf("ShortRegexpString(%s) = %#q", s, res)
+	// }(fmt.Sprintf("%#q", vs))
+
+	// The one to beat: just put ORs between them (after escaping meta-characters)
+	best := make([]string, len(vs))
+	for i := range vs {
+		best[i] = regexp.QuoteMeta(vs[i])
+	}
+
+	cacheKey := render(best, false)
+	bestCost := len(cacheKey)
+
+	if cached, ok := cache[cacheKey]; ok {
+		return cached
+	}
+	defer func(key string) {
+		// Put clauses in a canonical order and cache them.
+		sort.Strings(res)
+		cache[key] = res
+	}(cacheKey)
+
+	recurse := func(prefix, suffix string, data commonSs) (result []string) {
+		// debugf("> recurse(%#q, %#q, %v) on %#q", prefix, suffix, data, vs)
+		// defer func() {
+		// 	debugf("  recurse(%#q, %#q, %v) on %#q = %#q", prefix, suffix, data, vs, result)
+		// }()
+
+		//debugf("%v/%#q/%#q: %v\n", vs, prefix, suffix, data)
+		varying := make([]string, data.end-data.start)
+		allExist := true
+		var preExistingIndices []int
+		for i := data.start; i < data.end; i++ {
+			substr := vs[i][len(prefix) : len(vs[i])-len(suffix)]
+			varying[i-data.start] = substr
+			if allExist {
+				found := false
+				for i := 0; i < len(vs); i++ {
+					if i == data.start {
+						i = data.end - 1
+						continue
+					}
+					if substr == vs[i] {
+						found = true
+						preExistingIndices = append(preExistingIndices, i)
+						break
+					}
+				}
+				allExist = found
+			}
+		}
+
+		var others []string
+		// combined := make([]string, 0, len(preExistingIndices))
+		if allExist && (prefix == "" || suffix == "") {
+			others = make([]string, 0, len(vs)-2*len(preExistingIndices))
+			sort.Ints(preExistingIndices)
+			for i, k := 0, 0; i < len(vs) && k < len(preExistingIndices); i++ {
+				if i == data.start {
+					i = data.end - 1
+					continue
+				} else if i == preExistingIndices[k] {
+					// combined = append(combined, vs[i])
+					// debugf("Eliminating %#q", vs[i])
+					k++
+				} else {
+					others = append(others, vs[i])
+				}
+			}
+		} else {
+			others = make([]string, len(vs)-(data.end-data.start))
+			copy(others, vs[:data.start])
+			copy(others[data.start:], vs[data.end:])
+		}
+
+		middle := render(shortRegexpString(varying, cache), true)
+		// debugf(">> ShortRegexpString(%#q) = %#q", varying, middle)
+
+		prefix, suffix = regexp.QuoteMeta(prefix), regexp.QuoteMeta(suffix)
+		var cur string
+		switch {
+		case allExist && prefix == "": // M . S | M ==> M . S?
+			cur = middle + optional(suffix)
+		case allExist && suffix == "": // P . M | M ==> P? . M
+			cur = optional(prefix) + middle
+		default:
+			cur = prefix + middle + suffix
+		}
+		return append([]string{cur}, shortRegexpString(others, cache)...)
+	}
+
+	// Note that vs is still sorted here.
+	// debugf("Sorted: %#q", vs)
+	for prefix, preLoc := range commonPrefixes(vs, 1) {
+		suffix := sharedSuffix(len(prefix), vs[preLoc.start:preLoc.end])
+		strs := recurse(prefix, suffix, preLoc)
+		if c := cost(strs); c < bestCost { // || (c == len(best) && str < best) {
+			best = strs
+			bestCost = c
+		} else {
+			//debugf("! rejected %#q", str)
+			//debugf("  because: %#q", best)
+		}
+	}
+
+	sort.Sort(reverseStrings(vs))
+	// debugf("Reverse-sorted: %#q", vs)
+	for suffix, sufLoc := range commonSuffixes(vs, 1) {
+		// sufLoc := suffixes[suffix]
+		prefix := sharedPrefix(len(suffix), vs[sufLoc.start:sufLoc.end])
+		strs := recurse(prefix, suffix, sufLoc)
+		if c := cost(strs); c < bestCost { //|| (len(str) == len(best) && str < best) {
+			best = strs
+			bestCost = c
+		} else {
+			//debugf("! rejected %#q", str)
+			//debugf("  because: %#q", best)
+		}
+	}
+
+	singleChar := true
+	optional := ""
+	for i := range vs {
+		if len(vs[i]) == 0 {
+			optional = "?"
+		} else if len(vs[i]) != 1 {
+			// FIXME: should allow single non-ASCII characters
+			singleChar = false
+			break
+		}
+	}
+	if singleChar {
+		// Construct an array of characters in the right order:
+		//   ']' first, '-' last, rest alphabetically
+		class := make([]byte, 0, len(vs))
+		last := ""
+		for i, s := range vs {
+			if s == "]" {
+				// Must be first
+				class = append(class, ']')
+				vs[i] = "" // delete
+			} else if s == "-" {
+				// Must be last
+				last = s
+				vs[i] = "" // delete
+			}
+		}
+		sortFirst := len(class)
+		for _, s := range vs {
+			class = append(class, s...)
+		}
+		sort.Sort(sortBytes(class[sortFirst:]))
+		class = append(class, last...)
+
+		// Collapse character ranges
+		w := 0
+		first := -1
+		for i := 0; i < len(class); i++ {
+			if first >= 0 {
+				// Do we need to finish the range?
+				if class[i] != class[i-1]+1 {
+					// Does it pay to use a range?
+					if i-first > 3 {
+						// Build a range
+						class[w-(i-first-1)] = '-'
+						class[w-(i-first-1)+1] = class[i-1]
+						// Rewind the write position
+						w = w - (i - first - 1) + 2
+						first = i
+					}
+				}
+			} else {
+				first = i
+			}
+			// Write the current character
+			class[w] = class[i]
+			w++
+		}
+		class = class[:w]
+
+		if len(class) == 1 {
+			str := regexp.QuoteMeta(string(class)) + optional
+			if len(str) <= bestCost {
+				best = []string{str}
+				bestCost = len(str)
+			}
+		}
+		if cost := len(class) + 2 + len(optional); cost <= bestCost {
+			best = []string{"[" + string(class) + "]" + optional}
+			bestCost = cost
+		}
+	}
+
+	return best
+}
+
+func render(clauses []string, asSingle bool) string {
+	switch len(clauses) {
+	case 0:
+		return "$.^" // Unmatchable?
+	case 1:
+		return clauses[0]
+	default:
+		if len(clauses[0]) == 0 {
+			clauses = clauses[1:]
+			if len(clauses) == 1 {
+				return optional(clauses[0])
+			}
+			return render(clauses, true) + "?"
+		}
+
+		result := strings.Join(clauses, "|")
+		if asSingle {
+			result = "(" + result + ")"
+		}
+		return result
+	}
+}
+
+func cost(clauses []string) int {
+	// TODO: real implementation
+	return len(render(clauses, false))
+}
+
+func optional(s string) string {
+	if len(s) > 1 {
+		s = "(" + s + ")?"
+	} else if s != "" {
+		s += "?"
+	}
+	return s
+}
+
+// removeDups removes duplicate strings from vs and returns it.
+// It assumes that vs has been sorted such that duplicates are next to each
+// other.
+func removeDups(vs []string) []string {
+	insertPos := 1
+	for i := 1; i < len(vs); i++ {
+		if vs[i-1] != vs[i] {
+			vs[insertPos] = vs[i]
+			insertPos++
+		}
+	}
+	return vs[:insertPos]
+}
+
+func dup(vs []string) []string {
+	result := make([]string, len(vs))
+	copy(result, vs)
+	return result
+}
+
+// reverseStrings is a sort.Interface that sort strings by their reverse values.
+type reverseStrings []string
+
+func (rs reverseStrings) Less(i, j int) bool {
+	for m, n := len(rs[i])-1, len(rs[j])-1; m >= 0 && n >= 0; m, n = m-1, n-1 {
+		if rs[i][m] != rs[j][n] {
+			// We want to compare runes, not bytes. So find the start of the
+			// current runes and decode them.
+			for ; m > 0 && !utf8.RuneStart(rs[i][m]); m-- {
+			}
+			for ; n > 0 && !utf8.RuneStart(rs[j][n]); n-- {
+			}
+			ri, _ := utf8.DecodeRuneInString(rs[i][m:])
+			rj, _ := utf8.DecodeRuneInString(rs[j][n:])
+			return ri < rj
+		}
+	}
+	return len(rs[i]) < len(rs[j])
+}
+func (rs reverseStrings) Swap(i, j int) { rs[i], rs[j] = rs[j], rs[i] }
+func (rs reverseStrings) Len() int      { return len(rs) }
+
+// sortBytes is a sort.Interface that sort bytes.
+type sortBytes []byte
+
+func (sb sortBytes) Less(i, j int) bool { return sb[i] < sb[j] }
+func (sb sortBytes) Swap(i, j int)      { sb[i], sb[j] = sb[j], sb[i] }
+func (sb sortBytes) Len() int           { return len(sb) }
+
+// commonSs holds information on where to find a common substring.
+type commonSs struct {
+	start, end int
+}
+
+// commonPrefixes returns a map from prefixes to number of occurrences. Not all
+// strings in vs need to have a prefix for it to be returned.
+// Assumes vs to have been sorted with sort.Strings()
+func commonPrefixes(vs []string, minLength int) (result map[string]commonSs) {
+	result = make(map[string]commonSs)
+	for i := 0; i < len(vs)-1; i++ {
+		j := i + 1
+		k := 0
+		for ; k < len(vs[i]) && k < len(vs[j]); k++ {
+			if vs[i][k] != vs[j][k] {
+				break
+			}
+		}
+		if k < minLength {
+			continue
+		}
+		prefix := vs[i][:k]
+		if _, exists := result[prefix]; !exists {
+			first := prefixStart(vs[:i], prefix)
+			//debugf("prefixStart(%#q, %#q) == %v", vs[:i], prefix, first)
+			// prefixEnd(vs, prefix) - first + 1
+			// == prefixEnd(vs[first:], prefix) + 1
+			// == prefixEnd(vs[first+1:], prefix) + 2
+			end := first + 1 + prefixEnd(vs[first+1:], prefix)
+			result[prefix] = commonSs{
+				first, end,
+			}
+			//debugf("prefixEnd(%#q, %#q) == %v", vs, prefix, result[prefix].end)
+		}
+	}
+	// debugf("# %v..", result)
+	return result
+}
+
+func prefixStart(vs []string, prefix string) int {
+	if prefix == "" {
+		return 0
+	}
+	return findFirst(vs, func(s string) bool {
+		return strings.HasPrefix(s, prefix)
+	})
+}
+
+func prefixEnd(vs []string, prefix string) int {
+	if prefix == "" {
+		return len(vs)
+	}
+	//debugf("prefixEnd(%v, %#q)", vs, prefix)
+	return findFirst(vs, func(s string) bool {
+		return !strings.HasPrefix(s, prefix)
+	})
+}
+
+// commonSuffixes returns a map from suffixes to number of occurrences. Not all
+// strings in vs need to have a suffix for it to be returned.
+// Assumes vs to have been sorted using sort.Sort(reverseStrings(vs))
+func commonSuffixes(vs []string, minLength int) (result map[string]commonSs) {
+	result = make(map[string]commonSs)
+	for i := 0; i < len(vs)-1; i++ {
+		j := i + 1
+		k := 0
+		for ; k < len(vs[i]) && k < len(vs[j]); k++ {
+			if vs[i][len(vs[i])-k-1] != vs[j][len(vs[j])-k-1] {
+				break
+			}
+		}
+		if k < minLength {
+			continue
+		}
+		suffix := vs[i][len(vs[i])-k:]
+		if _, exists := result[suffix]; !exists {
+			first := suffixStart(vs[:i], suffix)
+			//debugf("suffixStart<%#q>(%#q) == %v", suffix, vs[:i], first)
+			// suffixEnd(vs, suffix) - first + 1
+			// == suffixEnd(vs[first:], suffix) + 1
+			// == suffixEnd(vs[first+1:], suffix) + 2
+			end := first + 1 + suffixEnd(vs[first+1:], suffix)
+			result[suffix] = commonSs{
+				first, end,
+			}
+			//debugf("suffixEnd  <%#q>(%#q) == %v", suffix, vs, result[suffix].end)
+			//debugf("selected(%#q): %q\n\n", suffix, vs[first:result[suffix].end])
+		}
+	}
+	// debugf("# ..%v", result)
+	return result
+}
+
+func suffixStart(vs []string, suffix string) int {
+	// //debugf("suffixStart(%#q, %#q)", vs, suffix)
+	if suffix == "" {
+		return 0
+	}
+	return findFirst(vs, func(s string) bool {
+		return strings.HasSuffix(s, suffix)
+	})
+}
+
+func suffixEnd(vs []string, suffix string) int {
+	// //debugf("suffixEnd  (%#q, %#q)", vs, suffix)
+	if suffix == "" {
+		return len(vs)
+	}
+	return findFirst(vs, func(s string) bool {
+		return !strings.HasSuffix(s, suffix)
+	})
+}
+
+// findFirst finds the first element of vs that satisfies the predicate.
+// It assumes that the first N strings don't match the predicate, and the rest
+// do. If all of the strings satisfy the predicate, it returns 0, and if none
+// do it returns len(vs).
+func findFirst(vs []string, predicate func(string) bool) int {
+	l, h := -1, len(vs)
+	// Invariant: vs[l] does not match, vs[h] does.
+	// -1 and len(vs) are sentinal values, never tested but assumed to mismatch and match, respectively.
+	for l+1 < h {
+		m := (l + h) / 2 // Must now be a valid value
+		// //debugf("%d %d %d", l, m, h)
+		if predicate(vs[m]) {
+			h = m
+		} else {
+			l = m
+		}
+	}
+	//debugf("==> %d", h)
+	return h
+}
+
+// sharedPrefix returns the longest prefix which all the parameters share but
+// ignores a number of characters at the end of each string.
+func sharedPrefix(ignore int, vs []string) (result string) {
+	//debugf("sharedPrefix(%d, %#q)", ignore, vs)
+	// defer func() {
+	//debugf("==> %#q", result)
+	// }()
+	switch len(vs) {
+	case 0:
+		return ""
+	case 1:
+		return vs[0]
+	}
+	for i := 0; i < len(vs[0])-ignore; i++ {
+		for n := 1; n < len(vs); n++ {
+			if i >= len(vs[n])-ignore || vs[0][i] != vs[n][i] {
+				return vs[0][:i]
+			}
+		}
+	}
+	return vs[0][:len(vs[0])-ignore]
+}
+
+// sharedSuffix returns the longest suffix which all the parameters share but
+// ignores a number of characters at the start of each string.
+func sharedSuffix(ignore int, vs []string) (result string) {
+	//debugf("sharedSuffix(%d, %#q)", ignore, vs)
+	// defer func() {
+	//debugf("==> %#q", result)
+	// }()
+	switch len(vs) {
+	case 0:
+		return ""
+	case 1:
+		return vs[0]
+	}
+	first := vs[0]
+	for i := 0; i < len(first)-ignore; i++ {
+		for n := 1; n < len(vs); n++ {
+			cur := vs[n]
+			if i == len(cur)-ignore {
+				return cur[ignore:]
+			}
+			if first[len(first)-i-1] != cur[len(cur)-i-1] {
+				return first[len(first)-i:]
+			}
+		}
+	}
+	return first[ignore:]
+}

--- a/vendor/vbom.ml/util/regexp_test.go
+++ b/vendor/vbom.ml/util/regexp_test.go
@@ -1,0 +1,115 @@
+package util
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+)
+
+func TestShortRegexpString(t *testing.T) {
+	for _, test := range []struct {
+		in  []string
+		out string
+	}{
+		{[]string{"abc", "def"}, "abc|def"},
+		{[]string{"abc", "def", "abc"}, "abc|def"},
+		{[]string{"a", ""}, "a?"},
+		{[]string{"a", "e"}, "a|e"},
+		{[]string{"man", "men", "min"}, "m[aei]n"},
+		{[]string{"man", "men", "min", "mon"}, "m[aeio]n"},
+		{[]string{"man", "men", "min", "mn"}, "m[aei]?n"},
+		{[]string{"man", "mbn", "mcn", "mdn", "mfn", "mgn"}, "m[a-dfg]n"},
+		{[]string{"man", "mbn", "mcn", "mn", "mfn", "mgn"}, "m[abcfg]?n"},
+		{[]string{"mbn", "mn", "mfn", "mcn", "man", "mgn"}, "m[abcfg]?n"},
+		{[]string{"abccf", "abcde"}, "abc(cf|de)"},
+		{[]string{"abcdefabcf", "abcdefabde", "abc"}, "abc(defab(cf|de))?"},
+		{[]string{"css/bootstrap.css", "css/bootstrap.min.css", "css/bootstrap-theme.css", "css/bootstrap-theme.min.css"},
+			`css/bootstrap(-theme)?(\.min)?\.css`},
+		{[]string{`bootstrap-theme`, `main`, `normalize`, `bootstrap-theme.min`, `bootstrap.min`, `bootstrap`, `pygment_highlights`},
+			`bootstrap(-theme)?(\.min)?|main|normalize|pygment_highlights`},
+		{[]string{"css/bootstrap.css", "css/bootstrap.min.css", "css/bootstrap-theme.css", "css/bootstrap-theme.min.css", "css/main.css", "css/normalize.css", "css/pygment_highlights.css", "feed.xml", "img/avatar-icon.png", "js/bootstrap.js", "js/bootstrap.min.js", "js/jquery-1.11.2.min.js", "js/main.js"},
+			`css/(bootstrap(-theme)?(\.min)?|main|normalize|pygment_highlights)\.css|feed\.xml|img/avatar-icon\.png|js/(bootstrap(\.min)?|jquery-1\.11\.2\.min|main)\.js`},
+	} {
+		input := fmt.Sprintf("%#q", test.in)
+		got := ShortRegexpString(test.in...)
+		if got != test.out {
+			t.Errorf("expected:\n\t%#q,\ngot\n\t%#q for\n\t%s", test.out, got, input)
+		}
+		re, err := regexp.Compile("^(" + got + ")$")
+		if err != nil {
+			t.Errorf("regexp compile failure: %q\n\tfor %#q", err, got)
+		} else {
+			for _, str := range test.in {
+				if !re.MatchString(str) {
+					t.Errorf("regexp does not match input %#q:\n\t%#q", str, got)
+				}
+			}
+		}
+	}
+}
+
+func TestCommonPrefixes(t *testing.T) {
+	for _, test := range []struct {
+		in  []string
+		out map[string]int
+	}{
+		{[]string{"abc", "def"}, nil},
+		{[]string{"abcf", "abde"},
+			map[string]int{"ab": 2}},
+		{[]string{"abcf", "abcde", "abd"},
+			map[string]int{"abc": 2, "ab": 3}},
+	} {
+		got := commonPrefixes(test.in, 2)
+		want := test.out
+		input := fmt.Sprintf("%v", test.in)
+		if len(got) != len(want) {
+			t.Errorf("expected: %v, got %v for\n\t%s", test.out, got, input)
+			continue
+		}
+		for k, v := range want {
+			if got[k].end-got[k].start != v {
+				t.Errorf("expected: %v, got %v for\n\t%s", test.out, got, input)
+				break
+			}
+		}
+	}
+}
+
+func TestCommonSuffixes(t *testing.T) {
+	for _, test := range []struct {
+		in  []string
+		out map[string]int
+	}{
+		{[]string{"abc", "def"}, nil},
+		{[]string{"fcba", "edba"},
+			map[string]int{"ba": 2}},
+		{[]string{"fcba", "decba", "dba"},
+			map[string]int{"cba": 2, "ba": 3}},
+	} {
+		// log.Print(test)
+		got := commonSuffixes(test.in, 2)
+		// log.Print(got)
+		want := test.out
+		input := fmt.Sprintf("%v", test.in)
+		if len(got) != len(want) {
+			t.Errorf("expected: %v, got %v for\n\t%s", test.out, got, input)
+			continue
+		}
+		for k, v := range want {
+			if got[k].end-got[k].start != v {
+				t.Errorf("expected: %v, got %v for\n\t%s", test.out, got, input)
+				break
+			}
+		}
+	}
+}
+
+func BenchmarkShortRegexpString(b *testing.B) {
+	input := []string{"css/bootstrap.css", "css/bootstrap.min.css", "css/bootstrap-theme.css", "css/bootstrap-theme.min.css", "css/main.css", "css/normalize.css", "css/pygment_highlights.css", "feed.xml", "img/avatar-icon.png", "js/bootstrap.js", "js/bootstrap.min.js", "js/jquery-1.11.2.min.js", "js/main.js"}
+
+	for i := 0; i < b.N; i++ {
+		arr := make([]string, len(input))
+		copy(arr, input)
+		_ = ShortRegexpString(arr...)
+	}
+}

--- a/vendor/vbom.ml/util/rope/README.md
+++ b/vendor/vbom.ml/util/rope/README.md
@@ -1,0 +1,9 @@
+## rope [![GoDoc](https://godoc.org/vbom.ml/util/rope?status.svg)](https://godoc.org/vbom.ml/util/rope)
+
+    import "vbom.ml/util/rope"
+
+Package rope implements a "heavy-weight string", which represents very long strings more efficiently (especially when many concatenations are performed).
+
+It may also need less memory if it contains repeated substrings, or if you use several large strings that are similar to each other.
+
+Rope values are immutable, so each operation returns its result instead of modifying the receiver. This immutability also makes them thread-safe.

--- a/vendor/vbom.ml/util/rope/concat.go
+++ b/vendor/vbom.ml/util/rope/concat.go
@@ -1,0 +1,126 @@
+package rope
+
+import "io"
+
+// A node representing the concatenation of two smaller nodes.
+type concat struct {
+	// Subtrees. Neither may be nil or length zero.
+	Left, Right node
+	// Length of Left subtree. (relative index where the substrings meet)
+	Split int64
+	// Cached length of Right subtree, or 0 if out of range.
+	RLen rLenT
+	// Cached depth of the tree.
+	TreeDepth depthT
+}
+
+type rLenT uint32
+
+func (c *concat) depth() depthT { return c.TreeDepth }
+
+func (c *concat) length() int64 {
+	return c.Split + c.rLength()
+}
+
+func (c *concat) at(idx int64) byte {
+	if idx < c.Split {
+		return c.Left.at(idx)
+	}
+	return c.Right.at(idx - c.Split)
+}
+
+func (c *concat) rLength() int64 {
+	if c.RLen > 0 {
+		return int64(c.RLen)
+	}
+	return c.Right.length()
+}
+
+func (c *concat) WriteTo(w io.Writer) (n int64, err error) {
+	n, err = c.Left.WriteTo(w)
+	if err != nil {
+		return
+	}
+
+	m, err := c.Right.WriteTo(w)
+	return n + m, err
+}
+
+// Precondition: start < end
+func (c *concat) slice(start, end int64) node {
+	// If only slicing into one side, recurse to that side.
+	if end <= c.Split {
+		return c.Left.slice(start, end)
+	}
+	if start >= c.Split {
+		return c.Right.slice(start-c.Split, end-c.Split)
+	}
+	clength := c.Split + c.rLength()
+	if start <= 0 && end >= clength {
+		return c
+	}
+
+	Left := c.Left
+	LeftLen := c.Split
+	if start > 0 || end < c.Split {
+		Left = Left.slice(start, end)
+		LeftLen = -1 // Recompute if needed.
+	}
+
+	Right := c.Right
+	RightLen := int64(c.RLen)
+	if start > c.Split || end < clength {
+		Right = c.Right.slice(start-c.Split, end-c.Split)
+		RightLen = -1 // Recompute if needed.
+	}
+
+	return conc(Left, Right, LeftLen, RightLen)
+}
+
+func (c *concat) dropPrefix(start int64) node {
+	switch {
+	case start <= 0:
+		return c
+	case start < c.Split:
+		return conc(c.Left.dropPrefix(start), c.Right,
+			c.Split-start, int64(c.RLen))
+	default: // start >= c.Split
+		return c.Right.dropPrefix(start - c.Split)
+	}
+}
+
+func (c *concat) dropPostfix(end int64) node {
+	switch {
+	case end <= 0:
+		return emptyNode
+	case end <= c.Split:
+		return c.Left.dropPostfix(end)
+	case end >= c.Split+c.rLength():
+		return c
+	default: // c.Split < end < c.length()
+		end -= c.Split
+		return conc(c.Left, c.Right.dropPostfix(end), c.Split, end)
+	}
+}
+
+func (c *concat) walkLeaves(f func(string) error) (err error) {
+	err = c.Left.walkLeaves(f)
+	if err == nil {
+		err = c.Right.walkLeaves(f)
+	}
+	return
+}
+
+func (c *concat) readAt(p []byte, start int64) (n int) {
+	if start < c.Split {
+		n = c.Left.readAt(p, start)
+		if int64(n) < c.Split-start && n != len(p) {
+			panic("incomplete readAt")
+		}
+		if n == len(p) {
+			return
+		}
+	}
+	m := c.Right.readAt(p[n:], start+int64(n)-c.Split)
+	return m + n
+}

--- a/vendor/vbom.ml/util/rope/concat_test.go
+++ b/vendor/vbom.ml/util/rope/concat_test.go
@@ -1,0 +1,196 @@
+package rope
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/bruth/assert"
+)
+
+var (
+	lhs  = leaf("123")
+	rhs  = leaf("456")
+	tree node
+)
+var substrings []struct {
+	orig, want node
+	start, end int64
+}
+
+func init() {
+	defer disableCoalesce()()
+
+	tree = conc(lhs, rhs, 0, 0)
+
+	substrings = []struct {
+		orig, want node
+		start, end int64
+	}{
+		{
+			orig:  tree,
+			want:  tree,
+			start: 0,
+			end:   tree.length(),
+		},
+		{
+			orig:  tree,
+			want:  tree,
+			start: -100,
+			end:   100,
+		},
+		{
+			orig:  tree,
+			want:  leaf("1"),
+			start: 0,
+			end:   1,
+		},
+		{
+			orig:  tree,
+			want:  conc(lhs, leaf("4"), 0, 0),
+			start: 0,
+			end:   4,
+		},
+		{
+			orig:  tree,
+			want:  leaf("1"),
+			start: -100,
+			end:   1,
+		},
+		{
+			orig:  tree,
+			want:  conc(leaf("3"), rhs, 0, 0),
+			start: 2,
+			end:   tree.length(),
+		},
+		{
+			orig:  tree,
+			want:  rhs,
+			start: 3,
+			end:   tree.length(),
+		},
+		{
+			orig:  tree,
+			want:  leaf(""),
+			start: 3,
+			end:   2,
+		},
+		{
+			orig:  tree,
+			want:  lhs,
+			start: 0,
+			end:   3,
+		},
+		{
+			orig:  tree,
+			want:  tree,
+			start: 0,
+			end:   100,
+		},
+		{
+			orig:  tree,
+			want:  leaf(""),
+			start: 0,
+			end:   0,
+		},
+		{
+			orig:  tree,
+			want:  leaf(""),
+			start: -200,
+			end:   -100,
+		},
+		{
+			orig:  tree,
+			want:  conc(leaf("23"), leaf("4"), 0, 0),
+			start: 1,
+			end:   4,
+		},
+	}
+}
+
+func TestConcatLength(t *testing.T) {
+	assert.Equal(t, depthT(1), tree.depth())
+	assert.Equal(t, int64(6), tree.length())
+}
+
+func TestConcatSubstr(t *testing.T) {
+	defer disableCoalesce()()
+
+	for _, ss := range substrings {
+		got := ss.orig.slice(ss.start, ss.end)
+		msg := fmt.Sprintf("%q[%v:%v] != %q", Rope{ss.orig}, ss.start, ss.end, Rope{got})
+		assert.Equal(t, ss.want, got, msg)
+	}
+}
+
+func TestConcatDropPrefix(t *testing.T) {
+	defer disableCoalesce()()
+
+	for _, ss := range substrings {
+		if ss.end < ss.orig.length() {
+			// Ignore non-suffix substrings
+			continue
+		}
+		got := ss.orig.dropPrefix(ss.start)
+		msg := fmt.Sprintf("%q[%v:] != %q", Rope{ss.orig}, ss.start, Rope{got})
+		assert.Equal(t, ss.want, got, msg)
+	}
+}
+
+func TestConcatDropPostfix(t *testing.T) {
+	defer disableCoalesce()()
+
+	for _, ss := range substrings {
+		if ss.start > 0 {
+			// Ignore non-prefix substrings
+			continue
+		}
+		got := ss.orig.dropPostfix(ss.end)
+		msg := fmt.Sprintf("%q[:%v] != %q", Rope{ss.orig}, ss.end, Rope{got})
+		assert.Equal(t, ss.want, got, msg)
+	}
+}
+
+func TestConcatWriteTo(t *testing.T) {
+	buf := bytes.NewBuffer(nil)
+	_, _ = tree.WriteTo(buf)
+	assert.Equal(t, string(lhs+rhs), buf.String())
+}
+
+func TestConcatWalkLeaves(t *testing.T) {
+	counter := 0
+	err := tree.walkLeaves(func(l string) error {
+		switch counter {
+		case 0:
+			assert.Equal(t, string(lhs), l)
+		case 1:
+			assert.Equal(t, string(rhs), l)
+		case 2:
+			t.Errorf("leaf.walkLeaves: function called too many times")
+		default:
+			// Ignore more than two calls, error has already been produced.
+		}
+		counter++
+
+		return nil
+	})
+	assert.Nil(t, err)
+
+	counter = 0
+	err = tree.walkLeaves(func(l string) error {
+		switch counter {
+		case 0:
+			assert.Equal(t, string(lhs), l)
+			return errors.New("stop now")
+		case 1:
+			t.Errorf("leaf.walkLeaves: did not stop after returning true")
+		default:
+			// Ignore more than two calls, error has already been produced.
+		}
+		counter++
+
+		return nil
+	})
+	assert.Equal(t, errors.New("stop now"), err)
+}

--- a/vendor/vbom.ml/util/rope/debug.go
+++ b/vendor/vbom.ml/util/rope/debug.go
@@ -1,0 +1,12 @@
+package rope
+
+// debug enables debug output.
+const debug = true
+
+// MarkGoStringedRope is a flag that, when enabled, prepends "/*Rope*/ " to the
+// result of Rope.GoString(). This can be useful when debugging code using
+// interface{} values, where Ropes and strings can coexist.
+//
+// This should only ever be changed from init() functions, to ensure there are
+// no data races.
+var MarkGoStringedRope = true

--- a/vendor/vbom.ml/util/rope/leaf.go
+++ b/vendor/vbom.ml/util/rope/leaf.go
@@ -1,0 +1,69 @@
+package rope
+
+import (
+	"io"
+)
+
+// A node representing a contiguous string
+type leaf string
+
+func (l leaf) depth() depthT     { return 0 }
+func (l leaf) length() int64     { return int64(len(l)) }
+func (l leaf) at(idx int64) byte { return l[idx] }
+
+func (l leaf) WriteTo(w io.Writer) (n int64, err error) {
+	n1, err := io.WriteString(w, string(l))
+	return int64(n1), err
+}
+
+func (l leaf) slice(start, end int64) node {
+	if start < 0 {
+		start = 0
+	}
+	if end > int64(len(l)) {
+		end = int64(len(l))
+	}
+	// The precondition may have been destroyed by above fixes.
+	if start >= end {
+		// Don't hold a 0-length substring, let the GC have it.
+		return emptyNode
+	}
+	return l[start:end]
+}
+
+func (l leaf) dropPrefix(start int64) node {
+	switch {
+	case start >= int64(len(l)):
+		return emptyNode
+	case start <= 0:
+		return l
+	default: // 0 < start < len(l)
+		return l[start:]
+	}
+}
+
+func (l leaf) dropPostfix(end int64) node {
+	switch {
+	case end >= int64(len(l)):
+		return l
+	case end <= 0:
+		return emptyNode
+	default:
+		return l[:end]
+	}
+}
+
+func (l leaf) walkLeaves(f func(string) error) error {
+	if len(l) == 0 {
+		// Don't bother walking empty leaves.
+		return nil
+	}
+	return f(string(l))
+}
+
+func (l leaf) readAt(p []byte, start int64) (n int) {
+	if start > int64(len(l)) {
+		return 0
+	}
+	return copy(p, l[start:])
+}

--- a/vendor/vbom.ml/util/rope/leaf_test.go
+++ b/vendor/vbom.ml/util/rope/leaf_test.go
@@ -1,0 +1,53 @@
+package rope
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/bruth/assert"
+)
+
+func TestLeaf(t *testing.T) {
+	v := leaf("foo")
+
+	assert.Equal(t, depthT(0), v.depth())
+	assert.Equal(t, int64(3), v.length())
+
+	assert.Equal(t, v, v.slice(0, v.length()))
+	assert.Equal(t, v, v.slice(-100, 100))
+	assert.Equal(t, leaf("f"), v.slice(0, 1))
+	assert.Equal(t, leaf("f"), v.slice(-100, 1))
+	assert.Equal(t, leaf("o"), v.slice(2, v.length()))
+	assert.Equal(t, leaf(""), v.slice(2, 1))
+
+	assert.Equal(t, v, v.dropPrefix(0))
+	assert.Equal(t, v, v.dropPrefix(-100))
+	assert.Equal(t, leaf("oo"), v.dropPrefix(1))
+	assert.Equal(t, leaf(""), v.dropPrefix(3))
+	assert.Equal(t, leaf(""), v.dropPrefix(100))
+
+	assert.Equal(t, v, v.dropPostfix(3))
+	assert.Equal(t, v, v.dropPostfix(100))
+	assert.Equal(t, leaf("fo"), v.dropPostfix(2))
+	assert.Equal(t, leaf(""), v.dropPostfix(0))
+	assert.Equal(t, leaf(""), v.dropPostfix(-100))
+
+	buf := bytes.NewBuffer(nil)
+	_, _ = v.WriteTo(buf)
+	assert.Equal(t, "foo", buf.String())
+
+	counter := 0
+	err := v.walkLeaves(func(l string) error {
+		if counter > 0 {
+			t.Errorf("leaf.walkLeaves: function called too many times")
+			return errors.New("called a lot")
+		}
+		counter++
+
+		assert.Equal(t, string(v), l)
+
+		return nil
+	})
+	assert.Nil(t, err)
+}

--- a/vendor/vbom.ml/util/rope/node.go
+++ b/vendor/vbom.ml/util/rope/node.go
@@ -1,0 +1,120 @@
+package rope
+
+import (
+	"bytes"
+	"io"
+)
+
+// The internal representation of a Rope.
+type node interface {
+	// A rope without subtrees is at depth 0, others at
+	// max(left.depth,right.depth) + 1
+	depth() depthT
+	length() int64
+
+	at(idx int64) byte
+
+	// Slice returns a slice of the node.
+	slice(start, end int64) node
+
+	dropPrefix(start int64) node
+	dropPostfix(end int64) node
+
+	io.WriterTo
+
+	// walkLeaves calls f on each leaf of the graph in order.
+	walkLeaves(f func(string) error) error
+
+	readAt(p []byte, start int64) (n int)
+}
+
+type depthT uint32
+
+var emptyNode = node(leaf("")) // The canonical empty node.
+
+// Concatenations below this size threshold are combined into a single leaf
+// node.
+//
+// The value is only modified by tests.
+var concatThreshold = int64(1024) // int64(6 * 8)
+
+// Helper function: returns the concatenation of the arguments.
+// If lhsLength or rhsLength are <= 0, they are determined automatically if
+// needed.
+func conc(lhs, rhs node, lhsLength, rhsLength int64) node {
+	if lhs == emptyNode {
+		return rhs
+	}
+	if rhs == emptyNode {
+		return lhs
+	}
+
+	depth := lhs.depth()
+	if d := rhs.depth(); d > depth {
+		depth = d
+	}
+
+	if lhsLength <= 0 {
+		lhsLength = lhs.length()
+	}
+	if rhsLength <= 0 {
+		rhsLength = rhs.length()
+	}
+
+	// Optimize small + small
+	if lhsLength+rhsLength <= concatThreshold {
+		buf := bytes.NewBuffer(make([]byte, 0, lhsLength+rhsLength))
+		_, _ = lhs.WriteTo(buf)
+		_, _ = rhs.WriteTo(buf)
+		return leaf(buf.String())
+	}
+	// Re-associate (large+small) + small ==> large + (small+small)
+	if cc, ok := lhs.(*concat); ok {
+		ccrlen := cc.rLength()
+		if ccrlen+rhsLength <= concatThreshold {
+			return conc(
+				cc.Left,
+				conc(cc.Right, rhs, ccrlen, rhsLength),
+				cc.Split,
+				ccrlen+rhsLength)
+		}
+	}
+	// Re-associate small + (small+large) ==> (small+small) + large
+	if cc, ok := rhs.(*concat); ok {
+		if lhsLength+cc.Split <= concatThreshold {
+			return conc(
+				conc(lhs, cc.Left, lhsLength, cc.Split),
+				cc.Right,
+				lhsLength+cc.Split,
+				cc.rLength())
+		}
+	}
+
+	if rhsLength > int64(^rLenT(0)) {
+		// Out of range
+		rhsLength = 0
+	}
+
+	return &concat{
+		Left:      lhs,
+		Right:     rhs,
+		TreeDepth: depth + 1,
+		Split:     lhsLength,
+		RLen:      rLenT(rhsLength),
+	}
+}
+
+// Helper function: returns the concatenation of all the arguments, in order.
+// nil is interpreted as an empty string. Never returns nil.
+func concMany(first node, others ...node) node {
+	if first == nil {
+		first = emptyNode
+	}
+	if len(others) == 0 {
+		return first
+	}
+	split := len(others) / 2
+	lhs := concMany(first, others[:split]...)
+	rhs := concMany(others[split], others[split+1:]...)
+	return conc(lhs, rhs, 0, 0)
+}

--- a/vendor/vbom.ml/util/rope/node_test.go
+++ b/vendor/vbom.ml/util/rope/node_test.go
@@ -1,0 +1,88 @@
+package rope
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/bruth/assert"
+)
+
+var (
+	small = leaf("x")      // small+small is below the leaf concat threshold.
+	big   = leaf("bigger") // A string above the leaf concat threshold.
+)
+
+func lowerCoalesceThreshold() func() {
+	// Temporarily lower auto-coalescing threshold.
+	thr := concatThreshold
+	concatThreshold = 3
+	return func() { concatThreshold = thr }
+}
+
+func expectConcat(t *testing.T, n node) *concat {
+	cc, ok := n.(*concat)
+	if !ok {
+		t.Fatalf("concatenation is not *concat: %#v", n)
+	}
+	return cc
+}
+
+func TestConcSimple(t *testing.T) {
+	assert.Equal(t, small, conc(emptyNode, small, -1, -1))
+	assert.Equal(t, small, conc(small, emptyNode, -1, -1))
+	assert.Equal(t, small+small, conc(small, small, -1, -1))
+}
+
+func TestConcNoCoalesce(t *testing.T) {
+	defer lowerCoalesceThreshold()()
+
+	result := conc(big, big, -1, -1)
+	cc := expectConcat(t, result)
+
+	assert.Equal(t, big+big, flatten(cc))
+	assert.Equal(t, big, cc.Left)
+	assert.Equal(t, big, cc.Right)
+	assert.Equal(t, big.length(), cc.Split)
+	assert.Equal(t, rLenT(big.length()), cc.RLen)
+	assert.Equal(t, depthT(1), cc.depth())
+}
+
+func TestConcCoalesceLeft(t *testing.T) {
+	defer lowerCoalesceThreshold()()
+
+	base := conc(small, big, -1, -1)
+	_ = expectConcat(t, base)
+
+	n := conc(small, base, -1, -1)
+	cc := expectConcat(t, n)
+
+	assert.Equal(t, small+small+big, flatten(cc))
+	assert.Equal(t, small+small, cc.Left)
+	assert.Equal(t, big, cc.Right)
+	assert.Equal(t, 2*small.length(), cc.Split)
+	assert.Equal(t, rLenT(big.length()), cc.RLen)
+	assert.Equal(t, depthT(1), cc.depth())
+}
+
+func TestConcCoalesceRight(t *testing.T) {
+	defer lowerCoalesceThreshold()()
+
+	base := conc(big, small, -1, -1)
+	_ = expectConcat(t, base)
+
+	n := conc(base, small, -1, -1)
+	cc := expectConcat(t, n)
+
+	assert.Equal(t, big+small+small, flatten(cc))
+	assert.Equal(t, big, cc.Left)
+	assert.Equal(t, big.length(), cc.Split)
+	assert.Equal(t, small+small, cc.Right)
+	assert.Equal(t, rLenT(2*small.length()), cc.RLen)
+	assert.Equal(t, depthT(1), cc.depth())
+}
+
+func flatten(n node) leaf {
+	buf := &bytes.Buffer{}
+	_, _ = n.WriteTo(buf)
+	return leaf(buf.String())
+}

--- a/vendor/vbom.ml/util/rope/reader.go
+++ b/vendor/vbom.ml/util/rope/reader.go
@@ -1,0 +1,76 @@
+package rope
+
+import (
+	"fmt"
+	"io"
+)
+
+// Reader is an io.Reader that reads from a Rope.
+type Reader struct {
+	stack []*concat // The stack of internal nodes whose right subtrees we need to visit.
+	cur   leaf      // The unread part of the current leaf
+}
+
+// NewReader returns a Reader that reads from the specified Rope.
+func NewReader(rope Rope) *Reader {
+	// Put the leftmost path on the stack.
+	var reader Reader
+	if rope.node != nil {
+		reader.stack = make([]*concat, 0, rope.node.depth())
+		reader.pushSubtree(rope.node)
+	}
+	return &reader
+}
+
+func (r *Reader) pushSubtree(n node) {
+	for {
+		if leaf, ok := n.(leaf); ok {
+			r.cur = leaf
+			return
+		}
+		conc := n.(*concat)
+		r.stack = append(r.stack, conc)
+		n = conc.Left
+	}
+}
+
+func (r *Reader) nextNode() {
+	last := r.stack[len(r.stack)-1]
+
+	r.stack = r.stack[:len(r.stack)-1]
+
+	r.pushSubtree(last.Right)
+}
+
+// Read implements io.Reader.
+func (r *Reader) Read(p []byte) (n int, err error) {
+	if false && debug {
+		defer func(p []byte) {
+			fmt.Printf("Wrote %v bytes: %q (err=%v)\n", n, p[:n], err)
+			if err != nil {
+				fmt.Println()
+			}
+		}(p)
+	}
+
+	for len(p) > 0 {
+		if len(r.cur) == 0 {
+			if len(r.stack) == 0 {
+				// No more nodes to read.
+				return n, io.EOF
+			}
+			// Done reading this node.
+			r.nextNode()
+		}
+
+		m := copy(p, r.cur)
+		r.cur = r.cur[m:]
+		p = p[m:]
+		n += m
+	}
+	if len(r.cur) == 0 && len(r.stack) == 0 {
+		err = io.EOF
+	}
+
+	return
+}

--- a/vendor/vbom.ml/util/rope/reader_test.go
+++ b/vendor/vbom.ml/util/rope/reader_test.go
@@ -1,0 +1,84 @@
+package rope
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/bruth/assert"
+)
+
+var readerTests []struct {
+	r    node
+	want string
+}
+
+func init() {
+	defer disableCoalesce()()
+
+	readerTests = []struct {
+		r    node
+		want string
+	}{
+		{
+			r:    leaf("abc"),
+			want: "abc",
+		},
+		{
+			r:    conc(leaf("abc"), leaf("def"), 0, 0),
+			want: "abcdef",
+		},
+		{
+			r:    conc(conc(leaf("abc"), leaf("123"), 0, 0), leaf("def"), 0, 0),
+			want: "abc123def",
+		},
+	}
+}
+
+func TestReader(t *testing.T) {
+	buf := bytes.NewBuffer(nil)
+	for _, test := range readerTests {
+		buf.Reset()
+		_, _ = io.Copy(buf, NewReader(Rope{test.r}))
+		assert.Equal(t, test.want, buf.String())
+	}
+}
+
+func TestShortRead(t *testing.T) {
+	var result []byte
+	var buf [2]byte
+
+	for _, test := range readerTests {
+		result = result[:0]
+
+		var (
+			r   = NewReader(Rope{test.r})
+			n   int
+			err error
+		)
+		for err == nil {
+			n, err = r.Read(buf[:])
+
+			if err == nil {
+				assert.NotEqual(t, n, 0, "Zero-length Read()")
+			}
+
+			result = append(result, buf[:n]...)
+		}
+		assert.Equal(t, test.want, string(result))
+		assert.Equal(t, err, io.EOF, "Non-EOF error: "+err.Error())
+	}
+}
+
+func TestFullRead(t *testing.T) {
+	var buf [9]byte // Big enough for all the test strings. Exactly right size for one of them.
+
+	for _, test := range readerTests {
+		r := NewReader(Rope{test.r})
+		n, err := r.Read(buf[:])
+
+		assert.Equal(t, n, len(test.want), "partial read")
+		assert.Equal(t, err, io.EOF, "no immediate EOF")
+		assert.Equal(t, test.want, string(buf[:n]), "wrong data")
+	}
+}

--- a/vendor/vbom.ml/util/rope/rebalance.go
+++ b/vendor/vbom.ml/util/rope/rebalance.go
@@ -1,0 +1,167 @@
+package rope
+
+import "sync"
+
+var (
+	// A cache of Fibonacci numbers.
+	// Initialized to some initial ones to get us started.
+	// Note: duplicate 1 is omitted.
+	fibCache = []int64{
+		1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610, 987,
+		1597, 2584, 4181, 6765, 10946, 17711, 28657, 46368, 75025, 121393,
+		196418, 317811, 514229, 832040,
+	}
+
+	// A lock to hold while accessing fibCache.
+	fibLock sync.RWMutex
+)
+
+// reverseFib returns the index of the smallest element >= N in a sorted array.
+// If the array is empty, 0 is returned. If the array's largest element is <= N,
+// len(arr) is returned.
+// If multiple array values are equal, any one of them may be returned.
+func binSearch(N int64, arr []int64) int {
+	// Assuming "virtual" elements -1 and len(arr) which are respectively
+	// 1 smaller or larger than the first or last element actually in the array:
+	// invariant: arr[start] < N < arr[end]
+	start, end := -1, len(arr)
+	for end-start > 1 {
+		mid := (start + end) / 2
+		elt := arr[mid]
+		switch {
+		case elt < N:
+			start = mid
+		case N < elt:
+			end = mid
+		default: // Exactly equal
+			return mid
+		}
+	}
+	// start + 1 == end, so the invariant gives us: arr[end-1] < N < arr[end]
+	return end
+}
+
+// reverseFib returns the index of the smallest Fibonacci number >= N.
+func reverseFib(N int64) int {
+	return binSearch(N, getFibCache(N))
+}
+
+// getFibCache gets a reference to the current fibCache, extended to at least
+// cover N. This reference is safe to use without locking since the only
+// modification to fibCache is appending, which doesn't affect previous slices.
+func getFibCache(N int64) []int64 {
+	fibLock.RLock()
+	defer fibLock.RUnlock()
+
+	if fibCache[len(fibCache)-1] < N {
+		// Calculate some more numbers
+		extendFibs(N)
+	}
+	return fibCache
+}
+
+// extendFibs extends fibCache until the largest number is >= N.
+// Precondition: holding a Read-lock on fibLock.
+func extendFibs(N int64) {
+	// Get a write lock, and make sure we reaquire a read lock on exit.
+	fibLock.RUnlock()
+	fibLock.Lock()
+	defer func() {
+		fibLock.Unlock()
+		fibLock.RLock()
+	}()
+
+	// Note that if we lose the race for a write lock, the loop does not run.
+	a, b := fibCache[len(fibCache)-2], fibCache[len(fibCache)-1]
+	for b < N {
+		a, b = b, a+b
+
+		if b <= a {
+			// Overflow
+			break
+		}
+
+		fibCache = append(fibCache, b)
+	}
+}
+
+// A rope is balanced if its length <= fib(depth).
+func (r Rope) isBalanced() bool {
+	if r.node == nil || r.node == emptyNode {
+		return true
+	}
+
+	len := r.Len()
+	maxDepth := reverseFib(len)
+	return int(r.node.depth()) <= maxDepth
+}
+
+// Rebalance rebalances a rope.
+func (r Rope) Rebalance() Rope {
+	if r.node == nil {
+		return r
+	}
+
+	rLen := r.Len()
+	fibs := getFibCache(rLen)
+
+	// The concatenation of non-empty nodes in the scratch array, in order of
+	// decreasing index, is equivalent to the concatenation of leaves walked
+	// so far.
+	type B struct {
+		n   node
+		len int64
+	}
+	scratch := make([]B, 1+binSearch(rLen, fibs))
+
+	_ = r.node.walkLeaves(func(ls string) error {
+		l := leaf(ls)
+		nLen := l.length()
+		n := node(l)
+
+		// Find the right place for this node. It must be in the lowest non-nil
+		// index, so it accumulates older nodes as it passes them on the way to
+		// its bucket. This means its target bucket may in fact change as it
+		// grows.
+		i := 0
+		for ; i < len(fibs) && fibs[i] <= nLen; i++ {
+			b := scratch[i]
+			if b.n != nil {
+				n = conc(b.n, n, b.len, nLen)
+				nLen += b.len
+				scratch[i] = B{}
+			}
+		}
+		if i > 0 {
+			i-- // We went one bucket too far.
+		}
+
+		scratch[i] = B{n, nLen}
+
+		return nil
+	})
+	nw := B{}
+	for _, b := range scratch {
+		if b.n != nil {
+			if nw.n == nil {
+				nw = b
+			} else {
+				nw.n = conc(b.n, nw.n, b.len, nw.len)
+				nw.len += b.len
+			}
+		}
+	}
+
+	if nw.n == r.node {
+		return r
+	}
+	return Rope{nw.n}
+}
+
+func balanced(r Rope) Rope {
+	if r.isBalanced() {
+		return r
+	}
+
+	return r.Rebalance()
+}

--- a/vendor/vbom.ml/util/rope/rebalance_test.go
+++ b/vendor/vbom.ml/util/rope/rebalance_test.go
@@ -1,0 +1,60 @@
+package rope
+
+import (
+	"testing"
+
+	"github.com/bruth/assert"
+)
+
+func disableCoalesce() func() {
+	// Temporarily disable auto-coalescing.
+	thr := concatThreshold
+	concatThreshold = 0
+	return func() { concatThreshold = thr }
+}
+
+var rebalanceTestRopes []Rope
+
+func init() {
+	defer disableCoalesce()()
+
+	rebalanceTestRopes = []Rope{
+		New("a").Append(New("bc").Append(New("d").AppendString("ef"))), //.AppendString("g"),
+		New("a").Append(New("bc").Append(New("d").AppendString("ef"))).AppendString("g"),
+		New("a").AppendString("bcd").AppendString("efghijkl").AppendString("mno"),
+		New("abc").AppendString("def").AppendString("def").AppendString("def").AppendString("def").AppendString("def").AppendString("ghiklmnopqrstuvwxyzklmnopqrstuvwxyz").AppendString("j").AppendString("j").AppendString("j").AppendString("j").AppendString("j").AppendString("klmnopqrstuvwxyz"),
+	}
+	//~ for i, r := range largeRopes {
+	//~ for j := 0; j < 8; j++ {
+	//~ r = r.Append(r)
+	//~ }
+	//~ largeRopes[i] = r
+	//~ }
+	//~ n := New("a")
+
+	var r Rope
+	for i := 0; i < 100; i++ {
+		r = r.AppendString(string(' ' + i))
+	}
+	rebalanceTestRopes = append(rebalanceTestRopes, r)
+
+	rebalanceTestRopes = append(rebalanceTestRopes, emptyRope, Rope{})
+}
+
+func TestRebalance(t *testing.T) {
+	defer disableCoalesce()()
+
+	for _, orig := range rebalanceTestRopes {
+		origStr := orig.String()
+		rebalanced := orig.Rebalance()
+		rebalancedStr := rebalanced.String()
+
+		//~ pretty.Println(orig, "(", orig.isBalanced(), ") ==> (", rebalanced.isBalanced(), ")", rebalanced)
+
+		assert.Equal(t, origStr, rebalancedStr)
+		if rebalanced.node != nil && orig.node != nil {
+			assert.True(t, rebalanced.node.depth() <= orig.node.depth())
+		}
+		assert.True(t, rebalanced.isBalanced())
+	}
+}

--- a/vendor/vbom.ml/util/rope/rope.go
+++ b/vendor/vbom.ml/util/rope/rope.go
@@ -1,0 +1,229 @@
+// Package rope implements a "heavy-weight string", which represents very long
+// strings more efficiently (especially when many concatenations are performed).
+//
+// It may also need less memory if it contains repeated substrings, or if you
+// use several large strings that are similar to each other.
+//
+// Rope values are immutable, so each operation returns its result instead
+// of modifying the receiver. This immutability also makes them thread-safe.
+package rope // import "vbom.ml/util/rope"
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+)
+
+var emptyRope = Rope{emptyNode} // A Rope containing the empty node.
+
+// Rope implements a non-contiguous string.
+// The zero value is an empty rope.
+type Rope struct {
+	node node // The root node of this rope. May be nil.
+}
+
+// New returns a Rope representing a given string.
+func New(arg string) Rope {
+	if len(arg) == 0 {
+		return emptyRope
+	}
+	return Rope{
+		node: leaf(arg),
+	}
+}
+
+// String materializes the Rope as a string value.
+func (r Rope) String() string {
+	if r.node == nil {
+		return ""
+	}
+	// In the trivial case, avoid allocation
+	if l, ok := r.node.(leaf); ok {
+		return string(l)
+	}
+	// The rope is not contiguous.
+	return string(r.Bytes())
+}
+
+// GoString materializes the Rope as a quoted string value.
+func (r Rope) GoString() string {
+	// Perhaps technically more correct, but not nearly as useful:
+	//	 return fmt.Sprintf("rope.New(%q)", r.String())
+
+	// Instead, (mostly) pretend we're a regular string.
+	if MarkGoStringedRope {
+		return fmt.Sprintf("/*Rope*/ %#v", r.String())
+	}
+	return fmt.Sprintf("%#v", r.String())
+}
+
+// Bytes returns the string represented by this Rope as a []byte.
+func (r Rope) Bytes() []byte {
+	len := r.Len()
+	if len == 0 {
+		return nil
+	}
+	buf := bytes.NewBuffer(make([]byte, 0, len))
+	_, _ = r.WriteTo(buf)
+	return buf.Bytes()
+}
+
+// WriteTo writes the value of this Rope to the provided writer.
+func (r Rope) WriteTo(w io.Writer) (n int64, err error) {
+	if r.node == nil {
+		return 0, nil // Nothing to do
+	}
+	return r.node.WriteTo(w)
+}
+
+// At returns the byte at index idx.
+// The index must be >= 0 and < r.Len().
+func (r Rope) At(idx int64) byte {
+	if idx < 0 || idx >= r.Len() {
+		panic("rope: index out of bounds")
+	}
+	return r.node.at(idx)
+}
+
+// Len returns the length of the string represented by the Rope.
+func (r Rope) Len() int64 {
+	if r.node == nil {
+		return 0
+	}
+	return r.node.length()
+}
+
+// Depth returns the depth of the directed acyclic graph the Rope consists of
+// internally
+func (r Rope) Depth() uint32 {
+	return uint32(r.node.depth())
+}
+
+// Append returns the Rope representing the arguments appended to this rope.
+func (r Rope) Append(rhs ...Rope) Rope {
+	// Handle nil-node receiver
+	for r.node == nil && len(rhs) > 0 {
+		r = rhs[0]
+		rhs = rhs[1:]
+	}
+	if len(rhs) == 0 {
+		return r
+	}
+
+	list := make([]node, 0, len(rhs))
+	for _, item := range rhs {
+		if item.node != nil && item.node != emptyNode {
+			list = append(list, item.node)
+		}
+	}
+	node := concMany(r.node, list...)
+	return balanced(Rope{node: node})
+}
+
+// AppendString is like Append, but accepts strings.
+func (r Rope) AppendString(rhs ...string) Rope {
+	leafs := make([]node, 0, len(rhs))
+	for _, str := range rhs {
+		if len(str) != 0 {
+			leafs = append(leafs, leaf(str))
+		}
+	}
+	return balanced(Rope{node: concMany(r.node, leafs...)})
+}
+
+// Repeat returns the receiver, repeated a number of times.
+func (r Rope) Repeat(count int64) Rope {
+	// Special cases:
+	switch count {
+	case 0:
+		return emptyRope
+	case 1:
+		return r
+	}
+
+	// General case:
+	orig := r
+	r = r.Repeat(count / 2)
+	r = r.Append(r)
+	if count%2 == 1 {
+		return r.Append(orig)
+	}
+	return balanced(r)
+}
+
+// DropPrefix returns a postfix of a rope, starting at index.
+// It's analogous to str[start:].
+//
+// If start >= r.Len(), an empty Rope is returned.
+func (r Rope) DropPrefix(start int64) Rope {
+	if start <= 0 || r.node == nil {
+		return r
+	}
+	return Rope{
+		node: r.node.dropPrefix(start),
+	}
+}
+
+// DropPostfix returns the prefix of a rope ending at end.
+// It's analogous to str[:end].
+//
+// If end <= 0, an empty Rope is returned.
+func (r Rope) DropPostfix(end int64) Rope {
+	if r.node == nil {
+		return r
+	}
+	return Rope{
+		node: r.node.dropPostfix(end),
+	}
+}
+
+// Slice returns the substring of a Rope, analogous to str[start:end].
+// It is equivalent to r.DropPostfix(end).DropPrefix(start).
+//
+// If start >= end, start >= r.Len() or end == 0, an empty Rope is returned.
+func (r Rope) Slice(start, end int64) Rope {
+	if r.node == nil {
+		return r
+	}
+	if start < 0 {
+		start = 0
+	}
+	if start >= end {
+		return emptyRope
+	}
+	return Rope{node: r.node.slice(start, end)}
+}
+
+// Walk passes the Rope, piece-by-piece, to f.
+// If f returns an error Walk() returns that error without calling f again.
+func (r Rope) Walk(f func(string) error) error {
+	if r.node == nil {
+		return nil
+	}
+	return r.node.walkLeaves(f)
+}
+
+// ReadAt implements io.ReaderAt.
+func (r Rope) ReadAt(p []byte, off int64) (n int, err error) {
+	expected := len(p)
+	if off < 0 {
+		return 0, errors.New("Rope.ReadAt: invalid offset")
+	}
+
+	if len(p) == 0 {
+		return
+	}
+
+	if r.node == nil {
+		if len(p) > 0 {
+			err = io.EOF
+		}
+		return
+	}
+	n = r.node.readAt(p, off)
+	if n < expected {
+		err = io.EOF
+	}
+	return
+}

--- a/vendor/vbom.ml/util/rope/rope_test.go
+++ b/vendor/vbom.ml/util/rope/rope_test.go
@@ -1,0 +1,272 @@
+package rope
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/bruth/assert"
+)
+
+func TestEmptyRope(t *testing.T) {
+	for _, r := range []Rope{Rope{}, New("")} {
+		assert.Equal(t, int64(0), r.Len())
+
+		assert.Equal(t, nil, r.Bytes())
+		assert.Equal(t, "", r.String())
+
+		assert.Equal(t, "", r.DropPrefix(3).String())
+		assert.Equal(t, "", r.DropPrefix(-1).String())
+		assert.Equal(t, "", r.DropPostfix(3).String())
+		assert.Equal(t, "", r.DropPostfix(-1).String())
+
+		assert.Equal(t, "", r.Slice(-1, 200).String())
+		assert.Equal(t, "", r.Slice(0, 1).String())
+
+		buf := bytes.NewBuffer(nil)
+		_, _ = r.WriteTo(buf)
+		assert.Equal(t, 0, buf.Len())
+	}
+}
+
+func TestNew(t *testing.T) {
+	for _, str := range []string{"", "abc"} {
+		r := New(str)
+		assert.Equal(t, r.node, leaf(str))
+	}
+}
+
+func TestAppend(t *testing.T) {
+	defer disableCoalesce()()
+
+	r := New("123")
+	assert.Equal(t, "123", r.String())
+
+	assert.Equal(t, r, r.Append(Rope{}))
+	assert.Equal(t, r, r.Append(New("")))
+
+	// Test for structural equality in presence of empty strings.
+	rab := r.Append(New("a"), New("c"), New("b"))
+	raeb := r.Append(New("a"), New("c"), New(""), New("b"))
+	assert.Equal(t, rab, raeb, "should ignore empty arguments to Append")
+
+	r2 := r.Append(New("456"))
+	assert.Equal(t, "123456", r2.String())
+	assert.Equal(t, "123", r.String())
+
+	r2 = r.Append(New("456"), New("abc"), New("def"))
+	assert.Equal(t, "123456abcdef", r2.String())
+	assert.Equal(t, "123", r.String())
+}
+
+func TestAppendString(t *testing.T) {
+	defer disableCoalesce()()
+
+	r := New("123")
+	assert.Equal(t, "123", r.String())
+
+	assert.Equal(t, r, r.Append(Rope{}))
+	assert.Equal(t, r, r.Append(New("")))
+
+	// Test for structural equality in presence of empty strings.
+	rab := r.AppendString("a", "c", "b")
+	raeb := r.AppendString("a", "c", "", "b")
+	assert.Equal(t, rab, raeb, "should ignore empty arguments to AppendString")
+
+	r2 := r.AppendString("456")
+	assert.Equal(t, "123456", r2.String())
+	assert.Equal(t, "123", r.String())
+
+	r2 = r.AppendString("456", "abc", "def")
+	assert.Equal(t, "123456abcdef", r2.String())
+	assert.Equal(t, "123", r.String())
+}
+
+func TestRepeat(t *testing.T) {
+	r := New("a")
+	assert.Equal(t, "", r.Repeat(0).String())
+	assert.Equal(t, "a", r.Repeat(1).String())
+	assert.Equal(t, "aa", r.Repeat(2).String())
+	assert.Equal(t, "aaa", r.Repeat(3).String())
+	assert.Equal(t, "aaaa", r.Repeat(4).String())
+	assert.Equal(t, "aaaaa", r.Repeat(5).String())
+	assert.Equal(t, "aaaaaa", r.Repeat(6).String())
+}
+
+var treeR Rope
+
+func init() {
+	defer disableCoalesce()()
+
+	treeR = New("123").AppendString("456", "abc").AppendString("def")
+}
+
+func TestAt(t *testing.T) {
+	str := treeR.String()
+	length := treeR.Len()
+	for i := int64(0); i < length; i++ {
+		assert.Equal(t, str[i], treeR.At(i))
+	}
+}
+
+func TestLen(t *testing.T) {
+	assert.Equal(t, int64(0), Rope{}.Len())
+	assert.Equal(t, int64(12), treeR.Len())
+}
+
+func TestString(t *testing.T) {
+	assert.Equal(t, "", Rope{}.String())
+	assert.Equal(t, "123456abcdef", treeR.String())
+}
+
+func TestBytes(t *testing.T) {
+	assert.Equal(t, []byte(nil), Rope{}.Bytes())
+	assert.Equal(t, []byte(nil), New("").Bytes())
+	assert.Equal(t, []byte("123456abcdef"), treeR.Bytes())
+}
+
+func TestWriteTo(t *testing.T) {
+	buf := bytes.NewBuffer(nil)
+	_, _ = treeR.WriteTo(buf)
+
+	assert.Equal(t, "123456abcdef", buf.String())
+}
+
+func TestSlice(t *testing.T) {
+	defer disableCoalesce()()
+
+	// See concat_test.go for the table used.
+	for _, ss := range substrings {
+		orig := Rope{ss.orig}
+		got := orig.Slice(ss.start, ss.end)
+		msg := fmt.Sprintf("%q[%v:%v] != %q", orig, ss.start, ss.end, got)
+		assert.Equal(t, ss.want, got.node, msg)
+	}
+}
+
+func TestDropPrefix(t *testing.T) {
+	defer disableCoalesce()()
+
+	// See concat_test.go for the table used.
+	for _, ss := range substrings {
+		if ss.end < ss.orig.length() {
+			// Ignore non-suffix substrings
+			continue
+		}
+		orig := Rope{ss.orig}
+		got := orig.DropPrefix(ss.start)
+		msg := fmt.Sprintf("%q[%v:] != %q", orig, ss.start, got)
+		assert.Equal(t, ss.want, got.node, msg)
+	}
+}
+
+func TestDropPostfix(t *testing.T) {
+	defer disableCoalesce()()
+
+	// See concat_test.go for the table used.
+	for _, ss := range substrings {
+		if ss.start > 0 {
+			// Ignore non-prefix substrings
+			continue
+		}
+		orig := Rope{ss.orig}
+		got := orig.DropPostfix(ss.end)
+		msg := fmt.Sprintf("%q[:%v] != %q", orig, ss.end, got)
+		assert.Equal(t, ss.want, got.node, msg)
+	}
+}
+
+func TestGoString(t *testing.T) {
+	for i, format := range []string{"%v", "%#v"} {
+		for _, str := range []string{"abc", "\""} {
+			want := fmt.Sprintf(format, str)
+			if MarkGoStringedRope && i == 1 {
+				// GoStringer
+				want = "/*Rope*/ " + want
+			}
+			assert.Equal(t, want, fmt.Sprintf(format, New(str)))
+		}
+	}
+}
+
+func TestWalk(t *testing.T) {
+	defer disableCoalesce()()
+
+	for _, r := range []Rope{Rope{}, emptyRope} {
+		_ = r.Walk(func(_ string) error {
+			t.Error("call to empty Rope's Walk parameter")
+			return nil
+		})
+	}
+
+	for _, r := range []Rope{
+		New("abc").AppendString("def").AppendString("ghi"),
+	} {
+		str := r.String()
+		err := r.Walk(func(part string) error {
+			assert.Equal(t, str[:len(part)], part)
+			str = str[len(part):]
+			return nil
+		})
+		assert.Nil(t, err)
+		assert.Equal(t, "", str)
+	}
+
+	for _, r := range []Rope{
+		New("abc").AppendString("def").AppendString("ghi"),
+	} {
+		str := r.String()
+		err := r.Walk(func(part string) error {
+			assert.Equal(t, str[:len(part)], part)
+			str = str[len(part):]
+			if len(str) < 4 {
+				return errors.New("stop now")
+			}
+			return nil
+		})
+		assert.Equal(t, err, errors.New("stop now"))
+		assert.True(t, 0 < len(str) && len(str) < 4)
+	}
+
+}
+
+func TestReadAt(t *testing.T) {
+	want := treeR.Bytes()
+
+	buf := make([]byte, len(want)+1)
+
+	for start := 0; start < len(buf); start++ {
+		for end := start; end <= len(buf); end++ {
+			length := end - start
+			b := buf[0:length]
+			n, err := treeR.ReadAt(b, int64(start))
+
+			// Basic io.ReaderAt contract
+			assert.True(t, n <= length)
+			if n < length {
+				assert.Equal(t, io.EOF, err)
+			}
+
+			// Expected actual end and length
+			eEnd := end
+			if eEnd > len(want) {
+				eEnd = len(want)
+			}
+			eLen := eEnd - start
+
+			// Check for correctness
+			assert.Equal(t, eLen, n)
+			if eLen < length {
+				assert.Equal(t, io.EOF, err)
+			} else if eLen > length {
+				assert.Nil(t, err)
+			} else {
+				assert.True(t, err == nil || err == io.EOF)
+			}
+
+			assert.Equal(t, want[start:eEnd], b[:n])
+		}
+	}
+}

--- a/vendor/vbom.ml/util/sortorder/README.md
+++ b/vendor/vbom.ml/util/sortorder/README.md
@@ -1,0 +1,5 @@
+## sortorder [![GoDoc](https://godoc.org/vbom.ml/util/sortorder?status.svg)](https://godoc.org/vbom.ml/util/sortorder)
+
+    import "vbom.ml/util/sortorder"
+
+Sort orders and comparison functions.

--- a/vendor/vbom.ml/util/sortorder/doc.go
+++ b/vendor/vbom.ml/util/sortorder/doc.go
@@ -1,0 +1,5 @@
+// Package sortorder implements sort orders and comparison functions.
+//
+// Currently, it only implements so-called "natural order", where integers
+// embedded in strings are compared by value.
+package sortorder // import "vbom.ml/util/sortorder"

--- a/vendor/vbom.ml/util/sortorder/natsort.go
+++ b/vendor/vbom.ml/util/sortorder/natsort.go
@@ -1,0 +1,76 @@
+package sortorder
+
+// Natural implements sort.Interface to sort strings in natural order. This
+// means that e.g. "abc2" < "abc12".
+//
+// Non-digit sequences and numbers are compared separately. The former are
+// compared bytewise, while the latter are compared numerically (except that
+// the number of leading zeros is used as a tie-breaker, so e.g. "2" < "02")
+//
+// Limitation: only ASCII digits (0-9) are considered.
+type Natural []string
+
+func (n Natural) Len() int           { return len(n) }
+func (n Natural) Swap(i, j int)      { n[i], n[j] = n[j], n[i] }
+func (n Natural) Less(i, j int) bool { return NaturalLess(n[i], n[j]) }
+
+func isdigit(b byte) bool { return '0' <= b && b <= '9' }
+
+// NaturalLess compares two strings using natural ordering. This means that e.g.
+// "abc2" < "abc12".
+//
+// Non-digit sequences and numbers are compared separately. The former are
+// compared bytewise, while the latter are compared numerically (except that
+// the number of leading zeros is used as a tie-breaker, so e.g. "2" < "02")
+//
+// Limitation: only ASCII digits (0-9) are considered.
+func NaturalLess(str1, str2 string) bool {
+	idx1, idx2 := 0, 0
+	for idx1 < len(str1) && idx2 < len(str2) {
+		c1, c2 := str1[idx1], str2[idx2]
+		dig1, dig2 := isdigit(c1), isdigit(c2)
+		switch {
+		case dig1 != dig2: // Digits before other characters.
+			return dig1 // True if LHS is a digit, false if the RHS is one.
+		case !dig1: // && !dig2, because dig1 == dig2
+			// UTF-8 compares bytewise-lexicographically, no need to decode
+			// codepoints.
+			if c1 != c2 {
+				return c1 < c2
+			}
+			idx1++
+			idx2++
+		default: // Digits
+			// Eat zeros.
+			for ; idx1 < len(str1) && str1[idx1] == '0'; idx1++ {
+			}
+			for ; idx2 < len(str2) && str2[idx2] == '0'; idx2++ {
+			}
+			// Eat all digits.
+			nonZero1, nonZero2 := idx1, idx2
+			for ; idx1 < len(str1) && isdigit(str1[idx1]); idx1++ {
+			}
+			for ; idx2 < len(str2) && isdigit(str2[idx2]); idx2++ {
+			}
+			// If lengths of numbers with non-zero prefix differ, the shorter
+			// one is less.
+			if len1, len2 := idx1-nonZero1, idx2-nonZero2; len1 != len2 {
+				return len1 < len2
+			}
+			// If they're not equal, string comparison is correct.
+			if nr1, nr2 := str1[nonZero1:idx1], str2[nonZero2:idx2]; nr1 != nr2 {
+				return nr1 < nr2
+			}
+			// Otherwise, the one with less zeros is less.
+			// Because everything up to the number is equal, comparing the index
+			// after the zeros is sufficient.
+			if nonZero1 != nonZero2 {
+				return nonZero1 < nonZero2
+			}
+		}
+		// They're identical so far, so continue comparing.
+	}
+	// So far they are identical. At least one is ended. If the other continues,
+	// it sorts last.
+	return len(str1) < len(str2)
+}

--- a/vendor/vbom.ml/util/sortorder/natsort_test.go
+++ b/vendor/vbom.ml/util/sortorder/natsort_test.go
@@ -1,0 +1,206 @@
+package sortorder
+
+import (
+	"flag"
+	"math/rand"
+	"reflect"
+	"sort"
+	"strconv"
+	"testing"
+
+	"github.com/xlab/handysort"
+)
+
+func TestStringSort(t *testing.T) {
+	a := []string{
+		"ab", "abc1",
+		"abc01", "abc2",
+		"abc5", "abc10",
+	}
+	b := []string{
+		"abc5", "abc1",
+		"abc01", "ab",
+		"abc10", "abc2",
+	}
+	sort.Sort(Natural(b))
+	if !reflect.DeepEqual(a, b) {
+		t.Errorf("Error: sort failed, expected: %#q, got: %#q", a, b)
+	}
+}
+
+func TestNaturalLess(t *testing.T) {
+	testset := []struct {
+		s1, s2 string
+		less   bool
+	}{
+		{"0", "00", true},
+		{"00", "0", false},
+		{"aa", "ab", true},
+		{"ab", "abc", true},
+		{"abc", "ad", true},
+		{"ab1", "ab2", true},
+		{"ab1c", "ab1c", false},
+		{"ab12", "abc", true},
+		{"ab2a", "ab10", true},
+		{"a0001", "a0000001", true},
+		{"a10", "abcdefgh2", true},
+		{"аб2аб", "аб10аб", true},
+		{"2аб", "3аб", true},
+		//
+		{"a1b", "a01b", true},
+		{"a01b", "a1b", false},
+		{"ab01b", "ab010b", true},
+		{"ab010b", "ab01b", false},
+		{"a01b001", "a001b01", true},
+		{"a001b01", "a01b001", false},
+		{"a1", "a1x", true},
+		{"1ax", "1b", true},
+		{"1b", "1ax", false},
+		//
+		{"082", "83", true},
+		//
+		{"083a", "9a", false},
+		{"9a", "083a", true},
+	}
+	for _, v := range testset {
+		if res := NaturalLess(v.s1, v.s2); res != v.less {
+			t.Errorf("Compared %#q to %#q: expected %v, got %v",
+				v.s1, v.s2, v.less, res)
+		}
+		if res := handysort.StringLess(v.s1, v.s2); res != v.less {
+			t.Logf("handysort: Compared %#q to %#q: expected %v, got %v",
+				v.s1, v.s2, v.less, res)
+		}
+	}
+}
+
+var testEquivalence = flag.Bool("equivalence", false, "Test equivalence with handysort")
+
+func TestEquivalenceToXlabStringLess(t *testing.T) {
+	t.Skip("Skipping equivalence test due to bug in handysort")
+
+	if !*testEquivalence {
+		t.Skip("Skipping exhaustive test with -short")
+	}
+
+	set := testSet(300)
+	for _, list := range set[:1] {
+		list = list[:100]
+		for _, lhs := range list {
+			for _, rhs := range list {
+				nl := NaturalLess(lhs, rhs)
+				sl := handysort.StringLess(lhs, rhs)
+				if nl != sl {
+					t.Errorf("difference to handysort: %v vs %v for %#q < %#q", nl, sl, lhs, rhs)
+				}
+			}
+		}
+	}
+}
+
+func BenchmarkStringSort(b *testing.B) {
+	set := testSet(300)
+	arr := make([]string, len(set[0]))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, list := range set {
+			copy(arr, list)
+			sort.Strings(arr)
+		}
+	}
+}
+
+func BenchmarkUtilStringSort(b *testing.B) {
+	set := testSet(300)
+	arr := make([]string, len(set[0]))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, list := range set {
+			copy(arr, list)
+			sort.Sort(Natural(arr))
+		}
+	}
+}
+
+func BenchmarkHandyStringSort(b *testing.B) {
+	set := testSet(300)
+	arr := make([]string, len(set[0]))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, list := range set {
+			copy(arr, list)
+			sort.Sort(handysort.Strings(arr))
+		}
+	}
+}
+
+func BenchmarkStringLess(b *testing.B) {
+	set := testSet(300)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for j := range set[0] {
+			k := (j + 1) % len(set[0])
+			_ = handysort.StringLess(set[0][j], set[0][k])
+		}
+	}
+}
+
+func BenchmarkNaturalLess(b *testing.B) {
+	set := testSet(300)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for j := range set[0] {
+			k := (j + 1) % len(set[0])
+			_ = NaturalLess(set[0][j], set[0][k])
+		}
+	}
+}
+
+// Get 1000 arrays of 10000-string-arrays.
+func testSet(seed int) [][]string {
+	gen := &generator{
+		src: rand.New(rand.NewSource(
+			int64(seed),
+		)),
+	}
+	set := make([][]string, 1000)
+	for i := range set {
+		strings := make([]string, 10000)
+		for idx := range strings {
+			// random length
+			strings[idx] = gen.NextString()
+		}
+		set[i] = strings
+	}
+	return set
+}
+
+type generator struct {
+	src *rand.Rand
+}
+
+func (g *generator) NextInt(max int) int {
+	return g.src.Intn(max)
+}
+
+// Gets random random-length alphanumeric string.
+func (g *generator) NextString() (str string) {
+	// random-length 3-8 chars part
+	strlen := g.src.Intn(6) + 3
+	// random-length 1-3 num
+	numlen := g.src.Intn(3) + 1
+	// random position for num in string
+	numpos := g.src.Intn(strlen + 1)
+	var num string
+	for i := 0; i < numlen; i++ {
+		num += strconv.Itoa(g.src.Intn(10))
+	}
+	for i := 0; i < strlen+1; i++ {
+		if i == numpos {
+			str += num
+		} else {
+			str += string('a' + g.src.Intn(16))
+		}
+	}
+	return str
+}


### PR DESCRIPTION
Contains just the `Prune` command for static pod installer revisions first created in https://github.com/openshift/library-go/pull/82

part of https://jira.coreos.com/browse/MSTR-221