### PR TITLE
operator: ignore Unmanaged state in control plane operators

### DIFF
--- a/pkg/operator/management/management_state.go
+++ b/pkg/operator/management/management_state.go
@@ -1,0 +1,69 @@
+package management
+
+import (
+	"github.com/openshift/api/operator/v1"
+)
+
+var (
+	allowOperatorUnmanagedState = true
+	allowOperatorRemovedState   = true
+)
+
+// These are for unit testing
+var (
+	getAllowedOperatorUnmanaged = func() bool {
+		return allowOperatorUnmanagedState
+	}
+	getAllowedOperatorRemovedState = func() bool {
+		return allowOperatorRemovedState
+	}
+)
+
+// SetOperatorAlwaysManaged is one time choice when an operator want to opt-out from supporting the "unmanaged" state.
+// This is a case of control plane operators or operators that are required to always run otherwise the cluster will
+// get into unstable state or critical components will stop working.
+func SetOperatorAlwaysManaged() {
+	allowOperatorUnmanagedState = false
+}
+
+// SetOperatorNotRemovable is one time choice the operator author can make to indicate the operator does not support
+// removing of his operand. This makes sense for operators like kube-apiserver where removing operand will lead to a
+// bricked, non-automatically recoverable state.
+func SetOperatorNotRemovable() {
+	allowOperatorRemovedState = false
+}
+
+// IsOperatorAlwaysManaged means the operator can't be set to unmanaged state.
+func IsOperatorAlwaysManaged() bool {
+	return !getAllowedOperatorUnmanaged()
+}
+
+// IsOperatorNotRemovable means the operator can't bet set to removed state.
+func IsOperatorNotRemovable() bool {
+	return !getAllowedOperatorRemovedState()
+}
+
+func IsOperatorUnknownState(state v1.ManagementState) bool {
+	switch state {
+	case v1.Managed, v1.Removed, v1.Unmanaged:
+		return false
+	default:
+		return true
+	}
+}
+
+// IsOperatorManaged indicates whether the operator management state allows the control loop to proceed and manage the operand.
+func IsOperatorManaged(state v1.ManagementState) bool {
+	if IsOperatorAlwaysManaged() || IsOperatorNotRemovable() {
+		return true
+	}
+	switch state {
+	case v1.Managed:
+		return true
+	case v1.Removed:
+		return false
+	case v1.Unmanaged:
+		return false
+	}
+	return true
+}

--- a/pkg/operator/management/management_state_controller.go
+++ b/pkg/operator/management/management_state_controller.go
@@ -1,0 +1,138 @@
+package management
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/golang/glog"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+var workQueueKey = "instance"
+
+// ManagementStateController watches changes of `managementState` field and react in case that field is set to an unsupported value.
+// As each operator can opt-out from supporting `unmanaged` or `removed` states, this controller will add failing condition when the
+// value for this field is set to this values for those operators.
+type ManagementStateController struct {
+	operatorName   string
+	operatorClient operatorv1helpers.OperatorClient
+	eventRecorder  events.Recorder
+
+	// queue only ever has one item, but it has nice error handling backoff/retry semantics
+	queue workqueue.RateLimitingInterface
+}
+
+func NewOperatorManagementStateController(
+	name string,
+	operatorStatusProvider operatorv1helpers.OperatorClient,
+	recorder events.Recorder,
+) *ManagementStateController {
+	c := &ManagementStateController{
+		operatorName:   name,
+		operatorClient: operatorStatusProvider,
+		eventRecorder:  recorder,
+
+		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "ManagementStateController-"+name),
+	}
+
+	operatorStatusProvider.Informer().AddEventHandler(c.eventHandler())
+	// TODO watch clusterOperator.status changes when it moves to openshift/api
+
+	return c
+}
+
+func (c ManagementStateController) sync() error {
+	detailedSpec, _, _, err := c.operatorClient.GetOperatorState()
+	if apierrors.IsNotFound(err) {
+		c.eventRecorder.Warningf("StatusNotFound", "Unable to determine current operator status for %s", c.operatorName)
+		return nil
+	}
+
+	cond := operatorv1.OperatorCondition{
+		Type:   "ManagementStateFailing",
+		Status: operatorv1.ConditionFalse,
+	}
+
+	if IsOperatorAlwaysManaged() && detailedSpec.ManagementState == operatorv1.Unmanaged {
+		cond.Status = operatorv1.ConditionTrue
+		cond.Reason = "Unmanaged"
+		cond.Message = fmt.Sprintf("Unmanaged is not supported for %s operator", c.operatorName)
+	}
+
+	if IsOperatorNotRemovable() && detailedSpec.ManagementState == operatorv1.Removed {
+		cond.Status = operatorv1.ConditionTrue
+		cond.Reason = "Removed"
+		cond.Message = fmt.Sprintf("Removed is not supported for %s operator", c.operatorName)
+	}
+
+	if IsOperatorUnknownState(detailedSpec.ManagementState) {
+		cond.Status = operatorv1.ConditionTrue
+		cond.Reason = "Unknown"
+		cond.Message = fmt.Sprintf("Unsupported management state %q for %s operator", detailedSpec.ManagementState, c.operatorName)
+	}
+
+	if _, _, updateError := v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
+		if err == nil {
+			return updateError
+		}
+	}
+
+	return nil
+}
+
+func (c *ManagementStateController) Run(workers int, stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	glog.Infof("Starting management-state-controller-" + c.operatorName)
+	defer glog.Infof("Shutting down management-state-controller-" + c.operatorName)
+
+	// doesn't matter what workers say, only start one.
+	go wait.Until(c.runWorker, time.Second, stopCh)
+
+	<-stopCh
+}
+
+func (c *ManagementStateController) runWorker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+func (c *ManagementStateController) processNextWorkItem() bool {
+	dsKey, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(dsKey)
+
+	err := c.sync()
+	if err == nil {
+		c.queue.Forget(dsKey)
+		return true
+	}
+
+	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", dsKey, err))
+	c.queue.AddRateLimited(dsKey)
+
+	return true
+}
+
+// eventHandler queues the operator to check spec and status
+func (c *ManagementStateController) eventHandler() cache.ResourceEventHandler {
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { c.queue.Add(workQueueKey) },
+		UpdateFunc: func(old, new interface{}) { c.queue.Add(workQueueKey) },
+		DeleteFunc: func(obj interface{}) { c.queue.Add(workQueueKey) },
+	}
+}

