### PR TITLE
segregate and simplify the cert rotation config

### DIFF
--- a/pkg/operator/certrotation/cabundle.go
+++ b/pkg/operator/certrotation/cabundle.go
@@ -8,31 +8,45 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1informers "k8s.io/client-go/informers/core/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/util/cert"
 
 	"github.com/openshift/library-go/pkg/crypto"
+	"github.com/openshift/library-go/pkg/operator/events"
 )
 
-func (c CertRotationController) ensureConfigMapCABundle(signingCertKeyPair *crypto.CA) error {
+type CABundleRotation struct {
+	Namespace string
+	Name      string
+
+	Informer      corev1informers.ConfigMapInformer
+	Lister        corev1listers.ConfigMapLister
+	Client        corev1client.ConfigMapsGetter
+	EventRecorder events.Recorder
+}
+
+func (c CABundleRotation) ensureConfigMapCABundle(signingCertKeyPair *crypto.CA) error {
 	// by this point we have current signing cert/key pair.  We now need to make sure that the ca-bundle configmap has this cert and
 	// doesn't have any expired certs
-	originalCABundleConfigMap, err := c.caBundleLister.ConfigMaps(c.caBundleNamespace).Get(c.caBundleConfigMapName)
+	originalCABundleConfigMap, err := c.Lister.ConfigMaps(c.Namespace).Get(c.Name)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
 	caBundleConfigMap := originalCABundleConfigMap.DeepCopy()
 	if apierrors.IsNotFound(err) {
 		// create an empty one
-		caBundleConfigMap = &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: c.caBundleNamespace, Name: c.caBundleConfigMapName}}
+		caBundleConfigMap = &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: c.Namespace, Name: c.Name}}
 	}
 	if err := manageCABundleConfigMap(caBundleConfigMap, signingCertKeyPair.Config.Certs[0]); err != nil {
 		return err
 	}
 	if originalCABundleConfigMap == nil || originalCABundleConfigMap.Data == nil || !equality.Semantic.DeepEqual(originalCABundleConfigMap.Data, caBundleConfigMap.Data) {
-		c.eventRecorder.Eventf("CABundleUpdateRequired", "%q in %q requires a new cert", c.caBundleNamespace, c.caBundleConfigMapName)
-		actualCABundleConfigMap, err := c.configmapsClient.ConfigMaps(c.caBundleNamespace).Update(caBundleConfigMap)
+		c.EventRecorder.Eventf("CABundleUpdateRequired", "%q in %q requires a new cert", c.Namespace, c.Name)
+		actualCABundleConfigMap, err := c.Client.ConfigMaps(c.Namespace).Update(caBundleConfigMap)
 		if apierrors.IsNotFound(err) {
-			actualCABundleConfigMap, err = c.configmapsClient.ConfigMaps(c.caBundleNamespace).Create(caBundleConfigMap)
+			actualCABundleConfigMap, err = c.Client.ConfigMaps(c.Namespace).Create(caBundleConfigMap)
 			if err != nil {
 				return err
 			}

--- a/pkg/operator/certrotation/cabundle_test.go
+++ b/pkg/operator/certrotation/cabundle_test.go
@@ -210,13 +210,13 @@ func TestEnsureConfigMapCABundle(t *testing.T) {
 				client = kubefake.NewSimpleClientset(startingObj)
 			}
 
-			c := &CertRotationController{
-				caBundleNamespace:     "ns",
-				caBundleConfigMapName: "trust-bundle",
+			c := &CABundleRotation{
+				Namespace: "ns",
+				Name:      "trust-bundle",
 
-				configmapsClient: client.CoreV1(),
-				caBundleLister:   corev1listers.NewConfigMapLister(indexer),
-				eventRecorder:    events.NewInMemoryRecorder("test"),
+				Client:        client.CoreV1(),
+				Lister:        corev1listers.NewConfigMapLister(indexer),
+				EventRecorder: events.NewInMemoryRecorder("test"),
 			}
 
 			newCA, err := test.caFn()

--- a/pkg/operator/certrotation/signer.go
+++ b/pkg/operator/certrotation/signer.go
@@ -5,34 +5,49 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/openshift/library-go/pkg/crypto"
+	"github.com/openshift/library-go/pkg/operator/events"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/openshift/library-go/pkg/crypto"
+	corev1informers "k8s.io/client-go/informers/core/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 )
 
-func (c CertRotationController) ensureSigningCertKeyPair() (*crypto.CA, error) {
-	originalSigningCertKeyPairSecret, err := c.signingLister.Secrets(c.signingNamespace).Get(c.signingCertKeyPairSecretName)
+type SigningRotation struct {
+	Namespace         string
+	Name              string
+	Validity          time.Duration
+	RefreshPercentage float32
+
+	Informer      corev1informers.SecretInformer
+	Lister        corev1listers.SecretLister
+	Client        corev1client.SecretsGetter
+	EventRecorder events.Recorder
+}
+
+func (c SigningRotation) ensureSigningCertKeyPair() (*crypto.CA, error) {
+	originalSigningCertKeyPairSecret, err := c.Lister.Secrets(c.Namespace).Get(c.Name)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return nil, err
 	}
 	signingCertKeyPairSecret := originalSigningCertKeyPairSecret.DeepCopy()
 	if apierrors.IsNotFound(err) {
 		// create an empty one
-		signingCertKeyPairSecret = &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: c.signingNamespace, Name: c.signingCertKeyPairSecretName}}
+		signingCertKeyPairSecret = &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: c.Namespace, Name: c.Name}}
 	}
 	signingCertKeyPairSecret.Type = corev1.SecretTypeTLS
 
