### PR TITLE
operator: stop logging not found as errors

### DIFF
--- a/pkg/operator/staticpod/controller/prune/prune_controller.go
+++ b/pkg/operator/staticpod/controller/prune/prune_controller.go
@@ -138,7 +138,8 @@ func (c *PruneController) excludedRevisionHistory(operatorStatus *operatorv1.Sta
 
 	// Return early if nothing to prune
 	if len(succeededRevisionIDs)+len(failedRevisionIDs) == 0 {
-		return []int{}, fmt.Errorf("no revision IDs currently eligible to prune")
+		glog.V(2).Info("no revision IDs currently eligible to prune")
+		return []int{}, nil
 	}
 
 	// Get list of protected IDs

--- a/pkg/operator/status/status_controller.go
+++ b/pkg/operator/status/status_controller.go
@@ -82,7 +82,10 @@ func (c StatusSyncer) sync() error {
 	if apierrors.IsNotFound(err) {
 		glog.Infof("operator.status not found: %v", err)
 		c.eventRecorder.Warningf("StatusNotFound", "Unable to determine current operator status for %s", c.clusterOperatorName)
-		return c.clusterOperatorClient.ClusterOperators().Delete(c.clusterOperatorName, nil)
+		if err := c.clusterOperatorClient.ClusterOperators().Delete(c.clusterOperatorName, nil); err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+		return nil
 	}
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes pruning controller that logs no-op as error and status controller that logs not found as error when deleting cluster operator.