### PR TITLE
revision-controller: log possible LatestAvailableRevision race

### DIFF
--- a/pkg/operator/staticpod/controller/revision/revision_controller.go
+++ b/pkg/operator/staticpod/controller/revision/revision_controller.go
@@ -117,6 +117,10 @@ func (c RevisionController) createRevisionIfNeeded(operatorSpec *operatorv1.Stat
 		Status: operatorv1.ConditionFalse,
 	}
 	if _, updated, updateError := v1helpers.UpdateStaticPodStatus(c.operatorConfigClient, v1helpers.UpdateStaticPodConditionFn(cond), func(operatorStatus *operatorv1.StaticPodOperatorStatus) error {
+		if operatorStatus.LatestAvailableRevision == nextRevision {
+			glog.Warningf("revision %d is unexpectedly already the latest available revision. This is a possible race!", nextRevision)
+			return fmt.Errorf("conflicting latestAvailableRevision %d", operatorStatus.LatestAvailableRevision)
+		}
 		operatorStatus.LatestAvailableRevision = nextRevision
 		return nil
 	}); updateError != nil {


### PR DESCRIPTION
We do a quorum read for the operator status, and the revision controller is the only actor changing LatestAvailableRevision. So seeing it being mutated outside of the controller loop hints at a serious race. This PR adds logging to see whether we experience this race.