### PR TITLE
add reasons about why a cert was rotated

### DIFF
--- a/pkg/operator/certrotation/client_cert_rotation_controller.go
+++ b/pkg/operator/certrotation/client_cert_rotation_controller.go
@@ -125,27 +125,6 @@ func (c CertRotationController) syncWorker() error {
 	return nil
 }
 
-func needNewCertKeyPairForTime(annotations map[string]string, validity time.Duration, renewalPercentage float32) bool {
-	signingCertKeyPairExpiry := annotations[CertificateExpiryAnnotation]
-	if len(signingCertKeyPairExpiry) == 0 {
-		return true
-	}
-	certExpiry, err := time.Parse(time.RFC3339, signingCertKeyPairExpiry)
-	if err != nil {
-		glog.Infof("bad expiry: %q", signingCertKeyPairExpiry)
-		// just create a new one
-		return true
-	}
-
-	// If Certificate is not-expired, skip this iteration.
-	renewalDuration := -1 * float32(validity) * (1 - renewalPercentage)
-	if certExpiry.Add(time.Duration(renewalDuration)).After(time.Now()) {
-		return false
-	}
-
-	return true
-}
-
 func (c *CertRotationController) Run(workers int, stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
 	defer c.queue.ShutDown()

--- a/pkg/operator/certrotation/signer.go
+++ b/pkg/operator/certrotation/signer.go
@@ -41,8 +41,8 @@ func (c SigningRotation) ensureSigningCertKeyPair() (*crypto.CA, error) {
 	}
 	signingCertKeyPairSecret.Type = corev1.SecretTypeTLS
 
-	if needNewSigningCertKeyPair(signingCertKeyPairSecret.Annotations, c.Validity, c.RefreshPercentage) {
-		c.EventRecorder.Eventf("SignerUpdateRequired", "%q in %q requires a new signing cert/key pair", c.Name, c.Namespace)
+	if reason := needNewSigningCertKeyPair(signingCertKeyPairSecret.Annotations, c.Validity, c.RefreshPercentage); len(reason) > 0 {
+		c.EventRecorder.Eventf("SignerUpdateRequired", "%q in %q requires a new signing cert/key pair: %v", c.Name, c.Namespace, reason)
 		if err := setSigningCertKeyPairSecret(signingCertKeyPairSecret, c.Validity); err != nil {
 			return nil, err
 		}
@@ -68,8 +68,23 @@ func (c SigningRotation) ensureSigningCertKeyPair() (*crypto.CA, error) {
 	return signingCertKeyPair, nil
 }
 
-func needNewSigningCertKeyPair(annotations map[string]string, validity time.Duration, renewalPercentage float32) bool {
-	return needNewCertKeyPairForTime(annotations, validity, renewalPercentage)
+func needNewSigningCertKeyPair(annotations map[string]string, validity time.Duration, renewalPercentage float32) string {
+	signingCertKeyPairExpiry := annotations[CertificateExpiryAnnotation]
+	if len(signingCertKeyPairExpiry) == 0 {
+		return "missing target expiry"
+	}
+	certExpiry, err := time.Parse(time.RFC3339, signingCertKeyPairExpiry)
+	if err != nil {
+		return fmt.Sprintf("bad expiry: %q", signingCertKeyPairExpiry)
+	}
+
+	// If Certificate is not-expired, skip this iteration.
+	renewalDuration := -1 * float32(validity) * (1 - renewalPercentage)
+	if certExpiry.Add(time.Duration(renewalDuration)).After(time.Now()) {
+		return ""
+	}
+
+	return fmt.Sprintf("past its renewal time %v, versus %v", certExpiry, certExpiry.Add(time.Duration(renewalDuration)))
 }
 
 // setSigningCertKeyPairSecret creates a new signing cert/key pair and sets them in the secret

--- a/pkg/operator/certrotation/target_test.go
+++ b/pkg/operator/certrotation/target_test.go
@@ -41,7 +41,7 @@ func TestNeedNewTargetCertKeyPairForTime(t *testing.T) {
 		validity          time.Duration
 		renewalPercentage float32
 
-		expected bool
+		expected string
 	}{
 		{
 			name: "from nothing",
@@ -50,7 +50,7 @@ func TestNeedNewTargetCertKeyPairForTime(t *testing.T) {
 			},
 			validity:          100 * time.Minute,
 			renewalPercentage: 0.5,
-			expected:          true,
+			expected:          "missing target expiry",
 		},
 		{
 			name:        "malformed",
@@ -60,7 +60,7 @@ func TestNeedNewTargetCertKeyPairForTime(t *testing.T) {
 			},
 			validity:          100 * time.Minute,
 			renewalPercentage: 0.5,
-			expected:          true,
+			expected:          `bad expiry: "malformed"`,
 		},
 		{
 			name:        "past midpoint and cert is ready",
@@ -70,7 +70,7 @@ func TestNeedNewTargetCertKeyPairForTime(t *testing.T) {
 			},
 			validity:          100 * time.Minute,
 			renewalPercentage: 0.5,
-			expected:          true,
+			expected:          "past its renewal time",
 		},
 		{
 			name:        "past midpoint and cert is new",
@@ -80,7 +80,7 @@ func TestNeedNewTargetCertKeyPairForTime(t *testing.T) {
 			},
 			validity:          100 * time.Minute,
 			renewalPercentage: 0.5,
-			expected:          false,
+			expected:          "",
 		},
 	}
 
@@ -92,7 +92,7 @@ func TestNeedNewTargetCertKeyPairForTime(t *testing.T) {
 			}
 
 			actual := needNewTargetCertKeyPairForTime(test.annotations, signer, test.validity, test.renewalPercentage)
-			if test.expected != actual {
+			if !strings.HasPrefix(actual, test.expected) {
 				t.Errorf("expected %v, got %v", test.expected, actual)
 			}
 		})


### PR DESCRIPTION
We need this to figure out why a particular cert is getting rotated. We know that it is, but we don't know why.

/assign @mfojtik 