### PR TITLE
simplify the clusteroperator status logic

### DIFF
--- a/pkg/operator/status/condition.go
+++ b/pkg/operator/status/condition.go
@@ -1,0 +1,58 @@
+package status
+
+import (
+	"fmt"
+	"strings"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// conditionMergeState indicates whether you want to merge all Falses or merge all Trues.  For instance, Failures merge
+// on true, but Available merges on false.  Thing of it like an anti-default.
+func unionCondition(conditionType string, conditionMergeState operatorv1.ConditionStatus, allConditions ...operatorv1.OperatorCondition) configv1.ClusterOperatorStatusCondition {
+	var interestingConditions []operatorv1.OperatorCondition
+	for _, condition := range allConditions {
+		if strings.HasSuffix(condition.Type, conditionType) && condition.Status == conditionMergeState {
+			interestingConditions = append(interestingConditions, condition)
+		}
+	}
+
+	unionedCondition := operatorv1.OperatorCondition{Type: conditionType, Status: operatorv1.ConditionUnknown}
+	if len(interestingConditions) > 0 {
+		unionedCondition.Status = conditionMergeState
+		var messages []string
+		latestTransitionTime := metav1.Time{}
+		for _, condition := range interestingConditions {
+			if latestTransitionTime.Before(&condition.LastTransitionTime) {
+				latestTransitionTime = condition.LastTransitionTime
+			}
+
+			if len(condition.Message) == 0 {
+				continue
+			}
+			for _, message := range strings.Split(condition.Message, "\n") {
+				messages = append(messages, fmt.Sprintf("%s: %s", condition.Type, message))
+			}
+		}
+		if len(messages) > 0 {
+			unionedCondition.Message = strings.Join(messages, "\n")
+		}
+		if len(interestingConditions) == 1 {
+			unionedCondition.Reason = interestingConditions[0].Type
+		} else {
+			unionedCondition.Reason = "MultipleConditionsMatching"
+		}
+		unionedCondition.LastTransitionTime = latestTransitionTime
+
+	} else {
+		if conditionMergeState == operatorv1.ConditionTrue {
+			unionedCondition.Status = operatorv1.ConditionFalse
+		} else {
+			unionedCondition.Status = operatorv1.ConditionTrue
+		}
+	}
+
+	return OperatorConditionToClusterOperatorCondition(unionedCondition)
+}

--- a/pkg/operator/status/status_controller.go
+++ b/pkg/operator/status/status_controller.go
@@ -2,7 +2,6 @@ package status
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -93,18 +92,30 @@ func (c StatusSyncer) sync() error {
 		c.eventRecorder.Warningf("StatusFailed", "Unable to get current operator status for %s: %v", c.clusterOperatorName, err)
 		return err
 	}
-	clusterOperatorObj := originalClusterOperatorObj.DeepCopy()
 
-	if clusterOperatorObj == nil || apierrors.IsNotFound(err) {
+	// ensure that we have a clusteroperator resource
+	if originalClusterOperatorObj == nil || apierrors.IsNotFound(err) {
 		glog.Infof("clusteroperator/%s not found", c.clusterOperatorName)
-		clusterOperatorObj = &configv1.ClusterOperator{
+		var createErr error
+		originalClusterOperatorObj, createErr = c.clusterOperatorClient.ClusterOperators().Create(&configv1.ClusterOperator{
 			ObjectMeta: metav1.ObjectMeta{Name: c.clusterOperatorName},
+		})
+		if apierrors.IsNotFound(createErr) {
+			// this means that the API isn't present.  We did not fail.  Try again later
+			glog.Infof("ClusterOperator API not created")
+			c.queue.AddRateLimited(workQueueKey)
+			return nil
+		}
+		if createErr != nil {
+			c.eventRecorder.Warningf("StatusCreateFailed", "Failed to create operator status: %v", err)
+			return createErr
 		}
 	}
-	clusterOperatorObj.Status.RelatedObjects = c.relatedObjects
+	clusterOperatorObj := originalClusterOperatorObj.DeepCopy()
 
 	// if we are unmanaged, force everything to Unknown.
 	if detailedSpec.ManagementState == operatorv1.Unmanaged {
+		clusterOperatorObj.Status = configv1.ClusterOperatorStatus{}
 		configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorAvailable, Status: configv1.ConditionUnknown, Reason: "Unmanaged"})
 		configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorProgressing, Status: configv1.ConditionUnknown, Reason: "Unmanaged"})
 		configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorFailing, Status: configv1.ConditionUnknown, Reason: "Unmanaged"})
