### PR TITLE
assets: add more sense to creater verbose messages

### DIFF
--- a/pkg/assets/create/create_test.go
+++ b/pkg/assets/create/create_test.go
@@ -132,7 +132,7 @@ func TestEnsureManifestsCreated(t *testing.T) {
 	if !strings.Contains(out.String(), `no matches for kind "KubeAPIServerOperatorConfig"`) {
 		t.Fatalf("expected error logged to output when verbose is on, got: %s\n", out.String())
 	}
-	if !strings.Contains(out.String(), `Creating kubeapiserver.operator.openshift.io/v1alpha1`) {
+	if !strings.Contains(out.String(), `Created apiextensions.k8s.io/v1beta1`) {
 		t.Fatalf("expected success logged to output when verbose is on, got: %s\n", out.String())
 	}
 }


### PR DESCRIPTION
1) in case the asset already exists, it is skipped (not created again), but user still see:

```
Feb 21 09:54:23 ip-10-0-13-88 bootkube.sh[13308]: Creating /v1, Resource=namespaces ...
Feb 21 09:54:23 ip-10-0-13-88 bootkube.sh[13308]: Creating /v1, Resource=namespaces ...
Feb 21 09:54:23 ip-10-0-13-88 bootkube.sh[13308]: Creating /v1, Resource=namespaces ...
```

2) in case of error, the user will see summary of errors at the end, but we should print error immediately in verbose mode

3) move the created message when the resource is really created