### PR TITLE
resourceapply: log changes when objects are modified

### DIFF
--- a/pkg/operator/resource/resourceapply/core_test.go
+++ b/pkg/operator/resource/resourceapply/core_test.go
@@ -9,7 +9,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
 
@@ -47,7 +46,7 @@ func TestApplyConfigMap(t *testing.T) {
 				}
 				actual := actions[1].(clienttesting.CreateAction).GetObject().(*corev1.ConfigMap)
 				if !equality.Semantic.DeepEqual(expected, actual) {
-					t.Error(diff.ObjectDiff(expected, actual))
+					t.Error(JSONPatch(expected, actual))
 				}
 			},
 		},
@@ -99,7 +98,7 @@ func TestApplyConfigMap(t *testing.T) {
 				}
 				actual := actions[1].(clienttesting.UpdateAction).GetObject().(*corev1.ConfigMap)
 				if !equality.Semantic.DeepEqual(expected, actual) {
-					t.Error(diff.ObjectDiff(expected, actual))
+					t.Error(JSONPatch(expected, actual))
 				}
 			},
 		},
@@ -136,7 +135,7 @@ func TestApplyConfigMap(t *testing.T) {
 				}
 				actual := actions[1].(clienttesting.UpdateAction).GetObject().(*corev1.ConfigMap)
 				if !equality.Semantic.DeepEqual(expected, actual) {
-					t.Error(diff.ObjectDiff(expected, actual))
+					t.Error(JSONPatch(expected, actual))
 				}
 			},
 		},

--- a/pkg/operator/resource/resourceapply/event_helpers.go
+++ b/pkg/operator/resource/resourceapply/event_helpers.go
@@ -11,6 +11,7 @@ import (
 	kubescheme "k8s.io/client-go/kubernetes/scheme"
 
 	openshiftapi "github.com/openshift/api"
+
 	"github.com/openshift/library-go/pkg/operator/events"
 )
 

--- a/pkg/operator/resource/resourceapply/generic_test.go
+++ b/pkg/operator/resource/resourceapply/generic_test.go
@@ -3,10 +3,11 @@ package resourceapply
 import (
 	"testing"
 
-	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/davecgh/go-spew/spew"
+
 	"k8s.io/client-go/kubernetes/fake"
 
-	"github.com/davecgh/go-spew/spew"
+	"github.com/openshift/library-go/pkg/operator/events"
 )
 
 func TestApplyDirectly(t *testing.T) {

--- a/pkg/operator/resource/resourceapply/json_patch_helpers.go
+++ b/pkg/operator/resource/resourceapply/json_patch_helpers.go
@@ -1,0 +1,33 @@
+package resourceapply
+
+import (
+	"fmt"
+
+	patch "github.com/evanphx/json-patch"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// JSONPatch generates a JSON patch between original and modified objects and return the JSON as a string.
+// In case of error, the returned string will contain the error messages.
+func JSONPatch(original, modified runtime.Object) string {
+	if original == nil {
+		return "original object is nil"
+	}
+	if modified == nil {
+		return "modified object is nil"
+	}
+	originalJSON, err := runtime.Encode(unstructured.UnstructuredJSONScheme, original)
+	if err != nil {
+		return fmt.Sprintf("unable to decode original to JSON: %v", err)
+	}
+	modifiedJSON, err := runtime.Encode(unstructured.UnstructuredJSONScheme, modified)
+	if err != nil {
+		return fmt.Sprintf("unable to decode modified to JSON: %v", err)
+	}
+	patchBytes, err := patch.CreateMergePatch(originalJSON, modifiedJSON)
+	if err != nil {
+		return fmt.Sprintf("unable to create JSON patch: %v", err)
+	}
+	return string(patchBytes)
+}

--- a/pkg/operator/resource/resourceapply/json_patch_helpers_test.go
+++ b/pkg/operator/resource/resourceapply/json_patch_helpers_test.go
@@ -1,0 +1,89 @@
+package resourceapply
+
+import (
+	"testing"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestJSONPatch(t *testing.T) {
+	tests := []struct {
+		name     string
+		original runtime.Object
+		modified runtime.Object
+		expected string
+	}{
+		{
+			name: "simple diff in pod",
+			original: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Annotations: map[string]string{"foo": "bar"}},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "test-container",
+						},
+					},
+				},
+			},
+			modified: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Annotations: map[string]string{"foo": "nobar"}},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "test-container",
+						},
+					},
+				},
+			},
+			expected: `{"metadata":{"annotations":{"foo":"nobar"}}}`,
+		},
+		{
+			name: "removing annotation in pod",
+			original: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Annotations: map[string]string{"foo": "bar"}},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "test-container",
+						},
+					},
+				},
+			},
+			modified: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod"},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "test-container",
+						},
+					},
+				},
+			},
+			expected: `{"metadata":{"annotations":null}}`,
+		},
+		{
+			name: "modified is nil",
+			original: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Annotations: map[string]string{"foo": "bar"}},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "test-container",
+						},
+					},
+				},
+			},
+			expected: `modified object is nil`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if output := JSONPatch(test.original, test.modified); output != test.expected {
+				t.Errorf("returned string:\n%s\n\n does not match expected string:\n%s\n", output, test.expected)
+			}
+		})
+	}
+}

