### PR TITLE
crd-schema-gen: allow a *-yaml-merge-patch file to post-kubebuilder-gen patch validation schemata

### DIFF
--- a/cmd/crd-schema-gen/generator/generator.go
+++ b/cmd/crd-schema-gen/generator/generator.go
@@ -10,11 +10,13 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/evanphx/json-patch"
 	"gopkg.in/yaml.v2"
 
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
 	crdgenerator "sigs.k8s.io/controller-tools/pkg/crd/generator"
 )
 
@@ -110,14 +112,58 @@ func Run() error {
 		}
 
 		crd := existing[existingFileName]
+
 		// TODO: support multiple versions
 		validation, _, err := nested(withValidation.Yaml, "spec", "validation")
 		if err != nil {
 			return fmt.Errorf("failed to access spec.validation in %s: %v", fn, err)
 		}
+
+		// yaml merge patch exists?
+		patchFileName := existingFileName + "-merge-patch"
+		if _, err := os.Stat(patchFileName); err == nil {
+			yamlPatch, err := ioutil.ReadFile(patchFileName)
+			if err != nil {
+				return fmt.Errorf("failed to read yaml-merge-patch %q: %v", patchFileName, err)
+			}
+			var patch yaml.MapSlice
+			if err := yaml.Unmarshal(yamlPatch, &patch); err != nil {
+				return fmt.Errorf("failed to unmarshal yaml merge patch %q: %v", patchFileName, err)
+			}
+			if !onlyHasNoneOr(patch, "spec", "validation") {
+				return fmt.Errorf("patch in %q can only have spec.validation", patchFileName)
+			}
+			validationPatch, _, err := nested(patch, "spec", "validation")
+			if err != nil {
+				return fmt.Errorf("failed to get spec.validation from %q: %v", patchFileName, err)
+			}
+			if yamlPatch, err = yaml.Marshal(validationPatch); err != nil {
+				return fmt.Errorf("failed to marshal spec.validation of %q: %v", patchFileName, err)
+			}
+			jsonPatch, err := utilyaml.ToJSON(yamlPatch)
+			if err != nil {
+				return fmt.Errorf("failed to convert yaml of %q to json: %v", patchFileName, err)
+			}
+			yamlValidation, err := yaml.Marshal(validation)
+			if err != nil {
+				return fmt.Errorf("failed to marshal generated validation schema of %q: %v", existingFileName, err)
+			}
+			jsonValidation, err := utilyaml.ToJSON(yamlValidation)
+			if err != nil {
+				return fmt.Errorf("failed to convert yaml validation of %q to json: %v", existingFileName, err)
+			}
+			if jsonValidation, err = jsonpatch.MergePatch(jsonValidation, jsonPatch); err != nil {
+				return fmt.Errorf("failed to patch %q with %q: %v", existingFileName, patchFileName, err)
+			}
+			if err := yaml.Unmarshal(jsonValidation, &validation); err != nil {
+				return fmt.Errorf("failed to unmarshal patched validation schema of %q: %v", existingFileName, err)
+			}
+		}
+
 		if validation == nil {
 			continue
 		}
+
 		updated, err := set(crd.Yaml, validation, "spec", "validation")
 		if err != nil {
 			return fmt.Errorf("failed to set spec.validation in %s: %v", existingFileName, err)
@@ -232,6 +278,29 @@ func set(x interface{}, v interface{}, pth ...string) (interface{}, error) {
 	}
 	ret[foundAt].Value = result
 	return ret, nil
+}
+
+// onlyHasNoneOr checks for existance of the given path, but nothing next to it is allowed
+func onlyHasNoneOr(x interface{}, pth ...string) bool {
+	if len(pth) == 0 {
+		return true
+	}
+	m, ok := x.(yaml.MapSlice)
+	if !ok {
+		return false
+	}
+	switch len(m) {
+	case 0:
+		return true
+	case 1:
+		s, ok := m[0].Key.(string)
+		if !ok || s != pth[0] {
+			return false
+		}
+		return onlyHasNoneOr(m[0].Value, pth[1:]...)
+	default:
+		return false
+	}
 }
 
 type NamedYaml struct {


### PR DESCRIPTION
Put a `<crd>.yaml-merge-patch` merge patch (https://tools.ietf.org/html/rfc7386) next to a CRD manifest `<crd>.yaml` and it will be applied to the CRD after the kubebuilder openapi generator has been run (only `spec.validation` changes are supported for now). This is useful to customize behaviour of shared types for specific types, e.g. ObjectMeta or OperatorSpec.