### PR TITLE
rotate only after the signer has had some time to propogate

### DIFF
--- a/pkg/operator/certrotation/client_cert_rotation_controller_test.go
+++ b/pkg/operator/certrotation/client_cert_rotation_controller_test.go
@@ -1,0 +1,57 @@
+package certrotation
+
+import (
+	"testing"
+	"time"
+)
+
+func TestIsOverlapSufficient(t *testing.T) {
+	tests := []struct {
+		name string
+
+		saValidity              time.Duration
+		saRefreshPercentage     float32
+		targetValidity          time.Duration
+		targetRefreshPercentage float32
+
+		expected bool
+	}{
+		{
+			name:                    "plenty",
+			saValidity:              4,
+			saRefreshPercentage:     0.5,
+			targetValidity:          2,
+			targetRefreshPercentage: 0.5,
+			expected:                true,
+		},
+		{
+			name:                    "tight",
+			saValidity:              10,
+			saRefreshPercentage:     0.5,
+			targetValidity:          5,
+			targetRefreshPercentage: 0.5,
+			expected:                true,
+		},
+		{
+			name:                    "not enough",
+			saValidity:              10,
+			saRefreshPercentage:     0.3,
+			targetValidity:          100,
+			targetRefreshPercentage: 0.8,
+			expected:                false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := isOverlapSufficient(
+				SigningRotation{Validity: test.saValidity, RefreshPercentage: test.saRefreshPercentage},
+				TargetRotation{Validity: test.targetValidity, RefreshPercentage: test.targetRefreshPercentage},
+			)
+			if test.expected != actual {
+				t.Errorf("expected %v, got %v", test.expected, actual)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
This makes us wait for 10% of available overlap for the signer to age before we sign.  Assuming we refresh the target a lot more often than the signer, this works.

Also adds a time based trigger every minute to check if we need to do work.

/assign @sttts 