### PR TITLE
wire updated retry on connection logic to installer pod

### DIFF
--- a/pkg/operator/resource/retry/retry.go
+++ b/pkg/operator/resource/retry/retry.go
@@ -1,0 +1,59 @@
+package retry
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+)
+
+// ignoreConnectionErrors is a wrapper for condition function that will cause to retry on all errors like
+// connection refused, EOF, no route to host, etc. but also all 50x API server errors.
+// This wrapper will return immediately on HTTP 40x client errors and those will not be retried.
+func ignoreConnectionErrors(lastError *error, fn ConditionWithContextFunc) ConditionWithContextFunc {
+	return func(ctx context.Context) (bool, error) {
+		done, err := fn(ctx)
+		switch {
+		case done:
+			return true, err
+		case err == nil:
+			return true, nil
+		case IsHTTPClientError(err):
+			return false, err
+		default:
+			*lastError = err
+			return false, nil
+		}
+	}
+}
+
+// RetryOnConnectionErrors will take context and condition function and retry the condition function until:
+// 1) no error is returned
+// 2) a client (4xx) HTTP error is returned
+// 3) the context passed to the condition function is done
+// 4) numbers of steps in the exponential backoff are met
+// In case of 3) or 4) the error returned will be the last observed error from the condition function.
+func RetryOnConnectionErrors(ctx context.Context, fn ConditionWithContextFunc) error {
+	var lastRetryErr error
+	err := ExponentialBackoffWithContext(ctx, retry.DefaultBackoff, ignoreConnectionErrors(&lastRetryErr, fn))
+	switch err {
+	case wait.ErrWaitTimeout:
+		if lastRetryErr != nil {
+			return lastRetryErr
+		}
+		return err
+	default:
+		return err
+	}
+}
+
+// IsHTTPClientError indicates whether the error passes is an 4xx API server error (client error).
+func IsHTTPClientError(err error) bool {
+	switch t := err.(type) {
+	case errors.APIStatus:
+		return t.Status().Code >= 400 && t.Status().Code < 500
+	default:
+		return false
+	}
+}

--- a/pkg/operator/resource/retry/retry_test.go
+++ b/pkg/operator/resource/retry/retry_test.go
@@ -1,0 +1,122 @@
+package retry
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestRetryOnConnectionErrors(t *testing.T) {
+	tests := []struct {
+		name           string
+		contextTimeout time.Duration
+		jobDuration    time.Duration
+		jobError       error
+		jobDone        bool
+		evalError      func(*testing.T, error)
+		evalAttempts   func(*testing.T, int)
+	}{
+		{
+			name:           "timeout on context deadline",
+			contextTimeout: 200 * time.Millisecond,
+			jobDuration:    500 * time.Millisecond,
+			jobError:       errors.NewInternalError(fmt.Errorf("internal error")),
+			evalError: func(t *testing.T, e error) {
+				if !errors.IsInternalError(e) {
+					t.Errorf("expected internal server error, got %v", e)
+				}
+			},
+			evalAttempts: func(t *testing.T, attempts int) {
+				if attempts != 1 {
+					t.Errorf("expected only one attempt, got %d", attempts)
+				}
+			},
+		},
+		{
+			name:           "retry on internal server error",
+			contextTimeout: 500 * time.Millisecond,
+			jobDuration:    200 * time.Millisecond,
+			jobError:       errors.NewInternalError(fmt.Errorf("internal error")),
+			evalError: func(t *testing.T, e error) {
+				if !errors.IsInternalError(e) {
+					t.Errorf("expected internal server error, got %v", e)
+				}
+			},
+			evalAttempts: func(t *testing.T, attempts int) {
+				if attempts <= 1 {
+					t.Errorf("expected more than one attempt, got %d", attempts)
+				}
+			},
+		},
+		{
+			name:           "return on not found error",
+			contextTimeout: 500 * time.Millisecond,
+			jobDuration:    100 * time.Millisecond,
+			jobError:       errors.NewNotFound(schema.GroupResource{Resource: "pods"}, "test-pod"),
+			evalError: func(t *testing.T, e error) {
+				if !errors.IsNotFound(e) {
+					t.Errorf("expected not found error, got %v", e)
+				}
+			},
+			evalAttempts: func(t *testing.T, attempts int) {
+				if attempts != 1 {
+					t.Errorf("expected only one attempt, got %d", attempts)
+				}
+			},
+		},
+		{
+			name:           "return on no error",
+			contextTimeout: 500 * time.Millisecond,
+			jobDuration:    50 * time.Millisecond,
+			evalError: func(t *testing.T, e error) {
+				if e != nil {
+					t.Errorf("expected no error, got %v", e)
+				}
+			},
+			evalAttempts: func(t *testing.T, attempts int) {
+				if attempts != 1 {
+					t.Errorf("expected only one attempt, got %d", attempts)
+				}
+			},
+		},
+		{
+			name:           "return on done",
+			contextTimeout: 500 * time.Millisecond,
+			jobDuration:    50 * time.Millisecond,
+			jobDone:        true,
+			evalError: func(t *testing.T, e error) {
+				if e != nil {
+					t.Errorf("expected no error, got %v", e)
+				}
+			},
+			evalAttempts: func(t *testing.T, attempts int) {
+				if attempts != 1 {
+					t.Errorf("expected only one attempt, got %d", attempts)
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.TODO(), test.contextTimeout)
+			defer cancel()
+			attempts := 0
+			err := RetryOnConnectionErrors(ctx, func(context.Context) (bool, error) {
+				time.Sleep(test.jobDuration)
+				attempts++
+				if test.jobError != nil {
+					return test.jobDone, test.jobError
+				}
+				return test.jobDone, nil
+			})
+			test.evalError(t, err)
+			test.evalAttempts(t, attempts)
+		})
+	}
+
+}

