### PR TITLE
certrotation: don't start rotation with less than 30 min cert validity

### DIFF
--- a/pkg/operator/certrotation/signer.go
+++ b/pkg/operator/certrotation/signer.go
@@ -69,7 +69,7 @@ func needNewSigningCertKeyPair(annotations map[string]string, refresh time.Durat
 		return reason
 	}
 
-	maxWait := notAfter.Sub(notBefore) / 5
+	maxWait := min(minDeploymentDuration, notAfter.Sub(notBefore)/5)
 	latestTime := notAfter.Add(-maxWait)
 	if time.Now().After(latestTime) {
 		return fmt.Sprintf("past its latest possible time %v", latestTime)


### PR DESCRIPTION
Before this PR the minDeploymentDuration was 20% of the cert validity. With 30+ days validity, this is a lot, far too much to be on the safe side, and surprising for the admin.