### PR TITLE
installer: quorum-read for configmap+secrets

### DIFF
--- a/pkg/operator/staticpod/controller/installer/installer_controller_test.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller_test.go
@@ -74,6 +74,7 @@ func TestNewNodeStateForInstallInProgress(t *testing.T) {
 		fakeStaticPodOperatorClient,
 		kubeClient.CoreV1(),
 		kubeClient.CoreV1(),
+		kubeClient.CoreV1(),
 		eventRecorder,
 	)
 	c.ownerRefsFn = func(revision int32) ([]metav1.OwnerReference, error) {
@@ -288,6 +289,7 @@ func TestCreateInstallerPod(t *testing.T) {
 		fakeStaticPodOperatorClient,
 		kubeClient.CoreV1(),
 		kubeClient.CoreV1(),
+		kubeClient.CoreV1(),
 		eventRecorder,
 	)
 	c.ownerRefsFn = func(revision int32) ([]metav1.OwnerReference, error) {
@@ -455,6 +457,7 @@ func TestEnsureInstallerPod(t *testing.T) {
 				[]string{"/bin/true"},
 				kubeInformers,
 				fakeStaticPodOperatorClient,
+				kubeClient.CoreV1(),
 				kubeClient.CoreV1(),
 				kubeClient.CoreV1(),
 				eventRecorder,
@@ -999,6 +1002,7 @@ func TestCreateInstallerPodMultiNode(t *testing.T) {
 				[]string{"/bin/true"},
 				kubeInformers,
 				fakeStaticPodOperatorClient,
+				kubeClient.CoreV1(),
 				kubeClient.CoreV1(),
 				kubeClient.CoreV1(),
 				eventRecorder,

--- a/pkg/operator/staticpod/controllers.go
+++ b/pkg/operator/staticpod/controllers.go
@@ -147,6 +147,7 @@ func (b *staticPodOperatorControllerBuilder) ToControllers() (*staticPodOperator
 			operandInformers,
 			b.staticPodOperatorClient,
 			configMapClient,
+			secretsClient,
 			podClient,
 			eventRecorder,
 		)


### PR DESCRIPTION
GETs are served from cache by default. Deletes only propagate through the API servers. This means that installer pod might not see the deletion.

We have two ways to solve this:
1. do quorum reads for configmaps+secrets to be used in installer pod (either in the operator or in the installer).
2. increase the revision on each revision controller sync. Never delete or update resources (i.e. no sync, only non-overriding copy).