### PR TITLE
helper for logging resource names

### DIFF
--- a/pkg/operator/resource/resourceapply/event_helpers_test.go
+++ b/pkg/operator/resource/resourceapply/event_helpers_test.go
@@ -110,14 +110,14 @@ func TestReportUpdateEvent(t *testing.T) {
 			object:               &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "podName"}},
 			details:              "because reasons",
 			expectedEventReason:  "PodUpdated",
-			expectedEventMessage: "Updated Pod/podName: because reasons",
+			expectedEventMessage: "Updated Pod/podName:\nbecause reasons",
 		},
 		{
 			name:                 "pod-with-namespace-and-details--without-error",
 			object:               &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "podName", Namespace: "nsName"}},
 			details:              "because reasons",
 			expectedEventReason:  "PodUpdated",
-			expectedEventMessage: "Updated Pod/podName -n nsName: because reasons",
+			expectedEventMessage: "Updated Pod/podName -n nsName:\nbecause reasons",
 		},
 	}
 
@@ -128,6 +128,83 @@ func TestReportUpdateEvent(t *testing.T) {
 				reportUpdateEvent(recorder, test.object, test.err)
 			} else {
 				reportUpdateEvent(recorder, test.object, test.err, test.details)
+			}
+			recordedEvents := recorder.Events()
+
+			if eventCount := len(recordedEvents); eventCount != 1 {
+				t.Errorf("expected one event to be recorded, got %d", eventCount)
+			}
+
+			if recordedEvents[0].Message != test.expectedEventMessage {
+				t.Errorf("expected one event message %q, got %q", test.expectedEventMessage, recordedEvents[0].Message)
+			}
+
+			if recordedEvents[0].Reason != test.expectedEventReason {
+				t.Errorf("expected one event reason %q, got %q", test.expectedEventReason, recordedEvents[0].Reason)
+			}
+		})
+	}
+}
+
+func TestReportDeleteEvent(t *testing.T) {
+	testErr := errors.New("test")
+	tests := []struct {
+		name                 string
+		object               runtime.Object
+		err                  error
+		details              string
+		expectedEventMessage string
+		expectedEventReason  string
+	}{
+		{
+			name:                 "pod-with-error",
+			object:               &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "podName"}},
+			err:                  testErr,
+			expectedEventReason:  "PodDeleteFailed",
+			expectedEventMessage: "Failed to delete Pod/podName: test",
+		},
+		{
+			name:                 "pod-with-namespace",
+			object:               &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "podName", Namespace: "nsName"}},
+			err:                  testErr,
+			expectedEventReason:  "PodDeleteFailed",
+			expectedEventMessage: "Failed to delete Pod/podName -n nsName: test",
+		},
+		{
+			name:                 "pod-without-error",
+			object:               &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "podName"}},
+			expectedEventReason:  "PodDeleted",
+			expectedEventMessage: "Deleted Pod/podName",
+		},
+		{
+			name:                 "pod-with-namespace-without-error",
+			object:               &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "podName", Namespace: "nsName"}},
+			expectedEventReason:  "PodDeleted",
+			expectedEventMessage: "Deleted Pod/podName -n nsName",
+		},
+		{
+			name:                 "pod-with-details-without-error",
+			object:               &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "podName"}},
+			details:              "because reasons",
+			expectedEventReason:  "PodDeleted",
+			expectedEventMessage: "Deleted Pod/podName:\nbecause reasons",
+		},
+		{
+			name:                 "pod-with-namespace-and-details--without-error",
+			object:               &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "podName", Namespace: "nsName"}},
+			details:              "because reasons",
+			expectedEventReason:  "PodDeleted",
+			expectedEventMessage: "Deleted Pod/podName -n nsName:\nbecause reasons",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			recorder := events.NewInMemoryRecorder("test")
+			if len(test.details) == 0 {
+				reportDeleteEvent(recorder, test.object, test.err)
+			} else {
+				reportDeleteEvent(recorder, test.object, test.err, test.details)
 			}
 			recordedEvents := recorder.Events()
 

--- a/pkg/operator/resource/resourcehelper/resource_helpers.go
+++ b/pkg/operator/resource/resourcehelper/resource_helpers.go
@@ -1,0 +1,76 @@
+package resourcehelper
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	"github.com/openshift/api"
+)
+
+var (
+	openshiftScheme = runtime.NewScheme()
+)
+
+func init() {
+	if err := api.Install(openshiftScheme); err != nil {
+		panic(err)
+	}
+}
+
+// FormatResourceForCLIWithNamespace generates a string that can be copy/pasted for use with oc get that includes
+// specifying the namespace with the -n option (e.g., `ConfigMap/cluster-config-v1 -n kube-system`).
+func FormatResourceForCLIWithNamespace(obj runtime.Object) string {
+	gvk := GuessObjectGroupVersionKind(obj)
+	kind := gvk.Kind
+	group := gvk.Group
+	var name, namespace string
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		name = "<unknown>"
+		namespace = "<unknown>"
+	} else {
+		name = accessor.GetName()
+		namespace = accessor.GetNamespace()
+	}
+	if len(group) > 0 {
+		group = "." + group
+	}
+	if len(namespace) > 0 {
+		namespace = " -n " + namespace
+	}
+	return kind + group + "/" + name + namespace
+}
+
+// FormatResourceForCLI generates a string that can be copy/pasted for use with oc get.
+func FormatResourceForCLI(obj runtime.Object) string {
+	gvk := GuessObjectGroupVersionKind(obj)
+	kind := gvk.Kind
+	group := gvk.Group
+	var name string
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		name = "<unknown>"
+	} else {
+		name = accessor.GetName()
+	}
+	if len(group) > 0 {
+		group = "." + group
+	}
+	return kind + group + "/" + name
+}
+
+// GuessObjectGroupVersionKind returns a human readable for the passed runtime object.
+func GuessObjectGroupVersionKind(object runtime.Object) schema.GroupVersionKind {
+	if gvk := object.GetObjectKind().GroupVersionKind(); len(gvk.Kind) > 0 {
+		return gvk
+	}
+	if kinds, _, _ := scheme.Scheme.ObjectKinds(object); len(kinds) > 0 {
+		return kinds[0]
+	}
+	if kinds, _, _ := openshiftScheme.ObjectKinds(object); len(kinds) > 0 {
+		return kinds[0]
+	}
+	return schema.GroupVersionKind{Kind: "<unknown>"}
+}


### PR DESCRIPTION
Generates a string that can be copy/pasted for use with `oc get`.

e.g.: `oc get TYPE[.GROUP]/NAME[ -n NS_NAME]`

Can be used by operator impls to report (log/event/etc.) on resources.