### PR TITLE
add better event information and glog info on diff

### DIFF
--- a/pkg/config/clusteroperator/v1helpers/status_test.go
+++ b/pkg/config/clusteroperator/v1helpers/status_test.go
@@ -76,7 +76,7 @@ func TestGetStatusConditionDiff(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result := GetStatusConditionDiff(test.oldConditions, test.newConditions)
+			result := GetStatusDiff(configv1.ClusterOperatorStatus{Conditions: test.oldConditions}, configv1.ClusterOperatorStatus{Conditions: test.newConditions})
 			if !reflect.DeepEqual(test.expectedMessages, strings.Split(result, ",")) {
 				t.Errorf("expected %#v, got %#v", test.expectedMessages, result)
 			}


### PR DESCRIPTION
Makes sure we always have a message about what is changing.  If we don't see an explicit change, we will serialize it to json.  If we end up with a cardinality problem on events, we can deal with it, but this is a fallthrough to find our ghost writes.

/assign @sanchezl 