### PR TITLE
assets: add creater based on dynamic client

### DIFF
--- a/pkg/assets/create/OWNERS
+++ b/pkg/assets/create/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+  - mfojtik
+approvers:
+  - mfojtik

--- a/pkg/assets/create/create_test.go
+++ b/pkg/assets/create/create_test.go
@@ -1,0 +1,269 @@
+package create
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
+	ktesting "k8s.io/client-go/testing"
+
+	"github.com/openshift/library-go/pkg/assets"
+)
+
+func init() {
+	fetchLatestDiscoveryInfoFn = func(dc *discovery.DiscoveryClient) (meta.RESTMapper, error) {
+		resourcesForEnsureMutex.Lock()
+		defer resourcesForEnsureMutex.Unlock()
+		return restmapper.NewDiscoveryRESTMapper(resourcesForEnsure), nil
+	}
+	newClientsFn = func(config *rest.Config) (dynamic.Interface, *discovery.DiscoveryClient, error) {
+		fakeScheme := runtime.NewScheme()
+		// TODO: This is a workaround for dynamic fake client bug where the List kind is enforced and duplicated in object reactor.
+		fakeScheme.AddKnownTypeWithName(schema.GroupVersionKind{Version: "v1", Kind: "ListList"}, &unstructured.UnstructuredList{})
+		dynamicClient := dynamicfake.NewSimpleDynamicClient(fakeScheme)
+		return dynamicClient, nil, nil
+	}
+}
+
+var (
+	resources = []*restmapper.APIGroupResources{
+		{
+			Group: metav1.APIGroup{
+				Name: "kubeapiserver.operator.openshift.io",
+				Versions: []metav1.GroupVersionForDiscovery{
+					{Version: "v1alpha1"},
+				},
+				PreferredVersion: metav1.GroupVersionForDiscovery{Version: "v1alpha1"},
+			},
+			VersionedResources: map[string][]metav1.APIResource{
+				"v1alpha1": {
+					{Name: "kubeapiserveroperatorconfigs", Namespaced: false, Kind: "KubeAPIServerOperatorConfig"},
+				},
+			},
+		},
+		{
+			Group: metav1.APIGroup{
+				Name: "apiextensions.k8s.io",
+				Versions: []metav1.GroupVersionForDiscovery{
+					{Version: "v1beta1"},
+				},
+				PreferredVersion: metav1.GroupVersionForDiscovery{Version: "v1beta1"},
+			},
+			VersionedResources: map[string][]metav1.APIResource{
+				"v1beta1": {
+					{Name: "customresourcedefinitions", Namespaced: false, Kind: "CustomResourceDefinition"},
+				},
+			},
+		},
+		{
+			Group: metav1.APIGroup{
+				Name: "",
+				Versions: []metav1.GroupVersionForDiscovery{
+					{Version: "v1"},
+				},
+				PreferredVersion: metav1.GroupVersionForDiscovery{Version: "v1"},
+			},
+			VersionedResources: map[string][]metav1.APIResource{
+				"v1": {
+					{Name: "namespaces", Namespaced: false, Kind: "Namespace"},
+					{Name: "configmaps", Namespaced: true, Kind: "ConfigMap"},
+					{Name: "secrets", Namespaced: true, Kind: "Secret"},
+				},
+			},
+		},
+	}
+
+	// Copy this to not overlap with other tests if ran in parallel
+	resourcesForEnsure      = resources
+	resourcesForEnsureMutex sync.Mutex
+)
+
+func TestEnsureManifestsCreated(t *testing.T) {
+	// Success
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err := EnsureManifestsCreated(ctx, "testdata", nil, CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Missing discovery info for kubeapiserverconfig
+	out := &bytes.Buffer{}
+	operatorResource := resourcesForEnsure[0]
+	resourcesForEnsure = resourcesForEnsure[1:]
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	err = EnsureManifestsCreated(ctx, "testdata", nil, CreateOptions{Verbose: true, StdErr: out})
+	if err == nil {
+		t.Fatal("expected error creating kubeapiserverconfig resource, got none")
+	}
+	if !strings.Contains(out.String(), "unable to get REST mapping") {
+		t.Fatalf("expected error logged to output when verbose is on, got: %s\n", out.String())
+	}
+
+	// Should succeed on updated discovery info
+	go func() {
+		time.Sleep(2 * time.Second)
+		resourcesForEnsureMutex.Lock()
+		defer resourcesForEnsureMutex.Unlock()
+		resourcesForEnsure = append(resourcesForEnsure, operatorResource)
+	}()
+	out = &bytes.Buffer{}
+	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	err = EnsureManifestsCreated(ctx, "testdata", nil, CreateOptions{Verbose: true, StdErr: out})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `no matches for kind "KubeAPIServerOperatorConfig"`) {
+		t.Fatalf("expected error logged to output when verbose is on, got: %s\n", out.String())
+	}
+	if !strings.Contains(out.String(), `Creating kubeapiserver.operator.openshift.io/v1alpha1`) {
+		t.Fatalf("expected success logged to output when verbose is on, got: %s\n", out.String())
+	}
+}
+
+func TestCreate(t *testing.T) {
+	resourcesWithoutKubeAPIServer := resources[1:]
+	testConfigMap := &unstructured.Unstructured{}
+	testConfigMap.SetGroupVersionKind(schema.GroupVersionKind{
+		Version: "v1",
+		Kind:    "ConfigMap",
+	})
+	testConfigMap.SetName("aggregator-client-ca")
+	testConfigMap.SetNamespace("openshift-kube-apiserver")
+
+	tests := []struct {
+		name              string
+		discovery         []*restmapper.APIGroupResources
+		expectError       bool
+		expectFailedCount int
+		expectReload      bool
+		existingObjects   []runtime.Object
+		evalActions       func(*testing.T, []ktesting.Action)
+	}{
+		{
+			name:      "create all resources",
+			discovery: resources,
+		},
+		{
+			name:              "fail to create kube apiserver operator config",
+			discovery:         resourcesWithoutKubeAPIServer,
+			expectFailedCount: 1,
+			expectError:       true,
+			expectReload:      true,
+		},
+		{
+			name:            "create all resources",
+			discovery:       resources,
+			existingObjects: []runtime.Object{testConfigMap},
+		},
+	}
+
+	fakeScheme := runtime.NewScheme()
+	// TODO: This is a workaround for dynamic fake client bug where the List kind is enforced and duplicated in object reactor.
+	fakeScheme.AddKnownTypeWithName(schema.GroupVersionKind{Version: "v1", Kind: "ListList"}, &unstructured.UnstructuredList{})
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			manifests, err := load("testdata", CreateOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			dynamicClient := dynamicfake.NewSimpleDynamicClient(fakeScheme, tc.existingObjects...)
+			restMapper := restmapper.NewDiscoveryRESTMapper(tc.discovery)
+
+			err, reload := create(manifests, dynamicClient, restMapper, CreateOptions{Verbose: true, StdErr: os.Stderr})
+			if tc.expectError && err == nil {
+				t.Errorf("expected error, got no error")
+				return
+			}
+			if !tc.expectError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			if tc.expectReload && !reload {
+				t.Errorf("expected reload, got none")
+				return
+			}
+			if !tc.expectReload && reload {
+				t.Errorf("unexpected reload, got one")
+				return
+			}
+			if len(manifests) != tc.expectFailedCount {
+				t.Errorf("expected %d failed manifests, got %d", tc.expectFailedCount, len(manifests))
+				return
+			}
+			if tc.evalActions != nil {
+				tc.evalActions(t, dynamicClient.Actions())
+			}
+		})
+
+	}
+}
+
+func TestLoad(t *testing.T) {
+	tests := []struct {
+		name                  string
+		options               CreateOptions
+		assetDir              string
+		expectedManifestCount int
+		expectError           bool
+	}{
+		{
+			name:                  "read all manifests",
+			assetDir:              "testdata",
+			expectedManifestCount: 5,
+		},
+		{
+			name:        "handle missing dir",
+			assetDir:    "foo",
+			expectError: true,
+		},
+		{
+			name: "read only 00_ prefixed files",
+			options: CreateOptions{
+				Filters: []assets.FileInfoPredicate{
+					func(info os.FileInfo) bool {
+						return strings.HasPrefix(info.Name(), "00")
+					},
+				},
+			},
+			assetDir:              "testdata",
+			expectedManifestCount: 2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := load(tc.assetDir, tc.options)
+			if tc.expectError && err == nil {
+				t.Errorf("expected error, got no error")
+				return
+			}
+			if !tc.expectError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			if len(result) != tc.expectedManifestCount {
+				t.Errorf("expected %d manifests loaded, got %d", tc.expectedManifestCount, len(result))
+				return
+			}
+		})
+	}
+}

