### PR TITLE
resourcesynccontroller: use cached get to confirm resource exists before deleting target

### DIFF
--- a/pkg/operator/resource/resourceapply/core.go
+++ b/pkg/operator/resource/resourceapply/core.go
@@ -230,6 +230,9 @@ func SyncConfigMap(client coreclientv1.ConfigMapsGetter, recorder events.Recorde
 	switch {
 	case apierrors.IsNotFound(err):
 		deleteErr := client.ConfigMaps(targetNamespace).Delete(targetName, nil)
+		if _, getErr := client.ConfigMaps(targetNamespace).Get(targetName, metav1.GetOptions{}); getErr != nil && apierrors.IsNotFound(getErr) {
+			return nil, true, nil
+		}
 		if apierrors.IsNotFound(deleteErr) {
 			return nil, false, nil
 		}
@@ -253,6 +256,9 @@ func SyncSecret(client coreclientv1.SecretsGetter, recorder events.Recorder, sou
 	source, err := client.Secrets(sourceNamespace).Get(sourceName, metav1.GetOptions{})
 	switch {
 	case apierrors.IsNotFound(err):
+		if _, getErr := client.Secrets(targetNamespace).Get(targetName, metav1.GetOptions{}); getErr != nil && apierrors.IsNotFound(getErr) {
+			return nil, true, nil
+		}
 		deleteErr := client.Secrets(targetNamespace).Delete(targetName, nil)
 		if apierrors.IsNotFound(deleteErr) {
 			return nil, false, nil

--- a/pkg/operator/resourcesynccontroller/resourcesync_controller.go
+++ b/pkg/operator/resourcesynccontroller/resourcesync_controller.go
@@ -149,6 +149,13 @@ func (c *ResourceSyncController) sync() error {
 
 	for destination, source := range c.configMapSyncRules {
 		if source == emptyResourceLocation {
+			// use the cache to check whether the configmap exists in target namespace, if not skip the extra delete call.
+			if _, err := c.configMapGetter.ConfigMaps(destination.Namespace).Get(destination.Name, metav1.GetOptions{}); err != nil {
+				if !apierrors.IsNotFound(err) {
+					errors = append(errors, err)
+				}
+				continue
+			}
 			if err := c.configMapGetter.ConfigMaps(destination.Namespace).Delete(destination.Name, nil); err != nil && !apierrors.IsNotFound(err) {
 				errors = append(errors, err)
 			}
@@ -162,6 +169,13 @@ func (c *ResourceSyncController) sync() error {
 	}
 	for destination, source := range c.secretSyncRules {
 		if source == emptyResourceLocation {
+			// use the cache to check whether the secret exists in target namespace, if not skip the extra delete call.
+			if _, err := c.secretGetter.Secrets(destination.Namespace).Get(destination.Name, metav1.GetOptions{}); err != nil {
+				if !apierrors.IsNotFound(err) {
+					errors = append(errors, err)
+				}
+				continue
+			}
 			if err := c.secretGetter.Secrets(destination.Namespace).Delete(destination.Name, nil); err != nil && !apierrors.IsNotFound(err) {
 				errors = append(errors, err)
 			}

--- a/pkg/operator/resourcesynccontroller/resourcesync_controller_test.go
+++ b/pkg/operator/resourcesynccontroller/resourcesync_controller_test.go
@@ -3,9 +3,15 @@ package resourcesynccontroller
 import (
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
+	"k8s.io/apimachinery/pkg/runtime"
+	ktesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/openshift/library-go/pkg/operator/events/eventstesting"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 
 	corev1 "k8s.io/api/core/v1"
@@ -15,8 +21,143 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
+
 	"github.com/openshift/library-go/pkg/operator/events"
 )
+
+func TestSyncSecret(t *testing.T) {
+	kubeClient := fake.NewSimpleClientset(
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "config", Name: "foo"},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "operator", Name: "to-remove"},
+		},
+	)
+
+	destinationSecretCreated := make(chan struct{})
+	destinationSecretBarChecked := make(chan struct{})
+	destinationSecretEmptySourceChecked := make(chan struct{})
+
+	kubeClient.PrependReactor("create", "secrets", func(action ktesting.Action) (bool, runtime.Object, error) {
+		actual, isCreate := action.(ktesting.CreateAction)
+		if !isCreate {
+			return false, nil, nil
+		}
+		secret, isSecret := actual.GetObject().(*corev1.Secret)
+		if !isSecret {
+			return false, nil, nil
+		}
+		if secret.Name == "foo" && secret.Namespace == "operator" {
+			close(destinationSecretCreated)
+		}
+		return false, nil, nil
+	})
+
+	deleteSecretCounterMutex := sync.Mutex{}
+	deleteSecretCounter := 0
+
+	kubeClient.PrependReactor("delete", "secrets", func(action ktesting.Action) (bool, runtime.Object, error) {
+		deleteSecretCounterMutex.Lock()
+		defer deleteSecretCounterMutex.Unlock()
+		deleteSecretCounter++
+		return false, nil, nil
+	})
+
+	kubeClient.PrependReactor("get", "secrets", func(action ktesting.Action) (bool, runtime.Object, error) {
+		actual, isGet := action.(ktesting.GetAction)
+		if !isGet {
+			return false, nil, nil
+		}
+		if actual.GetNamespace() == "operator" {
+			switch actual.GetName() {
+			case "bar":
+				close(destinationSecretBarChecked)
+			case "empty-source":
+				close(destinationSecretEmptySourceChecked)
+			}
+		}
+		return false, nil, nil
+	})
+
+	secretInformers := informers.NewSharedInformerFactoryWithOptions(kubeClient, 1*time.Minute, informers.WithNamespace("config"))
+	operatorInformers := informers.NewSharedInformerFactoryWithOptions(kubeClient, 1*time.Minute, informers.WithNamespace("operator"))
+	fakeStaticPodOperatorClient := v1helpers.NewFakeOperatorClient(
+		&operatorv1.OperatorSpec{
+			ManagementState: operatorv1.Managed,
+		},
+		&operatorv1.OperatorStatus{},
+		nil,
+	)
+	eventRecorder := eventstesting.NewTestingEventRecorder(t)
+	c := NewResourceSyncController(
+		fakeStaticPodOperatorClient,
+		v1helpers.NewFakeKubeInformersForNamespaces(map[string]informers.SharedInformerFactory{
+			"config":   secretInformers,
+			"operator": operatorInformers,
+		}),
+		kubeClient.CoreV1(),
+		kubeClient.CoreV1(),
+		eventRecorder,
+	)
+	c.preRunCachesSynced = []cache.InformerSynced{
+		secretInformers.Core().V1().Secrets().Informer().HasSynced,
+	}
+	c.configMapGetter = kubeClient.CoreV1()
+	c.secretGetter = kubeClient.CoreV1()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	go secretInformers.Start(stopCh)
+	go c.Run(1, stopCh)
+
+	// The source secret was removed (404) but the destination exists. This should increase the "deleteSecretCounter"
+	if err := c.SyncSecret(ResourceLocation{Namespace: "operator", Name: "to-remove"}, ResourceLocation{Namespace: "config", Name: "removed"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// The source secret exists, but the destination does not. This should close the "destinationSecretCreated" channel
+	if err := c.SyncSecret(ResourceLocation{Namespace: "operator", Name: "foo"}, ResourceLocation{Namespace: "config", Name: "foo"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// The source secret does not exists nor the destination secret. This should close the "destinationSecretBarChecked" and should not increase
+	// the deleteSecretCounter (we don't issue Delete() call when Get() returns 404)
+	if err := c.SyncSecret(ResourceLocation{Namespace: "operator", Name: "bar"}, ResourceLocation{Namespace: "config", Name: "bar"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// The source resource location is not set and the destination does not exists. This should close the "destinationSecretEmptySourceChecked" and
+	// should not increase the deleteSecretCounter (this is special case in resource sync controller.
+	if err := c.SyncSecret(ResourceLocation{Namespace: "operator", Name: "empty-source"}, ResourceLocation{}); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-destinationSecretCreated:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout while waiting for destination secret to be created")
+	}
+
+	select {
+	case <-destinationSecretBarChecked:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout while waiting for destination secret 'bar' to be checked for existence")
+	}
+
+	select {
+	case <-destinationSecretEmptySourceChecked:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout while waiting for destination secret 'empty-source' to be checked for existence")
+	}
+
+	deleteSecretCounterMutex.Lock()
+	defer deleteSecretCounterMutex.Unlock()
+	if deleteSecretCounter != 1 {
+		t.Fatalf("expected exactly 1 delete call for this test, got %d", deleteSecretCounter)
+	}
+}
 
 func TestSyncConfigMap(t *testing.T) {
 	kubeClient := fake.NewSimpleClientset(


### PR DESCRIPTION
This change will make us check cache before making a DELETE call that hits the API server.
This will reduce the amount of DELETE requests we issue when the resource (secret/configmap) does not exists in the target namespace (and therefore the DELETE call always returned 404).

/cc @smarterclayton 