### PR TITLE
pull the version-mapping from the correct namespace

### DIFF
--- a/pkg/operator/staticpod/controller/staticpodstate/staticpodstate_controller.go
+++ b/pkg/operator/staticpod/controller/staticpodstate/staticpodstate_controller.go
@@ -30,9 +30,10 @@ var (
 // StaticPodStateController is a controller that watches static pods and will produce a failing status if the
 //// static pods start crashing for some reason.
 type StaticPodStateController struct {
-	targetNamespace string
-	staticPodName   string
-	operandName     string
+	targetNamespace   string
+	staticPodName     string
+	operandName       string
+	operatorNamespace string
 
 	operatorConfigClient v1helpers.StaticPodOperatorClient
 	configMapGetter      corev1client.ConfigMapsGetter
@@ -47,7 +48,7 @@ type StaticPodStateController struct {
 // NewStaticPodStateController creates a controller that watches static pods and will produce a failing status if the
 // static pods start crashing for some reason.
 func NewStaticPodStateController(
-	targetNamespace, operandName, staticPodName string,
+	targetNamespace, staticPodName, operatorNamespace, operandName string,
 	kubeInformersForTargetNamespace informers.SharedInformerFactory,
 	operatorConfigClient v1helpers.StaticPodOperatorClient,
 	configMapGetter corev1client.ConfigMapsGetter,
@@ -56,9 +57,10 @@ func NewStaticPodStateController(
 	eventRecorder events.Recorder,
 ) *StaticPodStateController {
 	c := &StaticPodStateController{
-		targetNamespace: targetNamespace,
-		staticPodName:   staticPodName,
-		operandName:     operandName,
+		targetNamespace:   targetNamespace,
+		staticPodName:     staticPodName,
+		operandName:       operandName,
+		operatorNamespace: operatorNamespace,
 
 		operatorConfigClient: operatorConfigClient,
 		configMapGetter:      configMapGetter,
@@ -129,7 +131,7 @@ func (c *StaticPodStateController) sync() error {
 	} else {
 		c.versionRecorder.SetVersion(
 			c.operandName,
-			status.VersionForOperand(c.targetNamespace, images.List()[0], c.configMapGetter, c.eventRecorder),
+			status.VersionForOperand(c.operatorNamespace, images.List()[0], c.configMapGetter, c.eventRecorder),
 		)
 	}
 

--- a/pkg/operator/staticpod/controllers.go
+++ b/pkg/operator/staticpod/controllers.go
@@ -156,8 +156,9 @@ func (b *staticPodOperatorControllerBuilder) ToControllers() (*staticPodOperator
 		// TODO add handling for operator configmap changes to get version-mapping changes
 		controllers.staticPodStateController = staticpodstate.NewStaticPodStateController(
 			b.operandNamespace,
-			b.operandName,
 			b.staticPodName,
+			b.operatorNamespace,
+			b.operandName,
 			operandInformers,
 			b.staticPodOperatorClient,
 			configMapClient,


### PR DESCRIPTION
fixes the mapping bug. Testing in 
https://github.com/openshift/cluster-kube-controller-manager-operator/pull/164

/hold