--- a/pkg/assets/create/creater.go
+++ b/pkg/assets/create/creater.go
@@ -1,0 +1,224 @@
+package create
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/ghodss/yaml"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
+
+	"github.com/openshift/library-go/pkg/assets"
+)
+
+// CreateOptions allow to specify additional create options.
+type CreateOptions struct {
+	// Filters allows to filter which files we will read from disk.
+	// Multiple filters can be specified, in that case only files matching all filters will be returned.
+	Filters []assets.FileInfoPredicate
+
+	// Verbose if true will print out extra messages for debugging
+	Verbose bool
+
+	// StdErr allows to override the standard error output for printing verbose messages.
+	// If not set, os.StdErr is used.
+	StdErr io.Writer
+}
+
+// EnsureManifestsCreated ensures that all resource manifests from the specified directory are created.
+// This function will keep retrying creation until no errors are reported.
+// Pass the context to indicate how much time you are willing to wait until all resources are created.
+func EnsureManifestsCreated(ctx context.Context, manifestDir string, restConfig *rest.Config, options CreateOptions) error {
+	client, dc, err := newClientsFn(restConfig)
+	if err != nil {
+		return err
+	}
+
+	manifests, err := load(manifestDir, options)
+	if err != nil {
+		return err
+	}
+
+	if options.Verbose && options.StdErr == nil {
+		options.StdErr = os.Stderr
+	}
+
+	// Default QPS in client (when not specified) is 5 requests/per second
+	// This specifies the interval between "create-all-resources", no need to make this configurable.
+	interval := 200 * time.Millisecond
+
+	// Retry creation until no errors are returned or the timeout is hit.
+	var (
+		lastCreateError      error
+		retryCount           int
+		mapper               meta.RESTMapper
+		needDiscoveryRefresh bool = true
+	)
+	err = wait.PollImmediateUntil(interval, func() (bool, error) {
+		retryCount++
+		// If we get rest mapper error, we need to pull updated discovery info from API server
+		if needDiscoveryRefresh {
+			mapper, err = fetchLatestDiscoveryInfoFn(dc)
+			if err != nil {
+				return false, err
+			}
+		}
+		lastCreateError, needDiscoveryRefresh = create(manifests, client, mapper, options)
+		if lastCreateError == nil {
+			return true, nil
+		}
+		if options.Verbose {
+			fmt.Fprintf(options.StdErr, "[#%d] %s\n", retryCount, lastCreateError)
+		}
+		return false, nil
+	}, ctx.Done())
+
+	// Return the last observed set of errors from the create process instead of timeout error.
+	if lastCreateError != nil {
+		return lastCreateError
+	}
+
+	return err
+}
+
+// allow to override in unit test
+var newClientsFn = newClients
+
+func newClients(config *rest.Config) (dynamic.Interface, *discovery.DiscoveryClient, error) {
+	client, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: We can use cacheddiscovery.NewMemCacheClient(dc) and then call .Invalidate() instead of fetchLatestDiscoveryInfo.
+	// It will require more work in unit test though.
+	dc, err := discovery.NewDiscoveryClientForConfig(config)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return client, dc, nil
+}
+
+// allow to override in unit test
+var fetchLatestDiscoveryInfoFn = fetchLatestDiscoveryInfo
+
+func fetchLatestDiscoveryInfo(dc *discovery.DiscoveryClient) (meta.RESTMapper, error) {
+	gr, err := restmapper.GetAPIGroupResources(dc)
+	if err != nil {
+		return nil, err
+	}
+	return restmapper.NewDiscoveryRESTMapper(gr), nil
+}
+
+func create(manifests map[string]*unstructured.Unstructured, client dynamic.Interface, mapper meta.RESTMapper, options CreateOptions) (error, bool) {
+	// Sort all manifests, so in case they use number prefixes, we follow their order, which will increase
+	// the chances for the create loop to succeed faster.
+	sortedManifestPaths := []string{}
+	for key := range manifests {
+		sortedManifestPaths = append(sortedManifestPaths, key)
+	}
+	sort.Strings(sortedManifestPaths)
+
+	// Record all errors for the given manifest path (so when we report errors, users can see what manifest failed).
+	errs := map[string]error{}
+
+	// In case we fail to find a rest-mapping for the resource, force to fetch the updated discovery on next run.
+	reloadDiscovery := false
+
+	for _, path := range sortedManifestPaths {
+		gvk := manifests[path].GetObjectKind().GroupVersionKind()
+		mappings, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+		if err != nil {
+			errs[path] = fmt.Errorf("unable to get REST mapping: %v", err)
+			reloadDiscovery = true
+			continue
+		}
+
+		if options.Verbose {
+			fmt.Fprintf(options.StdErr, "Creating %s ...\n", mappings.Resource.String())
+		}
+		if mappings.Scope.Name() == meta.RESTScopeNameRoot {
+			_, err = client.Resource(mappings.Resource).Create(manifests[path], metav1.CreateOptions{})
+		} else {
+			_, err = client.Resource(mappings.Resource).Namespace(manifests[path].GetNamespace()).Create(manifests[path], metav1.CreateOptions{})
+		}
+
+		// Resource already exists means we already succeeded
+		// This should never happen as we remove already created items from the manifest list, unless the resource existed beforehand.
+		if kerrors.IsAlreadyExists(err) {
+			delete(manifests, path)
+			continue
+		}
+
+		if err != nil {
+			errs[path] = fmt.Errorf("failed to create: %v", err)
+			continue
+		}
+
+		// Creation succeeded lets remove the manifest from the list to avoid creating it second time
+		delete(manifests, path)
+	}
+
+	return formatErrors("failed to create some manifests", errs), reloadDiscovery
+}
+
+func formatErrors(prefix string, errors map[string]error) error {
+	if len(errors) == 0 {
+		return nil
+	}
+	aggregatedErrMessages := []string{}
+	keys := []string{}
+	for key := range errors {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		aggregatedErrMessages = append(aggregatedErrMessages, fmt.Sprintf("%q: %v", k, errors[k]))
+	}
+	return fmt.Errorf("%s:\n%s", prefix, strings.Join(aggregatedErrMessages, "\n"))
+}
+
+func load(assetsDir string, options CreateOptions) (map[string]*unstructured.Unstructured, error) {
+	manifests := map[string]*unstructured.Unstructured{}
+	manifestsBytesMap, err := assets.LoadFilesRecursively(assetsDir, options.Filters...)
+	if err != nil {
+		return nil, err
+	}
+
+	errs := map[string]error{}
+	for manifestPath, manifestBytes := range manifestsBytesMap {
+		manifestJSON, err := yaml.YAMLToJSON(manifestBytes)
+		if err != nil {
+			errs[manifestPath] = fmt.Errorf("unable to convert asset %q from YAML to JSON: %v", manifestPath, err)
+			continue
+		}
+		manifestObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, manifestJSON)
+		if err != nil {
+			errs[manifestPath] = fmt.Errorf("unable to decode asset %q: %v", manifestPath, err)
+			continue
+		}
+		manifestUnstructured, ok := manifestObj.(*unstructured.Unstructured)
+		if !ok {
+			errs[manifestPath] = fmt.Errorf("unable to convert asset %q to unstructed", manifestPath)
+			continue
+		}
+		manifests[manifestPath] = manifestUnstructured
+	}
+
+	return manifests, formatErrors("failed to load some manifests", errs)
+}