--- a/pkg/operator/resource/resourceapply/monitoring.go
+++ b/pkg/operator/resource/resourceapply/monitoring.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/ghodss/yaml"
+	"github.com/golang/glog"
 	"github.com/imdario/mergo"
 
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -75,13 +76,19 @@ func ApplyServiceMonitor(client dynamic.Interface, recorder events.Recorder, ser
 		return true, nil
 	}
 
-	updated, endpointsModified, err := ensureServiceMonitorSpec(required, existing)
+	existingCopy := existing.DeepCopy()
+
+	updated, endpointsModified, err := ensureServiceMonitorSpec(required, existingCopy)
 	if err != nil {
 		return false, err
 	}
 
 	if !endpointsModified {
 		return false, nil
+	}
+
+	if glog.V(4) {
+		glog.Infof("ServiceMonitor %q changes: %v", namespace+"/"+required.GetName(), JSONPatch(existing, existingCopy))
 	}
 
 	if _, err = client.Resource(serviceMonitorGVR).Namespace(namespace).Update(updated, metav1.UpdateOptions{}); err != nil {

--- a/pkg/operator/staticpod/controller/revision/revision_controller_test.go
+++ b/pkg/operator/staticpod/controller/revision/revision_controller_test.go
@@ -166,7 +166,7 @@ func TestRevisionController(t *testing.T) {
 					t.Errorf("expected config to have name 'test-config-1', got %q", config.Name)
 				}
 				if len(config.OwnerReferences) != 1 {
-					t.Errorf("expected config to have ownerreferences set, got %q", config.OwnerReferences)
+					t.Errorf("expected config to have ownerreferences set, got %+v", config.OwnerReferences)
 				}
 				secret, hasSecret := createdObjects[2].(*v1.Secret)
 				if !hasSecret {
@@ -177,7 +177,7 @@ func TestRevisionController(t *testing.T) {
 					t.Errorf("expected secret to have name 'test-secret-1', got %q", secret.Name)
 				}
 				if len(secret.OwnerReferences) != 1 {
-					t.Errorf("expected secret to have ownerreferences set, got %q", secret.OwnerReferences)
+					t.Errorf("expected secret to have ownerreferences set, got %+v", secret.OwnerReferences)
 				}
 			},
 		},


### PR DESCRIPTION
This change will cause logging all changes to resources that we apply updates to. We already log diffs with CR's but we don't see why we changing things like pods/role bindings/etc.

I think this will improve our ability to debug changes done by operators and identify changes that are not desired which is worth the extra `DeepCopy()` ?

Test bump: https://github.com/openshift/cluster-kube-controller-manager-operator/pull/160