### PR TITLE
config: fix panic in client_config

### DIFF
--- a/pkg/config/client/client_config.go
+++ b/pkg/config/client/client_config.go
@@ -24,7 +24,10 @@ func GetKubeConfigOrInClusterConfig(kubeConfigFile string, overrides *ClientConn
 
 	applyClientConnectionOverrides(overrides, clientConfig)
 
-	t := clientTransportOverrides{maxIdleConnsPerHost: overrides.MaxIdleConnsPerHost}
+	t := &clientTransportOverrides{}
+	if overrides != nil {
+		t.maxIdleConnsPerHost = overrides.MaxIdleConnsPerHost
+	}
 	clientConfig.WrapTransport = t.defaultClientTransport
 
 	return clientConfig, nil
@@ -46,7 +49,10 @@ func GetClientConfig(kubeConfigFile string, overrides *ClientConnectionOverrides
 	}
 	applyClientConnectionOverrides(overrides, clientConfig)
 
-	t := clientTransportOverrides{maxIdleConnsPerHost: overrides.MaxIdleConnsPerHost}
+	t := &clientTransportOverrides{}
+	if overrides != nil {
+		t.maxIdleConnsPerHost = overrides.MaxIdleConnsPerHost
+	}
 	clientConfig.WrapTransport = t.defaultClientTransport
 
 	return clientConfig, nil


### PR DESCRIPTION
Found this in the bump PR:

```
"message": "y-go/pkg/controller/controllercmd/builder.go:261 +0x48\ngithub.com/openshift/cluster-kube-apiserver-operator/vendor/github.com/openshift/library-go/pkg/controller/controllercmd.(*ControllerBuilder).Run(0xc42023c6c0, 0xc420106670, 0x1dc4660, 0xc420232b80, 0x3, 0xc42023c6c0)\n\t/go/src/github.com/openshift/cluster-kube-apiserver-operator/vendor/github.com/openshift/library-go/pkg/controller/controllercmd/builder.go:156 +0x43\ngithub.com/openshift/cluster-kube-apiserver-operator/vendor/github.com/openshift/library-go/pkg/controller/controllercmd.(*ControllerCommandConfig).StartController(0xc420124000, 0x1dc46a0, 0xc420052028, 0x2c68928, 0x0)\n\t/go/src/github.com/openshift/cluster-kube-apiserver-operator/vendor/github.com/openshift/library-go/pkg/controller/controllercmd/cmd.go:173 +0x588\ngithub.com/openshift/cluster-kube-apiserver-operator/vendor/github.com/openshift/library-go/pkg/controller/controllercmd.(*ControllerCommandConfig).NewCommand.func1(0xc4203c2280, 0xc42000cac0, 0x0, 0x2)\n\t/go/src/github.com/openshift/cluster-kube-apiserver-operator/vendor/github.com/openshift/library-go/pkg/controller/controllercmd/cmd.go:67 +0x271\ngithub.com/openshift/cluster-kube-apiserver-operator/vendor/github.com/spf13/cobra.(*Command).execute(0xc4203c2280, 0xc42000ca40, 0x2, 0x2, 0xc4203c2280, 0xc42000ca40)\n\t/go/src/github.com/openshift/cluster-kube-apiserver-operator/vendor/github.com/spf13/cobra/command.go:760 +0x2c1\ngithub.com/openshift/cluster-kube-apiserver-operator/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc4203c2000, 0x0, 0x0, 0x0)\n\t/go/src/github.com/openshift/cluster-kube-apiserver-operator/vendor/github.com/spf13/cobra/command.go:846 +0x30a\ngithub.com/openshift/cluster-kube-apiserver-operator/vendor/github.com/spf13/cobra.(*Command).Execute(0xc4203c2000, 0x1cce628, 0x2c47320)\n\t/go/src/github.com/openshift/cluster-kube-apiserver-operator/vendor/github.com/spf13/cobra/command.go:794 +0x2b\nmain.main()\n\t/go/src/github.com/openshift/cluster-kube-apiserver-operator/cmd/cluster-kube-apiserver-operator/main.go:33 +0x187\n",
```

This is fixing the nil pointer panic.