### PR TITLE
Add UpdateStaticPodOperatorSpec function

### DIFF
--- a/pkg/operator/staticpod/controller/installer/installer_controller_test.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller_test.go
@@ -57,6 +57,7 @@ func TestNewNodeStateForInstallInProgress(t *testing.T) {
 			},
 		},
 		nil,
+		nil,
 	)
 
 	eventRecorder := events.NewRecorder(kubeClient.CoreV1().Events("test"), "test-operator", &v1.ObjectReference{})
@@ -268,6 +269,7 @@ func TestCreateInstallerPod(t *testing.T) {
 			},
 		},
 		nil,
+		nil,
 	)
 	eventRecorder := events.NewRecorder(kubeClient.CoreV1().Events("test"), "test-operator", &v1.ObjectReference{})
 
@@ -432,6 +434,7 @@ func TestEnsureInstallerPod(t *testing.T) {
 						},
 					},
 				},
+				nil,
 				nil,
 			)
 			eventRecorder := events.NewRecorder(kubeClient.CoreV1().Events("test"), "test-operator", &v1.ObjectReference{})
@@ -972,6 +975,7 @@ func TestCreateInstallerPodMultiNode(t *testing.T) {
 					NodeStatuses:            test.nodeStatuses,
 				},
 				statusUpdateErrorFunc,
+				nil,
 			)
 
 			eventRecorder := events.NewRecorder(kubeClient.CoreV1().Events("test"), "test-operator", &v1.ObjectReference{})

--- a/pkg/operator/staticpod/controller/monitoring/monitoring_resource_controller_test.go
+++ b/pkg/operator/staticpod/controller/monitoring/monitoring_resource_controller_test.go
@@ -65,6 +65,7 @@ func TestNewMonitoringResourcesController(t *testing.T) {
 				},
 				&operatorv1.StaticPodOperatorStatus{},
 				nil,
+				nil,
 			),
 			validateActions: func(t *testing.T, actions []clienttesting.Action) {
 				if len(actions) != 4 {
@@ -96,6 +97,7 @@ func TestNewMonitoringResourcesController(t *testing.T) {
 					},
 				},
 				&operatorv1.StaticPodOperatorStatus{},
+				nil,
 				nil,
 			),
 			startingDynamicObjects: []runtime.Object{mustAssetServiceMonitor("target-namespace")},

--- a/pkg/operator/staticpod/controller/node/node_controller_test.go
+++ b/pkg/operator/staticpod/controller/node/node_controller_test.go
@@ -115,6 +115,7 @@ func TestNewNodeController(t *testing.T) {
 					NodeStatuses:            test.startNodeStatus,
 				},
 				nil,
+				nil,
 			)
 
 			eventRecorder := events.NewRecorder(kubeClient.CoreV1().Events("test"), "test-operator", &v1.ObjectReference{})

--- a/pkg/operator/staticpod/controller/prune/prune_controller_test.go
+++ b/pkg/operator/staticpod/controller/prune/prune_controller_test.go
@@ -196,6 +196,7 @@ func TestPruneAPIResources(t *testing.T) {
 				},
 			},
 			nil,
+			nil,
 		)
 		eventRecorder := events.NewRecorder(kubeClient.CoreV1().Events("test"), "test-operator", &v1.ObjectReference{})
 
@@ -407,6 +408,7 @@ func TestPruneDiskResources(t *testing.T) {
 						},
 					},
 				},
+				nil,
 				nil,
 			)
 			eventRecorder := events.NewRecorder(kubeClient.CoreV1().Events("test"), "test-operator", &v1.ObjectReference{})

--- a/pkg/operator/staticpod/controller/revision/revision_controller_test.go
+++ b/pkg/operator/staticpod/controller/revision/revision_controller_test.go
@@ -59,6 +59,7 @@ func TestRevisionController(t *testing.T) {
 				},
 				&operatorv1.StaticPodOperatorStatus{},
 				nil,
+				nil,
 			),
 			validateActions: func(t *testing.T, actions []clienttesting.Action) {
 				createdObjects := filterCreateActions(actions)
@@ -86,6 +87,7 @@ func TestRevisionController(t *testing.T) {
 						},
 					},
 				},
+				nil,
 				nil,
 			),
 			testConfigs:     []RevisionResource{{Name: "test-config"}},
@@ -122,6 +124,7 @@ func TestRevisionController(t *testing.T) {
 						},
 					},
 				},
+				nil,
 				nil,
 			),
 			startingObjects: []runtime.Object{
@@ -188,6 +191,7 @@ func TestRevisionController(t *testing.T) {
 						},
 					},
 				},
+				nil,
 				nil,
 			),
 			startingObjects: []runtime.Object{
@@ -267,6 +271,7 @@ func TestRevisionController(t *testing.T) {
 					},
 				},
 				nil,
+				nil,
 			),
 			startingObjects: []runtime.Object{
 				&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "test-secret", Namespace: targetNamespace}},
@@ -327,6 +332,7 @@ func TestRevisionController(t *testing.T) {
 					},
 				},
 				nil,
+				nil,
 			),
 			startingObjects: []runtime.Object{
 				&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "test-secret", Namespace: targetNamespace}},
@@ -363,6 +369,7 @@ func TestRevisionController(t *testing.T) {
 						},
 					},
 				},
