### PR TITLE
web profiler should take implicit dependency on net/http/pprof

### DIFF
--- a/pkg/serviceability/profiler.go
+++ b/pkg/serviceability/profiler.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"runtime"
 
+	_ "net/http/pprof" // include the default Go profiler mux
+
 	"github.com/golang/glog"
 )
 


### PR DESCRIPTION
Otherwise components that don't pull in net/http/pprof can't use
it automatically.