-	if needNewSigningCertKeyPair(signingCertKeyPairSecret.Annotations, c.signingCertKeyPairValidity, c.newSigningPercentage) {
-		c.eventRecorder.Eventf("SignerUpdateRequired", "%q in %q requires a new signing cert/key pair", c.signingCertKeyPairSecretName, c.signingNamespace)
-		if err := setSigningCertKeyPairSecret(signingCertKeyPairSecret, c.signingCertKeyPairValidity); err != nil {
+	if needNewSigningCertKeyPair(signingCertKeyPairSecret.Annotations, c.Validity, c.RefreshPercentage) {
+		c.EventRecorder.Eventf("SignerUpdateRequired", "%q in %q requires a new signing cert/key pair", c.Name, c.Namespace)
+		if err := setSigningCertKeyPairSecret(signingCertKeyPairSecret, c.Validity); err != nil {
 			return nil, err
 		}
 
-		actualSigningCertKeyPairSecret, err := c.secretsClient.Secrets(c.signingNamespace).Update(signingCertKeyPairSecret)
+		actualSigningCertKeyPairSecret, err := c.Client.Secrets(c.Namespace).Update(signingCertKeyPairSecret)
 		if apierrors.IsNotFound(err) {
-			actualSigningCertKeyPairSecret, err = c.secretsClient.Secrets(c.signingNamespace).Create(signingCertKeyPairSecret)
+			actualSigningCertKeyPairSecret, err = c.Client.Secrets(c.Namespace).Create(signingCertKeyPairSecret)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/operator/certrotation/signer_test.go
+++ b/pkg/operator/certrotation/signer_test.go
@@ -99,14 +99,14 @@ func TestEnsureSigningCertKeyPair(t *testing.T) {
 				client = kubefake.NewSimpleClientset(test.initialSecret)
 			}
 
-			c := &CertRotationController{
-				signingNamespace:             "ns",
-				signingCertKeyPairSecretName: "signer",
-				signingCertKeyPairValidity:   24 * time.Hour,
-				newSigningPercentage:         .50,
-				secretsClient:                client.CoreV1(),
-				signingLister:                corev1listers.NewSecretLister(indexer),
-				eventRecorder:                events.NewInMemoryRecorder("test"),
+			c := &SigningRotation{
+				Namespace:         "ns",
+				Name:              "signer",
+				Validity:          24 * time.Hour,
+				RefreshPercentage: .50,
+				Client:            client.CoreV1(),
+				Lister:            corev1listers.NewSecretLister(indexer),
+				EventRecorder:     events.NewInMemoryRecorder("test"),
 			}
 
 			_, err := c.ensureSigningCertKeyPair()

--- a/pkg/operator/certrotation/target.go
+++ b/pkg/operator/certrotation/target.go
@@ -4,6 +4,11 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/openshift/library-go/pkg/operator/events"
+	corev1informers "k8s.io/client-go/informers/core/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,31 +18,55 @@ import (
 	"github.com/openshift/library-go/pkg/crypto"
 )
 
-func (c CertRotationController) ensureTargetCertKeyPair(signingCertKeyPair *crypto.CA) error {
+type TargetRotation struct {
+	Namespace         string
+	Name              string
+	Validity          time.Duration
+	RefreshPercentage float32
+
+	ClientRotation  *ClientRotation
+	ServingRotation *ServingRotation
+
+	Informer      corev1informers.SecretInformer
+	Lister        corev1listers.SecretLister
+	Client        corev1client.SecretsGetter
+	EventRecorder events.Recorder
+}
+
+type ClientRotation struct {
+	UserInfo user.Info
+}
+
+type ServingRotation struct {
+	Hostnames              []string
+	CertificateExtensionFn []crypto.CertificateExtensionFunc
+}
+
+func (c TargetRotation) ensureTargetCertKeyPair(signingCertKeyPair *crypto.CA) error {
 	// at this point our trust bundle has been updated.  We don't know for sure that consumers have updated, but that's why we have a second
 	// validity percentage.  We always check to see if we need to sign.  Often we are signing with an old key or we have no target
 	// and need to mint one
 	// TODO do the cross signing thing, but this shows the API consumers want and a very simple impl.
-	originalTargetCertKeyPairSecret, err := c.targetLister.Secrets(c.targetNamespace).Get(c.targetCertKeyPairSecretName)
+	originalTargetCertKeyPairSecret, err := c.Lister.Secrets(c.Namespace).Get(c.Name)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
 	targetCertKeyPairSecret := originalTargetCertKeyPairSecret.DeepCopy()
 	if apierrors.IsNotFound(err) {
 		// create an empty one
-		targetCertKeyPairSecret = &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: c.targetNamespace, Name: c.targetCertKeyPairSecretName}}
+		targetCertKeyPairSecret = &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: c.Namespace, Name: c.Name}}
 	}
 	targetCertKeyPairSecret.Type = corev1.SecretTypeTLS
 
-	if needNewTargetCertKeyPair(targetCertKeyPairSecret.Annotations, signingCertKeyPair, c.targetCertKeyPairValidity, c.newTargetPercentage) {
-		c.eventRecorder.Eventf("TargetUpdateRequired", "%q in %q requires a new target cert/key pair", c.targetCertKeyPairSecretName, c.targetNamespace)
-		if err := setTargetCertKeyPairSecret(targetCertKeyPairSecret, c.targetCertKeyPairValidity, signingCertKeyPair, c.targetUserInfo, c.targetServingHostnames, c.targetServingCertificateExtensionFn...); err != nil {
+	if needNewTargetCertKeyPair(targetCertKeyPairSecret.Annotations, signingCertKeyPair, c.Validity, c.RefreshPercentage) {
+		c.EventRecorder.Eventf("TargetUpdateRequired", "%q in %q requires a new target cert/key pair", c.Name, c.Namespace)
+		if err := setTargetCertKeyPairSecret(targetCertKeyPairSecret, c.Validity, signingCertKeyPair, c.ClientRotation, c.ServingRotation); err != nil {
 			return err
 		}
 
-		actualTargetCertKeyPairSecret, err := c.secretsClient.Secrets(c.targetNamespace).Update(targetCertKeyPairSecret)
+		actualTargetCertKeyPairSecret, err := c.Client.Secrets(c.Namespace).Update(targetCertKeyPairSecret)
 		if apierrors.IsNotFound(err) {
-			actualTargetCertKeyPairSecret, err = c.secretsClient.Secrets(c.targetNamespace).Create(targetCertKeyPairSecret)
+			actualTargetCertKeyPairSecret, err = c.Client.Secrets(c.Namespace).Create(targetCertKeyPairSecret)
 			if err != nil {
 				return err
 			}
@@ -67,8 +96,8 @@ func needNewTargetCertKeyPair(annotations map[string]string, signer *crypto.CA, 
 }
 
 // setTargetCertKeyPairSecret creates a new cert/key pair and sets them in the secret
-func setTargetCertKeyPairSecret(targetCertKeyPairSecret *corev1.Secret, validity time.Duration, signer *crypto.CA, user user.Info, servingHostnames []string, servingCertificateExtensionFn ...crypto.CertificateExtensionFunc) error {
-	if len(servingHostnames) > 0 && user != nil {
+func setTargetCertKeyPairSecret(targetCertKeyPairSecret *corev1.Secret, validity time.Duration, signer *crypto.CA, clientRotation *ClientRotation, servingRotation *ServingRotation) error {
+	if (servingRotation != nil) == (clientRotation != nil) {
 		return fmt.Errorf("must be one of server or client cert")
 	}
 	if targetCertKeyPairSecret.Annotations == nil {
@@ -80,10 +109,10 @@ func setTargetCertKeyPairSecret(targetCertKeyPairSecret *corev1.Secret, validity
 
 	var certKeyPair *crypto.TLSCertificateConfig
 	var err error
-	if len(servingHostnames) > 0 {
-		certKeyPair, err = signer.MakeServerCertForDuration(sets.NewString(servingHostnames...), validity, servingCertificateExtensionFn...)
+	if servingRotation != nil {
+		certKeyPair, err = signer.MakeServerCertForDuration(sets.NewString(servingRotation.Hostnames...), validity, servingRotation.CertificateExtensionFn...)
 	} else {
-		certKeyPair, err = signer.MakeClientCertificateForDuration(user, validity)
+		certKeyPair, err = signer.MakeClientCertificateForDuration(clientRotation.UserInfo, validity)
 	}
 	if err != nil {
 		return err

--- a/pkg/operator/certrotation/target_test.go
+++ b/pkg/operator/certrotation/target_test.go
@@ -95,16 +95,18 @@ func TestEnsureTargetCertKeyPair(t *testing.T) {
 				client = kubefake.NewSimpleClientset(startingObj)
 			}
 
-			c := &CertRotationController{
-				targetNamespace:             "ns",
-				targetCertKeyPairValidity:   24 * time.Hour,
-				newTargetPercentage:         .50,
-				targetCertKeyPairSecretName: "target-secret",
-				targetServingHostnames:      []string{"foo"},
+			c := &TargetRotation{
+				Namespace:         "ns",
+				Validity:          24 * time.Hour,
+				RefreshPercentage: .50,
+				Name:              "target-secret",
+				ServingRotation: &ServingRotation{
+					Hostnames: []string{"foo"},
+				},
 
-				secretsClient: client.CoreV1(),
-				targetLister:  corev1listers.NewSecretLister(indexer),
-				eventRecorder: events.NewInMemoryRecorder("test"),
+				Client:        client.CoreV1(),
+				Lister:        corev1listers.NewSecretLister(indexer),
+				EventRecorder: events.NewInMemoryRecorder("test"),
 			}
 
 			newCA, err := test.caFn()


### PR DESCRIPTION
per @mfojtik's suggestion, this switches us to use structs for each bit of a cert rotation logic


/assign @sttts 