### PR TITLE
operator: stop managing on unknown management state

### DIFF
--- a/pkg/operator/resourcesynccontroller/resourcesync_controller.go
+++ b/pkg/operator/resourcesynccontroller/resourcesync_controller.go
@@ -135,10 +135,13 @@ func (c *ResourceSyncController) sync() error {
 	}
 
 	switch operatorSpec.ManagementState {
+	case operatorv1.Managed:
 	case operatorv1.Unmanaged:
 		return nil
 	case operatorv1.Removed:
-		// TODO: Should we try to actively remove the resources created by this controller here?
+		// TODO probably just fail
+		return nil
+	default:
 		return nil
 	}
 

--- a/pkg/operator/staticpod/controller/backingresource/backing_resource_controller.go
+++ b/pkg/operator/staticpod/controller/backingresource/backing_resource_controller.go
@@ -98,10 +98,13 @@ func (c BackingResourceController) sync() error {
 	}
 
 	switch operatorSpec.ManagementState {
+	case operatorv1.Managed:
 	case operatorv1.Unmanaged:
 		return nil
 	case operatorv1.Removed:
-		// TODO: Should we delete the installer-sa and cluster role binding?
+		// TODO probably just fail
+		return nil
+	default:
 		return nil
 	}
 

--- a/pkg/operator/staticpod/controller/installer/installer_controller.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller.go
@@ -668,12 +668,16 @@ func (c InstallerController) sync() error {
 	operatorStatus := originalOperatorStatus.DeepCopy()
 
 	switch operatorSpec.ManagementState {
+	case operatorv1.Managed:
 	case operatorv1.Unmanaged:
 		return nil
 	case operatorv1.Removed:
-		// TODO probably just fail.  Static pod managers can't be removed.
+		// TODO probably just fail
+		return nil
+	default:
 		return nil
 	}
+
 	requeue, syncErr := c.manageInstallationPods(operatorSpec, operatorStatus, resourceVersion)
 	if requeue && syncErr == nil {
 		return fmt.Errorf("synthetic requeue request")

--- a/pkg/operator/staticpod/controller/monitoring/monitoring_resource_controller.go
+++ b/pkg/operator/staticpod/controller/monitoring/monitoring_resource_controller.go
@@ -99,10 +99,13 @@ func (c MonitoringResourceController) sync() error {
 	}
 
 	switch operatorSpec.ManagementState {
+	case operatorv1.Managed:
 	case operatorv1.Unmanaged:
 		return nil
 	case operatorv1.Removed:
-		// TODO: Should we try to actively remove the resources created by this controller here?
+		// TODO probably just fail
+		return nil
+	default:
 		return nil
 	}
 

--- a/pkg/operator/staticpod/controller/revision/revision_controller.go
+++ b/pkg/operator/staticpod/controller/revision/revision_controller.go
@@ -234,10 +234,13 @@ func (c RevisionController) sync() error {
 	operatorStatus := originalOperatorStatus.DeepCopy()
 
 	switch operatorSpec.ManagementState {
+	case operatorv1.Managed:
 	case operatorv1.Unmanaged:
 		return nil
 	case operatorv1.Removed:
-		// TODO probably just fail.  Static pod managers can't be removed.
+		// TODO probably just fail
+		return nil
+	default:
 		return nil
 	}
 

--- a/pkg/operator/staticpod/controller/staticpodstate/staticpodstate_controller.go
+++ b/pkg/operator/staticpod/controller/staticpodstate/staticpodstate_controller.go
@@ -71,10 +71,13 @@ func (c *StaticPodStateController) sync() error {
 	}
 
 	switch operatorSpec.ManagementState {
+	case operatorv1.Managed:
 	case operatorv1.Unmanaged:
 		return nil
 	case operatorv1.Removed:
-		// TODO probably just fail.  Static pod managers can't be removed.
+		// TODO probably just fail
+		return nil
+	default:
 		return nil
 	}
 


### PR DESCRIPTION
When the management state value is set to `foo`, we should stop managing and additionally emit a warning. We don't want to emit a warning per controller loop, so I added one to target config reconciler in each operator. 