### PR TITLE
staticpod: set priority class and tolerations for installer pod

### DIFF
--- a/pkg/operator/staticpod/controller/installer/bindata/bindata.go
+++ b/pkg/operator/staticpod/controller/installer/bindata/bindata.go
@@ -74,6 +74,9 @@ spec:
         limits:
           memory: 100M
   restartPolicy: Never
+  priorityClassName: system-node-critical
+  tolerations:
+    - operator: "Exists"
   securityContext:
     runAsUser: 0
   volumes:

--- a/pkg/operator/staticpod/controller/installer/manifests/installer-pod.yaml
+++ b/pkg/operator/staticpod/controller/installer/manifests/installer-pod.yaml
@@ -27,6 +27,9 @@ spec:
         limits:
           memory: 100M
   restartPolicy: Never
+  priorityClassName: system-node-critical
+  tolerations:
+    - operator: "Exists"
   securityContext:
     runAsUser: 0
   volumes:


### PR DESCRIPTION
This PR sets the podPriorityClass to for the static pod installer pods as these pods should be scheduled first in all cases. AFAIK this does not guarantee the memory for them.

xref: https://github.com/openshift/library-go/issues/208