+				nil,
 				nil,
 			),
 			startingObjects: []runtime.Object{

--- a/pkg/operator/v1helpers/interfaces.go
+++ b/pkg/operator/v1helpers/interfaces.go
@@ -9,9 +9,9 @@ type OperatorClient interface {
 	Informer() cache.SharedIndexInformer
 	// GetOperatorState returns the operator spec, status and the resource version, potentially from a lister.
 	GetOperatorState() (spec *operatorv1.OperatorSpec, status *operatorv1.OperatorStatus, resourceVersion string, err error)
-	// UpdateOperatorSpec updates the spec of the operator, assuming the given resource verison.
+	// UpdateOperatorSpec updates the spec of the operator, assuming the given resource version.
 	UpdateOperatorSpec(oldResourceVersion string, in *operatorv1.OperatorSpec) (out *operatorv1.OperatorSpec, newResourceVersion string, err error)
-	// UpdateOperatorStatus updates the status of the operator, assuming the given resource verison.
+	// UpdateOperatorStatus updates the status of the operator, assuming the given resource version.
 	UpdateOperatorStatus(oldResourceVersion string, in *operatorv1.OperatorStatus) (out *operatorv1.OperatorStatus, err error)
 }
 
@@ -25,4 +25,6 @@ type StaticPodOperatorClient interface {
 	GetStaticPodOperatorStateWithQuorum() (spec *operatorv1.StaticPodOperatorSpec, status *operatorv1.StaticPodOperatorStatus, resourceVersion string, err error)
 	// UpdateStaticPodOperatorStatus updates the status, assuming the given resource version.
 	UpdateStaticPodOperatorStatus(resourceVersion string, in *operatorv1.StaticPodOperatorStatus) (out *operatorv1.StaticPodOperatorStatus, err error)
+	// UpdateStaticPodOperatorSpec updates the spec, assuming the given resource  version.
+	UpdateStaticPodOperatorSpec(resourceVersion string, in *operatorv1.StaticPodOperatorSpec) (out *operatorv1.StaticPodOperatorSpec, newResourceVersion string, err error)
 }

--- a/pkg/operator/v1helpers/test_helpers.go
+++ b/pkg/operator/v1helpers/test_helpers.go
@@ -61,12 +61,14 @@ func (fakeSharedIndexInformer) GetIndexer() cache.Indexer {
 // NewFakeStaticPodOperatorClient returns a fake operator client suitable to use in static pod controller unit tests.
 func NewFakeStaticPodOperatorClient(
 	staticPodSpec *operatorv1.StaticPodOperatorSpec, staticPodStatus *operatorv1.StaticPodOperatorStatus,
-	triggerErr func(rv string, status *operatorv1.StaticPodOperatorStatus) error) StaticPodOperatorClient {
+	triggerStatusErr func(rv string, status *operatorv1.StaticPodOperatorStatus) error,
+	triggerSpecErr func(rv string, spec *operatorv1.StaticPodOperatorSpec) error) StaticPodOperatorClient {
 	return &fakeStaticPodOperatorClient{
 		fakeStaticPodOperatorSpec:   staticPodSpec,
 		fakeStaticPodOperatorStatus: staticPodStatus,
 		resourceVersion:             "0",
-		triggerStatusUpdateError:    triggerErr,
+		triggerStatusUpdateError:    triggerStatusErr,
+		triggerSpecUpdateError:      triggerSpecErr,
 	}
 }
 
@@ -76,6 +78,7 @@ type fakeStaticPodOperatorClient struct {
 	fakeStaticPodOperatorStatus *operatorv1.StaticPodOperatorStatus
 	resourceVersion             string
 	triggerStatusUpdateError    func(rv string, status *operatorv1.StaticPodOperatorStatus) error
+	triggerSpecUpdateError      func(rv string, status *operatorv1.StaticPodOperatorSpec) error
 }
 
 func (c *fakeStaticPodOperatorClient) Informer() cache.SharedIndexInformer {
@@ -106,6 +109,24 @@ func (c *fakeStaticPodOperatorClient) UpdateStaticPodOperatorStatus(resourceVers
 	}
 	c.fakeStaticPodOperatorStatus = status
 	return c.fakeStaticPodOperatorStatus, nil
+}
+
+func (c *fakeStaticPodOperatorClient) UpdateStaticPodOperatorSpec(resourceVersion string, spec *operatorv1.StaticPodOperatorSpec) (*operatorv1.StaticPodOperatorSpec, string, error) {
+	if c.resourceVersion != resourceVersion {
+		return nil, "", errors.NewConflict(schema.GroupResource{Group: operatorv1.GroupName, Resource: "TestOperatorConfig"}, "instance", fmt.Errorf("invalid resourceVersion"))
+	}
+	rv, err := strconv.Atoi(resourceVersion)
+	if err != nil {
+		return nil, "", err
+	}
+	c.resourceVersion = strconv.Itoa(rv + 1)
+	if c.triggerSpecUpdateError != nil {
+		if err := c.triggerSpecUpdateError(resourceVersion, spec); err != nil {
+			return nil, "", err
+		}
+	}
+	c.fakeStaticPodOperatorSpec = spec
+	return c.fakeStaticPodOperatorSpec, c.resourceVersion, nil
 }
 
 func (c *fakeStaticPodOperatorClient) GetOperatorState() (*operatorv1.OperatorSpec, *operatorv1.OperatorStatus, string, error) {


### PR DESCRIPTION
My use case: writing an e2e test for revision pruning, want to trigger a bunch of new revisions by updating the `ForceRedeploymentReason` in `StaticPodOperatorSpec`. Currently we can get the spec but I don't know of any way to update it.