### PR TITLE
staticpod: simplify retry mechanism

### DIFF
--- a/pkg/operator/staticpod/installerpod/copy.go
+++ b/pkg/operator/staticpod/installerpod/copy.go
@@ -1,0 +1,69 @@
+package installerpod
+
+import (
+	"time"
+
+	"github.com/golang/glog"
+	"golang.org/x/net/context"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// getSecretWithRetry will get a secret from API server.
+// It will retry on API server connection errors except not found error which is fatal for non-optional secrets.
+// In case the secret is optional and we fail to get it, no error is returned and the secret returning is nil.
+func (o *InstallOptions) getSecretWithRetry(ctx context.Context, secretNamePrefix string, isOptional bool) (*v1.Secret, error) {
+	var secret *v1.Secret
+	retryErr := wait.PollImmediateUntil(200*time.Millisecond, func() (done bool, err error) {
+		secret, err = o.KubeClient.CoreV1().Secrets(o.Namespace).Get(o.nameFor(secretNamePrefix), metav1.GetOptions{})
+		switch {
+		case errors.IsNotFound(err):
+			// if secret is optional, report success even when the secret was not found
+			if isOptional {
+				err = nil
+			}
+			return true, err
+		case err != nil:
+			if !isOptional {
+				glog.Warningf("Failed to get secret %q: %v (will retry)", o.Namespace+"/"+o.nameFor(secretNamePrefix), err)
+			}
+			// if secret is optional, report success on any error and never retry
+			return isOptional, nil
+		default:
+			return true, nil
+		}
+	}, ctx.Done())
+
+	return secret, retryErr
+}
+
+// getConfigMapWithRetry will get a config map from API server.
+// It will retry on API server connection errors except not found error which is fatal for non-optional secrets.
+// In case the config is optional and we fail to get it, no error is returned and the config returning is nil.
+func (o *InstallOptions) getConfigMapWithRetry(ctx context.Context, configNamePrefix string, isOptional bool) (*v1.ConfigMap, error) {
+	var config *v1.ConfigMap
+	retryErr := wait.PollImmediateUntil(200*time.Millisecond, func() (done bool, err error) {
+		config, err = o.KubeClient.CoreV1().ConfigMaps(o.Namespace).Get(o.nameFor(configNamePrefix), metav1.GetOptions{})
+		switch {
+		case errors.IsNotFound(err):
+			// if config is optional, report success even when the config was not found
+			if isOptional {
+				err = nil
+			}
+			return true, err
+		case err != nil:
+			if !isOptional {
+				glog.Warningf("Failed to get configMap %q: %v (will retry)", o.Namespace+"/"+o.nameFor(configNamePrefix), err)
+			}
+			// if config is optional, report success on any error and never retry
+			return isOptional, nil
+		default:
+			return true, nil
+		}
+	}, ctx.Done())
+
+	return config, retryErr
+}

--- a/pkg/operator/staticpod/installerpod/copy_test.go
+++ b/pkg/operator/staticpod/installerpod/copy_test.go
@@ -1,0 +1,135 @@
+package installerpod
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+)
+
+func addFakeSecret(name string) *v1.Secret {
+	secret := &v1.Secret{}
+	secret.Name = name
+	secret.Namespace = "test"
+	return secret
+}
+
+func TestGetSecretWithRetry(t *testing.T) {
+	tests := []struct {
+		name              string
+		getSecretPrefix   string
+		secrets           []runtime.Object
+		optional          bool
+		expectErr         bool
+		expectRetries     bool
+		sendInternalError bool
+	}{
+		{
+			name:            "required secret exists",
+			secrets:         []runtime.Object{addFakeSecret("test-secret-1")},
+			getSecretPrefix: "test-secret",
+		},
+		{
+			name:            "optional secret does not exists and we not expect error",
+			secrets:         []runtime.Object{},
+			getSecretPrefix: "test-secret",
+			optional:        true,
+			expectRetries:   false,
+			expectErr:       false,
+		},
+		{
+			name:            "required secret does not exists and no retry on not found error",
+			secrets:         []runtime.Object{},
+			getSecretPrefix: "test-secret",
+			expectRetries:   false,
+			expectErr:       true,
+		},
+		{
+			name:              "required secret exists and we retry on internal error",
+			secrets:           []runtime.Object{addFakeSecret("test-secret-1")},
+			getSecretPrefix:   "test-secret",
+			expectRetries:     true,
+			sendInternalError: true,
+			expectErr:         false,
+		},
+		{
+			name:              "optional secret does not exists and we not retry on internal error",
+			secrets:           []runtime.Object{},
+			getSecretPrefix:   "test-secret",
+			optional:          true,
+			sendInternalError: true,
+			expectRetries:     false,
+			expectErr:         false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := fake.NewSimpleClientset(test.secrets...)
+			ctx := context.TODO()
+			internalErrorChan := make(chan struct{})
+
+			client.PrependReactor("get", "secrets", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+				getAction := action.(ktesting.GetAction)
+				if getAction.GetName() != test.getSecretPrefix+"-1" {
+					return false, nil, nil
+				}
+
+				// Send 500 error. Closing the channel means we remove this reactor from the reaction chain.
+				if test.sendInternalError {
+					close(internalErrorChan)
+					return true, nil, errors.NewInternalError(fmt.Errorf("test"))
+				} else {
+					return false, nil, nil
+				}
+			})
+			timeoutContext, cancel := context.WithTimeout(ctx, 2*time.Second)
+			defer cancel()
+			ctx = timeoutContext
+
+			options := &InstallOptions{KubeClient: client, Namespace: "test", Revision: "1"}
+
+			// If we have test that send internal error, wait for the internal error to be send and then remove the
+			// reactor immediately. This should cause the client to retry and we observe that retries in actions.
+			if test.sendInternalError {
+				go func(c *fake.Clientset) {
+					<-internalErrorChan
+					c.Lock()
+					defer c.Unlock()
+					c.ReactionChain = c.ReactionChain[1 : len(c.ReactionChain)-1]
+				}(client)
+			}
+
+			_, err := options.getSecretWithRetry(ctx, test.getSecretPrefix, test.optional)
+			switch {
+			case err != nil && !test.expectErr:
+				t.Errorf("unexpected error: %v", err)
+				return
+			case err == nil && test.expectErr:
+				t.Errorf("expected error, got none")
+				return
+			}
+
+			// -1 means that we get 0 if we only got 1 request (which is ok if we don't expect any retries)
+			retries := -1
+			for _, action := range client.Actions() {
+				if action.GetVerb() != "get" || action.GetResource().Resource != "secrets" {
+					continue
+				}
+				retries++
+			}
+			switch {
+			case retries > 0 && !test.expectRetries:
+				t.Errorf("expected no retries, but got %d retries", retries)
+			case retries == 0 && test.expectRetries:
+				t.Error("expected retries, but got none")
+			}
+		})
+	}
+}


### PR DESCRIPTION
This simplify the retry mechanism when retrieving secrets and configmaps from API server and also fixes a case when we fail to obtain self-reference for an installer pod (events) and instead of retry we failed.

In addition this add more unit tests to exercise the retry mechanism to increase test coverage for this critical piece of infrastructure.