### PR TITLE
Change revision configmap from phase to status

### DIFF
--- a/pkg/operator/staticpod/controller/installer/installer_controller.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller.go
@@ -291,7 +291,7 @@ func (c *InstallerController) updateRevisionStatus(operatorStatus *operatorv1.St
 	return c.updateConfigMapForRevision(failedRevisions, string(corev1.PodFailed))
 }
 
-func (c *InstallerController) updateConfigMapForRevision(currentRevisions map[int32]struct{}, phase string) error {
+func (c *InstallerController) updateConfigMapForRevision(currentRevisions map[int32]struct{}, status string) error {
 	for currentRevision := range currentRevisions {
 		statusConfigMap, err := c.kubeClient.CoreV1().ConfigMaps(c.targetNamespace).Get(statusConfigMapNameForRevision(currentRevision), metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
@@ -300,7 +300,7 @@ func (c *InstallerController) updateConfigMapForRevision(currentRevisions map[in
 		if err != nil {
 			return err
 		}
-		statusConfigMap.Data["phase"] = phase
+		statusConfigMap.Data["status"] = status
 		_, _, err = resourceapply.ApplyConfigMap(c.kubeClient.CoreV1(), c.eventRecorder, statusConfigMap)
 		if err != nil {
 			return err

--- a/pkg/operator/staticpod/controller/prune/prune_controller.go
+++ b/pkg/operator/staticpod/controller/prune/prune_controller.go
@@ -118,7 +118,7 @@ func (c *PruneController) excludedRevisionHistory(operatorStatus *operatorv1.Sta
 			default:
 				// protect things you don't understand
 				unknownStatusRevisionIDs = append(unknownStatusRevisionIDs, revisionID)
-				c.eventRecorder.Event("UnknownRevisionStatus", fmt.Sprintf("unknown status for revision %d: %v", revisionID, configMap.Data["phase"]))
+				c.eventRecorder.Event("UnknownRevisionStatus", fmt.Sprintf("unknown status for revision %d: %v", revisionID, configMap.Data["status"]))
 			}
 		}
 	}


### PR DESCRIPTION
At some point we switched from using `phase` as the configmap value to using `status` (see https://github.com/openshift/library-go/blob/ab277dcc0384e180c6bb5e1f2cd2120143b2093c/pkg/operator/staticpod/controller/revision/revision_controller.go#L169), but some important parts never got updated. This updates them.