--- a/pkg/assets/create/testdata/0000_10_kube-apiserver-operator_01_config.crd.yaml
+++ b/pkg/assets/create/testdata/0000_10_kube-apiserver-operator_01_config.crd.yaml
@@ -1,0 +1,16 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kubeapiserveroperatorconfigs.kubeapiserver.operator.openshift.io
+spec:
+  scope: Cluster
+  group: kubeapiserver.operator.openshift.io
+  version: v1alpha1
+  names:
+    kind: KubeAPIServerOperatorConfig
+    plural: kubeapiserveroperatorconfigs
+    singular: kubeapiserveroperatorconfig
+    categories:
+    - coreoperators
+  subresources:
+    status: {}

--- a/pkg/assets/create/testdata/00_openshift-kube-apiserver-ns.yaml
+++ b/pkg/assets/create/testdata/00_openshift-kube-apiserver-ns.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-kube-apiserver
+  labels:
+    openshift.io/run-level: "0"

--- a/pkg/assets/create/testdata/configmap-aggregator-client-ca.yaml
+++ b/pkg/assets/create/testdata/configmap-aggregator-client-ca.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aggregator-client-ca
+  namespace: openshift-kube-apiserver
+data:
+  ca-bundle.crt:

--- a/pkg/assets/create/testdata/operator-config.yaml
+++ b/pkg/assets/create/testdata/operator-config.yaml
@@ -1,0 +1,6 @@
+apiVersion: kubeapiserver.operator.openshift.io/v1alpha1
+kind: KubeAPIServerOperatorConfig
+metadata:
+  name: instance
+spec:
+  managementState: Managed

--- a/pkg/assets/create/testdata/secret-aggregator-client.yaml
+++ b/pkg/assets/create/testdata/secret-aggregator-client.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aggregator-client
+  namespace: openshift-kube-apiserver
+type: SecretTypeTLS
+data:


### PR DESCRIPTION
This PR add `pkg/assets/create` package that contain helper to create multiple resources from disk and wait for them to be created.

The rationale here is to move this create and wait logic away from [cluster-bootstrap](https://github.com/openshift/cluster-bootstrap/pull/7) (former bootkube) and make it available for multiple components as needed.