### PR TITLE
use the resourceapply methods in the cert rotation

### DIFF
--- a/pkg/operator/certrotation/cabundle_test.go
+++ b/pkg/operator/certrotation/cabundle_test.go
@@ -49,7 +49,7 @@ func TestEnsureConfigMapCABundle(t *testing.T) {
 					t.Fatal(spew.Sdump(actions))
 				}
 
-				if !actions[0].Matches("update", "configmaps") {
+				if !actions[0].Matches("get", "configmaps") {
 					t.Error(actions[0])
 				}
 				if !actions[1].Matches("create", "configmaps") {
@@ -85,15 +85,15 @@ func TestEnsureConfigMapCABundle(t *testing.T) {
 			},
 			verifyActions: func(t *testing.T, client *kubefake.Clientset) {
 				actions := client.Actions()
-				if len(actions) != 1 {
+				if len(actions) != 2 {
 					t.Fatal(spew.Sdump(actions))
 				}
 
-				if !actions[0].Matches("update", "configmaps") {
-					t.Error(actions[0])
+				if !actions[1].Matches("update", "configmaps") {
+					t.Error(actions[1])
 				}
 
-				actual := actions[0].(clienttesting.UpdateAction).GetObject().(*corev1.ConfigMap)
+				actual := actions[1].(clienttesting.UpdateAction).GetObject().(*corev1.ConfigMap)
 				if len(actual.Data["ca-bundle.crt"]) == 0 {
 					t.Error(actual.Data)
 				}
@@ -129,15 +129,15 @@ func TestEnsureConfigMapCABundle(t *testing.T) {
 			},
 			verifyActions: func(t *testing.T, client *kubefake.Clientset) {
 				actions := client.Actions()
-				if len(actions) != 1 {
+				if len(actions) != 2 {
 					t.Fatal(spew.Sdump(actions))
 				}
 
-				if !actions[0].Matches("update", "configmaps") {
-					t.Error(actions[0])
+				if !actions[1].Matches("update", "configmaps") {
+					t.Error(actions[1])
 				}
 
-				actual := actions[0].(clienttesting.UpdateAction).GetObject().(*corev1.ConfigMap)
+				actual := actions[1].(clienttesting.UpdateAction).GetObject().(*corev1.ConfigMap)
 				if len(actual.Data["ca-bundle.crt"]) == 0 {
 					t.Error(actual.Data)
 				}
@@ -177,15 +177,15 @@ func TestEnsureConfigMapCABundle(t *testing.T) {
 			},
 			verifyActions: func(t *testing.T, client *kubefake.Clientset) {
 				actions := client.Actions()
-				if len(actions) != 1 {
+				if len(actions) != 2 {
 					t.Fatal(spew.Sdump(actions))
 				}
 
-				if !actions[0].Matches("update", "configmaps") {
-					t.Error(actions[0])
+				if !actions[1].Matches("update", "configmaps") {
+					t.Error(actions[1])
 				}
 
-				actual := actions[0].(clienttesting.UpdateAction).GetObject().(*corev1.ConfigMap)
+				actual := actions[1].(clienttesting.UpdateAction).GetObject().(*corev1.ConfigMap)
 				if len(actual.Data["ca-bundle.crt"]) == 0 {
 					t.Error(actual.Data)
 				}

--- a/pkg/operator/certrotation/signer.go
+++ b/pkg/operator/certrotation/signer.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/openshift/library-go/pkg/crypto"
 	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -47,13 +48,7 @@ func (c SigningRotation) ensureSigningCertKeyPair() (*crypto.CA, error) {
 			return nil, err
 		}
 
-		actualSigningCertKeyPairSecret, err := c.Client.Secrets(c.Namespace).Update(signingCertKeyPairSecret)
-		if apierrors.IsNotFound(err) {
-			actualSigningCertKeyPairSecret, err = c.Client.Secrets(c.Namespace).Create(signingCertKeyPairSecret)
-			if err != nil {
-				return nil, err
-			}
-		}
+		actualSigningCertKeyPairSecret, _, err := resourceapply.ApplySecret(c.Client, c.EventRecorder, signingCertKeyPairSecret)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/operator/certrotation/signer_test.go
+++ b/pkg/operator/certrotation/signer_test.go
@@ -35,7 +35,7 @@ func TestEnsureSigningCertKeyPair(t *testing.T) {
 					t.Fatal(spew.Sdump(actions))
 				}
 
-				if !actions[0].Matches("update", "secrets") {
+				if !actions[0].Matches("get", "secrets") {
 					t.Error(actions[0])
 				}
 				if !actions[1].Matches("create", "secrets") {
@@ -56,15 +56,15 @@ func TestEnsureSigningCertKeyPair(t *testing.T) {
 			verifyActions: func(t *testing.T, client *kubefake.Clientset) {
 				t.Helper()
 				actions := client.Actions()
-				if len(actions) != 1 {
+				if len(actions) != 2 {
 					t.Fatal(spew.Sdump(actions))
 				}
 
-				if !actions[0].Matches("update", "secrets") {
-					t.Error(actions[0])
+				if !actions[1].Matches("update", "secrets") {
+					t.Error(actions[1])
 				}
 
-				actual := actions[0].(clienttesting.UpdateAction).GetObject().(*corev1.Secret)
+				actual := actions[1].(clienttesting.UpdateAction).GetObject().(*corev1.Secret)
 				if len(actual.Data["tls.crt"]) == 0 || len(actual.Data["tls.key"]) == 0 {
 					t.Error(actual.Data)
 				}

--- a/pkg/operator/certrotation/target_test.go
+++ b/pkg/operator/certrotation/target_test.go
@@ -121,7 +121,7 @@ func TestEnsureTargetCertKeyPair(t *testing.T) {
 					t.Fatal(spew.Sdump(actions))
 				}
 
-				if !actions[0].Matches("update", "secrets") {
+				if !actions[0].Matches("get", "secrets") {
 					t.Error(actions[0])
 				}
 				if !actions[1].Matches("create", "secrets") {
@@ -148,15 +148,15 @@ func TestEnsureTargetCertKeyPair(t *testing.T) {
 			},
 			verifyActions: func(t *testing.T, client *kubefake.Clientset) {
 				actions := client.Actions()
-				if len(actions) != 1 {
+				if len(actions) != 2 {
 					t.Fatal(spew.Sdump(actions))
 				}
 
-				if !actions[0].Matches("update", "secrets") {
-					t.Error(actions[0])
+				if !actions[1].Matches("update", "secrets") {
+					t.Error(actions[1])
 				}
 
-				actual := actions[0].(clienttesting.UpdateAction).GetObject().(*corev1.Secret)
+				actual := actions[1].(clienttesting.UpdateAction).GetObject().(*corev1.Secret)
 				if len(actual.Data["tls.crt"]) == 0 || len(actual.Data["tls.key"]) == 0 {
 					t.Error(actual.Data)
 				}
@@ -230,7 +230,7 @@ func TestEnsureTargetSignerCertKeyPair(t *testing.T) {
 					t.Fatal(spew.Sdump(actions))
 				}
 
-				if !actions[0].Matches("update", "secrets") {
+				if !actions[0].Matches("get", "secrets") {
 					t.Error(actions[0])
 				}
 				if !actions[1].Matches("create", "secrets") {
@@ -269,15 +269,15 @@ func TestEnsureTargetSignerCertKeyPair(t *testing.T) {
 			},
 			verifyActions: func(t *testing.T, client *kubefake.Clientset) {
 				actions := client.Actions()
-				if len(actions) != 1 {
+				if len(actions) != 2 {
 					t.Fatal(spew.Sdump(actions))
 				}
 
-				if !actions[0].Matches("update", "secrets") {
-					t.Error(actions[0])
+				if !actions[1].Matches("update", "secrets") {
+					t.Error(actions[1])
 				}
 
-				actual := actions[0].(clienttesting.UpdateAction).GetObject().(*corev1.Secret)
+				actual := actions[1].(clienttesting.UpdateAction).GetObject().(*corev1.Secret)
 				if len(actual.Data["tls.crt"]) == 0 || len(actual.Data["tls.key"]) == 0 {
 					t.Error(actual.Data)
 				}


### PR DESCRIPTION
Our resourceapply methods emit events and handle the update/create logic.  This updates the cert rotator to use it.

/assign @mfojtik 