### PR TITLE
Fix building multiple binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,16 @@ all: build
 GO_PACKAGES :=./pkg/...
 # Packages to be compiled
 GO_BUILD_PACKAGES :=$(GO_PACKAGES)
+# Do not auto-expand packages for libraries or it would compile them separately
+GO_BUILD_PACKAGES_EXPANDED :=$(GO_BUILD_PACKAGES)
 
-include alpha-build-machinery/make/golang.mk
-include alpha-build-machinery/make/targets/openshift/deps.mk
-include alpha-build-machinery/make/targets/openshift/bindata.mk
+include $(addprefix alpha-build-machinery/make/, \
+	golang.mk \
+	targets/openshift/deps.mk \
+	targets/openshift/bindata.mk \
+)
 
 $(call add-bindata,backingresources,./pkg/operator/staticpod/controller/backingresource/manifests/...,bindata,bindata,./pkg/operator/staticpod/controller/backingresource/bindata/bindata.go)
 $(call add-bindata,monitoring,./pkg/operator/staticpod/controller/monitoring/manifests/...,bindata,bindata,./pkg/operator/staticpod/controller/monitoring/bindata/bindata.go)
 $(call add-bindata,installer,./pkg/operator/staticpod/controller/installer/manifests/...,bindata,bindata,./pkg/operator/staticpod/controller/installer/bindata/bindata.go)
 $(call add-bindata,staticpod,./pkg/operator/staticpod/controller/prune/manifests/...,bindata,bindata,./pkg/operator/staticpod/controller/prune/bindata/bindata.go)
-

--- a/alpha-build-machinery/Makefile
+++ b/alpha-build-machinery/Makefile
@@ -1,34 +1,40 @@
+SHELL :=/bin/bash
 all: verify
 .PHONY: all
 
 makefiles :=$(wildcard ./make/*.example.mk)
+examples :=$(wildcard ./make/examples/*/Makefile.test)
 
 # $1 - makefile name relative to ./make/ folder
-# $2 - output folder
+# $2 - target
+# $3 - output folder
 # We need to change dir to the final makefile directory or relative paths won't match
-define update-makefile-help
-$(MAKE) -C "$(dir $(1))" -f "$(notdir $(1))" --no-print-directory --warn-undefined-variables help 2>&1 | tee "$(2)"/"$(notdir $(1))".help
+define update-makefile-log
+mkdir -p "$(3)"
+$(MAKE) -C "$(dir $(1))" -f "$(notdir $(1))" --no-print-directory --warn-undefined-variables $(2) 2>&1 | tee "$(3)"/"$(notdir $(1))"$(subst ..,.,.$(2).log)
 
 endef
 
 
 # $1 - makefile name relative to ./make/ folder
-# $2 - output folder
-define check-makefile
-$(call update-makefile-help,$(1),$(2))
-diff -N "$(1).help" "$(2)/$(notdir $(1)).help"
+# $2 - target
+# $3 - output folder
+define check-makefile-log
+$(call update-makefile-log,$(1),$(2),$(3))
+diff -N "$(1)$(subst ..,.,.$(2).log)" "$(3)/$(notdir $(1))$(subst ..,.,.$(2).log)"
 
 endef
 
 update-makefiles:
-	$(foreach f,$(makefiles),$(call check-makefile,$(f),$(dir $(f))))
+	$(foreach f,$(makefiles),$(call check-makefile-log,$(f),help,$(dir $(f))))
+	$(foreach f,$(examples),$(call check-makefile-log,$(f),,$(dir $(f))))
 .PHONY: update-makefiles
 
 verify-makefiles: tmp_dir:=$(shell mktemp -d)
 verify-makefiles:
-	$(foreach f,$(makefiles),$(call check-makefile,$(f),$(tmp_dir)))
+	$(foreach f,$(makefiles),$(call check-makefile-log,$(f),help,$(tmp_dir)/$(dir $(f))))
+	$(foreach f,$(examples),$(call check-makefile-log,$(f),,$(tmp_dir)/$(dir $(f))))
 .PHONY: verify-makefiles
-
 
 verify: verify-makefiles
 .PHONY: verify

--- a/alpha-build-machinery/make/default.example.mk
+++ b/alpha-build-machinery/make/default.example.mk
@@ -1,18 +1,16 @@
 all: build
 .PHONY: all
 
-# Include the library makefile
-include ./default.mk
-# All the available targets are listed in <this-file>.help
-# or you can list it live by using `make help`
-
-
 # You can customize go tools depending on the directory layout.
 # example:
 GO_BUILD_PACKAGES :=./pkg/...
 # You can list all the golang related variables by:
 #   $ make -n --print-data-base | grep ^GO
 
+# Include the library makefile
+include ./default.mk
+# All the available targets are listed in <this-file>.help
+# or you can list it live by using `make help`
 
 # Codegen module needs setting these required variables
 CODEGEN_OUTPUT_PACKAGE :=github.com/openshift/cluster-openshift-apiserver-operator/pkg/generated

--- a/alpha-build-machinery/make/default.example.mk.help.log
+++ b/alpha-build-machinery/make/default.example.mk.help.log
@@ -1,6 +1,8 @@
 The following make targets are available:
 all
 build
+clean
+clean-binaries
 help
 image-origin-cluster-openshift-apiserver-operator
 images

--- a/alpha-build-machinery/make/examples/multiple-binaries/Makefile
+++ b/alpha-build-machinery/make/examples/multiple-binaries/Makefile
@@ -1,0 +1,3 @@
+include $(addprefix ../../, \
+	golang.mk \
+)

