### PR TITLE
certs: add helpers to unify cert format

### DIFF
--- a/pkg/certs/util.go
+++ b/pkg/certs/util.go
@@ -1,0 +1,55 @@
+package certs
+
+import (
+	"crypto/x509"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// CertificateToString parse provided certificate to human-readable form.
+// This function should guarantee consistent output format for must-gather tooling and any code
+// that prints the certificate details.
+func CertificateToString(certificate *x509.Certificate) string {
+	humanName := certificate.Subject.CommonName
+	signerHumanName := certificate.Issuer.CommonName
+
+	if certificate.Subject.CommonName == certificate.Issuer.CommonName {
+		signerHumanName = "<self-signed>"
+	}
+
+	usages := []string{}
+	for _, curr := range certificate.ExtKeyUsage {
+		if curr == x509.ExtKeyUsageClientAuth {
+			usages = append(usages, "client")
+			continue
+		}
+		if curr == x509.ExtKeyUsageServerAuth {
+			usages = append(usages, "serving")
+			continue
+		}
+
+		usages = append(usages, fmt.Sprintf("%d", curr))
+	}
+
+	validServingNames := []string{}
+	for _, ip := range certificate.IPAddresses {
+		validServingNames = append(validServingNames, ip.String())
+	}
+	for _, dnsName := range certificate.DNSNames {
+		validServingNames = append(validServingNames, dnsName)
+	}
+
+	servingString := ""
+	if len(validServingNames) > 0 {
+		servingString = fmt.Sprintf(" validServingFor=[%s]", strings.Join(validServingNames, ","))
+	}
+
+	groupString := ""
+	if len(certificate.Subject.Organization) > 0 {
+		groupString = fmt.Sprintf(" groups=[%s]", strings.Join(certificate.Subject.Organization, ","))
+	}
+
+	return fmt.Sprintf("%q [%s]%s%s issuer=%q (%v to %v (now=%v))", humanName, strings.Join(usages, ","), groupString,
+		servingString, signerHumanName, certificate.NotBefore.UTC(), certificate.NotAfter.UTC(), time.Now().UTC())
+}

--- a/pkg/certs/util.go
+++ b/pkg/certs/util.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-// CertificateToString parse provided certificate to human-readable form.
+// CertificateToString convert a certificate into a human readable string.
 // This function should guarantee consistent output format for must-gather tooling and any code
 // that prints the certificate details.
 func CertificateToString(certificate *x509.Certificate) string {
@@ -52,4 +52,13 @@ func CertificateToString(certificate *x509.Certificate) string {
 
 	return fmt.Sprintf("%q [%s]%s%s issuer=%q (%v to %v (now=%v))", humanName, strings.Join(usages, ","), groupString,
 		servingString, signerHumanName, certificate.NotBefore.UTC(), certificate.NotAfter.UTC(), time.Now().UTC())
+}
+
+// CertificateBundleToString convert a certificate bundle into a human readable string.
+func CertificateBundleToString(bundle []*x509.Certificate) string {
+	output := []string{}
+	for i, cert := range bundle {
+		output = append(output, fmt.Sprintf("[#%d]: %s", i, CertificateToString(cert)))
+	}
+	return strings.Join(output, "\n")
 }

--- a/pkg/certs/util.go
+++ b/pkg/certs/util.go
@@ -7,7 +7,12 @@ import (
 	"time"
 )
 
-// CertificateToString convert a certificate into a human readable string.
+const defaultOutputTimeFormat = "Jan 2 15:04:05 2006"
+
+// nowFn is used in unit test to freeze time.
+var nowFn = time.Now().UTC
+
+// CertificateToString converts a certificate into a human readable string.
 // This function should guarantee consistent output format for must-gather tooling and any code
 // that prints the certificate details.
 func CertificateToString(certificate *x509.Certificate) string {
@@ -51,10 +56,11 @@ func CertificateToString(certificate *x509.Certificate) string {
 	}
 
 	return fmt.Sprintf("%q [%s]%s%s issuer=%q (%v to %v (now=%v))", humanName, strings.Join(usages, ","), groupString,
-		servingString, signerHumanName, certificate.NotBefore.UTC(), certificate.NotAfter.UTC(), time.Now().UTC())
+		servingString, signerHumanName, certificate.NotBefore.UTC().Format(defaultOutputTimeFormat),
+		certificate.NotAfter.UTC().Format(defaultOutputTimeFormat), nowFn().Format(defaultOutputTimeFormat))
 }
 
-// CertificateBundleToString convert a certificate bundle into a human readable string.
+// CertificateBundleToString converts a certificate bundle into a human readable string.
 func CertificateBundleToString(bundle []*x509.Certificate) string {
 	output := []string{}
 	for i, cert := range bundle {

--- a/pkg/certs/util_test.go
+++ b/pkg/certs/util_test.go
@@ -1,0 +1,101 @@
+package certs
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"net"
+	"testing"
+	"time"
+)
+
+func init() {
+	nowFn = func() time.Time {
+		return time.Date(2019, time.January, 1, 0, 0, 0, 0, &time.Location{})
+	}
+}
+
+func TestCertificateToString(t *testing.T) {
+	tests := []struct {
+		name     string
+		cert     *x509.Certificate
+		expected string
+	}{
+		{
+			name:     "empty cert",
+			cert:     &x509.Certificate{},
+			expected: `"" [] issuer="<self-signed>" (Jan 1 00:00:00 0001 to Jan 1 00:00:00 0001 (now=Jan 1 00:00:00 2019))`,
+		},
+		{
+			name: "common name",
+			cert: &x509.Certificate{
+				Subject: pkix.Name{
+					CommonName: "test-subject",
+				},
+				Issuer: pkix.Name{
+					CommonName: "test-issuer",
+				},
+			},
+			expected: `"test-subject" [] issuer="test-issuer" (Jan 1 00:00:00 0001 to Jan 1 00:00:00 0001 (now=Jan 1 00:00:00 2019))`,
+		},
+		{
+			name: "self-signed",
+			cert: &x509.Certificate{
+				Subject: pkix.Name{
+					CommonName: "test-issuer",
+				},
+				Issuer: pkix.Name{
+					CommonName: "test-issuer",
+				},
+			},
+			expected: `"test-issuer" [] issuer="<self-signed>" (Jan 1 00:00:00 0001 to Jan 1 00:00:00 0001 (now=Jan 1 00:00:00 2019))`,
+		},
+		{
+			name: "valid serving for",
+			cert: &x509.Certificate{
+				Subject: pkix.Name{
+					CommonName: "test-subject",
+				},
+				Issuer: pkix.Name{
+					CommonName: "test-issuer",
+				},
+				IPAddresses: []net.IP{net.IPv4('1', '2', '3', '4')},
+			},
+			expected: `"test-subject" [] validServingFor=[49.50.51.52] issuer="test-issuer" (Jan 1 00:00:00 0001 to Jan 1 00:00:00 0001 (now=Jan 1 00:00:00 2019))`,
+		},
+		{
+			name: "organization",
+			cert: &x509.Certificate{
+				Subject: pkix.Name{
+					CommonName:   "test-subject",
+					Organization: []string{"foo", "bar"},
+				},
+				Issuer: pkix.Name{
+					CommonName: "test-issuer",
+				},
+			},
+			expected: `"test-subject" [] groups=[foo,bar] issuer="test-issuer" (Jan 1 00:00:00 0001 to Jan 1 00:00:00 0001 (now=Jan 1 00:00:00 2019))`,
+		},
+		{
+			name: "client auth",
+			cert: &x509.Certificate{
+				Subject: pkix.Name{
+					CommonName: "test-subject",
+				},
+				Issuer: pkix.Name{
+					CommonName: "test-issuer",
+				},
+				ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+			},
+			expected: `"test-subject" [client] issuer="test-issuer" (Jan 1 00:00:00 0001 to Jan 1 00:00:00 0001 (now=Jan 1 00:00:00 2019))`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			out := CertificateToString(test.cert)
+			if out != test.expected {
+				t.Errorf("expected %q, got %q", test.expected, out)
+			}
+		})
+	}
+}

--- a/pkg/operator/certrotation/target.go
+++ b/pkg/operator/certrotation/target.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/authentication/user"
 
+	"github.com/openshift/library-go/pkg/certs"
 	"github.com/openshift/library-go/pkg/crypto"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
@@ -95,7 +96,12 @@ func needNewTargetCertKeyPair(annotations map[string]string, signer *crypto.CA, 
 		}
 	}
 
