### PR TITLE
eliminate the race to read the serving certs in operator filepath change detection

### DIFF
--- a/pkg/controller/controllercmd/builder.go
+++ b/pkg/controller/controllercmd/builder.go
@@ -86,7 +86,7 @@ func NewController(componentName string, startFunc StartFunc) *ControllerBuilder
 
 // WithRestartOnChange will enable a file observer controller loop that observes changes into specified files. If a change to a file is detected,
 // the specified channel will be closed (allowing to graceful shutdown for other channels).
-func (b *ControllerBuilder) WithRestartOnChange(stopCh chan<- struct{}, files ...string) *ControllerBuilder {
+func (b *ControllerBuilder) WithRestartOnChange(stopCh chan<- struct{}, startingFileContent map[string][]byte, files ...string) *ControllerBuilder {
 	if len(files) == 0 {
 		return b
 	}
@@ -107,7 +107,7 @@ func (b *ControllerBuilder) WithRestartOnChange(stopCh chan<- struct{}, files ..
 		return nil
 	}
 
-	b.fileObserver.AddReactor(b.fileObserverReactorFn, files...)
+	b.fileObserver.AddReactor(b.fileObserverReactorFn, startingFileContent, files...)
 	return b
 }
 

--- a/pkg/controller/controllercmd/flags.go
+++ b/pkg/controller/controllercmd/flags.go
@@ -47,31 +47,31 @@ func (f *ControllerFlags) AddFlags(cmd *cobra.Command) {
 
 // ToConfigObj given completed flags, returns a config object for the flag that was specified.
 // TODO versions goes away in 1.11
-func (f *ControllerFlags) ToConfigObj() (*unstructured.Unstructured, error) {
+func (f *ControllerFlags) ToConfigObj() ([]byte, *unstructured.Unstructured, error) {
 	// no file means empty, not err
 	if len(f.ConfigFile) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	content, err := ioutil.ReadFile(f.ConfigFile)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	// empty file means empty, not err
 	if len(content) == 0 {
-		return nil, nil
+		return nil, nil, err
 	}
 
 	data, err := kyaml.ToJSON(content)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	uncastObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, data)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return uncastObj.(*unstructured.Unstructured), nil
+	return content, uncastObj.(*unstructured.Unstructured), nil
 }
 
 // ToClientConfig given completed flags, returns a rest.Config.  overrides are optional

--- a/pkg/controller/fileobserver/observer.go
+++ b/pkg/controller/fileobserver/observer.go
@@ -10,7 +10,7 @@ import (
 
 type Observer interface {
 	Run(stopChan <-chan struct{})
-	AddReactor(reaction reactorFn, files ...string) Observer
+	AddReactor(reaction reactorFn, startingFileContent map[string][]byte, files ...string) Observer
 }
 
 // ActionType define a type of action observed on the file

--- a/pkg/controller/fileobserver/observer_polling_test.go
+++ b/pkg/controller/fileobserver/observer_polling_test.go
@@ -54,7 +54,7 @@ func TestObserverSimple(t *testing.T) {
 
 	testFile := filepath.Join(dir, "test-file-1")
 
-	o.AddReactor(testReaction, testFile)
+	o.AddReactor(testReaction, nil, testFile)
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
@@ -123,4 +123,59 @@ func TestObserverSimple(t *testing.T) {
 
 	os.Remove(testFile)
 	<-fileRemoveObserved
+}
+
+func TestObserverSimpleContentSpecified(t *testing.T) {
+	dir, err := ioutil.TempDir("", "observer-simple-")
+	if err != nil {
+		t.Fatalf("tempdir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	o, err := NewObserver(200 * time.Millisecond)
+	if err != nil {
+		t.Fatalf("observer: %v", err)
+	}
+
+	reactions := newReactionRecorder()
+
+	testReaction := func(f string, action ActionType) error {
+		reactions.add(f, action)
+		return nil
+	}
+
+	testFile := filepath.Join(dir, "test-file-1")
+	ioutil.WriteFile(testFile, []byte("foo"), os.ModePerm)
+
+	o.AddReactor(
+		testReaction,
+		map[string][]byte{
+			testFile: {},
+		},
+		testFile)
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	go o.Run(stopCh)
+
+	fileModifyObserved := make(chan struct{})
+	go func() {
+		defer close(fileModifyObserved)
+		if err := wait.PollImmediateUntil(300*time.Millisecond, func() (bool, error) {
+			t.Logf("waiting for reaction ...")
+			if len(reactions.get(testFile)) == 0 {
+				return false, nil
+			}
+			if r := reactions.get(testFile)[0]; r != FileModified {
+				return true, fmt.Errorf("expected FileModified, got: %#v", reactions.get(testFile))
+			}
+			t.Logf("recv: %#v", reactions.get(testFile))
+			return true, nil
+		}, stopCh); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}()
+
+	<-fileModifyObserved
+	os.Remove(testFile)
 }

--- a/pkg/crypto/crypto.go
+++ b/pkg/crypto/crypto.go
@@ -222,7 +222,7 @@ type TLSCARoots struct {
 	Roots []*x509.Certificate
 }
 
-func (c *TLSCertificateConfig) writeCertConfigFile(certFile, keyFile string) error {
+func (c *TLSCertificateConfig) WriteCertConfigFile(certFile, keyFile string) error {
 	// ensure parent dir
 	if err := os.MkdirAll(filepath.Dir(certFile), os.FileMode(0755)); err != nil {
 		return err
@@ -496,7 +496,7 @@ func MakeSelfSignedCA(certFile, keyFile, serialFile, name string, expireDays int
 	if err != nil {
 		return nil, err
 	}
-	if err := caConfig.writeCertConfigFile(certFile, keyFile); err != nil {
+	if err := caConfig.WriteCertConfigFile(certFile, keyFile); err != nil {
 		return nil, err
 	}
 
@@ -606,7 +606,7 @@ func (ca *CA) MakeAndWriteServerCert(certFile, keyFile string, hostnames sets.St
 	if err != nil {
 		return nil, err
 	}
-	if err := server.writeCertConfigFile(certFile, keyFile); err != nil {
+	if err := server.WriteCertConfigFile(certFile, keyFile); err != nil {
 		return server, err
 	}
 	return server, nil


### PR DESCRIPTION
We knew we had a theoretical race, but we didn't expect to see it happen in any practical timeframe.  This is a good candidate fix for https://bugzilla.redhat.com/show_bug.cgi?id=1678929 which appears to happen sometimes.  We just force the initial values to hash.

/hold

hold for proof in another pull.