--- a/pkg/operator/resource/retry/wait.go
+++ b/pkg/operator/resource/retry/wait.go
@@ -1,0 +1,36 @@
+package retry
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// TODO: This should be added to k8s.io/client-go/util/retry
+
+// ConditionWithContextFunc returns true if the condition is satisfied, or an error
+// if the loop should be aborted. The context passed to condition function allow function body
+// to return faster than context.Done().
+type ConditionWithContextFunc func(ctx context.Context) (done bool, err error)
+
+// ExponentialBackoffWithContext repeats a condition check with exponential backoff and stop repeating
+// when the context passed to this function is done.
+//
+// It checks the condition up to Steps times, increasing the wait by multiplying
+// the previous duration by Factor.
+//
+// If Jitter is greater than zero, a random amount of each duration is added
+// (between duration and duration*(1+jitter)).
+//
+// If the condition never returns true, ErrWaitTimeout is returned. All other
+// errors terminate immediately.
+func ExponentialBackoffWithContext(ctx context.Context, backoff wait.Backoff, condition ConditionWithContextFunc) error {
+	return wait.ExponentialBackoff(backoff, func() (bool, error) {
+		select {
+		case <-ctx.Done():
+			return false, wait.ErrWaitTimeout
+		default:
+			return condition(ctx)
+		}
+	})
+}

--- a/pkg/operator/staticpod/installerpod/copy.go
+++ b/pkg/operator/staticpod/installerpod/copy.go
@@ -1,61 +1,67 @@
 package installerpod
 
 import (
-	"time"
-
 	"github.com/golang/glog"
 	"golang.org/x/net/context"
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/openshift/library-go/pkg/operator/resource/retry"
 )
 
