### PR TITLE
installerpod: fix retry handling and report events

### DIFF
--- a/pkg/operator/staticpod/controller/installer/bindata/bindata.go
+++ b/pkg/operator/staticpod/controller/installer/bindata/bindata.go
@@ -64,6 +64,11 @@ spec:
       securityContext:
         privileged: true
         runAsUser: 0
+      env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
       terminationMessagePolicy: FallbackToLogsOnError
       volumeMounts:
         - mountPath: /etc/kubernetes/

--- a/pkg/operator/staticpod/controller/installer/manifests/installer-pod.yaml
+++ b/pkg/operator/staticpod/controller/installer/manifests/installer-pod.yaml
@@ -17,6 +17,11 @@ spec:
       securityContext:
         privileged: true
         runAsUser: 0
+      env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
       terminationMessagePolicy: FallbackToLogsOnError
       volumeMounts:
         - mountPath: /etc/kubernetes/

--- a/pkg/operator/staticpod/installerpod/cmd.go
+++ b/pkg/operator/staticpod/installerpod/cmd.go
@@ -1,6 +1,7 @@
 package installerpod
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/ghodss/yaml"
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -16,10 +18,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/openshift/library-go/pkg/config/client"
+	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
 )
 
@@ -39,6 +45,9 @@ type InstallOptions struct {
 
 	ResourceDir    string
 	PodManifestDir string
+
+	Timeout  time.Duration
+	NodeName string
 
 	PodMutationFns []PodMutationFunc
 }