--- a/pkg/operator/management/management_state_controller_test.go
+++ b/pkg/operator/management/management_state_controller_test.go
@@ -1,0 +1,128 @@
+package management
+
+import (
+	"testing"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/openshift/library-go/pkg/operator/events"
+)
+
+func TestOperatorManagementStateController(t *testing.T) {
+	testCases := []struct {
+		name              string
+		initialConditions []operatorv1.OperatorCondition
+		managementState   string
+		allowUnmanaged    func() bool
+		allowRemove       func() bool
+
+		expectedFailingStatus bool
+		expectedMessage       string
+	}{
+		{
+			name:            "operator in managed state with no restrictions",
+			managementState: string(operatorv1.Managed),
+			allowRemove:     func() bool { return true },
+			allowUnmanaged:  func() bool { return true },
+		},
+		{
+			name:            "operator in unmanaged state with no restrictions",
+			managementState: string(operatorv1.Unmanaged),
+			allowRemove:     func() bool { return true },
+			allowUnmanaged:  func() bool { return true },
+		},
+		{
+			name:                  "operator in unknown state with no restrictions",
+			managementState:       string("UnknownState"),
+			expectedFailingStatus: true,
+			expectedMessage:       `Unsupported management state "UnknownState" for OPERATOR_NAME operator`,
+			allowRemove:           func() bool { return true },
+			allowUnmanaged:        func() bool { return true },
+		},
+		{
+			name:                  "operator in unmanaged state with unmanaged not allowed",
+			managementState:       string(operatorv1.Unmanaged),
+			expectedFailingStatus: true,
+			expectedMessage:       `Unmanaged is not supported for OPERATOR_NAME operator`,
+			allowRemove:           func() bool { return true },
+			allowUnmanaged:        func() bool { return false },
+		},
+		{
+			name:                  "operator in removed state with removed  not allowed",
+			managementState:       string(operatorv1.Removed),
+			expectedFailingStatus: true,
+			expectedMessage:       `Removed is not supported for OPERATOR_NAME operator`,
+			allowRemove:           func() bool { return false },
+			allowUnmanaged:        func() bool { return false },
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			getAllowedOperatorRemovedState = tc.allowRemove
+			getAllowedOperatorUnmanaged = tc.allowUnmanaged
+
+			statusClient := &statusClient{
+				t: t,
+				spec: operatorv1.OperatorSpec{
+					ManagementState: operatorv1.ManagementState(tc.managementState),
+				},
+				status: operatorv1.OperatorStatus{
+					Conditions: tc.initialConditions,
+				},
+			}
+			controller := &ManagementStateController{
+				operatorName:   "OPERATOR_NAME",
+				operatorClient: statusClient,
+				eventRecorder:  events.NewInMemoryRecorder("status"),
+			}
+			if err := controller.sync(); err != nil {
+				t.Errorf("unexpected sync error: %v", err)
+				return
+			}
+
+			_, result, _, _ := statusClient.GetOperatorState()
+
+			if tc.expectedFailingStatus && result.Conditions[0].Type == "ManagementStateFailing" && result.Conditions[0].Status == operatorv1.ConditionFalse {
+				t.Errorf("expected failing conditions")
+				return
+			}
+
+			if !tc.expectedFailingStatus && result.Conditions[0].Type == "ManagementStateFailing" && result.Conditions[0].Status != operatorv1.ConditionFalse {
+				t.Errorf("unexpected failing conditions: %#v", result.Conditions)
+				return
+			}
+
+			if tc.expectedFailingStatus {
+				if result.Conditions[0].Message != tc.expectedMessage {
+					t.Errorf("expected message %q, got %q", result.Conditions[0].Message, tc.expectedMessage)
+				}
+			}
+		})
+	}
+}
+
+// OperatorStatusProvider
+type statusClient struct {
+	t      *testing.T
+	spec   operatorv1.OperatorSpec
+	status operatorv1.OperatorStatus
+}
+
+func (c *statusClient) Informer() cache.SharedIndexInformer {
+	c.t.Log("Informer called")
+	return nil
+}
+
+func (c *statusClient) GetOperatorState() (*operatorv1.OperatorSpec, *operatorv1.OperatorStatus, string, error) {
+	return &c.spec, &c.status, "", nil
+}
+
+func (c *statusClient) UpdateOperatorSpec(string, *operatorv1.OperatorSpec) (spec *operatorv1.OperatorSpec, resourceVersion string, err error) {
+	panic("missing")
+}
+
+func (c *statusClient) UpdateOperatorStatus(version string, s *operatorv1.OperatorStatus) (status *operatorv1.OperatorStatus, err error) {
+	c.status = *s
+	return &c.status, nil
+}

