### PR TITLE
add pruner pod ownerrefs for revision

### DIFF
--- a/pkg/operator/staticpod/controller/installer/installer_controller_test.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller_test.go
@@ -75,6 +75,9 @@ func TestNewNodeStateForInstallInProgress(t *testing.T) {
 		kubeClient,
 		eventRecorder,
 	)
+	c.ownerRefsFn = func(revision int32) ([]metav1.OwnerReference, error) {
+		return []metav1.OwnerReference{}, nil
+	}
 	c.installerPodImageFn = func() string { return "docker.io/foo/bar" }
 
 	t.Log("setting target revision")
@@ -285,6 +288,9 @@ func TestCreateInstallerPod(t *testing.T) {
 		kubeClient,
 		eventRecorder,
 	)
+	c.ownerRefsFn = func(revision int32) ([]metav1.OwnerReference, error) {
+		return []metav1.OwnerReference{}, nil
+	}
 	c.installerPodImageFn = func() string { return "docker.io/foo/bar" }
 	if err := c.sync(); err != nil {
 		t.Fatal(err)
@@ -450,7 +456,9 @@ func TestEnsureInstallerPod(t *testing.T) {
 				kubeClient,
 				eventRecorder,
 			)
-
+			c.ownerRefsFn = func(revision int32) ([]metav1.OwnerReference, error) {
+				return []metav1.OwnerReference{}, nil
+			}
 			err := c.ensureInstallerPod("test-node-1", nil, 1)
 			if err != nil {
 				if tt.expectedErr == "" {
@@ -709,6 +717,9 @@ func TestCreateInstallerPodMultiNode(t *testing.T) {
 				kubeClient,
 				eventRecorder,
 			)
+			c.ownerRefsFn = func(revision int32) ([]metav1.OwnerReference, error) {
+				return []metav1.OwnerReference{}, nil
+			}
 			c.installerPodImageFn = func() string { return "docker.io/foo/bar" }
 
 			// Each node need at least 2 syncs to first create the pod and then acknowledge its existence.

--- a/pkg/operator/staticpod/controller/prune/prune_controller.go
+++ b/pkg/operator/staticpod/controller/prune/prune_controller.go
@@ -39,6 +39,8 @@ type PruneController struct {
 
 	// prunerPodImageFn returns the image name for the pruning pod
 	prunerPodImageFn func() string
+	// ownerRefsFn sets the ownerrefs on the pruner pod
+	ownerRefsFn func(revision int32) ([]metav1.OwnerReference, error)
 
 	operatorConfigClient v1helpers.StaticPodOperatorClient
 
@@ -71,15 +73,17 @@ func NewPruneController(
 		command:           command,
 
 		operatorConfigClient: operatorConfigClient,
-		configMapGetter:      configMapGetter,
-		secretGetter:         secretGetter,
-		podGetter:            podGetter,
-		eventRecorder:        eventRecorder,
+
+		configMapGetter: configMapGetter,
+		secretGetter:    secretGetter,
+		podGetter:       podGetter,
+		eventRecorder:   eventRecorder,
 
 		queue:            workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "PruneController"),
 		prunerPodImageFn: getPrunerPodImageFromEnv,
 	}
 
+	c.ownerRefsFn = c.setOwnerRefs
 	operatorConfigClient.Informer().AddEventHandler(c.eventHandler())
 
 	return c
@@ -223,8 +227,28 @@ func (c *PruneController) ensurePrunePod(nodeName string, maxEligibleRevision in
 		fmt.Sprintf("--static-pod-name=%s", c.podResourcePrefix),
 	)
 
-	_, _, err := resourceapply.ApplyPod(c.podGetter, c.eventRecorder, pod)
+	ownerRefs, err := c.ownerRefsFn(revision)
+	if err != nil {
+		return fmt.Errorf("unable to set pruner pod ownerrefs: %+v", err)
+	}
+	pod.OwnerReferences = ownerRefs
+
+	_, _, err = resourceapply.ApplyPod(c.podGetter, c.eventRecorder, pod)
 	return err
+}
+
+func (c *PruneController) setOwnerRefs(revision int32) ([]metav1.OwnerReference, error) {
+	ownerReferences := []metav1.OwnerReference{}
+	statusConfigMap, err := c.configMapGetter.ConfigMaps(c.targetNamespace).Get(fmt.Sprintf("revision-status-%d", revision), metav1.GetOptions{})
+	if err == nil {
+		ownerReferences = append(ownerReferences, metav1.OwnerReference{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+			Name:       statusConfigMap.Name,
+			UID:        statusConfigMap.UID,
+		})
+	}
+	return ownerReferences, err
 }
 
 func getPrunerPodName(nodeName string, revision int32) string {

--- a/pkg/operator/staticpod/controller/prune/prune_controller_test.go
+++ b/pkg/operator/staticpod/controller/prune/prune_controller_test.go
@@ -224,6 +224,9 @@ func TestPruneAPIResources(t *testing.T) {
 			eventRecorder:        eventRecorder,
 			operatorConfigClient: fakeStaticPodOperatorClient,
 		}
+		c.ownerRefsFn = func(revision int32) ([]metav1.OwnerReference, error) {
+			return []metav1.OwnerReference{}, nil
+		}
 		c.prunerPodImageFn = func() string { return "docker.io/foo/bar" }
 
 		operatorSpec, _, _, err := c.operatorConfigClient.GetStaticPodOperatorState()
@@ -436,6 +439,9 @@ func TestPruneDiskResources(t *testing.T) {
 				podGetter:            kubeClient.CoreV1(),
 				eventRecorder:        eventRecorder,
 				operatorConfigClient: fakeStaticPodOperatorClient,
+			}
+			c.ownerRefsFn = func(revision int32) ([]metav1.OwnerReference, error) {
+				return []metav1.OwnerReference{}, nil
 			}
 			c.prunerPodImageFn = func() string { return "docker.io/foo/bar" }
 


### PR DESCRIPTION
sets ownerrefs for pruning pods for revision pruning (and refactors previously merged installerpod ownerrefs, see https://github.com/openshift/library-go/pull/211)