### PR TITLE
(wip) Prune API resources owned by revision status configmap

### DIFF
--- a/pkg/operator/staticpod/controller/prune/prune_controller.go
+++ b/pkg/operator/staticpod/controller/prune/prune_controller.go
@@ -161,6 +161,7 @@ func (c *PruneController) ensurePrunePod(nodeName string, maxEligibleRevision in
 		fmt.Sprintf("--protected-ids=%s", revisionsToString(protectedRevisions)),
 		fmt.Sprintf("--resource-dir=%s", "/etc/kubernetes/static-pod-resources"),
 		fmt.Sprintf("--static-pod-name=%s", c.podResourcePrefix),
+		fmt.Sprintf("--namespace=%s", c.targetNamespace),
 	)
 
 	_, _, err := resourceapply.ApplyPod(c.kubeClient.CoreV1(), c.eventRecorder, pod)


### PR DESCRIPTION
Part of https://jira.coreos.com/browse/MSTR-221

Depends on:

1. https://github.com/openshift/cluster-kube-apiserver-operator/pull/179
2. https://github.com/openshift/library-go/pull/157
3. https://github.com/openshift/library-go/pull/159

