### PR TITLE
certrotation: label managed certificates

### DIFF
--- a/pkg/operator/certrotation/cabundle.go
+++ b/pkg/operator/certrotation/cabundle.go
@@ -50,6 +50,7 @@ func (c CABundleRotation) ensureConfigMapCABundle(signingCertKeyPair *crypto.CA)
 	}
 	if originalCABundleConfigMap == nil || originalCABundleConfigMap.Data == nil || !equality.Semantic.DeepEqual(originalCABundleConfigMap.Data, caBundleConfigMap.Data) {
 		c.EventRecorder.Eventf("CABundleUpdateRequired", "%q in %q requires a new cert", c.Name, c.Namespace)
+		LabelAsManagedConfigMap(caBundleConfigMap, CertificateTypeCABundle)
 
 		actualCABundleConfigMap, modified, err := resourceapply.ApplyConfigMap(c.Client, c.EventRecorder, caBundleConfigMap)
 		if err != nil {

--- a/pkg/operator/certrotation/cabundle_test.go
+++ b/pkg/operator/certrotation/cabundle_test.go
@@ -57,6 +57,9 @@ func TestEnsureConfigMapCABundle(t *testing.T) {
 				}
 
 				actual := actions[1].(clienttesting.CreateAction).GetObject().(*corev1.ConfigMap)
+				if certType, _ := CertificateTypeFromObject(actual); certType != CertificateTypeCABundle {
+					t.Errorf("expected certificate type 'ca-bundle', got: %v", certType)
+				}
 				if len(actual.Data["ca-bundle.crt"]) == 0 {
 					t.Error(actual.Data)
 				}
@@ -96,6 +99,9 @@ func TestEnsureConfigMapCABundle(t *testing.T) {
 				actual := actions[1].(clienttesting.UpdateAction).GetObject().(*corev1.ConfigMap)
 				if len(actual.Data["ca-bundle.crt"]) == 0 {
 					t.Error(actual.Data)
+				}
+				if certType, _ := CertificateTypeFromObject(actual); certType != CertificateTypeCABundle {
+					t.Errorf("expected certificate type 'ca-bundle', got: %v", certType)
 				}
 				result, err := cert.ParseCertsPEM([]byte(actual.Data["ca-bundle.crt"]))
 				if err != nil {
@@ -140,6 +146,9 @@ func TestEnsureConfigMapCABundle(t *testing.T) {
 				actual := actions[1].(clienttesting.UpdateAction).GetObject().(*corev1.ConfigMap)
 				if len(actual.Data["ca-bundle.crt"]) == 0 {
 					t.Error(actual.Data)
+				}
+				if certType, _ := CertificateTypeFromObject(actual); certType != CertificateTypeCABundle {
+					t.Errorf("expected certificate type 'ca-bundle', got: %v", certType)
 				}
 				result, err := cert.ParseCertsPEM([]byte(actual.Data["ca-bundle.crt"]))
 				if err != nil {
@@ -188,6 +197,9 @@ func TestEnsureConfigMapCABundle(t *testing.T) {
 				actual := actions[1].(clienttesting.UpdateAction).GetObject().(*corev1.ConfigMap)
 				if len(actual.Data["ca-bundle.crt"]) == 0 {
 					t.Error(actual.Data)
+				}
+				if certType, _ := CertificateTypeFromObject(actual); certType != CertificateTypeCABundle {
+					t.Errorf("expected certificate type 'ca-bundle', got: %v", certType)
 				}
 				result, err := cert.ParseCertsPEM([]byte(actual.Data["ca-bundle.crt"]))
 				if err != nil {

--- a/pkg/operator/certrotation/label.go
+++ b/pkg/operator/certrotation/label.go
@@ -1,0 +1,61 @@
+package certrotation
+
+import (
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+const (
+	// ManagedCertificateTypeLabelName marks config map or secret as object that contains managed certificates.
+	// This groups all objects that store certs and allow easy query to get them all.
+	// The value of this label should be set to "true".
+	ManagedCertificateTypeLabelName = "auth.openshift.io/managed-certificate-type"
+)
+
+type CertificateType string
+
+var (
+	CertificateTypeCABundle CertificateType = "ca-bundle"
+	CertificateTypeSigner   CertificateType = "signer"
+	CertificateTypeTarget   CertificateType = "target"
+	CertificateTypeUnknown  CertificateType = "unknown"
+)
+
+// LabelAsManagedConfigMap add label indicating the given config map contains certificates
+// that are managed.
+func LabelAsManagedConfigMap(config *v1.ConfigMap, certificateType CertificateType) {
+	if config.Labels == nil {
+		config.Labels = map[string]string{}
+	}
+	config.Labels[ManagedCertificateTypeLabelName] = string(certificateType)
+}
+
+// LabelAsManagedConfigMap add label indicating the given secret contains certificates
+// that are managed.
+func LabelAsManagedSecret(secret *v1.Secret, certificateType CertificateType) {
+	if secret.Labels == nil {
+		secret.Labels = map[string]string{}
+	}
+	secret.Labels[ManagedCertificateTypeLabelName] = string(certificateType)
+}
+
+// CertificateTypeFromObject returns the CertificateType based on the annotations of the object.
+func CertificateTypeFromObject(obj runtime.Object) (CertificateType, error) {
+	accesor, err := meta.Accessor(obj)
+	if err != nil {
+		return "", err
+	}
+	actualLabels := accesor.GetLabels()
+	if actualLabels == nil {
+		return CertificateTypeUnknown, nil
+	}
+
+	t := CertificateType(actualLabels[ManagedCertificateTypeLabelName])
+	switch t {
+	case CertificateTypeCABundle, CertificateTypeSigner, CertificateTypeTarget:
+		return t, nil
+	default:
+		return CertificateTypeUnknown, nil
+	}
+}

--- a/pkg/operator/certrotation/signer.go
+++ b/pkg/operator/certrotation/signer.go
@@ -48,6 +48,8 @@ func (c SigningRotation) ensureSigningCertKeyPair() (*crypto.CA, error) {
 			return nil, err
 		}
 
+		LabelAsManagedSecret(signingCertKeyPairSecret, CertificateTypeSigner)
+
 		actualSigningCertKeyPairSecret, _, err := resourceapply.ApplySecret(c.Client, c.EventRecorder, signingCertKeyPairSecret)
 		if err != nil {
 			return nil, err

--- a/pkg/operator/certrotation/signer_test.go
+++ b/pkg/operator/certrotation/signer_test.go
@@ -43,6 +43,9 @@ func TestEnsureSigningCertKeyPair(t *testing.T) {
 				}
 
 				actual := actions[1].(clienttesting.CreateAction).GetObject().(*corev1.Secret)
+				if certType, _ := CertificateTypeFromObject(actual); certType != CertificateTypeSigner {
+					t.Errorf("expected certificate type 'signer', got: %v", certType)
+				}
 				if len(actual.Data["tls.crt"]) == 0 || len(actual.Data["tls.key"]) == 0 {
 					t.Error(actual.Data)
 				}
@@ -65,6 +68,9 @@ func TestEnsureSigningCertKeyPair(t *testing.T) {
 				}
 
 				actual := actions[1].(clienttesting.UpdateAction).GetObject().(*corev1.Secret)
+				if certType, _ := CertificateTypeFromObject(actual); certType != CertificateTypeSigner {
+					t.Errorf("expected certificate type 'signer', got: %v", certType)
+				}
 				if len(actual.Data["tls.crt"]) == 0 || len(actual.Data["tls.key"]) == 0 {
 					t.Error(actual.Data)
 				}

--- a/pkg/operator/certrotation/target.go
+++ b/pkg/operator/certrotation/target.go
@@ -70,6 +70,8 @@ func (c TargetRotation) ensureTargetCertKeyPair(signingCertKeyPair *crypto.CA, c
 			return err
 		}
 
+		LabelAsManagedSecret(targetCertKeyPairSecret, CertificateTypeTarget)
+
 		actualTargetCertKeyPairSecret, _, err := resourceapply.ApplySecret(c.Client, c.EventRecorder, targetCertKeyPairSecret)
 		if err != nil {
 			return err

--- a/pkg/operator/certrotation/target_test.go
+++ b/pkg/operator/certrotation/target_test.go
@@ -303,6 +303,10 @@ func TestEnsureTargetSignerCertKeyPair(t *testing.T) {
 					t.Error(actual.Data)
 				}
 
+				if certType, _ := CertificateTypeFromObject(actual); certType != CertificateTypeTarget {
+					t.Errorf("expected certificate type 'target', got: %v", certType)
+				}
+
 				signingCertKeyPair, err := crypto.GetCAFromBytes(actual.Data["tls.crt"], actual.Data["tls.key"])
 				if err != nil {
 					t.Error(actual.Data)
@@ -341,6 +345,9 @@ func TestEnsureTargetSignerCertKeyPair(t *testing.T) {
 				actual := actions[1].(clienttesting.UpdateAction).GetObject().(*corev1.Secret)
 				if len(actual.Data["tls.crt"]) == 0 || len(actual.Data["tls.key"]) == 0 {
 					t.Error(actual.Data)
+				}
+				if certType, _ := CertificateTypeFromObject(actual); certType != CertificateTypeTarget {
+					t.Errorf("expected certificate type 'target', got: %v", certType)
 				}
 
 				signingCertKeyPair, err := crypto.GetCAFromBytes(actual.Data["tls.crt"], actual.Data["tls.key"])


### PR DESCRIPTION
This change will cause that all secrets and configs managed by certrotation controller will be labeled using their type.
This allows easier label queries.

/cc @soltysh 
/cc @deads2k 