### PR TITLE
events: fallback to use namespace as controller if we are not able to get pod

### DIFF
--- a/pkg/controller/controllercmd/builder.go
+++ b/pkg/controller/controllercmd/builder.go
@@ -172,7 +172,7 @@ func (b *ControllerBuilder) Run(config *unstructured.Unstructured, ctx context.C
 	}
 	controllerRef, err := events.GetControllerReferenceForCurrentPod(kubeClient, namespace, nil)
 	if err != nil {
-		panic(fmt.Sprintf("unable to obtain replicaset reference for events: %v", err))
+		klog.Warningf("unable to get owner reference (falling back to namespace): %v", err)
 	}
 	eventRecorder := events.NewKubeRecorder(kubeClient.CoreV1().Events(namespace), b.componentName, controllerRef)
 

--- a/pkg/operator/events/recorder.go
+++ b/pkg/operator/events/recorder.go
@@ -68,7 +68,6 @@ func GetControllerReferenceForCurrentPod(client kubernetes.Interface, targetName
 	case "Pod":
 		pod, err := client.CoreV1().Pods(reference.Namespace).Get(reference.Name, metav1.GetOptions{})
 		if err != nil {
-			klog.Warningf("Unable to get owner reference for pod %q (will use namespace instead): %v", podNameEnvFunc(), err)
 			return getControllerReferenceForNamespace(reference.Namespace), err
 		}
 		if podController := metav1.GetControllerOf(pod); podController != nil {
@@ -79,7 +78,6 @@ func GetControllerReferenceForCurrentPod(client kubernetes.Interface, targetName
 	case "ReplicaSet":
 		rs, err := client.AppsV1().ReplicaSets(reference.Namespace).Get(reference.Name, metav1.GetOptions{})
 		if err != nil {
-			klog.Warningf("Unable to get owner reference for replica set %q (will use namespace instead): %v", reference.Name, err)
 			return getControllerReferenceForNamespace(reference.Namespace), err
 		}
 		if rsController := metav1.GetControllerOf(rs); rsController != nil {

--- a/pkg/operator/events/recorder.go
+++ b/pkg/operator/events/recorder.go
@@ -44,6 +44,8 @@ var podNameEnvFunc = func() string {
 
 // GetControllerReferenceForCurrentPod provides an object reference to a controller managing the pod/container where this process runs.
 // The pod name must be provided via the POD_NAME name.
+// Even if this method returns an error, it always return valid reference to the namespace. It allows the callers to control the logging
+// and decide to fail or accept the namespace.
 func GetControllerReferenceForCurrentPod(client kubernetes.Interface, targetNamespace string, reference *corev1.ObjectReference) (*corev1.ObjectReference, error) {
 	if reference == nil {
 		// Try to get the pod name via POD_NAME environment variable
@@ -54,7 +56,10 @@ func GetControllerReferenceForCurrentPod(client kubernetes.Interface, targetName
 		// If that fails, lets try to guess the pod by listing all pods in namespaces and using the first pod in the list
 		reference, err := guessControllerReferenceForNamespace(client.CoreV1().Pods(targetNamespace))
 		if err != nil {
-			return nil, err
+			// If this fails, do not give up with error but instead use the namespace as controller reference for the pod
+			// NOTE: This is last resort, if we see this often it might indicate something is wrong in the cluster.
+			//       In some cases this might help with flakes.
+			return getControllerReferenceForNamespace(targetNamespace), err
 		}
 		return GetControllerReferenceForCurrentPod(client, targetNamespace, reference)
 	}
@@ -63,7 +68,8 @@ func GetControllerReferenceForCurrentPod(client kubernetes.Interface, targetName
 	case "Pod":
 		pod, err := client.CoreV1().Pods(reference.Namespace).Get(reference.Name, metav1.GetOptions{})
 		if err != nil {
-			return nil, err
+			klog.Warningf("Unable to get owner reference for pod %q (will use namespace instead): %v", podNameEnvFunc(), err)
+			return getControllerReferenceForNamespace(reference.Namespace), err
 		}
 		if podController := metav1.GetControllerOf(pod); podController != nil {
 			return GetControllerReferenceForCurrentPod(client, targetNamespace, makeObjectReference(podController, targetNamespace))
@@ -73,7 +79,8 @@ func GetControllerReferenceForCurrentPod(client kubernetes.Interface, targetName
 	case "ReplicaSet":
 		rs, err := client.AppsV1().ReplicaSets(reference.Namespace).Get(reference.Name, metav1.GetOptions{})
 		if err != nil {
-			return nil, err
+			klog.Warningf("Unable to get owner reference for replica set %q (will use namespace instead): %v", reference.Name, err)
+			return getControllerReferenceForNamespace(reference.Namespace), err
 		}
 		if rsController := metav1.GetControllerOf(rs); rsController != nil {
 			return GetControllerReferenceForCurrentPod(client, targetNamespace, makeObjectReference(rsController, targetNamespace))
@@ -82,6 +89,16 @@ func GetControllerReferenceForCurrentPod(client kubernetes.Interface, targetName
 		return reference, nil
 	default:
 		return reference, nil
+	}
+}
+
+// getControllerReferenceForNamespace returns an object reference to the given namespace.
+func getControllerReferenceForNamespace(targetNamespace string) *corev1.ObjectReference {
+	return &corev1.ObjectReference{
+		Kind:       "Namespace",
+		Namespace:  targetNamespace,
+		Name:       targetNamespace,
+		APIVersion: "v1",
 	}
 }
 

--- a/pkg/operator/events/recorder_test.go
+++ b/pkg/operator/events/recorder_test.go
@@ -163,3 +163,24 @@ func TestGetControllerReferenceForCurrentPod(t *testing.T) {
 		t.Errorf("expected objectReference to be Deployment, got %q", objectReference.GroupVersionKind().String())
 	}
 }
+
+func TestGetControllerReferenceForCurrentPodFallbackNamespace(t *testing.T) {
+	client := fake.NewSimpleClientset()
+
+	podNameEnvFunc = func() string {
+		return "test"
+	}
+
+	objectReference, err := GetControllerReferenceForCurrentPod(client, "test", nil)
+	if err == nil {
+		t.Fatalf("expected error: %v", err)
+	}
+
+	if objectReference.Name != "test" {
+		t.Errorf("expected objectReference name to be 'test', got %q", objectReference.Name)
+	}
+
+	if objectReference.GroupVersionKind().String() != "/v1, Kind=Namespace" {
+		t.Errorf("expected objectReference to be Namespace, got %q", objectReference.GroupVersionKind().String())
+	}
+}


### PR DESCRIPTION
With this change, when we are unable to get the pod running the operator or we are not able to guess the pod by listing all pods in namespace, instead of failing hard use the provided namespace as a controller.

This will prevent operator failure to start in some cases.

/cc @deads2k 