### PR TITLE
Add optional configMaps to revision controller

### DIFF
--- a/pkg/operator/staticpod/controllers.go
+++ b/pkg/operator/staticpod/controllers.go
@@ -34,10 +34,10 @@ type staticPodOperatorControllers struct {
 // 4. BackingResourceController - this creates the backing resources needed for the operand, such as cluster rolebindings and installer service
 //    account.
 // 5. MonitoringResourceController - this creates the service monitor used by prometheus to scrape metrics.
-func NewControllers(targetNamespaceName, staticPodName string, command, revisionConfigMaps, revisionSecrets []string,
-	staticPodOperatorClient v1helpers.StaticPodOperatorClient, configMapGetter corev1client.ConfigMapsGetter, secretGetter corev1client.SecretsGetter, kubeClient kubernetes.Interface, dynamicClient dynamic.Interface,
-	kubeInformersNamespaceScoped,
-	kubeInformersClusterScoped informers.SharedInformerFactory, eventRecorder events.Recorder) *staticPodOperatorControllers {
+func NewControllers(targetNamespaceName, staticPodName string, command []string, revisionConfigMaps, revisionSecrets []revision.RevisionResource,
+	staticPodOperatorClient v1helpers.StaticPodOperatorClient, configMapGetter corev1client.ConfigMapsGetter, secretGetter corev1client.SecretsGetter,
+	kubeClient kubernetes.Interface, dynamicClient dynamic.Interface, kubeInformersNamespaceScoped, kubeInformersClusterScoped informers.SharedInformerFactory,
+	eventRecorder events.Recorder) *staticPodOperatorControllers {
 	controller := &staticPodOperatorControllers{}
 
 	controller.revisionController = revision.NewRevisionController(

--- a/pkg/operator/staticpod/installerpod/cmd_test.go
+++ b/pkg/operator/staticpod/installerpod/cmd_test.go
@@ -91,6 +91,86 @@ func TestCopyContent(t *testing.T) {
 				checkFileContent(t, path.Join(podDir, "kube-apiserver-pod.yaml"), podYaml)
 			},
 		},
+		{
+			name: "optional-secrets-confmaps",
+			o: InstallOptions{
+				Revision:                      "006",
+				Namespace:                     "some-ns",
+				PodConfigMapNamePrefix:        "kube-apiserver-pod",
+				SecretNamePrefixes:            []string{"first", "second"},
+				OptionalSecretNamePrefixes:    []string{"third", "fourth"},
+				ConfigMapNamePrefixes:         []string{"alpha", "bravo"},
+				OptionalConfigMapNamePrefixes: []string{"charlie", "delta"},
+			},
+			client: func() *fake.Clientset {
+				return fake.NewSimpleClientset(
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{Namespace: "some-ns", Name: "first-006"},
+						Data: map[string][]byte{
+							"one-A.crt": []byte("one"),
+							"two-A.crt": []byte("two"),
+						},
+					},
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{Namespace: "some-ns", Name: "second-006"},
+						Data: map[string][]byte{
+							"uno-B.crt": []byte("uno"),
+							"dos-B.crt": []byte("dos"),
+						},
+					},
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{Namespace: "some-ns", Name: "third-006"},
+						Data: map[string][]byte{
+							"tres-C.crt":   []byte("tres"),
+							"cuatro-C.crt": []byte("cuatro"),
+						},
+					},
+					&corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{Namespace: "some-ns", Name: "alpha-006"},
+						Data: map[string]string{
+							"apple-A.crt":  "apple",
+							"banana-A.crt": "banana",
+						},
+					},
+					&corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{Namespace: "some-ns", Name: "bravo-006"},
+						Data: map[string]string{
+							"manzana-B.crt": "manzana",
+							"platano-B.crt": "platano",
+						},
+					},
+					&corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{Namespace: "some-ns", Name: "charlie-006"},
+						Data: map[string]string{
+							"apple-C.crt":  "apple",
+							"banana-C.crt": "banana",
+						},
+					},
+					&corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{Namespace: "some-ns", Name: "kube-apiserver-pod-006"},
+						Data: map[string]string{
+							"pod.yaml": podYaml,
+						},
+					},
+				)
+			},
+			expected: func(t *testing.T, resourceDir, podDir string) {
+				checkFileContent(t, path.Join(resourceDir, "kube-apiserver-pod-006", "secrets", "first", "one-A.crt"), "one")
+				checkFileContent(t, path.Join(resourceDir, "kube-apiserver-pod-006", "secrets", "first", "two-A.crt"), "two")
+				checkFileContent(t, path.Join(resourceDir, "kube-apiserver-pod-006", "secrets", "second", "uno-B.crt"), "uno")
+				checkFileContent(t, path.Join(resourceDir, "kube-apiserver-pod-006", "secrets", "second", "dos-B.crt"), "dos")
+				checkFileContent(t, path.Join(resourceDir, "kube-apiserver-pod-006", "secrets", "third", "tres-C.crt"), "tres")
+				checkFileContent(t, path.Join(resourceDir, "kube-apiserver-pod-006", "secrets", "third", "cuatro-C.crt"), "cuatro")
+				checkFileContent(t, path.Join(resourceDir, "kube-apiserver-pod-006", "configmaps", "alpha", "apple-A.crt"), "apple")
+				checkFileContent(t, path.Join(resourceDir, "kube-apiserver-pod-006", "configmaps", "alpha", "banana-A.crt"), "banana")
+				checkFileContent(t, path.Join(resourceDir, "kube-apiserver-pod-006", "configmaps", "bravo", "manzana-B.crt"), "manzana")
+				checkFileContent(t, path.Join(resourceDir, "kube-apiserver-pod-006", "configmaps", "bravo", "platano-B.crt"), "platano")
+				checkFileContent(t, path.Join(resourceDir, "kube-apiserver-pod-006", "configmaps", "charlie", "apple-C.crt"), "apple")
+				checkFileContent(t, path.Join(resourceDir, "kube-apiserver-pod-006", "configmaps", "charlie", "banana-C.crt"), "banana")
+				checkFileContent(t, path.Join(resourceDir, "kube-apiserver-pod-006", "kube-apiserver-pod.yaml"), podYaml)
+				checkFileContent(t, path.Join(podDir, "kube-apiserver-pod.yaml"), podYaml)
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This lets us pass optional configMaps to the controller that will not halt progress if they don't exist.
@deads2k @openshift/sig-security 
re: https://github.com/openshift/cluster-kube-apiserver-operator/pull/185