@@ -113,7 +124,6 @@ func (c StatusSyncer) sync() error {
 		if equality.Semantic.DeepEqual(clusterOperatorObj, originalClusterOperatorObj) {
 			return nil
 		}
-
 		if _, updateErr := c.clusterOperatorClient.ClusterOperators().UpdateStatus(clusterOperatorObj); err != nil {
 			return updateErr
 		}
@@ -121,54 +131,11 @@ func (c StatusSyncer) sync() error {
 		return nil
 	}
 
-	var failingConditions []operatorv1.OperatorCondition
-	for _, condition := range currentDetailedStatus.Conditions {
-		if strings.HasSuffix(condition.Type, "Failing") && condition.Status == operatorv1.ConditionTrue {
-			failingConditions = append(failingConditions, condition)
-		}
-	}
-	failingCondition := operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeFailing, Status: operatorv1.ConditionUnknown}
-	if len(failingConditions) > 0 {
-		failingCondition.Status = operatorv1.ConditionTrue
-		var messages []string
-		latestTransitionTime := metav1.Time{}
-		for _, condition := range failingConditions {
-			if latestTransitionTime.Before(&condition.LastTransitionTime) {
-				latestTransitionTime = condition.LastTransitionTime
-			}
-
-			if len(condition.Message) == 0 {
-				continue
-			}
-			for _, message := range strings.Split(condition.Message, "\n") {
-				messages = append(messages, fmt.Sprintf("%s: %s", condition.Type, message))
-			}
-		}
-		if len(messages) > 0 {
-			failingCondition.Message = strings.Join(messages, "\n")
-		}
-		if len(failingConditions) == 1 {
-			failingCondition.Reason = failingConditions[0].Type
-		} else {
-			failingCondition.Reason = "MultipleConditionsFailing"
-		}
-		failingCondition.LastTransitionTime = latestTransitionTime
-
-	} else {
-		failingCondition.Status = operatorv1.ConditionFalse
-	}
-	configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, OperatorConditionToClusterOperatorCondition(failingCondition))
-
-	if condition := operatorv1helpers.FindOperatorCondition(currentDetailedStatus.Conditions, operatorv1.OperatorStatusTypeAvailable); condition != nil {
-		configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, OperatorConditionToClusterOperatorCondition(*condition))
-	} else {
-		configv1helpers.RemoveStatusCondition(&clusterOperatorObj.Status.Conditions, configv1.ClusterStatusConditionType(operatorv1.OperatorStatusTypeAvailable))
-	}
-	if condition := operatorv1helpers.FindOperatorCondition(currentDetailedStatus.Conditions, operatorv1.OperatorStatusTypeProgressing); condition != nil {
-		configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, OperatorConditionToClusterOperatorCondition(*condition))
-	} else {
-		configv1helpers.RemoveStatusCondition(&clusterOperatorObj.Status.Conditions, configv1.ClusterStatusConditionType(operatorv1.OperatorStatusTypeProgressing))
-	}
+	clusterOperatorObj.Status.RelatedObjects = c.relatedObjects
+	configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, unionCondition("Failing", operatorv1.ConditionTrue, currentDetailedStatus.Conditions...))
+	configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, unionCondition("Progressing", operatorv1.ConditionTrue, currentDetailedStatus.Conditions...))
+	configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, unionCondition("Available", operatorv1.ConditionFalse, currentDetailedStatus.Conditions...))
+	configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, unionCondition("Upgradeable", operatorv1.ConditionFalse, currentDetailedStatus.Conditions...))
 
 	// TODO work out removal.  We don't always know the existing value, so removing early seems like a bad idea.  Perhaps a remove flag.
 	versions := c.versionGetter.GetVersions()
@@ -176,59 +143,16 @@ func (c StatusSyncer) sync() error {
 		operatorv1helpers.SetOperandVersion(&clusterOperatorObj.Status.Versions, configv1.OperandVersion{Name: operand, Version: version})
 	}
 
+	// if we have no diff, just return
 	if equality.Semantic.DeepEqual(clusterOperatorObj, originalClusterOperatorObj) {
 		return nil
 	}
-
 	glog.V(2).Infof("clusteroperator/%s diff %v", c.clusterOperatorName, resourceapply.JSONPatch(originalClusterOperatorObj, clusterOperatorObj))
 
