### PR TITLE
Leader election: increase LeaseDuration,RenewDeadline,RetryPeriod

### DIFF
--- a/pkg/config/leaderelection/leaderelection.go
+++ b/pkg/config/leaderelection/leaderelection.go
@@ -75,13 +75,13 @@ func LeaderElectionDefaulting(config configv1.LeaderElection, defaultNamespace, 
 	ret := *(&config).DeepCopy()
 
 	if ret.LeaseDuration.Duration == 0 {
-		ret.LeaseDuration.Duration = 15 * time.Second
+		ret.LeaseDuration.Duration = 120 * time.Second
 	}
 	if ret.RenewDeadline.Duration == 0 {
-		ret.RenewDeadline.Duration = 10 * time.Second
+		ret.RenewDeadline.Duration = 90 * time.Second
 	}
 	if ret.RetryPeriod.Duration == 0 {
-		ret.RetryPeriod.Duration = 2 * time.Second
+		ret.RetryPeriod.Duration = 20 * time.Second
 	}
 	if len(ret.Namespace) == 0 {
 		if len(defaultNamespace) > 0 {


### PR DESCRIPTION
@smarterclayton 
This PR increases leader election default periods. So, instead of pings every 2s, it's every 20s with this change.
* **k8s default** --> **thisPR**          
* lease-duration 15s  --> 120s
* renew-deadline 10s --> 90s
* retry-period 2s --> 20s
[k8s defaults](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-scheduler/)