### PR TITLE
don't create pruner pod with revision 0

### DIFF
--- a/pkg/operator/staticpod/controller/prune/prune_controller.go
+++ b/pkg/operator/staticpod/controller/prune/prune_controller.go
@@ -215,6 +215,9 @@ func protectedRevisions(revisions []int, revisionLimit int) []int {
 }
 
 func (c *PruneController) ensurePrunePod(nodeName string, maxEligibleRevision int, protectedRevisions []int, revision int32) error {
+	if revision == 0 {
+		return nil
+	}
 	pod := resourceread.ReadPodV1OrDie(bindata.MustAsset(filepath.Join("pkg/operator/staticpod/controller/prune", "manifests/pruner-pod.yaml")))
 
 	pod.Name = getPrunerPodName(nodeName, revision)

--- a/pkg/operator/staticpod/controller/prune/prune_controller_test.go
+++ b/pkg/operator/staticpod/controller/prune/prune_controller_test.go
@@ -194,7 +194,7 @@ func TestPruneAPIResources(t *testing.T) {
 				NodeStatuses: []operatorv1.NodeStatus{
 					{
 						NodeName:        "test-node-1",
-						CurrentRevision: 0,
+						CurrentRevision: 1,
 						TargetRevision:  0,
 					},
 				},
@@ -208,7 +208,7 @@ func TestPruneAPIResources(t *testing.T) {
 			NodeStatuses: []operatorv1.NodeStatus{
 				{
 					NodeName:        "test-node-1",
-					CurrentRevision: 0,
+					CurrentRevision: 1,
 					TargetRevision:  0,
 				},
 			},
@@ -410,7 +410,7 @@ func TestPruneDiskResources(t *testing.T) {
 					NodeStatuses: []operatorv1.NodeStatus{
 						{
 							NodeName:        "test-node-1",
-							CurrentRevision: 0,
+							CurrentRevision: 1,
 							TargetRevision:  0,
 						},
 					},
@@ -424,7 +424,7 @@ func TestPruneDiskResources(t *testing.T) {
 				NodeStatuses: []operatorv1.NodeStatus{
 					{
 						NodeName:        "test-node-1",
-						CurrentRevision: 0,
+						CurrentRevision: 1,
 						TargetRevision:  0,
 					},
 				},


### PR DESCRIPTION
We see errors like `E0306 19:58:57.817107       1 prune_controller.go:303] key failed with : unable to set pruner pod ownerrefs: configmap "revision-status-0" not found`, but there is no reason to try to make or prune a "revision 0" nor any reason one of our revisions should be at that number (that I know of)