### PR TITLE
Revert "resourcesynccontroller: use cached get to confirm resource ex…

### DIFF
--- a/pkg/operator/resourcesynccontroller/resourcesync_controller.go
+++ b/pkg/operator/resourcesynccontroller/resourcesync_controller.go
@@ -149,10 +149,6 @@ func (c *ResourceSyncController) sync() error {
 
 	for destination, source := range c.configMapSyncRules {
 		if source == emptyResourceLocation {
-			// use the cache to check whether the configmap exists in target namespace, if not skip the extra delete call.
-			if _, err := c.configMapGetter.ConfigMaps(destination.Namespace).Get(destination.Name, metav1.GetOptions{}); err != nil && apierrors.IsNotFound(err) {
-				continue
-			}
 			if err := c.configMapGetter.ConfigMaps(destination.Namespace).Delete(destination.Name, nil); err != nil && !apierrors.IsNotFound(err) {
 				errors = append(errors, err)
 			}
@@ -166,10 +162,6 @@ func (c *ResourceSyncController) sync() error {
 	}
 	for destination, source := range c.secretSyncRules {
 		if source == emptyResourceLocation {
-			// use the cache to check whether the secret exists in target namespace, if not skip the extra delete call.
-			if _, err := c.secretGetter.Secrets(destination.Namespace).Get(destination.Name, metav1.GetOptions{}); err != nil && apierrors.IsNotFound(err) {
-				continue
-			}
 			if err := c.secretGetter.Secrets(destination.Namespace).Delete(destination.Name, nil); err != nil && !apierrors.IsNotFound(err) {
 				errors = append(errors, err)
 			}


### PR DESCRIPTION
…ists before deleting target"

This reverts commit 25c83b74ab8e2b788715add632c9e5bef54dcb3b.

https://github.com/openshift/cluster-kube-apiserver-operator/pull/369 and the last commit of https://github.com/openshift/cluster-kube-apiserver-operator/pull/371 indicate that something is wrong with this code or it's usage.  We need to revert in order to bump all the operators, then we need to do a fake bump in KAS-o to sort it out.