@@ -71,7 +80,10 @@ func NewInstaller() *cobra.Command {
 			if err := o.Validate(); err != nil {
 				glog.Fatal(err)
 			}
-			if err := o.Run(); err != nil {
+
+			ctx, cancel := context.WithTimeout(context.TODO(), time.Duration(o.Timeout)*time.Second)
+			defer cancel()
+			if err := o.Run(ctx); err != nil {
 				glog.Fatal(err)
 			}
 		},
@@ -93,6 +105,7 @@ func (o *InstallOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringSliceVar(&o.OptionalConfigMapNamePrefixes, "optional-configmaps", o.OptionalConfigMapNamePrefixes, "list of optional configmaps to be included")
 	fs.StringVar(&o.ResourceDir, "resource-dir", o.ResourceDir, "directory for all files supporting the static pod manifest")
 	fs.StringVar(&o.PodManifestDir, "pod-manifest-dir", o.PodManifestDir, "directory for the static pod manifest")
+	fs.DurationVar(&o.Timeout, "timeout-duration", 120*time.Second, "maximum time in seconds to wait for the copying to complete (default: 2m)")
 }
 
 func (o *InstallOptions) Complete() error {
@@ -120,6 +133,9 @@ func (o *InstallOptions) Validate() error {
 	if len(o.ConfigMapNamePrefixes) == 0 {
 		return fmt.Errorf("--configmaps is required")
 	}
+	if o.Timeout == 0 {
+		return fmt.Errorf("--timeout-duration cannot be 0")
+	}
 
 	if o.KubeClient == nil {
 		return fmt.Errorf("missing client")
@@ -136,116 +152,157 @@ func (o *InstallOptions) prefixFor(name string) string {
 	return name[0 : len(name)-len(fmt.Sprintf("-%s", o.Revision))]
 }
 
-func (o *InstallOptions) copyContent() error {
-	// gather all secrets
+func (o *InstallOptions) copyContent(ctx context.Context) error {
+	secretPrefixes := sets.NewString(o.SecretNamePrefixes...)
+	optionalSecretPrefixes := sets.NewString(o.OptionalSecretNamePrefixes...)
+	configPrefixes := sets.NewString(o.ConfigMapNamePrefixes...)
+	optionalConfigPrefixes := sets.NewString(o.OptionalConfigMapNamePrefixes...)
+
+	// Gather secrets. If we get API server error, retry getting until we hit the timeout.
+	// Retrying will prevent temporary API server blips or networking issues.
+	// We return when all "required" secrets are gathered, optional secrets are not checked.
 	secrets := []*corev1.Secret{}
-	for _, currPrefix := range o.SecretNamePrefixes {
-		glog.Infof("getting secrets/%s -n %s", o.nameFor(currPrefix), o.Namespace)
-		val, err := o.KubeClient.CoreV1().Secrets(o.Namespace).Get(o.nameFor(currPrefix), metav1.GetOptions{})
-		if err != nil {
-			return err
+	err := utilwait.PollImmediateUntil(200*time.Millisecond, func() (bool, error) {
+		for _, prefix := range append(secretPrefixes.List(), optionalSecretPrefixes.List()...) {
+			secret, err := o.KubeClient.CoreV1().Secrets(o.Namespace).Get(o.nameFor(prefix), metav1.GetOptions{})
+			// When we encounter not found for required secret, return immediately
+			if errors.IsNotFound(err) {
+				if optionalSecretPrefixes.Has(prefix) {
+					optionalSecretPrefixes.Delete(prefix)
+					continue
+				}
+				return false, err
+			}
+			if err != nil {
+				glog.Infof("Failed to get secret %s/%s: %v", o.Namespace, o.nameFor(prefix), err)
+				return false, nil
+			}
+			optionalConfigPrefixes.Delete(prefix)
+			secretPrefixes.Delete(prefix)
+			secrets = append(secrets, secret)
 		}
-		secrets = append(secrets, val)
-	}
-	for _, currPrefix := range o.OptionalSecretNamePrefixes {
-		glog.Infof("getting optional secrets/%s -n %s", o.nameFor(currPrefix), o.Namespace)
-		val, err := o.KubeClient.CoreV1().Secrets(o.Namespace).Get(o.nameFor(currPrefix), metav1.GetOptions{})
-		if errors.IsNotFound(err) {
-			glog.Infof("missing optional secrets/%s -n %s", o.nameFor(currPrefix), o.Namespace)
-			continue
-		}
-		if err != nil {
-			return err
-		}
-		secrets = append(secrets, val)
-	}
 
-	// gather all configmaps
-	configmaps := []*corev1.ConfigMap{}
-	for _, currPrefix := range o.ConfigMapNamePrefixes {
-		glog.Infof("getting configmaps/%s -n %s", o.nameFor(currPrefix), o.Namespace)
-		val, err := o.KubeClient.CoreV1().ConfigMaps(o.Namespace).Get(o.nameFor(currPrefix), metav1.GetOptions{})
-		if err != nil {
-			return err
-		}
-		configmaps = append(configmaps, val)
-	}
-	for _, currPrefix := range o.OptionalConfigMapNamePrefixes {
-		glog.Infof("getting optional configmaps/%s -n %s", o.nameFor(currPrefix), o.Namespace)
-		val, err := o.KubeClient.CoreV1().ConfigMaps(o.Namespace).Get(o.nameFor(currPrefix), metav1.GetOptions{})
-		if errors.IsNotFound(err) {
-			glog.Infof("missing optional configmaps/%s -n %s", o.nameFor(currPrefix), o.Namespace)
-			continue
-		}
-		if err != nil {
-			return err
-		}
-		configmaps = append(configmaps, val)
-	}
-
-	// gather pod
-	glog.Infof("getting pod configmaps/%s -n %s", o.nameFor(o.PodConfigMapNamePrefix), o.Namespace)
-	podConfigMap, err := o.KubeClient.CoreV1().ConfigMaps(o.Namespace).Get(o.nameFor(o.PodConfigMapNamePrefix), metav1.GetOptions{})
+		// Exit when all required secrets are gathered
+		return secretPrefixes.Len() == 0, nil
+	}, ctx.Done())
 	if err != nil {
 		return err
 	}
-	podContent := podConfigMap.Data["pod.yaml"]
-	podContent = strings.Replace(podContent, "REVISION", o.Revision, -1)
 
-	// write secrets, configmaps, static pods
+	// Gather all config maps
+	configs := []*corev1.ConfigMap{}
+	err = utilwait.PollImmediateUntil(200*time.Millisecond, func() (bool, error) {
+		for _, prefix := range append(configPrefixes.List(), optionalConfigPrefixes.List()...) {
+			config, err := o.KubeClient.CoreV1().ConfigMaps(o.Namespace).Get(o.nameFor(prefix), metav1.GetOptions{})
+			// When we encounter not found for required secret, return immediately
+			if errors.IsNotFound(err) {
+				if optionalConfigPrefixes.Has(prefix) {
+					optionalConfigPrefixes.Delete(prefix)
+					continue
+				}
+				return false, err
+			}
+			if err != nil {
+				glog.Infof("Failed to get config map %s/%s: %v", o.Namespace, o.nameFor(prefix), err)
+				return false, nil
+			}
+			optionalConfigPrefixes.Delete(prefix)
+			configPrefixes.Delete(prefix)
+			configs = append(configs, config)
+		}
+
+		// Exit when all required config maps are gathered
+		return configPrefixes.Len() == 0, nil
+	}, ctx.Done())
+	if err != nil {
+		return err
+	}
+
+	// Gather pod yaml from config map
+	var podContent string
+	err = utilwait.PollImmediateUntil(200*time.Millisecond, func() (bool, error) {
+		glog.Infof("Getting pod configmaps/%s -n %s", o.nameFor(o.PodConfigMapNamePrefix), o.Namespace)
+		podConfigMap, err := o.KubeClient.CoreV1().ConfigMaps(o.Namespace).Get(o.nameFor(o.PodConfigMapNamePrefix), metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			return false, err
+		}
+		if err != nil {
+			glog.Infof("Failed to get pod %s/%s: %v", o.Namespace, o.nameFor(o.PodConfigMapNamePrefix), err)
+			return false, nil
+		}
+		podData, exists := podConfigMap.Data["pod.yaml"]
+		if !exists {
+			return false, fmt.Errorf("required 'pod.yaml' key does not exist in configmap")
+		}
+		podContent = strings.Replace(podData, "REVISION", o.Revision, -1)
+		return true, nil
+	}, ctx.Done())
+	if err != nil {
+		return err
+	}
+
+	// Write secrets, config maps and pod to disk
+	// This does not need timeout, instead we should fail hard when we are not able to write.
 	resourceDir := path.Join(o.ResourceDir, o.nameFor(o.PodConfigMapNamePrefix))
-	glog.Infof("creating dir %q", resourceDir)
+	glog.Infof("Creating target resource directory %q ...", resourceDir)
 	if err := os.MkdirAll(resourceDir, 0755); err != nil {
 		return err
 	}
 	for _, secret := range secrets {
 		contentDir := path.Join(resourceDir, "secrets", o.prefixFor(secret.Name))
-		glog.Infof("creating dir %q", contentDir)
+		glog.Infof("Creating directory %q ...", contentDir)
 		if err := os.MkdirAll(contentDir, 0755); err != nil {
 			return err
 		}
 		for filename, content := range secret.Data {
 			// TODO fix permissions
-			glog.Infof("writing secret file %q", path.Join(contentDir, filename))
+			glog.Infof("Writing secret manifest %q ...", path.Join(contentDir, filename))
 			if err := ioutil.WriteFile(path.Join(contentDir, filename), content, 0644); err != nil {
 				return err
 			}
 		}
 	}
-	for _, configmap := range configmaps {
+	for _, configmap := range configs {
 		contentDir := path.Join(resourceDir, "configmaps", o.prefixFor(configmap.Name))
-		glog.Infof("creating dir %q", contentDir)
+		glog.Infof("Creating directory %q ...", contentDir)
 		if err := os.MkdirAll(contentDir, 0755); err != nil {
 			return err
 		}
 		for filename, content := range configmap.Data {
-			glog.Infof("writing configmap file %q", path.Join(contentDir, filename))
+			glog.Infof("Writing config file %q ...", path.Join(contentDir, filename))
 			if err := ioutil.WriteFile(path.Join(contentDir, filename), []byte(content), 0644); err != nil {
 				return err
 			}
 		}
 	}
+
 	podFileName := o.PodConfigMapNamePrefix + ".yaml"
+	glog.Infof("Writing pod manifest %q ...", path.Join(resourceDir, podFileName))
 	if err := ioutil.WriteFile(path.Join(resourceDir, podFileName), []byte(podContent), 0644); err != nil {
 		return err
 	}
 
 	// copy static pod
-	glog.Infof("creating dir %q", o.PodManifestDir)
+	glog.Infof("Creating directory for static pod manifest %q ...", o.PodManifestDir)
 	if err := os.MkdirAll(o.PodManifestDir, 0755); err != nil {
 		return err
 	}
 
 	for _, fn := range o.PodMutationFns {
-		glog.V(2).Infof("customizing static pod")
+		glog.V(2).Infof("Customizing static pod ...")
 		pod := resourceread.ReadPodV1OrDie([]byte(podContent))
 		if err := fn(pod); err != nil {
 			return err
 		}
 		podContent = resourceread.WritePodV1OrDie(pod)
 	}
-	glog.Infof("writing static pod %q", path.Join(o.PodManifestDir, podFileName))
-	glog.Infof("writing static pod\n%s", podContent)
+
+	o.NodeName, err = getPodNodeName([]byte(podContent))
+	if err != nil {
+		return fmt.Errorf("failed to get pod node name: %v", err)
+	}
+
+	glog.Infof("Writing static pod manifest %q ...\n%s", path.Join(o.PodManifestDir, podFileName), podContent)
 	if err := ioutil.WriteFile(path.Join(o.PodManifestDir, podFileName), []byte(podContent), 0644); err != nil {
 		return err
 	}
@@ -253,27 +310,34 @@ func (o *InstallOptions) copyContent() error {
 	return nil
 }
 
-func (o *InstallOptions) Run() error {
-	// ~2 min total waiting
-	backoff := utilwait.Backoff{
-		Duration: time.Second,
-		Factor:   1.5,
-		Steps:    11,
-	}
-	attempts := 0
-	err := utilwait.ExponentialBackoff(backoff, func() (bool, error) {
-		attempts += 1
-		if copyErr := o.copyContent(); copyErr != nil {
-			fmt.Fprintf(os.Stderr, "#%d: failed to copy content: %v", attempts, copyErr)
-			return false, nil
-		}
-		return true, nil
-	})
+func getPodNodeName(podBytes []byte) (string, error) {
+	podJSONBytes, err := yaml.YAMLToJSON(podBytes)
 	if err != nil {
-		return fmt.Errorf("error: %v", err)
+		return "", err
+	}
+	unstructuredPodObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, podJSONBytes)
+	if err != nil {
+		return "", err
+	}
+	nodeName, found, err := unstructured.NestedString(unstructuredPodObj.(*unstructured.Unstructured).Object, "spec", "nodeName")
+	if !found {
+		nodeName = "<unknown>"
+	}
+	return nodeName, err
+}
+
+func (o *InstallOptions) Run(ctx context.Context) error {
+	eventTarget, err := events.GetControllerReferenceForCurrentPod(o.KubeClient, o.Namespace, nil)
+	if err != nil {
+		return err
 	}
 
-	// TODO wait for healthy pod status
+	recorder := events.NewRecorder(o.KubeClient.CoreV1().Events(o.Namespace), "static-pod-installer", eventTarget)
+	if err := o.copyContent(ctx); err != nil {
+		recorder.Warningf("StaticPodInstallerFailed", "Installing revision %s on node %q in namespace %q failed: %v", o.Revision, o.NodeName, o.Namespace, err)
+		return fmt.Errorf("failed to copy: %v", err)
+	}
 
+	recorder.Eventf("StaticPodInstallerCompleted", "Successfully installed revision %s on node %q in namespace %q", o.Revision, o.NodeName, o.Namespace)
 	return nil
 }


### PR DESCRIPTION
* Fix the retry logic to only retry failed gets from API server
* Use `context.Context` to handle timeout
* Report events back to API server (success/failure) (it seems like the ownerRefs for the installer pod is the ConfigMap so the events will be recorded for that object... but at least we get something ;-)