--- a/pkg/operator/resourcesynccontroller/resourcesync_controller.go
+++ b/pkg/operator/resourcesynccontroller/resourcesync_controller.go
@@ -19,6 +19,7 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 
 	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/management"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
@@ -134,14 +135,7 @@ func (c *ResourceSyncController) sync() error {
 		return err
 	}
 
-	switch operatorSpec.ManagementState {
-	case operatorv1.Managed:
-	case operatorv1.Unmanaged:
-		return nil
-	case operatorv1.Removed:
-		// TODO probably just fail
-		return nil
-	default:
+	if !management.IsOperatorManaged(operatorSpec.ManagementState) {
 		return nil
 	}
 

--- a/pkg/operator/staticpod/controller/backingresource/backing_resource_controller.go
+++ b/pkg/operator/staticpod/controller/backingresource/backing_resource_controller.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/openshift/library-go/pkg/operator/management"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 
 	"github.com/golang/glog"
@@ -97,14 +98,7 @@ func (c BackingResourceController) sync() error {
 		return err
 	}
 
-	switch operatorSpec.ManagementState {
-	case operatorv1.Managed:
-	case operatorv1.Unmanaged:
-		return nil
-	case operatorv1.Removed:
-		// TODO probably just fail
-		return nil
-	default:
+	if !management.IsOperatorManaged(operatorSpec.ManagementState) {
 		return nil
 	}
 

--- a/pkg/operator/staticpod/controller/installer/installer_controller.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller.go
@@ -26,6 +26,7 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 
 	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/management"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
 	"github.com/openshift/library-go/pkg/operator/staticpod/controller/installer/bindata"
@@ -667,14 +668,7 @@ func (c InstallerController) sync() error {
 	}
 	operatorStatus := originalOperatorStatus.DeepCopy()
 
-	switch operatorSpec.ManagementState {
-	case operatorv1.Managed:
-	case operatorv1.Unmanaged:
-		return nil
-	case operatorv1.Removed:
-		// TODO probably just fail
-		return nil
-	default:
+	if !management.IsOperatorManaged(operatorSpec.ManagementState) {
 		return nil
 	}
 

--- a/pkg/operator/staticpod/controller/monitoring/monitoring_resource_controller.go
+++ b/pkg/operator/staticpod/controller/monitoring/monitoring_resource_controller.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/openshift/library-go/pkg/operator/management"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 
 	"github.com/golang/glog"
@@ -98,14 +99,7 @@ func (c MonitoringResourceController) sync() error {
 		return err
 	}
 
-	switch operatorSpec.ManagementState {
-	case operatorv1.Managed:
-	case operatorv1.Unmanaged:
-		return nil
-	case operatorv1.Removed:
-		// TODO probably just fail
-		return nil
-	default:
+	if !management.IsOperatorManaged(operatorSpec.ManagementState) {
 		return nil
 	}
 

--- a/pkg/operator/staticpod/controller/revision/revision_controller.go
+++ b/pkg/operator/staticpod/controller/revision/revision_controller.go
@@ -20,6 +20,7 @@ import (
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/management"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
@@ -251,14 +252,7 @@ func (c RevisionController) sync() error {
 	}
 	operatorStatus := originalOperatorStatus.DeepCopy()
 
-	switch operatorSpec.ManagementState {
-	case operatorv1.Managed:
-	case operatorv1.Unmanaged:
-		return nil
-	case operatorv1.Removed:
-		// TODO probably just fail
-		return nil
-	default:
+	if !management.IsOperatorManaged(operatorSpec.ManagementState) {
 		return nil
 	}
 

--- a/pkg/operator/staticpod/controller/staticpodstate/staticpodstate_controller.go
+++ b/pkg/operator/staticpod/controller/staticpodstate/staticpodstate_controller.go
@@ -18,6 +18,7 @@ import (
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/management"
 	"github.com/openshift/library-go/pkg/operator/status"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
@@ -83,14 +84,7 @@ func (c *StaticPodStateController) sync() error {
 		return err
 	}
 
-	switch operatorSpec.ManagementState {
-	case operatorv1.Managed:
-	case operatorv1.Unmanaged:
-		return nil
-	case operatorv1.Removed:
-		// TODO probably just fail
-		return nil
-	default:
+	if !management.IsOperatorManaged(operatorSpec.ManagementState) {
 		return nil
 	}
 

--- a/pkg/operator/status/status_controller.go
+++ b/pkg/operator/status/status_controller.go
@@ -17,8 +17,10 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+
 	configv1helpers "github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers"
 	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/management"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
 )
@@ -113,9 +115,9 @@ func (c StatusSyncer) sync() error {
 	}
 	clusterOperatorObj := originalClusterOperatorObj.DeepCopy()
 
-	// if we are unmanaged, force everything to Unknown.
-	if detailedSpec.ManagementState == operatorv1.Unmanaged {
+	if detailedSpec.ManagementState == operatorv1.Unmanaged && !management.IsOperatorAlwaysManaged() {
 		clusterOperatorObj.Status = configv1.ClusterOperatorStatus{}
+
 		configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorAvailable, Status: configv1.ConditionUnknown, Reason: "Unmanaged"})
 		configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorProgressing, Status: configv1.ConditionUnknown, Reason: "Unmanaged"})
 		configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorFailing, Status: configv1.ConditionUnknown, Reason: "Unmanaged"})

--- a/pkg/operator/status/status_controller_test.go
+++ b/pkg/operator/status/status_controller_test.go
@@ -12,6 +12,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/client-go/config/clientset/versioned/fake"
+
 	"github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers"
 	"github.com/openshift/library-go/pkg/operator/events"
 )

--- a/pkg/operator/unsupportedconfigoverridescontroller/unsupportedconfigoverrides_controller.go
+++ b/pkg/operator/unsupportedconfigoverridescontroller/unsupportedconfigoverrides_controller.go
@@ -18,6 +18,7 @@ import (
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/management"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
 
@@ -64,14 +65,7 @@ func (c *UnsupportedConfigOverridesController) sync() error {
 		return err
 	}
 
-	switch operatorSpec.ManagementState {
-	case operatorv1.Managed:
-	case operatorv1.Unmanaged:
-		return nil
-	case operatorv1.Removed:
-		// TODO probably just fail
-		return nil
-	default:
+	if management.IsOperatorManaged(operatorSpec.ManagementState) {
 		return nil
 	}
 


### PR DESCRIPTION
Reasoning:
Making a core or control plane operator "Unmanaged" will likely lead to a bricked cluster (in case of cert rotation, the cluster will self-destruct in 5 days today). The "Unmanaged" should only be used for development or debugging and it makes sense on higher level operators, where the damage it can do can be recovered by reverting the management state to managed. For debugging core/control plane operators, people can use CVO overrides and deleting the operator deployment (not sure what debugging that can be).

Because the "unmanaged" is giving admins a supported way to brick the clusters, we should not support it.

UPDATED: `management.SetOperatorAlwaysManaged()` and `management.SetOperatorNotRemovable()` will make the operator ignore the "unmanaged" and "removed" state, so you can opt-in.

UPDATE2: Added `management.NewOperatorManagementStateController()` controller that observe the management state and report invalid/unsupported values back to cluster operator status via conditions.

/cc @bparees 
/cc @ravisantoshgudimetla 
/cc @adambkaplan 
/cc @ericavonb 

CC'ing the folks that will be affected by this change.