-	if len(clusterOperatorObj.ResourceVersion) != 0 {
-		if _, updateErr := c.clusterOperatorClient.ClusterOperators().UpdateStatus(clusterOperatorObj); err != nil {
-			return updateErr
-		}
-		c.eventRecorder.Eventf("OperatorStatusChanged", "Status for operator %s changed: %s", c.clusterOperatorName, configv1helpers.GetStatusDiff(originalClusterOperatorObj.Status, clusterOperatorObj.Status))
-		return nil
-	}
-
-	freshOperatorConfig, createErr := c.clusterOperatorClient.ClusterOperators().Create(clusterOperatorObj)
-	if apierrors.IsNotFound(createErr) {
-		// this means that the API isn't present.  We did not fail.  Try again later
-		glog.Infof("ClusterOperator API not created")
-		c.queue.AddRateLimited(workQueueKey)
-		return nil
-	}
-	if createErr != nil {
-		c.eventRecorder.Warningf("StatusCreateFailed", "Failed to create operator status: %v", err)
-		return createErr
-	}
-
-	if condition := configv1helpers.FindStatusCondition(clusterOperatorObj.Status.Conditions, configv1.OperatorAvailable); condition != nil {
-		configv1helpers.SetStatusCondition(&freshOperatorConfig.Status.Conditions, *condition)
-	} else {
-		configv1helpers.RemoveStatusCondition(&freshOperatorConfig.Status.Conditions, configv1.OperatorAvailable)
-	}
-	if condition := configv1helpers.FindStatusCondition(clusterOperatorObj.Status.Conditions, configv1.OperatorProgressing); condition != nil {
-		configv1helpers.SetStatusCondition(&freshOperatorConfig.Status.Conditions, *condition)
-	} else {
-		configv1helpers.RemoveStatusCondition(&freshOperatorConfig.Status.Conditions, configv1.OperatorProgressing)
-	}
-	if condition := configv1helpers.FindStatusCondition(clusterOperatorObj.Status.Conditions, configv1.OperatorFailing); condition != nil {
-		configv1helpers.SetStatusCondition(&freshOperatorConfig.Status.Conditions, *condition)
-	} else {
-		configv1helpers.RemoveStatusCondition(&freshOperatorConfig.Status.Conditions, configv1.OperatorFailing)
-	}
-
-	// TODO work out removal.  We don't always know the existing value, so removing early seems like a bad idea.  Perhaps a remove flag.
-	versions = c.versionGetter.GetVersions()
-	for operand, version := range versions {
-		operatorv1helpers.SetOperandVersion(&freshOperatorConfig.Status.Versions, configv1.OperandVersion{Name: operand, Version: version})
-	}
-
-	if _, updateErr := c.clusterOperatorClient.ClusterOperators().UpdateStatus(freshOperatorConfig); updateErr != nil {
+	if _, updateErr := c.clusterOperatorClient.ClusterOperators().UpdateStatus(clusterOperatorObj); err != nil {
 		return updateErr
 	}
 	c.eventRecorder.Eventf("OperatorStatusChanged", "Status for operator %s changed: %s", c.clusterOperatorName, configv1helpers.GetStatusDiff(originalClusterOperatorObj.Status, clusterOperatorObj.Status))
-
 	return nil
 }
 

--- a/pkg/operator/status/status_controller_test.go
+++ b/pkg/operator/status/status_controller_test.go
@@ -6,17 +6,18 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/openshift/library-go/pkg/operator/events"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/client-go/tools/cache"
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
-	fake "github.com/openshift/client-go/config/clientset/versioned/fake"
+	"github.com/openshift/client-go/config/clientset/versioned/fake"
+	"github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers"
+	"github.com/openshift/library-go/pkg/operator/events"
 )
 
-func TestSync(t *testing.T) {
+func TestFailing(t *testing.T) {
 
 	testCases := []struct {
 		conditions            []operatorv1.OperatorCondition
@@ -67,7 +68,7 @@ func TestSync(t *testing.T) {
 				{Type: "TypeDFailing", Status: operatorv1.ConditionTrue, Message: "a message from type d"},
 			},
 			expectedFailingStatus: configv1.ConditionTrue,
-			expectedReason:        "MultipleConditionsFailing",
+			expectedReason:        "MultipleConditionsMatching",
 			expectedMessages: []string{
 				"TypeBFailing: a message from type b",
 				"TypeBFailing: another message from type b",
@@ -99,29 +100,28 @@ func TestSync(t *testing.T) {
 				return
 			}
 			result, _ := clusterOperatorClient.ConfigV1().ClusterOperators().Get("OPERATOR_NAME", metav1.GetOptions{})
-			expected := &configv1.ClusterOperator{
-				ObjectMeta: metav1.ObjectMeta{Name: "OPERATOR_NAME", ResourceVersion: "12"},
-			}
 
+			var expectedCondition *configv1.ClusterOperatorStatusCondition
 			if tc.expectedFailingStatus != "" {
-				condition := configv1.ClusterOperatorStatusCondition{
+				expectedCondition = &configv1.ClusterOperatorStatusCondition{
 					Type:   configv1.OperatorFailing,
 					Status: configv1.ConditionStatus(string(tc.expectedFailingStatus)),
 				}
 				if len(tc.expectedMessages) > 0 {
-					condition.Message = strings.Join(tc.expectedMessages, "\n")
+					expectedCondition.Message = strings.Join(tc.expectedMessages, "\n")
 				}
 				if len(tc.expectedReason) > 0 {
-					condition.Reason = tc.expectedReason
+					expectedCondition.Reason = tc.expectedReason
 				}
-				expected.Status.Conditions = append(expected.Status.Conditions, condition)
 			}
+
 			for i := range result.Status.Conditions {
 				result.Status.Conditions[i].LastTransitionTime = metav1.Time{}
 			}
 
-			if !reflect.DeepEqual(expected, result) {
-				t.Error(diff.ObjectDiff(expected, result))
+			actual := v1helpers.FindStatusCondition(result.Status.Conditions, "Failing")
+			if !reflect.DeepEqual(expectedCondition, actual) {
+				t.Error(diff.ObjectDiff(expectedCondition, actual))
 			}
 		})
 	}


### PR DESCRIPTION
Simplify the logic for building CO status and make all conditions union conditions so we can set multiple `*Available` conditions

/assign @soltysh @sanchezl 