### PR TITLE
target signers should be signed by the original signer

### DIFF
--- a/pkg/controller/controllercmd/cmd.go
+++ b/pkg/controller/controllercmd/cmd.go
@@ -130,7 +130,7 @@ func (c *ControllerCommandConfig) StartController(ctx context.Context) error {
 				return err
 			}
 			signerName := fmt.Sprintf("%s-signer@%d", c.componentName, time.Now().Unix())
-			ca, err := crypto.MakeCA(
+			ca, err := crypto.MakeSelfSignedCA(
 				filepath.Join(temporaryCertDir, "serving-signer.crt"),
 				filepath.Join(temporaryCertDir, "serving-signer.key"),
 				filepath.Join(temporaryCertDir, "serving-signer.serial"),

--- a/pkg/operator/certrotation/signer.go
+++ b/pkg/operator/certrotation/signer.go
@@ -75,7 +75,7 @@ func needNewSigningCertKeyPair(annotations map[string]string, validity time.Dura
 // setSigningCertKeyPairSecret creates a new signing cert/key pair and sets them in the secret
 func setSigningCertKeyPairSecret(signingCertKeyPairSecret *corev1.Secret, validity time.Duration) error {
 	signerName := fmt.Sprintf("%s_%s@%d", signingCertKeyPairSecret.Namespace, signingCertKeyPairSecret.Name, time.Now().Unix())
-	ca, err := crypto.MakeCAConfigForDuration(signerName, validity)
+	ca, err := crypto.MakeSelfSignedCAConfigForDuration(signerName, validity)
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/certrotation/target.go
+++ b/pkg/operator/certrotation/target.go
@@ -202,7 +202,7 @@ func setTargetCertKeyPairSecret(targetCertKeyPairSecret *corev1.Secret, validity
 
 	case signerRotation != nil:
 		signerName := fmt.Sprintf("%s_@%d", signerRotation.SignerName, time.Now().Unix())
-		certKeyPair, err = crypto.MakeCAConfigForDuration(signerName, validity)
+		certKeyPair, err = crypto.MakeCAConfigForDuration(signerName, validity, signer)
 	}
 	if err != nil {
 		return err

--- a/pkg/operator/certrotation/target_test.go
+++ b/pkg/operator/certrotation/target_test.go
@@ -207,3 +207,135 @@ func TestEnsureTargetCertKeyPair(t *testing.T) {
 		})
 	}
 }
+
+func TestEnsureTargetSignerCertKeyPair(t *testing.T) {
+	tests := []struct {
+		name string
+
+		initialSecretFn func() *corev1.Secret
+		caFn            func() (*crypto.CA, error)
+
+		verifyActions func(t *testing.T, client *kubefake.Clientset)
+		expectedError string
+	}{
+		{
+			name: "initial create",
+			caFn: func() (*crypto.CA, error) {
+				return newTestCACertificate(pkix.Name{CommonName: "signer-tests"}, int64(1), metav1.Duration{Duration: time.Hour * 24 * 60}, time.Now)
+			},
+			initialSecretFn: func() *corev1.Secret { return nil },
+			verifyActions: func(t *testing.T, client *kubefake.Clientset) {
+				actions := client.Actions()
+				if len(actions) != 2 {
+					t.Fatal(spew.Sdump(actions))
+				}
+
+				if !actions[0].Matches("update", "secrets") {
+					t.Error(actions[0])
+				}
+				if !actions[1].Matches("create", "secrets") {
+					t.Error(actions[1])
+				}
+
+				actual := actions[1].(clienttesting.CreateAction).GetObject().(*corev1.Secret)
+				if len(actual.Data["tls.crt"]) == 0 || len(actual.Data["tls.key"]) == 0 {
+					t.Error(actual.Data)
+				}
+
+				signingCertKeyPair, err := crypto.GetCAFromBytes(actual.Data["tls.crt"], actual.Data["tls.key"])
+				if err != nil {
+					t.Error(actual.Data)
+				}
+				if signingCertKeyPair.Config.Certs[0].Issuer.CommonName != "signer-tests" {
+					t.Error(signingCertKeyPair.Config.Certs[0].Issuer.CommonName)
+
+				}
+				if signingCertKeyPair.Config.Certs[1].Subject.CommonName != "signer-tests" {
+					t.Error(signingCertKeyPair.Config.Certs[0].Issuer.CommonName)
+				}
+			},
+		},
+		{
+			name: "update write",
+			caFn: func() (*crypto.CA, error) {
+				return newTestCACertificate(pkix.Name{CommonName: "signer-tests"}, int64(1), metav1.Duration{Duration: time.Hour * 24 * 60}, time.Now)
+			},
+			initialSecretFn: func() *corev1.Secret {
+				caBundleSecret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "target-secret"},
+					Data:       map[string][]byte{},
+				}
+				return caBundleSecret
+			},
+			verifyActions: func(t *testing.T, client *kubefake.Clientset) {
+				actions := client.Actions()
+				if len(actions) != 1 {
+					t.Fatal(spew.Sdump(actions))
+				}
+
+				if !actions[0].Matches("update", "secrets") {
+					t.Error(actions[0])
+				}
+
+				actual := actions[0].(clienttesting.UpdateAction).GetObject().(*corev1.Secret)
+				if len(actual.Data["tls.crt"]) == 0 || len(actual.Data["tls.key"]) == 0 {
+					t.Error(actual.Data)
+				}
+
+				signingCertKeyPair, err := crypto.GetCAFromBytes(actual.Data["tls.crt"], actual.Data["tls.key"])
+				if err != nil {
+					t.Error(actual.Data)
+				}
+				if signingCertKeyPair.Config.Certs[0].Issuer.CommonName != "signer-tests" {
+					t.Error(signingCertKeyPair.Config.Certs[0].Issuer.CommonName)
+
+				}
+				if signingCertKeyPair.Config.Certs[1].Subject.CommonName != "signer-tests" {
+					t.Error(signingCertKeyPair.Config.Certs[0].Issuer.CommonName)
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+
+			client := kubefake.NewSimpleClientset()
+			if startingObj := test.initialSecretFn(); startingObj != nil {
+				indexer.Add(startingObj)
+				client = kubefake.NewSimpleClientset(startingObj)
+			}
+
+			c := &TargetRotation{
+				Namespace:         "ns",
+				Validity:          24 * time.Hour,
+				RefreshPercentage: .50,
+				Name:              "target-secret",
+				SignerRotation: &SignerRotation{
+					SignerName: "lower-signer",
+				},
+
+				Client:        client.CoreV1(),
+				Lister:        corev1listers.NewSecretLister(indexer),
+				EventRecorder: events.NewInMemoryRecorder("test"),
+			}
+
+			newCA, err := test.caFn()
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = c.ensureTargetCertKeyPair(newCA, newCA.Config.Certs)
+			switch {
+			case err != nil && len(test.expectedError) == 0:
+				t.Error(err)
+			case err != nil && !strings.Contains(err.Error(), test.expectedError):
+				t.Error(err)
+			case err == nil && len(test.expectedError) != 0:
+				t.Errorf("missing %q", test.expectedError)
+			}
+
+			test.verifyActions(t, client)
+		})
+	}
+}


### PR DESCRIPTION
Signers that were rotation targets were actually getting self-signed, defeating the purpose of a longer trust cycle.  This fixes that signer and includes it in the list of certs.

/assign @sjenning @enj 