### PR TITLE
status: print exact message to logs when status not found

### DIFF
--- a/pkg/operator/status/status_controller.go
+++ b/pkg/operator/status/status_controller.go
@@ -80,7 +80,7 @@ func NewClusterOperatorStatusController(
 func (c StatusSyncer) sync() error {
 	_, currentDetailedStatus, _, err := c.operatorClient.GetOperatorState()
 	if apierrors.IsNotFound(err) {
-		glog.Infof("operator.status not found")
+		glog.Infof("operator.status not found: %v", err)
 		c.eventRecorder.Warningf("StatusNotFound", "Unable to determine current operator status for %s", c.clusterOperatorName)
 		return c.clusterOperatorClient.ClusterOperators().Delete(c.clusterOperatorName, nil)
 	}


### PR DESCRIPTION
```
2019-02-05 07:38:53 +0100 CET  SignerUpdateRequired         "managed-kube-apiserver-serving-cert-signer" in "openshift-kube-apiserver-operator" requires a new signing cert/key pair
2019-02-05 07:38:53 +0100 CET  StatusNotFound               Unable to determine current operator status for kube-apiserver
2019-02-05 07:38:53 +0100 CET  OperatorStatusChanged        Status for operator kube-apiserver changed: Failing set to False (""),status.relatedObjects changed from [] to [{"operator.openshift.io" "kubeapiservers" "" "cluster"} {"" "namespaces" "" "openshift-config"} {"" "namespaces" "" "openshift-config-managed"} {"" "namespaces" "" "openshift-kube-apiserver-operator"} {"" "namespaces" "" "openshift-kube-apiserver"}]

// 2 minutes ago:

2019-02-05 07:40:37 +0100 CET  StatusNotFound               Unable to determine current operator status for kube-apiserver
```

We want to print the exact error message to logs to rule out resource not found vs. not found. 