### PR TITLE
events: allow to set component per controller

### DIFF
--- a/pkg/operator/events/eventstesting/recorder_testing.go
+++ b/pkg/operator/events/eventstesting/recorder_testing.go
@@ -16,6 +16,14 @@ func NewTestingEventRecorder(t *testing.T) events.Recorder {
 	return &TestingEventRecorder{t: t}
 }
 
+func (r *TestingEventRecorder) ComponentName() string {
+	return "test"
+}
+
+func (r *TestingEventRecorder) ForComponent(string) events.Recorder {
+	return r
+}
+
 func (r *TestingEventRecorder) Event(reason, message string) {
 	r.t.Logf("Event: %v: %v", reason, message)
 }

--- a/pkg/operator/events/recorder.go
+++ b/pkg/operator/events/recorder.go
@@ -19,6 +19,15 @@ type Recorder interface {
 	Eventf(reason, messageFmt string, args ...interface{})
 	Warning(reason, message string)
 	Warningf(reason, messageFmt string, args ...interface{})
+
+	// ForComponent allows to fiddle the component name before sending the event to sink.
+	// Making more unique components will prevent the spam filter in upstream event sink from dropping
+	// events.
+	ForComponent(componentName string) Recorder
+
+	// ComponentName returns the current source component name for the event.
+	// This allows to suffix the original component name with 'sub-component'.
+	ComponentName() string
 }
 
 // podNameEnv is a name of environment variable inside container that specifies the name of the current replica set.
@@ -119,6 +128,16 @@ type recorder struct {
 	eventClient       corev1client.EventInterface
 	involvedObjectRef *corev1.ObjectReference
 	sourceComponent   string
+}
+
+func (r *recorder) ComponentName() string {
+	return r.sourceComponent
+}
+
+func (r *recorder) ForComponent(componentName string) Recorder {
+	newRecorderForComponent := *r
+	newRecorderForComponent.sourceComponent = componentName
+	return &newRecorderForComponent
 }
 
 // Event emits the normal type event and allow formatting of message.

--- a/pkg/operator/events/recorder_in_memory.go
+++ b/pkg/operator/events/recorder_in_memory.go
@@ -33,6 +33,14 @@ func NewInMemoryRecorder(sourceComponent string) InMemoryRecorder {
 	return &inMemoryEventRecorder{events: []*corev1.Event{}, source: sourceComponent}
 }
 
+func (r *inMemoryEventRecorder) ComponentName() string {
+	return r.source
+}
+
+func (r *inMemoryEventRecorder) ForComponent(component string) Recorder {
+	return &inMemoryEventRecorder{events: []*corev1.Event{}, source: component}
+}
+
 // Events returns list of recorded events
 func (r *inMemoryEventRecorder) Events() []*corev1.Event {
 	return r.events

--- a/pkg/operator/events/recorder_logging.go
+++ b/pkg/operator/events/recorder_logging.go
@@ -7,11 +7,23 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-type LoggingEventRecorder struct{}
+type LoggingEventRecorder struct {
+	component string
+}
 
 // NewLoggingEventRecorder provides event recorder that will log all recorded events via glog.
-func NewLoggingEventRecorder() Recorder {
-	return &LoggingEventRecorder{}
+func NewLoggingEventRecorder(component string) Recorder {
+	return &LoggingEventRecorder{component: component}
+}
+
+func (r *LoggingEventRecorder) ComponentName() string {
+	return r.component
+}
+
+func (r *LoggingEventRecorder) ForComponent(component string) Recorder {
+	newRecorder := *r
+	newRecorder.component = component
+	return &newRecorder
 }
 
 func (r *LoggingEventRecorder) Event(reason, message string) {

--- a/pkg/operator/events/recorder_upstream.go
+++ b/pkg/operator/events/recorder_upstream.go
@@ -13,21 +13,36 @@ import (
 
 // NewKubeRecorder returns new event recorder.
 func NewKubeRecorder(client corev1client.EventInterface, sourceComponentName string, involvedObjectRef *corev1.ObjectReference) Recorder {
-	broadcaster := record.NewBroadcaster()
-	broadcaster.StartLogging(glog.Infof)
-	broadcaster.StartRecordingToSink(&corev1client.EventSinkImpl{Interface: client})
-	eventRecorder := broadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: sourceComponentName})
-
-	return &upstreamRecorder{
-		eventRecorder:     eventRecorder,
+	return (&upstreamRecorder{
+		client:            client,
+		component:         sourceComponentName,
 		involvedObjectRef: involvedObjectRef,
-	}
+	}).ForComponent(sourceComponentName)
 }
 
 // upstreamRecorder is an implementation of Recorder interface.
 type upstreamRecorder struct {
+	client            corev1client.EventInterface
+	component         string
+	broadcaster       record.EventBroadcaster
 	eventRecorder     record.EventRecorder
 	involvedObjectRef *corev1.ObjectReference
+}
+
+func (r *upstreamRecorder) ForComponent(componentName string) Recorder {
+	newRecorderForComponent := *r
+	broadcaster := record.NewBroadcaster()
+	broadcaster.StartLogging(glog.Infof)
+	broadcaster.StartRecordingToSink(&corev1client.EventSinkImpl{Interface: newRecorderForComponent.client})
+
+	newRecorderForComponent.eventRecorder = broadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: componentName})
+	newRecorderForComponent.component = componentName
+
+	return &newRecorderForComponent
+}
+
+func (r *upstreamRecorder) ComponentName() string {
+	return r.component
 }
 
 // Eventf emits the normal type event and allow formatting of message.

--- a/pkg/operator/staticpod/controllers.go
+++ b/pkg/operator/staticpod/controllers.go
@@ -127,7 +127,7 @@ func (b *staticPodOperatorControllerBuilder) ToControllers() (*staticPodOperator
 
 	eventRecorder := b.eventRecorder
 	if eventRecorder == nil {
-		eventRecorder = events.NewLoggingEventRecorder()
+		eventRecorder = events.NewLoggingEventRecorder("static-pod-operator-controller")
 	}
 	versionRecorder := b.versionRecorder
 	if versionRecorder == nil {


### PR DESCRIPTION
Based on https://github.com/openshift/library-go/blob/master/vendor/k8s.io/client-go/tools/record/events_cache.go#L414 the events are correlated and that also means the "spam" is filtered out. Based on the "key" for counting the events, if we keep the component the same for entire operator and all controller loops inside, we might get rate limited and some events might be dropped as "spam".

This change will allow to set custom component per-controller which should mitigate this issue. 