### PR TITLE
Prepare to use protobuf client-go

### DIFF
--- a/pkg/controller/controllercmd/builder.go
+++ b/pkg/controller/controllercmd/builder.go
@@ -18,6 +18,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
+
 	"github.com/openshift/library-go/pkg/config/client"
 	"github.com/openshift/library-go/pkg/config/configdefaults"
 	leaderelectionconverter "github.com/openshift/library-go/pkg/config/leaderelection"
@@ -40,8 +41,15 @@ type ControllerContext struct {
 	// Note that this config might not be safe for CR resources, instead it should be used for other resources.
 	ProtoKubeConfig *rest.Config
 
+	// EventRecorder is used to record events in controllers.
 	EventRecorder events.Recorder
-	Context       context.Context
+
+	stopChan <-chan struct{}
+}
+
+// Done returns a channel which will close on termination.
+func (c ControllerContext) Done() <-chan struct{} {
+	return c.stopChan
 }
 
 // defaultObserverInterval specifies the default interval that file observer will do rehash the files it watches and react to any changes
@@ -211,7 +219,7 @@ func (b *ControllerBuilder) Run(config *unstructured.Unstructured, ctx context.C
 		KubeConfig:      clientConfig,
 		ProtoKubeConfig: protoConfig,
 		EventRecorder:   eventRecorder,
-		Context:         ctx,
+		stopChan:        ctx.Done(),
 	}
 
 	if b.leaderElection == nil {
@@ -227,7 +235,7 @@ func (b *ControllerBuilder) Run(config *unstructured.Unstructured, ctx context.C
 	}
 
 	leaderElection.Callbacks.OnStartedLeading = func(ctx context.Context) {
-		controllerContext.Context = ctx
+		controllerContext.stopChan = ctx.Done()
 		if err := b.startFunc(controllerContext); err != nil {
 			glog.Fatal(err)
 		}

--- a/pkg/operator/resource/resourceapply/generic.go
+++ b/pkg/operator/resource/resourceapply/generic.go
@@ -34,7 +34,8 @@ type ApplyResult struct {
 	Error   error
 }
 
-func ApplyDirectly(client kubernetes.Interface, recorder events.Recorder, manifests AssetFunc, files ...string) []ApplyResult {
+// ApplyDirectly applies the given manifest files to API server.
+func ApplyDirectly(kubeClient kubernetes.Interface, recorder events.Recorder, manifests AssetFunc, files ...string) []ApplyResult {
 	ret := []ApplyResult{}
 
 	for _, file := range files {
@@ -53,27 +54,28 @@ func ApplyDirectly(client kubernetes.Interface, recorder events.Recorder, manife
 		}
 		result.Type = fmt.Sprintf("%T", requiredObj)
 
+		// NOTE: Do not add CR resources into this switch otherwise the protobuf client can cause problems.
 		switch t := requiredObj.(type) {
 		case *corev1.Namespace:
-			result.Result, result.Changed, result.Error = ApplyNamespace(client.CoreV1(), recorder, t)
+			result.Result, result.Changed, result.Error = ApplyNamespace(kubeClient.CoreV1(), recorder, t)
 		case *corev1.Service:
-			result.Result, result.Changed, result.Error = ApplyService(client.CoreV1(), recorder, t)
+			result.Result, result.Changed, result.Error = ApplyService(kubeClient.CoreV1(), recorder, t)
 		case *corev1.Pod:
-			result.Result, result.Changed, result.Error = ApplyPod(client.CoreV1(), recorder, t)
+			result.Result, result.Changed, result.Error = ApplyPod(kubeClient.CoreV1(), recorder, t)
 		case *corev1.ServiceAccount:
-			result.Result, result.Changed, result.Error = ApplyServiceAccount(client.CoreV1(), recorder, t)
+			result.Result, result.Changed, result.Error = ApplyServiceAccount(kubeClient.CoreV1(), recorder, t)
 		case *corev1.ConfigMap:
-			result.Result, result.Changed, result.Error = ApplyConfigMap(client.CoreV1(), recorder, t)
+			result.Result, result.Changed, result.Error = ApplyConfigMap(kubeClient.CoreV1(), recorder, t)
 		case *corev1.Secret:
-			result.Result, result.Changed, result.Error = ApplySecret(client.CoreV1(), recorder, t)
+			result.Result, result.Changed, result.Error = ApplySecret(kubeClient.CoreV1(), recorder, t)
 		case *rbacv1.ClusterRole:
-			result.Result, result.Changed, result.Error = ApplyClusterRole(client.RbacV1(), recorder, t)
+			result.Result, result.Changed, result.Error = ApplyClusterRole(kubeClient.RbacV1(), recorder, t)
 		case *rbacv1.ClusterRoleBinding:
-			result.Result, result.Changed, result.Error = ApplyClusterRoleBinding(client.RbacV1(), recorder, t)
+			result.Result, result.Changed, result.Error = ApplyClusterRoleBinding(kubeClient.RbacV1(), recorder, t)
 		case *rbacv1.Role:
-			result.Result, result.Changed, result.Error = ApplyRole(client.RbacV1(), recorder, t)
+			result.Result, result.Changed, result.Error = ApplyRole(kubeClient.RbacV1(), recorder, t)
 		case *rbacv1.RoleBinding:
-			result.Result, result.Changed, result.Error = ApplyRoleBinding(client.RbacV1(), recorder, t)
+			result.Result, result.Changed, result.Error = ApplyRoleBinding(kubeClient.RbacV1(), recorder, t)
 		default:
 			result.Error = fmt.Errorf("unhandled type %T", requiredObj)
 		}

--- a/pkg/operator/staticpod/controller/installer/installer_controller_test.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller_test.go
@@ -72,7 +72,8 @@ func TestNewNodeStateForInstallInProgress(t *testing.T) {
 		podCommand,
 		kubeInformers,
 		fakeStaticPodOperatorClient,
-		kubeClient,
+		kubeClient.CoreV1(),
+		kubeClient.CoreV1(),
 		eventRecorder,
 	)
 	c.ownerRefsFn = func(revision int32) ([]metav1.OwnerReference, error) {
@@ -285,7 +286,8 @@ func TestCreateInstallerPod(t *testing.T) {
 		[]string{"/bin/true"},
 		kubeInformers,
 		fakeStaticPodOperatorClient,
-		kubeClient,
+		kubeClient.CoreV1(),
+		kubeClient.CoreV1(),
 		eventRecorder,
 	)
 	c.ownerRefsFn = func(revision int32) ([]metav1.OwnerReference, error) {
@@ -453,7 +455,8 @@ func TestEnsureInstallerPod(t *testing.T) {
 				[]string{"/bin/true"},
 				kubeInformers,
 				fakeStaticPodOperatorClient,
-				kubeClient,
+				kubeClient.CoreV1(),
+				kubeClient.CoreV1(),
 				eventRecorder,
 			)
 			c.ownerRefsFn = func(revision int32) ([]metav1.OwnerReference, error) {
@@ -996,7 +999,8 @@ func TestCreateInstallerPodMultiNode(t *testing.T) {
 				[]string{"/bin/true"},
 				kubeInformers,
 				fakeStaticPodOperatorClient,
-				kubeClient,
+				kubeClient.CoreV1(),
+				kubeClient.CoreV1(),
 				eventRecorder,
 			)
 			c.ownerRefsFn = func(revision int32) ([]metav1.OwnerReference, error) {
@@ -1072,7 +1076,8 @@ func TestInstallerController_manageInstallationPods(t *testing.T) {
 				secrets:              tt.fields.secrets,
 				command:              tt.fields.command,
 				operatorConfigClient: tt.fields.operatorConfigClient,
-				kubeClient:           tt.fields.kubeClient,
+				configMapsGetter:     tt.fields.kubeClient.CoreV1(),
+				podsGetter:           tt.fields.kubeClient.CoreV1(),
 				eventRecorder:        tt.fields.eventRecorder,
 				queue:                tt.fields.queue,
 				installerPodImageFn:  tt.fields.installerPodImageFn,

--- a/pkg/operator/staticpod/controllers.go
+++ b/pkg/operator/staticpod/controllers.go
@@ -72,7 +72,8 @@ func NewControllers(
 		installerCommand,
 		kubeInformersNamespaceScoped,
 		staticPodOperatorClient,
-		kubeClient,
+		configMapGetter,
+		podsGetter,
 		eventRecorder,
 	)
 
@@ -81,7 +82,7 @@ func NewControllers(
 		staticPodName,
 		kubeInformersNamespaceScoped,
 		staticPodOperatorClient,
-		kubeClient,
+		podsGetter,
 		eventRecorder,
 	)
 


### PR DESCRIPTION
This change will prepare controllers to use protobuf enabled client-go. Via the `ControllerContext` we are going to provide two REST config (`KubeConfig` and `ProtoKubeConfig`). The later is a copy with accept set to prefer protobuf protocol.

We need to be careful to not use the protobuf for CR resources (@smarterclayton is fixing it?), so I renamed the `kubeClient` in controllers to `protoKubeClient`.

This change also remove usage of `kubernetes.Interface` and replace it with corresponding clients (pods/configmaps).

Lastly, this removes the `context.Context` from the controller context as storing the context in struct is discouraged in Go. Instead we just expose the `Done()` function.