### PR TITLE
create a cached version of getters to reduce qps

### DIFF
--- a/pkg/operator/resourcesynccontroller/resourcesync_controller.go
+++ b/pkg/operator/resourcesynccontroller/resourcesync_controller.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
@@ -45,9 +46,11 @@ type ResourceSyncController struct {
 	// queue only ever has one item, but it has nice error handling backoff/retry semantics
 	queue workqueue.RateLimitingInterface
 
-	kubeClient           kubernetes.Interface
-	operatorConfigClient v1helpers.OperatorClient
-	eventRecorder        events.Recorder
+	configMapGetter            corev1client.ConfigMapsGetter
+	secretGetter               corev1client.SecretsGetter
+	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces
+	operatorConfigClient       v1helpers.OperatorClient
+	eventRecorder              events.Recorder
 }
 
 var _ ResourceSyncer = &ResourceSyncController{}
@@ -63,12 +66,14 @@ func NewResourceSyncController(
 		operatorConfigClient: operatorConfigClient,
 		eventRecorder:        eventRecorder,
 
-		configMapSyncRules: map[ResourceLocation]ResourceLocation{},
-		secretSyncRules:    map[ResourceLocation]ResourceLocation{},
-		knownNamespaces:    sets.StringKeySet(kubeInformersForNamespaces),
+		configMapSyncRules:         map[ResourceLocation]ResourceLocation{},
+		secretSyncRules:            map[ResourceLocation]ResourceLocation{},
+		kubeInformersForNamespaces: kubeInformersForNamespaces,
+		knownNamespaces:            kubeInformersForNamespaces.Namespaces(),
 
-		queue:      workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "ResourceSyncController"),
-		kubeClient: kubeClient,
+		queue:           workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "ResourceSyncController"),
+		configMapGetter: v1helpers.CachedConfigMapGetter(kubeClient, kubeInformersForNamespaces),
+		secretGetter:    v1helpers.CachedSecretGetter(kubeClient, kubeInformersForNamespaces),
 	}
 
 	for namespace := range kubeInformersForNamespaces.Namespaces() {
@@ -143,26 +148,26 @@ func (c *ResourceSyncController) sync() error {
 
 	for destination, source := range c.configMapSyncRules {
 		if source == emptyResourceLocation {
-			if err := c.kubeClient.CoreV1().ConfigMaps(destination.Namespace).Delete(destination.Name, nil); err != nil && !apierrors.IsNotFound(err) {
+			if err := c.configMapGetter.ConfigMaps(destination.Namespace).Delete(destination.Name, nil); err != nil && !apierrors.IsNotFound(err) {
 				errors = append(errors, err)
 			}
 			continue
 		}
 
-		_, _, err := resourceapply.SyncConfigMap(c.kubeClient.CoreV1(), c.eventRecorder, source.Namespace, source.Name, destination.Namespace, destination.Name, []metav1.OwnerReference{})
+		_, _, err := resourceapply.SyncConfigMap(c.configMapGetter, c.eventRecorder, source.Namespace, source.Name, destination.Namespace, destination.Name, []metav1.OwnerReference{})
 		if err != nil {
 			errors = append(errors, err)
 		}
 	}
 	for destination, source := range c.secretSyncRules {
 		if source == emptyResourceLocation {
-			if err := c.kubeClient.CoreV1().Secrets(destination.Namespace).Delete(destination.Name, nil); err != nil && !apierrors.IsNotFound(err) {
+			if err := c.secretGetter.Secrets(destination.Namespace).Delete(destination.Name, nil); err != nil && !apierrors.IsNotFound(err) {
 				errors = append(errors, err)
 			}
 			continue
 		}
 
-		_, _, err := resourceapply.SyncSecret(c.kubeClient.CoreV1(), c.eventRecorder, source.Namespace, source.Name, destination.Namespace, destination.Name, []metav1.OwnerReference{})
+		_, _, err := resourceapply.SyncSecret(c.secretGetter, c.eventRecorder, source.Namespace, source.Name, destination.Namespace, destination.Name, []metav1.OwnerReference{})
 		if err != nil {
 			errors = append(errors, err)
 		}

--- a/pkg/operator/resourcesynccontroller/resourcesync_controller_test.go
+++ b/pkg/operator/resourcesynccontroller/resourcesync_controller_test.go
@@ -55,6 +55,8 @@ func TestSyncConfigMap(t *testing.T) {
 		kubeClient,
 		eventRecorder,
 	)
+	c.configMapGetter = kubeClient.CoreV1()
+	c.secretGetter = kubeClient.CoreV1()
 
 	// sync ones for namespaces we don't have
 	if err := c.SyncSecret(ResourceLocation{Namespace: "other", Name: "foo"}, ResourceLocation{Namespace: "operator", Name: "foo"}); err == nil || err.Error() != `not watching namespace "other"` {

--- a/pkg/operator/resourcesynccontroller/resourcesync_controller_test.go
+++ b/pkg/operator/resourcesynccontroller/resourcesync_controller_test.go
@@ -47,11 +47,11 @@ func TestSyncConfigMap(t *testing.T) {
 
 	c := NewResourceSyncController(
 		fakeStaticPodOperatorClient,
-		map[string]informers.SharedInformerFactory{
+		v1helpers.NewFakeKubeInformersForNamespaces(map[string]informers.SharedInformerFactory{
 			"config":         configInformers,
 			"config-managed": configManagedInformers,
 			"operator":       operatorInformers,
-		},
+		}),
 		kubeClient,
 		eventRecorder,
 	)

--- a/pkg/operator/staticpod/controller/prune/prune_controller_test.go
+++ b/pkg/operator/staticpod/controller/prune/prune_controller_test.go
@@ -165,7 +165,9 @@ func TestPruneAPIResources(t *testing.T) {
 			targetNamespace:        tc.targetNamespace,
 			podResourcePrefix:      "test-pod",
 			command:                []string{"/bin/true"},
-			kubeClient:             kubeClient,
+			configMapGetter:        kubeClient.CoreV1(),
+			secretGetter:           kubeClient.CoreV1(),
+			podGetter:              kubeClient.CoreV1(),
 			eventRecorder:          eventRecorder,
 			operatorConfigClient:   fakeStaticPodOperatorClient,
 			failedRevisionLimit:    tc.failedLimit,
@@ -181,7 +183,7 @@ func TestPruneAPIResources(t *testing.T) {
 			t.Fatalf("unexpected error %q", apiErr)
 		}
 
-		statusConfigMaps, err := c.kubeClient.CoreV1().ConfigMaps(tc.targetNamespace).List(metav1.ListOptions{})
+		statusConfigMaps, err := c.configMapGetter.ConfigMaps(tc.targetNamespace).List(metav1.ListOptions{})
 		if err != nil {
 			t.Fatalf("unexpected error %q", err)
 		}
@@ -345,7 +347,9 @@ func TestPruneDiskResources(t *testing.T) {
 				targetNamespace:        "test",
 				podResourcePrefix:      "test-pod",
 				command:                []string{"/bin/true"},
-				kubeClient:             kubeClient,
+				configMapGetter:        kubeClient.CoreV1(),
+				secretGetter:           kubeClient.CoreV1(),
+				podGetter:              kubeClient.CoreV1(),
 				eventRecorder:          eventRecorder,
 				operatorConfigClient:   fakeStaticPodOperatorClient,
 				failedRevisionLimit:    test.failedLimit,

--- a/pkg/operator/staticpod/controller/revision/revision_controller_test.go
+++ b/pkg/operator/staticpod/controller/revision/revision_controller_test.go
@@ -173,7 +173,8 @@ func TestRevisionController(t *testing.T) {
 				tc.testSecrets,
 				informers.NewSharedInformerFactoryWithOptions(kubeClient, 1*time.Minute, informers.WithNamespace(tc.targetNamespace)),
 				tc.staticPodOperatorClient,
-				kubeClient,
+				kubeClient.CoreV1(),
+				kubeClient.CoreV1(),
 				eventRecorder,
 			)
 			syncErr := c.sync()

--- a/pkg/operator/staticpod/controllers.go
+++ b/pkg/operator/staticpod/controllers.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 
 	"github.com/openshift/library-go/pkg/operator/staticpod/controller/backingresource"
 	"github.com/openshift/library-go/pkg/operator/staticpod/controller/installer"
@@ -34,7 +35,8 @@ type staticPodOperatorControllers struct {
 //    account.
 // 5. MonitoringResourceController - this creates the service monitor used by prometheus to scrape metrics.
 func NewControllers(targetNamespaceName, staticPodName string, command, revisionConfigMaps, revisionSecrets []string,
-	staticPodOperatorClient v1helpers.StaticPodOperatorClient, kubeClient kubernetes.Interface, dynamicClient dynamic.Interface, kubeInformersNamespaceScoped,
+	staticPodOperatorClient v1helpers.StaticPodOperatorClient, configMapGetter corev1client.ConfigMapsGetter, secretGetter corev1client.SecretsGetter, kubeClient kubernetes.Interface, dynamicClient dynamic.Interface,
+	kubeInformersNamespaceScoped,
 	kubeInformersClusterScoped informers.SharedInformerFactory, eventRecorder events.Recorder) *staticPodOperatorControllers {
 	controller := &staticPodOperatorControllers{}
 
@@ -44,7 +46,8 @@ func NewControllers(targetNamespaceName, staticPodName string, command, revision
 		revisionSecrets,
 		kubeInformersNamespaceScoped,
 		staticPodOperatorClient,
-		kubeClient,
+		configMapGetter,
+		secretGetter,
 		eventRecorder,
 	)
 

--- a/pkg/operator/v1helpers/core_getters.go
+++ b/pkg/operator/v1helpers/core_getters.go
@@ -1,0 +1,96 @@
+package v1helpers
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+)
+
+type combinedConfigMapGetter struct {
+	client  kubernetes.Interface
+	listers KubeInformersForNamespaces
+}
+
+func CachedConfigMapGetter(client kubernetes.Interface, listers KubeInformersForNamespaces) corev1client.ConfigMapsGetter {
+	return &combinedConfigMapGetter{
+		client:  client,
+		listers: listers,
+	}
+}
+
+type combinedConfigMapInterface struct {
+	corev1client.ConfigMapInterface
+	lister    corev1listers.ConfigMapNamespaceLister
+	namespace string
+}
+
+func (g combinedConfigMapGetter) ConfigMaps(namespace string) corev1client.ConfigMapInterface {
+	return combinedConfigMapInterface{
+		ConfigMapInterface: g.client.CoreV1().ConfigMaps(namespace),
+		lister:             g.listers.InformersFor(namespace).Core().V1().ConfigMaps().Lister().ConfigMaps(namespace),
+		namespace:          namespace,
+	}
+}
+
+func (g combinedConfigMapInterface) Get(name string, options metav1.GetOptions) (*corev1.ConfigMap, error) {
+	return g.lister.Get(name)
+
+}
+func (g combinedConfigMapInterface) List(opts metav1.ListOptions) (*corev1.ConfigMapList, error) {
+	list, err := g.lister.List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+
+	ret := &corev1.ConfigMapList{}
+	for i := range list {
+		ret.Items = append(ret.Items, *list[i])
+	}
+	return ret, nil
+}
+
+type combinedSecretGetter struct {
+	client  kubernetes.Interface
+	listers KubeInformersForNamespaces
+}
+
+func CachedSecretGetter(client kubernetes.Interface, listers KubeInformersForNamespaces) corev1client.SecretsGetter {
+	return &combinedSecretGetter{
+		client:  client,
+		listers: listers,
+	}
+}
+
+type combinedSecretInterface struct {
+	corev1client.SecretInterface
+	lister    corev1listers.SecretNamespaceLister
+	namespace string
+}
+
+func (g combinedSecretGetter) Secrets(namespace string) corev1client.SecretInterface {
+	return combinedSecretInterface{
+		SecretInterface: g.client.CoreV1().Secrets(namespace),
+		lister:          g.listers.InformersFor(namespace).Core().V1().Secrets().Lister().Secrets(namespace),
+		namespace:       namespace,
+	}
+}
+
+func (g combinedSecretInterface) Get(name string, options metav1.GetOptions) (*corev1.Secret, error) {
+	return g.lister.Get(name)
+
+}
+func (g combinedSecretInterface) List(opts metav1.ListOptions) (*corev1.SecretList, error) {
+	list, err := g.lister.List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+
+	ret := &corev1.SecretList{}
+	for i := range list {
+		ret.Items = append(ret.Items, *list[i])
+	}
+	return ret, nil
+}

--- a/pkg/operator/v1helpers/fake_informers.go
+++ b/pkg/operator/v1helpers/fake_informers.go
@@ -1,0 +1,7 @@
+package v1helpers
+
+import "k8s.io/client-go/informers"
+
+func NewFakeKubeInformersForNamespaces(informers map[string]informers.SharedInformerFactory) KubeInformersForNamespaces {
+	return kubeInformersForNamespaces(informers)
+}

--- a/pkg/operator/v1helpers/informers.go
+++ b/pkg/operator/v1helpers/informers.go
@@ -1,0 +1,96 @@
+package v1helpers
+
+import (
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+)
+
+// KubeInformersForNamespaces is a simple way to combine several shared informers into a single struct with unified listing power
+type KubeInformersForNamespaces interface {
+	Start(stopCh <-chan struct{})
+	InformersFor(namespace string) informers.SharedInformerFactory
+
+	ConfigMapLister() corev1listers.ConfigMapLister
+	SecretLister() corev1listers.SecretLister
+}
+
+func NewKubeInformersForNamespaces(kubeClient kubernetes.Interface, namespaces ...string) KubeInformersForNamespaces {
+	ret := kubeInformersForNamespaces{}
+	for _, namespace := range namespaces {
+		if len(namespace) == 0 {
+			ret[""] = informers.NewSharedInformerFactory(kubeClient, 10*time.Minute)
+			continue
+		}
+		ret[namespace] = informers.NewSharedInformerFactoryWithOptions(kubeClient, 10*time.Minute, informers.WithNamespace(namespace))
+	}
+
+	return ret
+}
+
+type kubeInformersForNamespaces map[string]informers.SharedInformerFactory
+
+func (i kubeInformersForNamespaces) Start(stopCh <-chan struct{}) {
+	for _, informer := range i {
+		informer.Start(stopCh)
+	}
+}
+
+func (i kubeInformersForNamespaces) InformersFor(namespace string) informers.SharedInformerFactory {
+	return i[namespace]
+}
+
+type configMapLister kubeInformersForNamespaces
+
+func (i kubeInformersForNamespaces) ConfigMapLister() corev1listers.ConfigMapLister {
+	return configMapLister(i)
+}
+
+func (l configMapLister) List(selector labels.Selector) (ret []*corev1.ConfigMap, err error) {
+	globalInformer, ok := l[""]
+	if !ok {
+		return nil, fmt.Errorf("combinedLister does not support cross namespace list")
+	}
+
+	return globalInformer.Core().V1().ConfigMaps().Lister().List(selector)
+}
+
+func (l configMapLister) ConfigMaps(namespace string) corev1listers.ConfigMapNamespaceLister {
+	informer, ok := l[namespace]
+	if !ok {
+		// coding error
+		panic(fmt.Sprintf("namespace %q is missing", namespace))
+	}
+
+	return informer.Core().V1().ConfigMaps().Lister().ConfigMaps(namespace)
+}
+
+type secretLister kubeInformersForNamespaces
+
+func (i kubeInformersForNamespaces) SecretLister() corev1listers.SecretLister {
+	return secretLister(i)
+}
+
+func (l secretLister) List(selector labels.Selector) (ret []*corev1.Secret, err error) {
+	globalInformer, ok := l[""]
+	if !ok {
+		return nil, fmt.Errorf("combinedLister does not support cross namespace list")
+	}
+
+	return globalInformer.Core().V1().Secrets().Lister().List(selector)
+}
+
+func (l secretLister) Secrets(namespace string) corev1listers.SecretNamespaceLister {
+	informer, ok := l[namespace]
+	if !ok {
+		// coding error
+		panic(fmt.Sprintf("namespace %q is missing", namespace))
+	}
+
+	return informer.Core().V1().Secrets().Lister().Secrets(namespace)
+}

--- a/pkg/operator/v1helpers/informers.go
+++ b/pkg/operator/v1helpers/informers.go
@@ -6,6 +6,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	corev1listers "k8s.io/client-go/listers/core/v1"
@@ -15,6 +16,7 @@ import (
 type KubeInformersForNamespaces interface {
 	Start(stopCh <-chan struct{})
 	InformersFor(namespace string) informers.SharedInformerFactory
+	Namespaces() sets.String
 
 	ConfigMapLister() corev1listers.ConfigMapLister
 	SecretLister() corev1listers.SecretLister
@@ -41,8 +43,15 @@ func (i kubeInformersForNamespaces) Start(stopCh <-chan struct{}) {
 	}
 }
 
+func (i kubeInformersForNamespaces) Namespaces() sets.String {
+	return sets.StringKeySet(i)
+}
 func (i kubeInformersForNamespaces) InformersFor(namespace string) informers.SharedInformerFactory {
 	return i[namespace]
+}
+
+func (i kubeInformersForNamespaces) HasInformersFor(namespace string) bool {
+	return i.InformersFor(namespace) != nil
 }
 
 type configMapLister kubeInformersForNamespaces


### PR DESCRIPTION
This pull creates capital to create cached configmap and secret getters which should dramatically reduce qps on repeated sync and apply calls

/assign @juanvallejo @damemi 