### PR TITLE
relax available to listing a current revision at all

### DIFF
--- a/pkg/operator/staticpod/controller/installer/installer_controller.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
@@ -328,28 +329,39 @@ func setAvailableProgressingConditions(newStatus *operatorv1.StaticPodOperatorSt
 	numAvailable := 0
 	numAtLatestRevision := 0
 	numProgressing := 0
+	counts := map[int32]int{}
 	for _, currNodeStatus := range newStatus.NodeStatuses {
-		if currNodeStatus.CurrentRevision != 0 && currNodeStatus.LastFailedRevision == 0 {
+		if currNodeStatus.CurrentRevision != 0 {
 			numAvailable++
 		}
+		existing := counts[currNodeStatus.CurrentRevision]
+		counts[currNodeStatus.CurrentRevision] = existing + 1
+
 		if newStatus.LatestAvailableRevision == currNodeStatus.CurrentRevision {
 			numAtLatestRevision += 1
 		} else {
 			numProgressing += 1
 		}
 	}
+
+	revisionStrings := []string{}
+	for revision, count := range counts {
+		revisionStrings = append(revisionStrings, fmt.Sprintf("%d nodes are at revision %d", count, revision))
+	}
+	revisionDescription := strings.Join(revisionStrings, "; ")
+
 	if numAvailable > 0 {
 		v1helpers.SetOperatorCondition(&newStatus.Conditions, operatorv1.OperatorCondition{
 			Type:    operatorv1.OperatorStatusTypeAvailable,
 			Status:  operatorv1.ConditionTrue,
-			Message: fmt.Sprintf("%d nodes are active; %d of %d nodes are at revision %d", numAvailable, numAtLatestRevision, len(newStatus.NodeStatuses), newStatus.LatestAvailableRevision),
+			Message: fmt.Sprintf("%d nodes are active; %s", numAvailable, revisionDescription),
 		})
 	} else {
 		v1helpers.SetOperatorCondition(&newStatus.Conditions, operatorv1.OperatorCondition{
 			Type:    operatorv1.OperatorStatusTypeAvailable,
 			Status:  operatorv1.ConditionFalse,
 			Reason:  "ZeroNodesActive",
-			Message: fmt.Sprintf("%d nodes are active; %d of %d nodes are at revision %d", numAvailable, numAtLatestRevision, len(newStatus.NodeStatuses), newStatus.LatestAvailableRevision),
+			Message: fmt.Sprintf("%d nodes are active; %s", numAvailable, revisionDescription),
 		})
 	}
 
@@ -358,14 +370,14 @@ func setAvailableProgressingConditions(newStatus *operatorv1.StaticPodOperatorSt
 		v1helpers.SetOperatorCondition(&newStatus.Conditions, operatorv1.OperatorCondition{
 			Type:    operatorv1.OperatorStatusTypeProgressing,
 			Status:  operatorv1.ConditionTrue,
-			Message: fmt.Sprintf("%d of %d nodes are at revision %d, %d are not", len(newStatus.NodeStatuses)-numProgressing, len(newStatus.NodeStatuses), newStatus.LatestAvailableRevision, numProgressing),
+			Message: fmt.Sprintf("%s", revisionDescription),
 		})
 	} else {
 		v1helpers.SetOperatorCondition(&newStatus.Conditions, operatorv1.OperatorCondition{
 			Type:    operatorv1.OperatorStatusTypeProgressing,
 			Status:  operatorv1.ConditionFalse,
 			Reason:  "AllNodesAtLatestRevision",
-			Message: fmt.Sprintf("%d nodes are at revision %d", len(newStatus.NodeStatuses), newStatus.LatestAvailableRevision),
+			Message: fmt.Sprintf("%s", revisionDescription),
 		})
 	}
 


### PR DESCRIPTION
Latest library-go bump doesn't appear to be producing new revisions.

Fixing the status here since we can have a current and a last failed.  Stilll debuging