### PR TITLE
events: provide more details when operator status change

### DIFF
--- a/pkg/config/clusteroperator/v1helpers/status_test.go
+++ b/pkg/config/clusteroperator/v1helpers/status_test.go
@@ -1,0 +1,85 @@
+package v1
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+func TestGetStatusConditionDiff(t *testing.T) {
+	tests := []struct {
+		name             string
+		newConditions    []configv1.ClusterOperatorStatusCondition
+		oldConditions    []configv1.ClusterOperatorStatusCondition
+		expectedMessages []string
+	}{
+		{
+			name: "new condition",
+			newConditions: []configv1.ClusterOperatorStatusCondition{
+				{
+					Type:    configv1.RetrievedUpdates,
+					Status:  configv1.ConditionTrue,
+					Message: "test",
+				},
+			},
+			expectedMessages: []string{`RetrievedUpdates set to True ("test")`},
+		},
+		{
+			name: "condition status change",
+			newConditions: []configv1.ClusterOperatorStatusCondition{
+				{
+					Type:    configv1.RetrievedUpdates,
+					Status:  configv1.ConditionFalse,
+					Message: "test",
+				},
+			},
+			oldConditions: []configv1.ClusterOperatorStatusCondition{
+				{
+					Type:    configv1.RetrievedUpdates,
+					Status:  configv1.ConditionTrue,
+					Message: "test",
+				},
+			},
+			expectedMessages: []string{`RetrievedUpdates changed from True to False ("test")`},
+		},
+		{
+			name: "condition message change",
+			newConditions: []configv1.ClusterOperatorStatusCondition{
+				{
+					Type:    configv1.RetrievedUpdates,
+					Status:  configv1.ConditionTrue,
+					Message: "foo",
+				},
+			},
+			oldConditions: []configv1.ClusterOperatorStatusCondition{
+				{
+					Type:    configv1.RetrievedUpdates,
+					Status:  configv1.ConditionTrue,
+					Message: "bar",
+				},
+			},
+			expectedMessages: []string{`RetrievedUpdates message changed from "bar" to "foo"`},
+		},
+		{
+			name: "condition message deleted",
+			oldConditions: []configv1.ClusterOperatorStatusCondition{
+				{
+					Type:    configv1.RetrievedUpdates,
+					Status:  configv1.ConditionTrue,
+					Message: "test",
+				},
+			},
+			expectedMessages: []string{"RetrievedUpdates was removed"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := GetStatusConditionDiff(test.oldConditions, test.newConditions)
+			if !reflect.DeepEqual(test.expectedMessages, strings.Split(result, ",")) {
+				t.Errorf("expected %#v, got %#v", test.expectedMessages, result)
+			}
+		})
+	}
+}

--- a/pkg/operator/status/status_controller.go
+++ b/pkg/operator/status/status_controller.go
@@ -153,7 +153,7 @@ func (c StatusSyncer) sync() error {
 		if _, updateErr := c.clusterOperatorClient.ClusterOperators().UpdateStatus(clusterOperatorObj); err != nil {
 			return updateErr
 		}
-		c.eventRecorder.Eventf("OperatorStatusChanged", "Status for operator %s changed", c.clusterOperatorName)
+		c.eventRecorder.Eventf("OperatorStatusChanged", "Status for operator %s changed: %s", c.clusterOperatorName, configv1helpers.GetStatusConditionDiff(originalClusterOperatorObj.Status.Conditions, clusterOperatorObj.Status.Conditions))
 		return nil
 	}
 
@@ -188,7 +188,7 @@ func (c StatusSyncer) sync() error {
 	if _, updateErr := c.clusterOperatorClient.ClusterOperators().UpdateStatus(freshOperatorConfig); updateErr != nil {
 		return updateErr
 	}
-	c.eventRecorder.Eventf("OperatorStatusChanged", "Status for operator %s changed", c.clusterOperatorName)
+	c.eventRecorder.Eventf("OperatorStatusChanged", "Status for operator %s changed: %s", c.clusterOperatorName, configv1helpers.GetStatusConditionDiff(originalClusterOperatorObj.Status.Conditions, clusterOperatorObj.Status.Conditions))
 
 	return nil
 }


### PR DESCRIPTION
This change provides more details into what changed in operator status conditions, instead of just printing the status changed.

/cc @deads2k 
/cc @smarterclayton 