-	return fmt.Sprintf("issuer %q, not in ca bundle", signerCommonName)
+	caBundleCertsStrings := []string{}
+	for _, crt := range caBundleCerts {
+		caBundleCertsStrings = append(caBundleCertsStrings, certs.CertificateToString(crt))
+	}
+
+	return fmt.Sprintf("issuer %q, not in ca bundle:\n%s", signerCommonName, strings.Join(caBundleCertsStrings, "\n"))
 }
 
 // needNewTargetCertKeyPairForTime returns true when

--- a/pkg/operator/certrotation/target.go
+++ b/pkg/operator/certrotation/target.go
@@ -96,12 +96,7 @@ func needNewTargetCertKeyPair(annotations map[string]string, signer *crypto.CA, 
 		}
 	}
 
-	caBundleCertsStrings := []string{}
-	for _, crt := range caBundleCerts {
-		caBundleCertsStrings = append(caBundleCertsStrings, certs.CertificateToString(crt))
-	}
-
-	return fmt.Sprintf("issuer %q, not in ca bundle:\n%s", signerCommonName, strings.Join(caBundleCertsStrings, "\n"))
+	return fmt.Sprintf("issuer %q, not in ca bundle:\n%s", signerCommonName, certs.CertificateBundleToString(caBundleCerts))
 }
 
 // needNewTargetCertKeyPairForTime returns true when


### PR DESCRIPTION
We use this in must-gather and we should make the output consistent across all tools.

/cc @deads2k 
/cc @sttts 