-// getSecretWithRetry will get a secret from API server.
-// It will retry on API server connection errors except not found error which is fatal for non-optional secrets.
-// In case the secret is optional and we fail to get it, no error is returned and the secret returning is nil.
-func (o *InstallOptions) getSecretWithRetry(ctx context.Context, secretNamePrefix string, isOptional bool) (*v1.Secret, error) {
-	var resultSecret *v1.Secret = nil
-	retryErr := wait.PollImmediateUntil(200*time.Millisecond, func() (bool, error) {
-		secret, err := o.KubeClient.CoreV1().Secrets(o.Namespace).Get(o.nameFor(secretNamePrefix), metav1.GetOptions{})
-		switch {
-		case errors.IsNotFound(err):
-			if isOptional {
-				err = nil
-			}
-			return true, err
-		case err != nil:
-			glog.Warningf("Failed to get secret %s/%s: %v (will retry)", o.Namespace, o.nameFor(secretNamePrefix), err)
-			return false, nil
-		default:
-			resultSecret = secret
-			return true, nil
+// getSecretWithRetry will attempt to get the secret from the API server and retry on any connection errors until
+// the context is not done or secret is returned or a HTTP client error is returned.
+// In case the optional flag is set, the 404 error is not reported and a nil object is returned instead.
+func (o *InstallOptions) getSecretWithRetry(ctx context.Context, name string, isOptional bool) (*v1.Secret, error) {
+	var secret *v1.Secret
+
+	err := retry.RetryOnConnectionErrors(ctx, func(ctx context.Context) (bool, error) {
+		var clientErr error
+		secret, clientErr = o.KubeClient.CoreV1().Secrets(o.Namespace).Get(name, metav1.GetOptions{})
+		if clientErr != nil {
+			glog.Infof("Failed to get secret %s/%s: %v", o.Namespace, name, clientErr)
+			return false, clientErr
 		}
-	}, ctx.Done())
-	return resultSecret, retryErr
+		return true, nil
+	})
+
+	switch {
+	case err == nil:
+		glog.Infof("Got secret %s/%s", o.Namespace, name)
+		return secret, nil
+	case errors.IsNotFound(err) && isOptional:
+		return nil, nil
+	default:
+		return nil, err
+	}
+
 }
 
-// getConfigMapWithRetry will get a config map from API server.
-// It will retry on API server connection errors except not found error which is fatal for non-optional secrets.
-// In case the config is optional and we fail to get it, no error is returned and the config returning is nil.
-func (o *InstallOptions) getConfigMapWithRetry(ctx context.Context, configNamePrefix string, isOptional bool) (*v1.ConfigMap, error) {
-	var resultConfig *v1.ConfigMap = nil
-	retryErr := wait.PollImmediateUntil(200*time.Millisecond, func() (bool, error) {
-		config, err := o.KubeClient.CoreV1().ConfigMaps(o.Namespace).Get(o.nameFor(configNamePrefix), metav1.GetOptions{})
-		switch {
-		case errors.IsNotFound(err):
-			if isOptional {
-				err = nil
-			}
-			return true, err
-		case err != nil:
-			glog.Warningf("Failed to get configmap %s/%s: %v (will retry)", o.Namespace, o.nameFor(configNamePrefix), err)
-			return false, nil
-		default:
-			resultConfig = config
-			return true, nil
+// getConfigMapWithRetry will attempt to get the configMap from the API server and retry on any connection errors until
+// the context is not done or configMap is returned or a HTTP client error is returned.
+// In case the optional flag is set, the 404 error is not reported and a nil object is returned instead.
+func (o *InstallOptions) getConfigMapWithRetry(ctx context.Context, name string, isOptional bool) (*v1.ConfigMap, error) {
+	var config *v1.ConfigMap
+
+	err := retry.RetryOnConnectionErrors(ctx, func(ctx context.Context) (bool, error) {
+		var clientErr error
+		config, clientErr = o.KubeClient.CoreV1().ConfigMaps(o.Namespace).Get(name, metav1.GetOptions{})
+		if clientErr != nil {
+			glog.Infof("Failed to get config map %s/%s: %v", o.Namespace, name, clientErr)
+			return false, clientErr
 		}
-	}, ctx.Done())
-	return resultConfig, retryErr
+		return true, nil
+	})
+
+	switch {
+	case err == nil:
+		glog.Infof("Got configMap %s/%s", o.Namespace, name)
+		return config, nil
+	case errors.IsNotFound(err) && isOptional:
+		return nil, nil
+	default:
+		return nil, err
+	}
 }


### PR DESCRIPTION
This is something I miss in the client-go `retry` package and I think we should add it there.

Retrying on connection errors or (transient) server errors become a common problem as all operators have to talk to a restarting API server and the clients in operators need to handle retries in that case gracefully. While in the operator control loops this problem is not urgent (and it is usually resolved by reconcile), in components like installer pods or pruning pods this problem is more imminent and require some plumbing.

The retry mechanism here use exponential backoff (similar to retry on conflict) and it retry on all errors except the HTTP client errors (not found, auth, etc). The context passed to this function should specify the timeout and the user function should observe the context cancellation (if the function only do client call, it is no-op until client-go get context support).

upstream PR: [kubernetes/kubernetes#74722](https://github.com/kubernetes/kubernetes/pull/74722)

I will create a proof PR.