### PR TITLE
Set an arbitrary event namespace when not running inside a cluster

### DIFF
--- a/pkg/controller/controllercmd/builder.go
+++ b/pkg/controller/controllercmd/builder.go
@@ -67,10 +67,11 @@ type ControllerBuilder struct {
 	fileObserver            fileobserver.Observer
 	fileObserverReactorFn   func(file string, action fileobserver.ActionType) error
 
-	startFunc        StartFunc
-	componentName    string
-	instanceIdentity string
-	observerInterval time.Duration
+	startFunc          StartFunc
+	componentName      string
+	componentNamespace string
+	instanceIdentity   string
+	observerInterval   time.Duration
 
 	servingInfo          *configv1.HTTPServingInfo
 	authenticationConfig *operatorv1alpha1.DelegatedAuthentication
@@ -111,6 +112,11 @@ func (b *ControllerBuilder) WithRestartOnChange(stopCh chan<- struct{}, starting
 	}
 
 	b.fileObserver.AddReactor(b.fileObserverReactorFn, startingFileContent, files...)
+	return b
+}
+
+func (b *ControllerBuilder) WithComponentNamespace(ns string) *ControllerBuilder {
+	b.componentNamespace = ns
 	return b
 }
 
@@ -166,9 +172,9 @@ func (b *ControllerBuilder) Run(config *unstructured.Unstructured, ctx context.C
 	}
 
 	kubeClient := kubernetes.NewForConfigOrDie(clientConfig)
-	namespace, err := b.getNamespace()
+	namespace, err := b.getComponentNamespace()
 	if err != nil {
-		panic("unable to read the namespace")
+		klog.Warningf("unable to identify the current namespace for events: %v", err)
 	}
 	controllerRef, err := events.GetControllerReferenceForCurrentPod(kubeClient, namespace, nil)
 	if err != nil {
@@ -246,12 +252,15 @@ func (b *ControllerBuilder) Run(config *unstructured.Unstructured, ctx context.C
 	return fmt.Errorf("exited")
 }
 
-func (b *ControllerBuilder) getNamespace() (string, error) {
+func (b *ControllerBuilder) getComponentNamespace() (string, error) {
+	if len(b.componentNamespace) > 0 {
+		return b.componentNamespace, nil
+	}
 	nsBytes, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 	if err != nil {
-		return "", err
+		return "openshift-config-managed", err
 	}
-	return string(nsBytes), err
+	return string(nsBytes), nil
 }
 
 func (b *ControllerBuilder) getClientConfig() (*rest.Config, error) {


### PR DESCRIPTION
openshift-config is a reasonable place for operators to report events,
although they may not have access. Allow a builder to set it so we can
both test locally and override it for some operators.

At worst, we will attempt to log events to "openshift-config"