### PR TITLE
Remove artificial cert rotation scale limitation on unsupported config

### DIFF
--- a/pkg/operator/certrotation/config.go
+++ b/pkg/operator/certrotation/config.go
@@ -1,7 +1,6 @@
 package certrotation
 
 import (
-	"fmt"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -32,9 +31,6 @@ func GetCertRotationScale(client kubernetes.Interface, namespace string) (time.D
 	})
 	if err != nil {
 		return 0, err
-	}
-	if certRotationScale > 24*time.Hour {
-		return 0, fmt.Errorf("scale longer than 24h is not allowed: %v", certRotationScale)
 	}
 	return certRotationScale, nil
 }


### PR DESCRIPTION
We already limit the available choices on the supported config. There is no reason to limit the unsupported choices where we already claim it UNSUPPORTED** to force **artificial** limitations on users agreeing to the terms of being unsupported and changing it on their own.

**The supported config is where we express our opinions on what the setting should be**. The unsupported config is where user or developer expresses his opinions and gets to do stuff that may not work but only because there is reason to, not because a developer though he is smarter.

I think the above is a sufficient reason on it's own but:

This could easily unblock the whole CodeReady Containers (used to be CDK) efforts in minutes time by letting them override the value to a large duration for now.

It also let developers to change the value to test cert rotation.

/assign @deads2k 

(fyi @soltysh since I know we really disagree on this topic, but don't want to go behind your back in secret)
