### PR TITLE
staticpodstate: do not report failing when containers are initializing

### DIFF
--- a/pkg/operator/staticpod/controller/staticpodstate/staticpodstate_controller.go
+++ b/pkg/operator/staticpod/controller/staticpodstate/staticpodstate_controller.go
@@ -107,7 +107,7 @@ func (c *StaticPodStateController) sync() error {
 				// We will still reflect the container not ready state in error conditions, but we don't set the operator as failed.
 				errs = append(errs, fmt.Errorf("nodes/%s pods/%s container=%q is not ready", node.NodeName, pod.Name, containerStatus.Name))
 			}
-			if containerStatus.State.Waiting != nil {
+			if containerStatus.State.Waiting != nil && containerStatus.State.Waiting.Message != "PodInitializing" {
 				errs = append(errs, fmt.Errorf("nodes/%s pods/%s container=%q is waiting: %q - %q", node.NodeName, pod.Name, containerStatus.Name, containerStatus.State.Waiting.Reason, containerStatus.State.Waiting.Message))
 				failingErrorCount++
 			}


### PR DESCRIPTION
`Mar 13 13:57:31.824 E clusteroperator/kube-apiserver changed Failing to True: StaticPodsFailing: StaticPodsFailing: nodes/ip-10-0-131-22.ec2.internal pods/kube-apiserver-ip-10-0-131-22.ec2.internal container="kube-apiserver-7" is not ready\nStaticPodsFailing: nodes/ip-10-0-131-22.ec2.internal pods/kube-apiserver-ip-10-0-131-22.ec2.internal container="kube-apiserver-7" is waiting: "PodInitializing" - ""\nStaticPodsFailing: nodes/ip-10-0-131-22.ec2.internal pods/kube-apiserver-ip-10-0-131-22.ec2.internal container="kube-apiserver-cert-syncer-7" is not ready\nStaticPodsFailing: nodes/ip-10-0-131-22.ec2.internal pods/kube-apiserver-ip-10-0-131-22.ec2.internal container="kube-apiserver-cert-syncer-7" is waiting: "PodInitializing" - ""
`