### PR TITLE
events: wire component name for each controller

### DIFF
--- a/pkg/operator/configobserver/config_observer_controller.go
+++ b/pkg/operator/configobserver/config_observer_controller.go
@@ -63,7 +63,7 @@ func NewConfigObserver(
 ) *ConfigObserver {
 	return &ConfigObserver{
 		operatorConfigClient: operatorClient,
-		eventRecorder:        eventRecorder,
+		eventRecorder:        eventRecorder.WithComponentSuffix("config-observer"),
 
 		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "ConfigObserver"),
 

--- a/pkg/operator/events/eventstesting/recorder_testing.go
+++ b/pkg/operator/events/eventstesting/recorder_testing.go
@@ -8,20 +8,25 @@ import (
 )
 
 type TestingEventRecorder struct {
-	t *testing.T
+	t         *testing.T
+	component string
 }
 
 // NewTestingEventRecorder provides event recorder that will log all recorded events to the error log.
 func NewTestingEventRecorder(t *testing.T) events.Recorder {
-	return &TestingEventRecorder{t: t}
+	return &TestingEventRecorder{t: t, component: "test"}
 }
 
 func (r *TestingEventRecorder) ComponentName() string {
-	return "test"
+	return r.component
 }
 
-func (r *TestingEventRecorder) ForComponent(string) events.Recorder {
-	return r
+func (r *TestingEventRecorder) ForComponent(c string) events.Recorder {
+	return &TestingEventRecorder{t: r.t, component: c}
+}
+
+func (r *TestingEventRecorder) WithComponentSuffix(suffix string) events.Recorder {
+	return r.ForComponent(fmt.Sprintf("%s-%s", r.ComponentName(), suffix))
 }
 
 func (r *TestingEventRecorder) Event(reason, message string) {

--- a/pkg/operator/events/recorder.go
+++ b/pkg/operator/events/recorder.go
@@ -25,6 +25,9 @@ type Recorder interface {
 	// events.
 	ForComponent(componentName string) Recorder
 
+	// WithComponentSuffix is similar to ForComponent except it just suffix the current component name instead of overriding.
+	WithComponentSuffix(componentNameSuffix string) Recorder
+
 	// ComponentName returns the current source component name for the event.
 	// This allows to suffix the original component name with 'sub-component'.
 	ComponentName() string
@@ -138,6 +141,10 @@ func (r *recorder) ForComponent(componentName string) Recorder {
 	newRecorderForComponent := *r
 	newRecorderForComponent.sourceComponent = componentName
 	return &newRecorderForComponent
+}
+
+func (r *recorder) WithComponentSuffix(suffix string) Recorder {
+	return r.ForComponent(fmt.Sprintf("%s-%s", r.ComponentName(), suffix))
 }
 
 // Event emits the normal type event and allow formatting of message.

--- a/pkg/operator/events/recorder_in_memory.go
+++ b/pkg/operator/events/recorder_in_memory.go
@@ -41,6 +41,10 @@ func (r *inMemoryEventRecorder) ForComponent(component string) Recorder {
 	return &inMemoryEventRecorder{events: []*corev1.Event{}, source: component}
 }
 
+func (r *inMemoryEventRecorder) WithComponentSuffix(suffix string) Recorder {
+	return r.ForComponent(fmt.Sprintf("%s-%s", r.ComponentName(), suffix))
+}
+
 // Events returns list of recorded events
 func (r *inMemoryEventRecorder) Events() []*corev1.Event {
 	return r.events

--- a/pkg/operator/events/recorder_logging.go
+++ b/pkg/operator/events/recorder_logging.go
@@ -26,6 +26,10 @@ func (r *LoggingEventRecorder) ForComponent(component string) Recorder {
 	return &newRecorder
 }
 
+func (r *LoggingEventRecorder) WithComponentSuffix(suffix string) Recorder {
+	return r.ForComponent(fmt.Sprintf("%s-%s", r.ComponentName(), suffix))
+}
+
 func (r *LoggingEventRecorder) Event(reason, message string) {
 	event := makeEvent(&inMemoryDummyObjectReference, "", corev1.EventTypeNormal, reason, message)
 	glog.Info(event.String())

--- a/pkg/operator/events/recorder_upstream.go
+++ b/pkg/operator/events/recorder_upstream.go
@@ -41,6 +41,10 @@ func (r *upstreamRecorder) ForComponent(componentName string) Recorder {
 	return &newRecorderForComponent
 }
 
+func (r *upstreamRecorder) WithComponentSuffix(suffix string) Recorder {
+	return r.ForComponent(fmt.Sprintf("%s-%s", r.ComponentName(), suffix))
+}
+
 func (r *upstreamRecorder) ComponentName() string {
 	return r.component
 }

--- a/pkg/operator/resourcesynccontroller/resourcesync_controller.go
+++ b/pkg/operator/resourcesynccontroller/resourcesync_controller.go
@@ -66,7 +66,7 @@ func NewResourceSyncController(
 ) *ResourceSyncController {
 	c := &ResourceSyncController{
 		operatorConfigClient: operatorConfigClient,
-		eventRecorder:        eventRecorder,
+		eventRecorder:        eventRecorder.WithComponentSuffix("resource-sync-controller"),
 
 		configMapSyncRules:         map[ResourceLocation]ResourceLocation{},
 		secretSyncRules:            map[ResourceLocation]ResourceLocation{},

--- a/pkg/operator/staticpod/certsyncpod/certsync_controller.go
+++ b/pkg/operator/staticpod/certsyncpod/certsync_controller.go
@@ -44,6 +44,7 @@ func NewCertSyncController(targetDir, targetNamespace string, configmaps, secret
 		namespace:      targetNamespace,
 		configMaps:     configmaps,
 		secrets:        secrets,
+		eventRecorder:  eventRecorder.WithComponentSuffix("cert-sync-controller"),
 
 		configMapLister: informers.Core().V1().ConfigMaps().Lister(),
 		secretLister:    informers.Core().V1().Secrets().Lister(),

--- a/pkg/operator/staticpod/controller/backingresource/backing_resource_controller.go
+++ b/pkg/operator/staticpod/controller/backingresource/backing_resource_controller.go
@@ -63,7 +63,7 @@ func NewBackingResourceController(
 	c := &BackingResourceController{
 		targetNamespace:      targetNamespace,
 		operatorConfigClient: operatorConfigClient,
-		eventRecorder:        eventRecorder,
+		eventRecorder:        eventRecorder.WithComponentSuffix("backing-resource-controller"),
 
 		saListerSynced: kubeInformersForTargetNamespace.Core().V1().ServiceAccounts().Informer().HasSynced,
 		saLister:       kubeInformersForTargetNamespace.Core().V1().ServiceAccounts().Lister(),

--- a/pkg/operator/staticpod/controller/installer/installer_controller.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller.go
@@ -132,7 +132,7 @@ func NewInstallerController(
 		operatorConfigClient: operatorConfigClient,
 		configMapsGetter:     configMapsGetter,
 		podsGetter:           podsGetter,
-		eventRecorder:        eventRecorder,
+		eventRecorder:        eventRecorder.WithComponentSuffix("installer-controller"),
 
 		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "InstallerController"),
 

--- a/pkg/operator/staticpod/controller/monitoring/monitoring_resource_controller.go
+++ b/pkg/operator/staticpod/controller/monitoring/monitoring_resource_controller.go
@@ -63,7 +63,7 @@ func NewMonitoringResourceController(
 	c := &MonitoringResourceController{
 		targetNamespace:      targetNamespace,
 		operatorConfigClient: operatorConfigClient,
-		eventRecorder:        eventRecorder,
+		eventRecorder:        eventRecorder.WithComponentSuffix("monitoring-resource-controller"),
 		serviceMonitorName:   serviceMonitorName,
 
 		clusterRoleBindingLister: kubeInformersForTargetNamespace.Rbac().V1().ClusterRoleBindings().Lister(),

--- a/pkg/operator/staticpod/controller/node/node_controller.go
+++ b/pkg/operator/staticpod/controller/node/node_controller.go
@@ -44,7 +44,7 @@ func NewNodeController(
 ) *NodeController {
 	c := &NodeController{
 		operatorConfigClient: operatorConfigClient,
-		eventRecorder:        eventRecorder,
+		eventRecorder:        eventRecorder.WithComponentSuffix("node-controller"),
 		nodeListerSynced:     kubeInformersClusterScoped.Core().V1().Nodes().Informer().HasSynced,
 		nodeLister:           kubeInformersClusterScoped.Core().V1().Nodes().Lister(),
 

--- a/pkg/operator/staticpod/controller/prune/prune_controller.go
+++ b/pkg/operator/staticpod/controller/prune/prune_controller.go
@@ -77,7 +77,7 @@ func NewPruneController(
 		configMapGetter: configMapGetter,
 		secretGetter:    secretGetter,
 		podGetter:       podGetter,
-		eventRecorder:   eventRecorder,
+		eventRecorder:   eventRecorder.WithComponentSuffix("prune-controller"),
 
 		queue:            workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "PruneController"),
 		prunerPodImageFn: getPrunerPodImageFromEnv,

--- a/pkg/operator/staticpod/controller/revision/revision_controller.go
+++ b/pkg/operator/staticpod/controller/revision/revision_controller.go
@@ -73,7 +73,7 @@ func NewRevisionController(
 		operatorConfigClient: operatorConfigClient,
 		configMapGetter:      configMapGetter,
 		secretGetter:         secretGetter,
-		eventRecorder:        eventRecorder,
+		eventRecorder:        eventRecorder.WithComponentSuffix("revision-controller"),
 
 		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "RevisionController"),
 	}

--- a/pkg/operator/staticpod/controller/staticpodstate/staticpodstate_controller.go
+++ b/pkg/operator/staticpod/controller/staticpodstate/staticpodstate_controller.go
@@ -67,7 +67,7 @@ func NewStaticPodStateController(
 		configMapGetter:      configMapGetter,
 		podsGetter:           podsGetter,
 		versionRecorder:      versionRecorder,
-		eventRecorder:        eventRecorder,
+		eventRecorder:        eventRecorder.WithComponentSuffix("static-pod-state-controller"),
 
 		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "StaticPodStateController"),
 	}

--- a/pkg/operator/status/status_controller.go
+++ b/pkg/operator/status/status_controller.go
@@ -63,7 +63,7 @@ func NewClusterOperatorStatusController(
 		versionGetter:         versionGetter,
 		clusterOperatorClient: clusterOperatorClient,
 		operatorClient:        operatorStatusProvider,
-		eventRecorder:         recorder,
+		eventRecorder:         recorder.WithComponentSuffix("status-controller"),
 
 		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "StatusSyncer-"+name),
 	}

--- a/pkg/operator/unsupportedconfigoverridescontroller/unsupportedconfigoverrides_controller.go
+++ b/pkg/operator/unsupportedconfigoverridescontroller/unsupportedconfigoverrides_controller.go
@@ -46,7 +46,7 @@ func NewUnsupportedConfigOverridesController(
 ) *UnsupportedConfigOverridesController {
 	c := &UnsupportedConfigOverridesController{
 		operatorClient: operatorClient,
-		eventRecorder:  eventRecorder,
+		eventRecorder:  eventRecorder.WithComponentSuffix("unsupported-config-overrides-controller"),
 
 		preRunCachesSynced: []cache.InformerSynced{
 			operatorClient.Informer().HasSynced,


### PR DESCRIPTION
Builds on https://github.com/openshift/library-go/pull/301

This will add `-controller-name` suffix to event recorder component name for each controller we own.