### PR TITLE
Lock installerpod manifests

### DIFF
--- a/pkg/filelock/posix.go
+++ b/pkg/filelock/posix.go
@@ -1,0 +1,72 @@
+// +build linux darwin freebsd openbsd netbsd dragonfly
+
+package filelock
+
+import (
+	"context"
+	"errors"
+	"syscall"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+func syscallToCond(err error) (bool, error) {
+	switch err {
+	case nil:
+		return true, nil
+	case syscall.EAGAIN, syscall.EINTR:
+		return false, nil
+	default:
+		return true, err
+	}
+}
+
+// Posix file locks are identified with [i_node, pid] pair.
+// Kernel will unlock them when your process terminates and they are left locked.
+type Posix struct {
+	fd uintptr
+}
+
+var ErrAlreadyHeld = errors.New("posix file lock is already held")
+var ErrNoneHeld = errors.New("posix file lock is not associated with file descriptor")
+
+func (l *Posix) ReadLock(ctx context.Context, fd uintptr) error {
+	if l.fd != 0 && fd != l.fd {
+		return ErrAlreadyHeld
+	}
+
+	l.fd = fd
+
+	return wait.PollUntil(100*time.Millisecond, func() (bool, error) {
+		return syscallToCond(syscall.FcntlFlock(fd, syscall.F_SETLK, &syscall.Flock_t{
+			Type: syscall.F_RDLCK,
+		}))
+	}, ctx.Done())
+}
+
+func (l *Posix) WriteLock(ctx context.Context, fd uintptr) error {
+	if l.fd != 0 && fd != l.fd {
+		return ErrAlreadyHeld
+	}
+
+	l.fd = fd
+
+	return wait.PollUntil(100*time.Millisecond, func() (bool, error) {
+		return syscallToCond(syscall.FcntlFlock(fd, syscall.F_SETLK, &syscall.Flock_t{
+			Type: syscall.F_WRLCK,
+		}))
+	}, ctx.Done())
+}
+
+func (l *Posix) Unlock(ctx context.Context) error {
+	if l.fd == 0 {
+		return ErrNoneHeld
+	}
+
+	return wait.PollUntil(100*time.Millisecond, func() (bool, error) {
+		return syscallToCond(syscall.FcntlFlock(l.fd, syscall.F_SETLK, &syscall.Flock_t{
+			Type: syscall.F_UNLCK,
+		}))
+	}, ctx.Done())
+}

--- a/pkg/filelock/posix_test.go
+++ b/pkg/filelock/posix_test.go
@@ -1,0 +1,112 @@
+// +build linux darwin freebsd openbsd netbsd dragonfly
+
+package filelock
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+// Posix locks are identified by [i_node, pid]
+// To test it properly we would have to fork here, but Golang doesn't support it,
+// so we will test the single PID case.
+//
+// (I guess we might be able to use ForkExec to somehow target back this unit test
+// but having integration test is likely to be easier.)
+//
+// TODO: add multi (PID) writer integration test
+
+func TestReadLock(t *testing.T) {
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	file, err := os.Create(dir + "/lock.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+
+	ctx := context.Background()
+
+	l := Posix{}
+
+	// First ReadLock
+	err = l.ReadLock(ctx, file.Fd())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Second ReadLock
+	err = l.ReadLock(ctx, file.Fd())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// a ReadLock on different fd should fail
+	err = l.ReadLock(ctx, uintptr(42))
+	if err != ErrAlreadyHeld {
+		t.Fatalf("expected %v, got: %v", ErrAlreadyHeld, err)
+	}
+
+	err = l.Unlock(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWriteLock(t *testing.T) {
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	file, err := os.Create(dir + "/lock.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+
+	ctx := context.Background()
+
+	l := Posix{}
+
+	// First WriteLock
+	err = l.WriteLock(ctx, file.Fd())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Second WriteLock
+	err = l.WriteLock(ctx, file.Fd())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// a WriteLock on different fd should fail
+	err = l.WriteLock(ctx, uintptr(42))
+	if err != ErrAlreadyHeld {
+		t.Fatalf("expected %v, got: %v", ErrAlreadyHeld, err)
+	}
+
+	err = l.Unlock(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestUnlock(t *testing.T) {
+	l := Posix{}
+
+	ctx := context.Background()
+
+	err := l.Unlock(ctx)
+	if err != ErrNoneHeld {
+		t.Fatalf("expected %v, got: %v", ErrAlreadyHeld, err)
+	}
+}


### PR DESCRIPTION
This avoids racing with cert recovery tool by using advisory POSIX file locks. These locks are identified by [i_node,pid] pair and kernel will release them if we are terminated (ungracefully).

/cc @deads2k 