### PR TITLE
resource: enforce apiGroup to role binding as well

### DIFF
--- a/pkg/operator/resource/resourceapply/rbac.go
+++ b/pkg/operator/resource/resourceapply/rbac.go
@@ -136,6 +136,9 @@ func ApplyRoleBinding(client rbacclientv1.RoleBindingsGetter, recorder events.Re
 	modified := resourcemerge.BoolPtr(false)
 	existingCopy := existing.DeepCopy()
 
+	// Enforce apiGroup field
+	existingCopy.RoleRef.APIGroup = rbacv1.GroupName
+
 	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
 	contentSame := equality.Semantic.DeepEqual(existingCopy.Subjects, required.Subjects) &&
 		deepEqualRoleRef(existingCopy.RoleRef, required.RoleRef)


### PR DESCRIPTION
I fixed cluster role binding and forget the role binding. There is still evidence in controller manager operator logs to stomp the apiGroup 130x during CI run. This should fix it.