### PR TITLE
allow hostnames to be specified and changed after initial creation

### DIFF
--- a/pkg/operator/certrotation/client_cert_rotation_controller.go
+++ b/pkg/operator/certrotation/client_cert_rotation_controller.go
@@ -61,6 +61,8 @@ func NewCertRotationController(
 	}
 
 	ret := &CertRotationController{
+		name: name,
+
 		SigningRotation:  signingRotation,
 		CABundleRotation: caBundleRotation,
 		TargetRotation:   targetRotation,
@@ -197,7 +199,7 @@ func (c *CertRotationController) processNextWorkItem() bool {
 		return true
 	}
 
-	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", dsKey, err))
+	utilruntime.HandleError(fmt.Errorf("%v: %v failed with: %v", c.name, dsKey, err))
 	c.queue.AddRateLimited(dsKey)
 
 	return true

--- a/pkg/operator/certrotation/target.go
+++ b/pkg/operator/certrotation/target.go
@@ -202,6 +202,9 @@ type ServingRotation struct {
 }
 
 func (r *ServingRotation) NewCertificate(signer *crypto.CA, validity time.Duration) (*crypto.TLSCertificateConfig, error) {
+	if len(r.Hostnames()) == 0 {
+		return nil, fmt.Errorf("no hostnames set")
+	}
 	return signer.MakeServerCertForDuration(sets.NewString(r.Hostnames()...), validity, r.CertificateExtensionFn...)
 }
 

--- a/pkg/operator/certrotation/target_test.go
+++ b/pkg/operator/certrotation/target_test.go
@@ -180,7 +180,7 @@ func TestEnsureTargetCertKeyPair(t *testing.T) {
 				Validity:          24 * time.Hour,
 				RefreshPercentage: .50,
 				Name:              "target-secret",
-				ServingRotation: &ServingRotation{
+				CertCreator: &ServingRotation{
 					Hostnames: []string{"foo"},
 				},
 
@@ -312,7 +312,7 @@ func TestEnsureTargetSignerCertKeyPair(t *testing.T) {
 				Validity:          24 * time.Hour,
 				RefreshPercentage: .50,
 				Name:              "target-secret",
-				SignerRotation: &SignerRotation{
+				CertCreator: &SignerRotation{
 					SignerName: "lower-signer",
 				},
 

--- a/pkg/operator/certrotation/target_test.go
+++ b/pkg/operator/certrotation/target_test.go
@@ -160,6 +160,9 @@ func TestEnsureTargetCertKeyPair(t *testing.T) {
 				if len(actual.Data["tls.crt"]) == 0 || len(actual.Data["tls.key"]) == 0 {
 					t.Error(actual.Data)
 				}
+				if actual.Annotations[CertificateHostnames] != "bar,foo" {
+					t.Error(actual.Annotations[CertificateHostnames])
+				}
 
 			},
 		},
@@ -181,7 +184,7 @@ func TestEnsureTargetCertKeyPair(t *testing.T) {
 				RefreshPercentage: .50,
 				Name:              "target-secret",
 				CertCreator: &ServingRotation{
-					Hostnames: []string{"foo"},
+					Hostnames: func() []string { return []string{"foo", "bar"} },
 				},
 
 				Client:        client.CoreV1(),
@@ -204,6 +207,60 @@ func TestEnsureTargetCertKeyPair(t *testing.T) {
 			}
 
 			test.verifyActions(t, client)
+		})
+	}
+}
+
+func TestServerHostnameCheck(t *testing.T) {
+	tests := []struct {
+		name string
+
+		existingHostnames string
+		requiredHostnames []string
+
+		expected string
+	}{
+		{
+			name:              "nothing",
+			existingHostnames: "",
+			requiredHostnames: []string{"foo"},
+			expected:          `"" are existing and not required, "foo" are required and not existing`,
+		},
+		{
+			name:              "exists",
+			existingHostnames: "foo",
+			requiredHostnames: []string{"foo"},
+			expected:          "",
+		},
+		{
+			name:              "hasExtra",
+			existingHostnames: "foo,bar",
+			requiredHostnames: []string{"foo"},
+			expected:          `"bar" are existing and not required, "" are required and not existing`,
+		},
+		{
+			name:              "needsAnother",
+			existingHostnames: "foo",
+			requiredHostnames: []string{"foo", "bar"},
+			expected:          `"" are existing and not required, "bar" are required and not existing`,
+		},
+		{
+			name:              "both",
+			existingHostnames: "foo,baz",
+			requiredHostnames: []string{"foo", "bar"},
+			expected:          `"baz" are existing and not required, "bar" are required and not existing`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r := &ServingRotation{
+				Hostnames: func() []string { return test.requiredHostnames },
+			}
+			actual := r.missingHostnames(map[string]string{CertificateHostnames: test.existingHostnames})
+			if actual != test.expected {
+				t.Fatal(actual)
+			}
 		})
 	}
 }


### PR DESCRIPTION
This updates rotation to have server hostnames settable after the fact using a function and provides a way to wire a channel to tickle the controller when there are changes

/hold

holding until I proof of working

/assign @sttts 