### PR TITLE
installer: do no report errors for nodes that are not failing

### DIFF
--- a/pkg/operator/staticpod/controller/installer/installer_controller.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller.go
@@ -476,6 +476,10 @@ func setAvailableProgressingNodeInstallerFailingConditions(newStatus *operatorv1
 	if len(failing) > 0 {
 		failingStrings := []string{}
 		for failingRevision, errorStrings := range failing {
+			// Do not report failing for nodes that are actually not failing.
+			if failingCount[failingRevision] == 0 {
+				continue
+			}
 			failingStrings = append(failingStrings, fmt.Sprintf("%d nodes are failing on revision %d:\n%v", failingCount[failingRevision], failingRevision, strings.Join(errorStrings, "\n")))
 		}
 		failingDescription := strings.Join(failingStrings, "; ")


### PR DESCRIPTION
`0 nodes are failing on revision 6:\nNodeInstallerFailing: static pod has been installed, but is not ready while new revision is pending` indicates we report errors for nodes that are not actually failing (their failing count == 0).

