### PR TITLE
don't prune when there are no IDs

### DIFF
--- a/pkg/operator/staticpod/controller/prune/prune_controller.go
+++ b/pkg/operator/staticpod/controller/prune/prune_controller.go
@@ -317,6 +317,10 @@ func (c *PruneController) sync() error {
 	if err != nil {
 		return err
 	}
+	// if no IDs are excluded, then there is nothing to prune
+	if len(excludedIDs) == 0 {
+		return nil
+	}
 
 	errs := []error{}
 	if diskErr := c.pruneDiskResources(operatorStatus, excludedIDs, excludedIDs[len(excludedIDs)-1]); diskErr != nil {


### PR DESCRIPTION
The excludedRevisionHistory method returns an empty slice and no error when there's nothing to prune.

see https://github.com/openshift/library-go/blob/master/pkg/operator/staticpod/controller/prune/prune_controller.go#L142

/assign @mfojtik 


fixes 
```
I0213 12:46:34.739534       1 prune_controller.go:141] no revision IDs currently eligible to prune
E0213 12:46:34.739754       1 runtime.go:69] Observed a panic: "index out of range" (runtime error: index out of range)
/go/src/github.com/openshift/cluster-kube-apiserver-operator/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:76
/go/src/github.com/openshift/cluster-kube-apiserver-operator/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:65
/go/src/github.com/openshift/cluster-kube-apiserver-operator/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:51
/usr/local/go/src/runtime/asm_amd64.s:573
/usr/local/go/src/runtime/panic.go:502
/usr/local/go/src/runtime/panic.go:28
/go/src/github.com/openshift/cluster-kube-apiserver-operator/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/prune/prune_controller.go:322
/go/src/github.com/openshift/cluster-kube-apiserver-operator/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/prune/prune_controller.go:297
/go/src/github.com/openshift/cluster-kube-apiserver-operator/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/prune/prune_controller.go:286
/go/src/github.com/openshift/cluster-kube-apiserver-operator/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/prune/prune_controller.go:280
/go/src/github.com/openshift/cluster-kube-apiserver-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133
/go/src/github.com/openshift/cluster-kube-apiserver-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:134
/go/src/github.com/openshift/cluster-kube-apiserver-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88
```

There's still a pruning problem (there's definitely stuff to prune), but this prevents panics