### PR TITLE
prevent panic on missing mutex

### DIFF
--- a/pkg/operator/status/version.go
+++ b/pkg/operator/status/version.go
@@ -3,13 +3,15 @@ package status
 import "sync"
 
 type versionGetter struct {
-	lock                 sync.Locker
+	lock                 sync.Mutex
 	versions             map[string]string
 	notificationChannels []chan struct{}
 }
 
 func NewVersionGetter() VersionGetter {
-	return &versionGetter{}
+	return &versionGetter{
+		versions: map[string]string{},
+	}
 }
 
 func (v *versionGetter) SetVersion(operandName, version string) {

--- a/pkg/operator/status/version_test.go
+++ b/pkg/operator/status/version_test.go
@@ -1,0 +1,35 @@
+package status
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestVersionGetterBasic(t *testing.T) {
+	versionGetter := NewVersionGetter()
+	versions := versionGetter.GetVersions()
+	if versions == nil {
+		t.Fatal(versions)
+	}
+
+	ch := versionGetter.VersionChangedChannel()
+	if ch == nil {
+		t.Fatal(ch)
+	}
+
+	versionGetter.SetVersion("foo", "bar")
+
+	select {
+	case <-ch:
+		actual := versionGetter.GetVersions()
+		expected := map[string]string{"foo": "bar"}
+		if !reflect.DeepEqual(expected, actual) {
+			t.Fatal(actual)
+		}
+
+	case <-time.After(5 * time.Second):
+		t.Fatal("missing")
+	}
+
+}


### PR DESCRIPTION
The locker was empty so we paniced.  I can actually use a mutex like the rest of the code, so do that instead.

@eparis 