### PR TITLE
ClusterOperatorStatusController: Wait for cache sync

### DIFF
--- a/pkg/operator/status/status_controller.go
+++ b/pkg/operator/status/status_controller.go
@@ -85,8 +85,10 @@ func NewClusterOperatorStatusController(
 func (c StatusSyncer) sync() error {
 	detailedSpec, currentDetailedStatus, _, err := c.operatorClient.GetOperatorState()
 	if apierrors.IsNotFound(err) {
-		// return nil here, wait for operatorClient to catch up
 		c.eventRecorder.Warningf("StatusNotFound", "Unable to determine current operator status for %s", c.clusterOperatorName)
+		if err := c.clusterOperatorClient.ClusterOperators().Delete(c.clusterOperatorName, nil); err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
 		return nil
 	}
 	if err != nil {


### PR DESCRIPTION
Without this PR, during upgrades, components that utilize the ClusterOperatorStatusController
(authentication and service-ca) have a glitch in reporting cluster operator version. This PR adds a wait for the operatorClient informer to catch up.

(testing now, this fixes the glitch in version reporting for auth, service-ca COs)