### PR TITLE
pkg/assets/create: Allow mid-create cancels

### DIFF
--- a/pkg/assets/create/create_test.go
+++ b/pkg/assets/create/create_test.go
@@ -138,6 +138,8 @@ func TestEnsureManifestsCreated(t *testing.T) {
 }
 
 func TestCreate(t *testing.T) {
+	ctx := context.Background()
+
 	resourcesWithoutKubeAPIServer := resources[1:]
 	testConfigMap := &unstructured.Unstructured{}
 	testConfigMap.SetGroupVersionKind(schema.GroupVersionKind{
@@ -188,7 +190,7 @@ func TestCreate(t *testing.T) {
 			dynamicClient := dynamicfake.NewSimpleDynamicClient(fakeScheme, tc.existingObjects...)
 			restMapper := restmapper.NewDiscoveryRESTMapper(tc.discovery)
 
-			err, reload := create(manifests, dynamicClient, restMapper, CreateOptions{Verbose: true, StdErr: os.Stderr})
+			err, reload := create(ctx, manifests, dynamicClient, restMapper, CreateOptions{Verbose: true, StdErr: os.Stderr})
 			if tc.expectError && err == nil {
 				t.Errorf("expected error, got no error")
 				return


### PR DESCRIPTION
As mentioned in the `interval` comment I'm removing, the REST client configuration includes its own requests-per-second configuration. There's no need for an additional 200ms sleep between loops on top of that.

I'm also passing the context into `create()` so we can cancel without waiting for all of the manifests to be attempted.  At the default 5 requests per second, the installer's 30+ manifests would take 6+ seconds in the "negligable network time" best-case, and we can be more responsive to cancels than that.

I've also shifted `retryCount` into the `for` loop, because that's where I'm used to seeing iteration counters.  And I've dropped logging on returned errors, because the caller will have the error and can make
that logging decision itself.  Logging should be reserved for internal progress updates, discarded errors, and other activity which the caller cannot access.

CC @mfojtik, @sttts