### PR TITLE
Set revision status ownerrefs when creating new revision

### DIFF
--- a/pkg/operator/resource/resourceapply/core.go
+++ b/pkg/operator/resource/resourceapply/core.go
@@ -167,7 +167,7 @@ func ApplySecret(client coreclientv1.SecretsGetter, recorder events.Recorder, re
 	return actual, true, err
 }
 
-func SyncConfigMap(client coreclientv1.ConfigMapsGetter, recorder events.Recorder, sourceNamespace, sourceName, targetNamespace, targetName string) (*corev1.ConfigMap, bool, error) {
+func SyncConfigMap(client coreclientv1.ConfigMapsGetter, recorder events.Recorder, sourceNamespace, sourceName, targetNamespace, targetName string, ownerRefs []metav1.OwnerReference) (*corev1.ConfigMap, bool, error) {
 	source, err := client.ConfigMaps(sourceNamespace).Get(sourceName, metav1.GetOptions{})
 	switch {
 	case apierrors.IsNotFound(err):
@@ -186,12 +186,12 @@ func SyncConfigMap(client coreclientv1.ConfigMapsGetter, recorder events.Recorde
 		source.Namespace = targetNamespace
 		source.Name = targetName
 		source.ResourceVersion = ""
-		source.OwnerReferences = []metav1.OwnerReference{}
+		source.OwnerReferences = ownerRefs
 		return ApplyConfigMap(client, recorder, source)
 	}
 }
 
-func SyncSecret(client coreclientv1.SecretsGetter, recorder events.Recorder, sourceNamespace, sourceName, targetNamespace, targetName string) (*corev1.Secret, bool, error) {
+func SyncSecret(client coreclientv1.SecretsGetter, recorder events.Recorder, sourceNamespace, sourceName, targetNamespace, targetName string, ownerRefs []metav1.OwnerReference) (*corev1.Secret, bool, error) {
 	source, err := client.Secrets(sourceNamespace).Get(sourceName, metav1.GetOptions{})
 	switch {
 	case apierrors.IsNotFound(err):
@@ -210,7 +210,7 @@ func SyncSecret(client coreclientv1.SecretsGetter, recorder events.Recorder, sou
 		source.Namespace = targetNamespace
 		source.Name = targetName
 		source.ResourceVersion = ""
-		source.OwnerReferences = []metav1.OwnerReference{}
+		source.OwnerReferences = ownerRefs
 		return ApplySecret(client, recorder, source)
 	}
 }

--- a/pkg/operator/resourcesynccontroller/resourcesync_controller.go
+++ b/pkg/operator/resourcesynccontroller/resourcesync_controller.go
@@ -8,6 +8,7 @@ import (
 	"github.com/golang/glog"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -145,7 +146,7 @@ func (c *ResourceSyncController) sync() error {
 			continue
 		}
 
-		_, _, err := resourceapply.SyncConfigMap(c.kubeClient.CoreV1(), c.eventRecorder, source.Namespace, source.Name, destination.Namespace, destination.Name)
+		_, _, err := resourceapply.SyncConfigMap(c.kubeClient.CoreV1(), c.eventRecorder, source.Namespace, source.Name, destination.Namespace, destination.Name, []metav1.OwnerReference{})
 		if err != nil {
 			errors = append(errors, err)
 		}
@@ -158,7 +159,7 @@ func (c *ResourceSyncController) sync() error {
 			continue
 		}
 
-		_, _, err := resourceapply.SyncSecret(c.kubeClient.CoreV1(), c.eventRecorder, source.Namespace, source.Name, destination.Namespace, destination.Name)
+		_, _, err := resourceapply.SyncSecret(c.kubeClient.CoreV1(), c.eventRecorder, source.Namespace, source.Name, destination.Namespace, destination.Name, []metav1.OwnerReference{})
 		if err != nil {
 			errors = append(errors, err)
 		}


### PR DESCRIPTION
When creating a new static pod deployment, sets the ownerrefs for copied resources to be the new revision-status configmap (see https://github.com/openshift/cluster-kube-apiserver-operator/pull/179), to be used for garbage collection as part of https://jira.coreos.com/browse/MSTR-221