### PR TITLE
staticpod: set operand version using environment variable

### DIFF
--- a/pkg/operator/staticpod/controller/staticpodstate/staticpodstate_controller.go
+++ b/pkg/operator/staticpod/controller/staticpodstate/staticpodstate_controller.go
@@ -130,7 +130,7 @@ func (c *StaticPodStateController) sync() error {
 	} else {
 		c.versionRecorder.SetVersion(
 			c.operandName,
-			status.VersionForOperand(c.operatorNamespace, images.List()[0], c.configMapGetter, c.eventRecorder),
+			status.VersionForOperandFromEnv(),
 		)
 	}
 

--- a/pkg/operator/status/version.go
+++ b/pkg/operator/status/version.go
@@ -1,6 +1,7 @@
 package status
 
 import (
+	"os"
 	"sync"
 
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -15,6 +16,10 @@ type versionGetter struct {
 	versions             map[string]string
 	notificationChannels []chan struct{}
 }
+
+const (
+	operandImageVersionEnvVarName = "OPERAND_IMAGE_VERSION"
+)
 
 func NewVersionGetter() VersionGetter {
 	return &versionGetter{
@@ -55,6 +60,10 @@ func (v *versionGetter) VersionChangedChannel() <-chan struct{} {
 	channel := make(chan struct{}, 50)
 	v.notificationChannels = append(v.notificationChannels, channel)
 	return channel
+}
+
+func VersionForOperandFromEnv() string {
+	return os.Getenv(operandImageVersionEnvVarName)
 }
 
 func VersionForOperand(namespace, imagePullSpec string, configMapGetter corev1client.ConfigMapsGetter, eventRecorder events.Recorder) string {


### PR DESCRIPTION
Set the operand version using `OPERAND_IMAGE_VERSION` variable.