### PR TITLE
Compare LastFailed and Current revisions for pruner pod

### DIFF
--- a/pkg/operator/staticpod/controller/prune/prune_controller.go
+++ b/pkg/operator/staticpod/controller/prune/prune_controller.go
@@ -102,7 +102,7 @@ func getRevisionLimits(operatorSpec *operatorv1.StaticPodOperatorSpec) (int32, i
 }
 
 func (c *PruneController) excludedRevisionHistory(operatorStatus *operatorv1.StaticPodOperatorStatus, failedRevisionLimit, succeededRevisionLimit int32) ([]int, error) {
-	var succeededRevisionIDs, failedRevisionIDs, inProgressRevisionIDs, unknownStatusRevisionIDs []int
+	var succeededRevisions, failedRevisions, inProgressRevisions, unknownStatusRevisions []int
 
 	configMaps, err := c.configMapGetter.ConfigMaps(c.targetNamespace).List(metav1.ListOptions{})
 	if err != nil {
@@ -114,53 +114,53 @@ func (c *PruneController) excludedRevisionHistory(operatorStatus *operatorv1.Sta
 		}
 
 		if revision, ok := configMap.Data["revision"]; ok {
-			revisionID, err := strconv.Atoi(revision)
+			revisionNumber, err := strconv.Atoi(revision)
 			if err != nil {
 				return []int{}, err
 			}
 			switch configMap.Data["status"] {
 			case string(corev1.PodSucceeded):
-				succeededRevisionIDs = append(succeededRevisionIDs, revisionID)
+				succeededRevisions = append(succeededRevisions, revisionNumber)
 			case string(corev1.PodFailed):
-				failedRevisionIDs = append(failedRevisionIDs, revisionID)
+				failedRevisions = append(failedRevisions, revisionNumber)
 
 			case "InProgress":
 				// we always protect inprogress
-				inProgressRevisionIDs = append(inProgressRevisionIDs, revisionID)
+				inProgressRevisions = append(inProgressRevisions, revisionNumber)
 
 			default:
 				// protect things you don't understand
-				unknownStatusRevisionIDs = append(unknownStatusRevisionIDs, revisionID)
-				c.eventRecorder.Event("UnknownRevisionStatus", fmt.Sprintf("unknown status for revision %d: %v", revisionID, configMap.Data["status"]))
+				unknownStatusRevisions = append(unknownStatusRevisions, revisionNumber)
+				c.eventRecorder.Event("UnknownRevisionStatus", fmt.Sprintf("unknown status for revision %d: %v", revisionNumber, configMap.Data["status"]))
 			}
 		}
 	}
 
 	// Return early if nothing to prune
-	if len(succeededRevisionIDs)+len(failedRevisionIDs) == 0 {
+	if len(succeededRevisions)+len(failedRevisions) == 0 {
 		glog.V(2).Info("no revision IDs currently eligible to prune")
 		return []int{}, nil
 	}
 
 	// Get list of protected IDs
-	protectedSucceededRevisionIDs := protectedIDs(succeededRevisionIDs, int(succeededRevisionLimit))
-	protectedFailedRevisionIDs := protectedIDs(failedRevisionIDs, int(failedRevisionLimit))
+	protectedSucceededRevisions := protectedRevisions(succeededRevisions, int(succeededRevisionLimit))
+	protectedFailedRevisions := protectedRevisions(failedRevisions, int(failedRevisionLimit))
 
-	excludedIDs := make([]int, 0, len(protectedSucceededRevisionIDs)+len(protectedFailedRevisionIDs)+len(inProgressRevisionIDs)+len(unknownStatusRevisionIDs))
-	excludedIDs = append(excludedIDs, protectedSucceededRevisionIDs...)
-	excludedIDs = append(excludedIDs, protectedFailedRevisionIDs...)
-	excludedIDs = append(excludedIDs, inProgressRevisionIDs...)
-	excludedIDs = append(excludedIDs, unknownStatusRevisionIDs...)
-	sort.Ints(excludedIDs)
+	excludedRevisions := make([]int, 0, len(protectedSucceededRevisions)+len(protectedFailedRevisions)+len(inProgressRevisions)+len(unknownStatusRevisions))
+	excludedRevisions = append(excludedRevisions, protectedSucceededRevisions...)
+	excludedRevisions = append(excludedRevisions, protectedFailedRevisions...)
+	excludedRevisions = append(excludedRevisions, inProgressRevisions...)
+	excludedRevisions = append(excludedRevisions, unknownStatusRevisions...)
+	sort.Ints(excludedRevisions)
 
 	// There should always be at least 1 excluded ID, otherwise we'll delete the current revision
-	if len(excludedIDs) == 0 {
+	if len(excludedRevisions) == 0 {
 		return []int{}, fmt.Errorf("need at least 1 excluded ID for revision pruning")
 	}
-	return excludedIDs, nil
+	return excludedRevisions, nil
 }
 
-func (c *PruneController) pruneDiskResources(operatorStatus *operatorv1.StaticPodOperatorStatus, excludedIDs []int, maxEligibleRevisionID int) error {
+func (c *PruneController) pruneDiskResources(operatorStatus *operatorv1.StaticPodOperatorStatus, excludedRevisions []int, maxEligibleRevision int) error {
 	// Run pruning pod on each node and pin it to that node
 	for _, nodeStatus := range operatorStatus.NodeStatuses {
 		// Use the highest value between CurrentRevision and LastFailedRevision
@@ -172,8 +172,8 @@ func (c *PruneController) pruneDiskResources(operatorStatus *operatorv1.StaticPo
 	return nil
 }
 
-func (c *PruneController) pruneAPIResources(excludedIDs []int, maxEligibleRevisionID int) error {
-	protectedIDs := sets.NewInt(excludedIDs...)
+func (c *PruneController) pruneAPIResources(excludedRevisions []int, maxEligibleRevision int) error {
+	protectedRevisions := sets.NewInt(excludedRevisions...)
 	statusConfigMaps, err := c.configMapGetter.ConfigMaps(c.targetNamespace).List(metav1.ListOptions{})
 	if err != nil {
 		return err
@@ -188,10 +188,10 @@ func (c *PruneController) pruneAPIResources(excludedIDs []int, maxEligibleRevisi
 			return fmt.Errorf("unexpected error converting revision to int: %+v", err)
 		}
 
-		if protectedIDs.Has(revision) {
+		if protectedRevisions.Has(revision) {
 			continue
 		}
-		if revision > maxEligibleRevisionID {
+		if revision > maxEligibleRevision {
 			continue
 		}
 		if err := c.configMapGetter.ConfigMaps(c.targetNamespace).Delete(cm.Name, &metav1.DeleteOptions{}); err != nil {
@@ -201,17 +201,17 @@ func (c *PruneController) pruneAPIResources(excludedIDs []int, maxEligibleRevisi
 	return nil
 }
 
-func protectedIDs(revisionIDs []int, revisionLimit int) []int {
-	sort.Ints(revisionIDs)
-	if len(revisionIDs) == 0 {
-		return revisionIDs
+func protectedRevisions(revisions []int, revisionLimit int) []int {
+	sort.Ints(revisions)
+	if len(revisions) == 0 {
+		return revisions
 	}
 	startKey := 0
 	// We use -1 = unlimited revisions, so protect all. Limit shouldn't ever be literally 0 either
-	if revisionLimit > 0 && len(revisionIDs) > revisionLimit {
-		startKey = len(revisionIDs) - revisionLimit
+	if revisionLimit > 0 && len(revisions) > revisionLimit {
+		startKey = len(revisions) - revisionLimit
 	}
-	return revisionIDs[startKey:]
+	return revisions[startKey:]
 }
 
 func (c *PruneController) ensurePrunePod(nodeName string, maxEligibleRevision int, protectedRevisions []int, revision int32) error {
@@ -224,8 +224,8 @@ func (c *PruneController) ensurePrunePod(nodeName string, maxEligibleRevision in
 	pod.Spec.Containers[0].Command = c.command
 	pod.Spec.Containers[0].Args = append(pod.Spec.Containers[0].Args,
 		fmt.Sprintf("-v=%d", 4),
-		fmt.Sprintf("--max-eligible-id=%d", maxEligibleRevision),
-		fmt.Sprintf("--protected-ids=%s", revisionsToString(protectedRevisions)),
+		fmt.Sprintf("--max-eligible-revision=%d", maxEligibleRevision),
+		fmt.Sprintf("--protected-revisions=%s", revisionsToString(protectedRevisions)),
 		fmt.Sprintf("--resource-dir=%s", "/etc/kubernetes/static-pod-resources"),
 		fmt.Sprintf("--static-pod-name=%s", c.podResourcePrefix),
 	)
@@ -309,26 +309,28 @@ func (c *PruneController) processNextWorkItem() bool {
 }
 
 func (c *PruneController) sync() error {
+	glog.V(5).Info("Syncing revision pruner")
 	operatorSpec, operatorStatus, _, err := c.operatorConfigClient.GetStaticPodOperatorState()
 	if err != nil {
 		return err
 	}
 	failedLimit, succeededLimit := getRevisionLimits(operatorSpec)
 
-	excludedIDs, err := c.excludedRevisionHistory(operatorStatus, failedLimit, succeededLimit)
+	excludedRevisions, err := c.excludedRevisionHistory(operatorStatus, failedLimit, succeededLimit)
 	if err != nil {
 		return err
 	}
 	// if no IDs are excluded, then there is nothing to prune
-	if len(excludedIDs) == 0 {
+	if len(excludedRevisions) == 0 {
+		glog.Info("No excluded revisions to prune, skipping")
 		return nil
 	}
 
 	errs := []error{}
-	if diskErr := c.pruneDiskResources(operatorStatus, excludedIDs, excludedIDs[len(excludedIDs)-1]); diskErr != nil {
+	if diskErr := c.pruneDiskResources(operatorStatus, excludedRevisions, excludedRevisions[len(excludedRevisions)-1]); diskErr != nil {
 		errs = append(errs, diskErr)
 	}
-	if apiErr := c.pruneAPIResources(excludedIDs, excludedIDs[len(excludedIDs)-1]); apiErr != nil {
+	if apiErr := c.pruneAPIResources(excludedRevisions, excludedRevisions[len(excludedRevisions)-1]); apiErr != nil {
 		errs = append(errs, apiErr)
 	}
 	return v1helpers.NewMultiLineAggregate(errs)

--- a/pkg/operator/staticpod/controller/prune/prune_controller_test.go
+++ b/pkg/operator/staticpod/controller/prune/prune_controller_test.go
@@ -235,11 +235,11 @@ func TestPruneAPIResources(t *testing.T) {
 		}
 		failedLimit, succeededLimit := getRevisionLimits(operatorSpec)
 
-		excludedIDs, err := c.excludedRevisionHistory(operatorStatus, failedLimit, succeededLimit)
+		excludedRevisions, err := c.excludedRevisionHistory(operatorStatus, failedLimit, succeededLimit)
 		if err != nil {
 			t.Fatalf("unexpected error %q", err)
 		}
-		if apiErr := c.pruneAPIResources(excludedIDs, excludedIDs[len(excludedIDs)-1]); apiErr != nil {
+		if apiErr := c.pruneAPIResources(excludedRevisions, excludedRevisions[len(excludedRevisions)-1]); apiErr != nil {
 			t.Fatalf("unexpected error %q", apiErr)
 		}
 
@@ -255,13 +255,13 @@ func TestPruneAPIResources(t *testing.T) {
 
 func TestPruneDiskResources(t *testing.T) {
 	tests := []struct {
-		name           string
-		failedLimit    int32
-		succeededLimit int32
-		maxEligibleID  int
-		protectedIDs   string
-		configMaps     []configMapInfo
-		expectedErr    string
+		name                string
+		failedLimit         int32
+		succeededLimit      int32
+		maxEligibleRevision int
+		protectedRevisions  string
+		configMaps          []configMapInfo
+		expectedErr         string
 	}{
 		{
 			name: "creates prune pod appropriately",
@@ -285,10 +285,10 @@ func TestPruneDiskResources(t *testing.T) {
 					phase:     string(v1.PodSucceeded),
 				},
 			},
-			maxEligibleID:  3,
-			protectedIDs:   "2,3",
-			failedLimit:    1,
-			succeededLimit: 1,
+			maxEligibleRevision: 3,
+			protectedRevisions:  "2,3",
+			failedLimit:         1,
+			succeededLimit:      1,
 		},
 
 		{
@@ -313,8 +313,8 @@ func TestPruneDiskResources(t *testing.T) {
 					phase:     string(v1.PodSucceeded),
 				},
 			},
-			maxEligibleID: 3,
-			protectedIDs:  "1,2,3",
+			maxEligibleRevision: 3,
+			protectedRevisions:  "1,2,3",
 		},
 
 		{
@@ -333,8 +333,8 @@ func TestPruneDiskResources(t *testing.T) {
 					phase:     "garbage",
 				},
 			},
-			maxEligibleID: 2,
-			protectedIDs:  "1,2",
+			maxEligibleRevision: 2,
+			protectedRevisions:  "1,2",
 		},
 		{
 			name: "handles revisions of only one type of phase",
@@ -352,10 +352,10 @@ func TestPruneDiskResources(t *testing.T) {
 					phase:     string(v1.PodSucceeded),
 				},
 			},
-			maxEligibleID:  2,
-			protectedIDs:   "2",
-			failedLimit:    1,
-			succeededLimit: 1,
+			maxEligibleRevision: 2,
+			protectedRevisions:  "2",
+			failedLimit:         1,
+			succeededLimit:      1,
 		},
 		{
 			name: "protects all with unlimited revisions",
@@ -373,10 +373,10 @@ func TestPruneDiskResources(t *testing.T) {
 					phase:     string(v1.PodSucceeded),
 				},
 			},
-			maxEligibleID:  2,
-			protectedIDs:   "2",
-			failedLimit:    1,
-			succeededLimit: 1,
+			maxEligibleRevision: 2,
+			protectedRevisions:  "2",
+			failedLimit:         1,
+			succeededLimit:      1,
 		},
 	}
 
@@ -451,11 +451,11 @@ func TestPruneDiskResources(t *testing.T) {
 			}
 			failedLimit, succeededLimit := getRevisionLimits(operatorSpec)
 
-			excludedIDs, err := c.excludedRevisionHistory(operatorStatus, failedLimit, succeededLimit)
+			excludedRevisions, err := c.excludedRevisionHistory(operatorStatus, failedLimit, succeededLimit)
 			if err != nil {
 				t.Fatalf("unexpected error %q", err)
 			}
-			if diskErr := c.pruneDiskResources(operatorStatus, excludedIDs, excludedIDs[len(excludedIDs)-1]); diskErr != nil {
+			if diskErr := c.pruneDiskResources(operatorStatus, excludedRevisions, excludedRevisions[len(excludedRevisions)-1]); diskErr != nil {
 				t.Fatalf("unexpected error %q", diskErr)
 			}
 
@@ -473,8 +473,8 @@ func TestPruneDiskResources(t *testing.T) {
 
 			expectedArgs := []string{
 				"-v=4",
-				fmt.Sprintf("--max-eligible-id=%d", test.maxEligibleID),
-				fmt.Sprintf("--protected-ids=%s", test.protectedIDs),
+				fmt.Sprintf("--max-eligible-revision=%d", test.maxEligibleRevision),
+				fmt.Sprintf("--protected-revisions=%s", test.protectedRevisions),
 				fmt.Sprintf("--resource-dir=%s", "/etc/kubernetes/static-pod-resources"),
 				fmt.Sprintf("--static-pod-name=%s", "test-pod"),
 			}

--- a/pkg/operator/staticpod/prune/cmd.go
+++ b/pkg/operator/staticpod/prune/cmd.go
@@ -17,8 +17,8 @@ import (
 )
 
 type PruneOptions struct {
-	MaxEligibleRevisionID int
-	ProtectedRevisionIDs  []int
+	MaxEligibleRevision int
+	ProtectedRevisions  []int
 
 	ResourceDir   string
 	StaticPodName string
@@ -53,8 +53,8 @@ func NewPrune() *cobra.Command {
 }
 
 func (o *PruneOptions) AddFlags(fs *pflag.FlagSet) {
-	fs.IntVar(&o.MaxEligibleRevisionID, "max-eligible-id", o.MaxEligibleRevisionID, "highest revision ID to be eligible for pruning")
-	fs.IntSliceVar(&o.ProtectedRevisionIDs, "protected-ids", o.ProtectedRevisionIDs, "list of revision IDs to preserve (not delete)")
+	fs.IntVar(&o.MaxEligibleRevision, "max-eligible-revision", o.MaxEligibleRevision, "highest revision ID to be eligible for pruning")
+	fs.IntSliceVar(&o.ProtectedRevisions, "protected-revisions", o.ProtectedRevisions, "list of revision IDs to preserve (not delete)")
 	fs.StringVar(&o.ResourceDir, "resource-dir", o.ResourceDir, "directory for all files supporting the static pod manifest")
 	fs.StringVar(&o.StaticPodName, "static-pod-name", o.StaticPodName, "name of the static pod")
 }
@@ -63,7 +63,7 @@ func (o *PruneOptions) Validate() error {
 	if len(o.ResourceDir) == 0 {
 		return fmt.Errorf("--resource-dir is required")
 	}
-	if o.MaxEligibleRevisionID == 0 {
+	if o.MaxEligibleRevision == 0 {
 		return fmt.Errorf("--max-eligible-id is required")
 	}
 	if len(o.StaticPodName) == 0 {
@@ -74,7 +74,7 @@ func (o *PruneOptions) Validate() error {
 }
 
 func (o *PruneOptions) Run() error {
-	protectedIDs := sets.NewInt(o.ProtectedRevisionIDs...)
+	protectedIDs := sets.NewInt(o.ProtectedRevisions...)
 
 	files, err := ioutil.ReadDir(o.ResourceDir)
 	if err != nil {
@@ -103,7 +103,7 @@ func (o *PruneOptions) Run() error {
 			continue
 		}
 		// And is less than or equal to the maxEligibleRevisionID
-		if revisionID > o.MaxEligibleRevisionID {
+		if revisionID > o.MaxEligibleRevision {
 			continue
 		}
 

--- a/pkg/operator/staticpod/prune/cmd_test.go
+++ b/pkg/operator/staticpod/prune/cmd_test.go
@@ -21,9 +21,9 @@ func TestRun(t *testing.T) {
 		{
 			name: "only deletes non-protected revisions of the specified pod",
 			o: PruneOptions{
-				MaxEligibleRevisionID: 3,
-				ProtectedRevisionIDs:  []int{3, 2},
-				StaticPodName:         "test",
+				MaxEligibleRevision: 3,
+				ProtectedRevisions:  []int{3, 2},
+				StaticPodName:       "test",
 			},
 			files:    []string{"test-1", "test-2", "test-3", "othertest-4"},
 			expected: []string{"test-2", "test-3", "othertest-4"},
@@ -31,9 +31,9 @@ func TestRun(t *testing.T) {
 		{
 			name: "doesn't delete anything higher than highest eligible revision",
 			o: PruneOptions{
-				MaxEligibleRevisionID: 2,
-				ProtectedRevisionIDs:  []int{2},
-				StaticPodName:         "test",
+				MaxEligibleRevision: 2,
+				ProtectedRevisions:  []int{2},
+				StaticPodName:       "test",
 			},
 			files:    []string{"test-1", "test-2", "test-3"},
 			expected: []string{"test-2", "test-3"},
@@ -41,9 +41,9 @@ func TestRun(t *testing.T) {
 		{
 			name: "revision numbers do not conflict between pods when detecting protected IDs",
 			o: PruneOptions{
-				MaxEligibleRevisionID: 2,
-				ProtectedRevisionIDs:  []int{2},
-				StaticPodName:         "test",
+				MaxEligibleRevision: 2,
+				ProtectedRevisions:  []int{2},
+				StaticPodName:       "test",
 			},
 			files:    []string{"test-1", "test-2", "othertest-1", "othertest-2"},
 			expected: []string{"test-2", "othertest-1", "othertest-2"},


### PR DESCRIPTION
Using `TargetRevision` for the revision of the pruner pod fails when the pruner takes too long to start the pod and the TargetRevision gets set back to 0 when the install completes (successfully or unsuccessfully). However, `CurrentRevision` only updates when we get a successful install and the pruner kicks off on every install no matter the status. So this compares the max of CurrentRevision and `LastFailedRevision`, the latter which updates whenever we get a failed install.

I also added a couple logging messages that might help debugging in the future