### PR TITLE
Add mutex and trace profiles to serviceability, handle unique

### DIFF
--- a/pkg/serviceability/serviceability.go
+++ b/pkg/serviceability/serviceability.go
@@ -3,6 +3,7 @@ package serviceability
 import (
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"github.com/pkg/profile"
@@ -18,15 +19,26 @@ type stopper struct{}
 func (stopper) Stop() {}
 
 // Profile returns an interface to defer for a profile: `defer serviceability.Profile(os.Getenv("OPENSHIFT_PROFILE")).Stop()` is common.
+// Suffixing the mode with `-tmp` will have the profiler write the run to a temporary directory with a unique name, which
+// is useful when running the same command multiple times.
 func Profile(mode string) Stop {
+	path := "."
+	if strings.HasSuffix(mode, "-tmp") {
+		mode = strings.TrimSuffix(mode, "-tmp")
+		path = ""
+	}
 	var stop Stop
 	switch mode {
 	case "mem":
-		stop = profileOnExit(profile.Start(profile.MemProfile, profile.ProfilePath("."), profile.NoShutdownHook, profile.Quiet))
+		stop = profileOnExit(profile.Start(profile.MemProfile, profile.ProfilePath(path), profile.NoShutdownHook, profile.Quiet))
 	case "cpu":
-		stop = profileOnExit(profile.Start(profile.CPUProfile, profile.ProfilePath("."), profile.NoShutdownHook, profile.Quiet))
+		stop = profileOnExit(profile.Start(profile.CPUProfile, profile.ProfilePath(path), profile.NoShutdownHook, profile.Quiet))
 	case "block":
-		stop = profileOnExit(profile.Start(profile.BlockProfile, profile.ProfilePath("."), profile.NoShutdownHook, profile.Quiet))
+		stop = profileOnExit(profile.Start(profile.BlockProfile, profile.ProfilePath(path), profile.NoShutdownHook, profile.Quiet))
+	case "mutex":
+		stop = profileOnExit(profile.Start(profile.MutexProfile, profile.ProfilePath(path), profile.NoShutdownHook, profile.Quiet))
+	case "trace":
+		stop = profileOnExit(profile.Start(profile.TraceProfile, profile.ProfilePath(path), profile.NoShutdownHook, profile.Quiet))
 	default:
 		stop = stopper{}
 	}


### PR DESCRIPTION
The current behavior of writing the file to the current directory is convenient but doesn't allow parallel profiles to be gathered for things like `openshift-tests` which uses child processes, or
short lived commands that you want to profile in a loop.

Callers may now append `-tmp` to the mode and profiling will write to the temp directory which will create a `profile-RANDOM/mode.pprof` file that is unique across runs.