--- a/alpha-build-machinery/make/examples/multiple-binaries/Makefile.test
+++ b/alpha-build-machinery/make/examples/multiple-binaries/Makefile.test
@@ -1,0 +1,9 @@
+all:
+	$(MAKE) -C . build
+	[[ -f ./openshift ]]
+	[[ -f ./oc ]]
+
+	$(MAKE) -C . clean
+	[[ ! -f ./openshift ]]
+	[[ ! -f ./oc ]]
+.PHONY: all

--- a/alpha-build-machinery/make/examples/multiple-binaries/Makefile.test.log
+++ b/alpha-build-machinery/make/examples/multiple-binaries/Makefile.test.log
@@ -1,0 +1,9 @@
+make -C . build
+go build  github.com/openshift/library-go/alpha-build-machinery/make/examples/multiple-binaries/cmd/oc
+go build  github.com/openshift/library-go/alpha-build-machinery/make/examples/multiple-binaries/cmd/openshift
+[[ -f ./openshift ]]
+[[ -f ./oc ]]
+make -C . clean
+rm -f oc openshift
+[[ ! -f ./openshift ]]
+[[ ! -f ./oc ]]

--- a/alpha-build-machinery/make/examples/multiple-binaries/cmd/oc/main.go
+++ b/alpha-build-machinery/make/examples/multiple-binaries/cmd/oc/main.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+
+}

--- a/alpha-build-machinery/make/examples/multiple-binaries/cmd/openshift/main.go
+++ b/alpha-build-machinery/make/examples/multiple-binaries/cmd/openshift/main.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+
+}

--- a/alpha-build-machinery/make/golang.example.mk
+++ b/alpha-build-machinery/make/golang.example.mk
@@ -1,14 +1,14 @@
 all: build
 .PHONY: all
 
-# Include the library makefile
-include ./golang.mk
-# All the available targets are listed in <this-file>.help
-# or you can list it live by using `make help`
-
 
 # You can customize go tools depending on the directory layout.
 # example:
 GO_BUILD_PACKAGES :=./pkg/...
 # You can list all the golang related variables by:
 #   $ make -n --print-data-base | grep ^GO
+
+# Include the library makefile
+include ./golang.mk
+# All the available targets are listed in <this-file>.help
+# or you can list it live by using `make help`

--- a/alpha-build-machinery/make/golang.example.mk.help.log
+++ b/alpha-build-machinery/make/golang.example.mk.help.log
@@ -1,6 +1,8 @@
 The following make targets are available:
 all
 build
+clean
+clean-binaries
 help
 test
 test-unit

--- a/alpha-build-machinery/make/golang.mk
+++ b/alpha-build-machinery/make/golang.mk
@@ -15,6 +15,9 @@ update: update-gofmt
 test: test-unit
 .PHONY: test
 
+clean: clean-binaries
+.PHONY: clean
+
 
 # We need to be careful to expand all the paths before any include is done
 # or self_dir could be modified for the next include by the included file.

--- a/alpha-build-machinery/make/lib/golang.mk
+++ b/alpha-build-machinery/make/lib/golang.mk
@@ -7,7 +7,9 @@ GO_FILES ?=$(shell find . -name '*.go' -not -path './vendor/*' -print)
 GO_PACKAGES ?=./...
 GO_TEST_PACKAGES ?=$(GO_PACKAGES)
 
-GO_BUILD_PACKAGES ?=$(shell find ./cmd -mindepth 1 -maxdepth 1 -print)
+GO_BUILD_PACKAGES ?=./cmd/...
+GO_BUILD_PACKAGES_EXPANDED ?=$(shell $(GO) list $(GO_BUILD_PACKAGES))
+go_build_binaries =$(notdir $(GO_BUILD_PACKAGES_EXPANDED))
 GO_BUILD_FLAGS ?=
 GO_TEST_FLAGS ?=-race
 

--- a/alpha-build-machinery/make/operator.example.mk
+++ b/alpha-build-machinery/make/operator.example.mk
@@ -1,17 +1,17 @@
 all: build
 .PHONY: all
 
-# Include the library makefile
-include ./operator.mk
-# All the available targets are listed in <this-file>.help
-# or you can list it live by using `make help`
-
 
 # You can customize go tools depending on the directory layout.
 # example:
 GO_BUILD_PACKAGES :=./pkg/...
 # You can list all the golang related variables by:
 #   $ make -n --print-data-base | grep ^GO
+
+# Include the library makefile
+include ./operator.mk
+# All the available targets are listed in <this-file>.help
+# or you can list it live by using `make help`
 
 
 # Codegen module needs setting these required variables

--- a/alpha-build-machinery/make/operator.example.mk.help.log
+++ b/alpha-build-machinery/make/operator.example.mk.help.log
@@ -1,6 +1,8 @@
 The following make targets are available:
 all
 build
+clean
+clean-binaries
 help
 image-origin-cluster-openshift-apiserver-operator
 images

--- a/alpha-build-machinery/make/targets/golang/build.mk
+++ b/alpha-build-machinery/make/targets/golang/build.mk
@@ -1,8 +1,17 @@
 self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
 
+define build-package
+	$(GO) build $(GO_BUILD_FLAGS) $(1)
+
+endef
+
+# We need to build each package separately so go build creates appropriate binaries
 build:
-	$(GO) build $(GO_BUILD_FLAGS) $(GO_BUILD_PACKAGES)
+	$(foreach package,$(GO_BUILD_PACKAGES_EXPANDED),$(call build-package,$(package)))
 .PHONY: build
+
+clean-binaries:
+	$(RM) $(go_build_binaries)
 
 # We need to be careful to expand all the paths before any include is done
 # or self_dir could be modified for the next include by the included file.


### PR DESCRIPTION
`go build` will produce a binary only with one package, otherwise it just compiles the code and no binary is produced, so we now call `go build` for each binary.

/cc @juanvallejo @soltysh @sttts @mfojtik 