### PR TITLE
Correctly run UnsupportedConfigOverridesController when Managed

### DIFF
--- a/pkg/operator/unsupportedconfigoverridescontroller/unsupportedconfigoverrides_controller.go
+++ b/pkg/operator/unsupportedconfigoverridescontroller/unsupportedconfigoverrides_controller.go
@@ -65,7 +65,7 @@ func (c *UnsupportedConfigOverridesController) sync() error {
 		return err
 	}
 
-	if management.IsOperatorManaged(operatorSpec.ManagementState) {
+	if !management.IsOperatorManaged(operatorSpec.ManagementState) {
 		return nil
 	}
 


### PR DESCRIPTION
Signed-off-by: Monis Khan <mkhan@redhat.com>

@openshift/sig-master 