### PR TITLE
wait for caches to synchronize before working

### DIFF
--- a/pkg/operator/certrotation/client_cert_rotation_controller.go
+++ b/pkg/operator/certrotation/client_cert_rotation_controller.go
@@ -43,10 +43,8 @@ type CertRotationController struct {
 	TargetRotation   TargetRotation
 	OperatorClient   v1helpers.StaticPodOperatorClient
 
-	cachesSynced []cache.InformerSynced
-
-	// queue only ever has one item, but it has nice error handling backoff/retry semantics
-	queue workqueue.RateLimitingInterface
+	cachesToSync []cache.InformerSynced
+	queue        workqueue.RateLimitingInterface
 }
 
 func NewCertRotationController(
@@ -56,7 +54,7 @@ func NewCertRotationController(
 	targetRotation TargetRotation,
 	operatorClient v1helpers.StaticPodOperatorClient,
 ) (*CertRotationController, error) {
-	ret := &CertRotationController{
+	c := &CertRotationController{
 		name: name,
 
 		SigningRotation:  signingRotation,
@@ -64,20 +62,18 @@ func NewCertRotationController(
 		TargetRotation:   targetRotation,
 		OperatorClient:   operatorClient,
 
-		cachesSynced: []cache.InformerSynced{
-			signingRotation.Informer.Informer().HasSynced,
-			caBundleRotation.Informer.Informer().HasSynced,
-			targetRotation.Informer.Informer().HasSynced,
-		},
-
 		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), name),
 	}
 
-	signingRotation.Informer.Informer().AddEventHandler(ret.eventHandler())
-	caBundleRotation.Informer.Informer().AddEventHandler(ret.eventHandler())
-	targetRotation.Informer.Informer().AddEventHandler(ret.eventHandler())
+	signingRotation.Informer.Informer().AddEventHandler(c.eventHandler())
+	caBundleRotation.Informer.Informer().AddEventHandler(c.eventHandler())
+	targetRotation.Informer.Informer().AddEventHandler(c.eventHandler())
 
-	return ret, nil
+	c.cachesToSync = append(c.cachesToSync, signingRotation.Informer.Informer().HasSynced)
+	c.cachesToSync = append(c.cachesToSync, caBundleRotation.Informer.Informer().HasSynced)
+	c.cachesToSync = append(c.cachesToSync, targetRotation.Informer.Informer().HasSynced)
+
+	return c, nil
 }
 
 func (c CertRotationController) sync() error {
@@ -123,8 +119,7 @@ func (c *CertRotationController) Run(workers int, stopCh <-chan struct{}) {
 
 	klog.Infof("Starting CertRotationController - %q", c.name)
 	defer klog.Infof("Shutting down CertRotationController - %q", c.name)
-
-	if !cache.WaitForCacheSync(stopCh, c.cachesSynced...) {
+	if !cache.WaitForCacheSync(stopCh, c.cachesToSync...) {
 		utilruntime.HandleError(fmt.Errorf("caches did not sync"))
 		return
 	}

--- a/pkg/operator/configobserver/config_observer_controller.go
+++ b/pkg/operator/configobserver/config_observer_controller.go
@@ -41,18 +41,17 @@ type Listers interface {
 type ObserveConfigFunc func(listers Listers, recorder events.Recorder, existingConfig map[string]interface{}) (observedConfig map[string]interface{}, errs []error)
 
 type ConfigObserver struct {
-	operatorConfigClient v1helpers.OperatorClient
-	eventRecorder        events.Recorder
-
-	// queue only ever has one item, but it has nice error handling backoff/retry semantics
-	queue workqueue.RateLimitingInterface
 
 	// observers are called in an undefined order and their results are merged to
 	// determine the observed configuration.
 	observers []ObserveConfigFunc
 
+	operatorClient v1helpers.OperatorClient
 	// listers are used by config observers to retrieve necessary resources
 	listers Listers
+
+	queue         workqueue.RateLimitingInterface
+	eventRecorder events.Recorder
 }
 
 func NewConfigObserver(
@@ -62,8 +61,8 @@ func NewConfigObserver(
 	observers ...ObserveConfigFunc,
 ) *ConfigObserver {
 	return &ConfigObserver{
-		operatorConfigClient: operatorClient,
-		eventRecorder:        eventRecorder.WithComponentSuffix("config-observer"),
+		operatorClient: operatorClient,
+		eventRecorder:  eventRecorder.WithComponentSuffix("config-observer"),
 
 		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "ConfigObserver"),
 
@@ -75,7 +74,7 @@ func NewConfigObserver(
 // sync reacts to a change in prereqs by finding information that is required to match another value in the cluster. This
 // must be information that is logically "owned" by another component.
 func (c ConfigObserver) sync() error {
-	originalSpec, _, _, err := c.operatorConfigClient.GetOperatorState()
+	originalSpec, _, _, err := c.operatorClient.GetOperatorState()
 	if err != nil {
 		return err
 	}
@@ -116,7 +115,7 @@ func (c ConfigObserver) sync() error {
 
 	if !equality.Semantic.DeepEqual(existingConfig, mergedObservedConfig) {
 		c.eventRecorder.Eventf("ObservedConfigChanged", "Writing updated observed config: %v", diff.ObjectDiff(existingConfig, mergedObservedConfig))
-		if _, _, err := v1helpers.UpdateSpec(c.operatorConfigClient, v1helpers.UpdateObservedConfigFn(mergedObservedConfig)); err != nil {
+		if _, _, err := v1helpers.UpdateSpec(c.operatorClient, v1helpers.UpdateObservedConfigFn(mergedObservedConfig)); err != nil {
 			// At this point we failed to write the updated config. If we are permanently broken, do not pile the errors from observers
 			// but instead reset the errors and only report single error condition.
 			errs = []error{fmt.Errorf("error writing updated observed config: %v", err)}
@@ -135,7 +134,7 @@ func (c ConfigObserver) sync() error {
 		cond.Reason = "Error"
 		cond.Message = configError.Error()
 	}
-	if _, _, updateError := v1helpers.UpdateStatus(c.operatorConfigClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
+	if _, _, updateError := v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
 		return updateError
 	}
 
@@ -148,7 +147,6 @@ func (c *ConfigObserver) Run(workers int, stopCh <-chan struct{}) {
 
 	klog.Infof("Starting ConfigObserver")
 	defer klog.Infof("Shutting down ConfigObserver")
-
 	if !cache.WaitForCacheSync(stopCh, c.listers.PreRunHasSynced()...) {
 		utilruntime.HandleError(fmt.Errorf("caches did not sync"))
 		return

--- a/pkg/operator/configobserver/config_observer_controller_test.go
+++ b/pkg/operator/configobserver/config_observer_controller_test.go
@@ -204,10 +204,10 @@ func TestSyncStatus(t *testing.T) {
 			eventClient := fake.NewSimpleClientset()
 
 			configObserver := ConfigObserver{
-				listers:              &fakeLister{},
-				operatorConfigClient: operatorConfigClient,
-				observers:            tc.observers,
-				eventRecorder:        events.NewRecorder(eventClient.CoreV1().Events("test"), "test-operator", &corev1.ObjectReference{}),
+				listers:        &fakeLister{},
+				operatorClient: operatorConfigClient,
+				observers:      tc.observers,
+				eventRecorder:  events.NewRecorder(eventClient.CoreV1().Events("test"), "test-operator", &corev1.ObjectReference{}),
 			}
 			err := configObserver.sync()
 			if tc.expectError && err == nil {

--- a/pkg/operator/loglevel/logging_controller.go
+++ b/pkg/operator/loglevel/logging_controller.go
@@ -18,11 +18,10 @@ var workQueueKey = "instance"
 
 type LogLevelController struct {
 	operatorClient operatorv1helpers.OperatorClient
-	cachesToSync   []cache.InformerSynced
-	eventRecorder  events.Recorder
 
-	// queue only ever has one item, but it has nice error handling backoff/retry semantics
-	queue workqueue.RateLimitingInterface
+	cachesToSync  []cache.InformerSynced
+	queue         workqueue.RateLimitingInterface
+	eventRecorder events.Recorder
 }
 
 // sets the klog level based on desired state
@@ -31,7 +30,6 @@ func NewClusterOperatorLoggingController(
 	recorder events.Recorder,
 ) *LogLevelController {
 	c := &LogLevelController{
-		cachesToSync:   []cache.InformerSynced{operatorClient.Informer().HasSynced},
 		operatorClient: operatorClient,
 		eventRecorder:  recorder.WithComponentSuffix("loglevel-controller"),
 
@@ -39,6 +37,8 @@ func NewClusterOperatorLoggingController(
 	}
 
 	operatorClient.Informer().AddEventHandler(c.eventHandler())
+
+	c.cachesToSync = append(c.cachesToSync, operatorClient.Informer().HasSynced)
 
 	return c
 }

--- a/pkg/operator/management/management_state_controller.go
+++ b/pkg/operator/management/management_state_controller.go
@@ -27,27 +27,28 @@ var workQueueKey = "instance"
 type ManagementStateController struct {
 	operatorName   string
 	operatorClient operatorv1helpers.OperatorClient
-	eventRecorder  events.Recorder
 
-	// queue only ever has one item, but it has nice error handling backoff/retry semantics
-	queue workqueue.RateLimitingInterface
+	cachesToSync  []cache.InformerSynced
+	queue         workqueue.RateLimitingInterface
+	eventRecorder events.Recorder
 }
 
 func NewOperatorManagementStateController(
 	name string,
-	operatorStatusProvider operatorv1helpers.OperatorClient,
+	operatorClient operatorv1helpers.OperatorClient,
 	recorder events.Recorder,
 ) *ManagementStateController {
 	c := &ManagementStateController{
 		operatorName:   name,
-		operatorClient: operatorStatusProvider,
+		operatorClient: operatorClient,
 		eventRecorder:  recorder,
 
 		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "ManagementStateController-"+name),
 	}
 
-	operatorStatusProvider.Informer().AddEventHandler(c.eventHandler())
-	// TODO watch clusterOperator.status changes when it moves to openshift/api
+	operatorClient.Informer().AddEventHandler(c.eventHandler())
+
+	c.cachesToSync = append(c.cachesToSync, operatorClient.Informer().HasSynced)
 
 	return c
 }
@@ -97,6 +98,9 @@ func (c *ManagementStateController) Run(workers int, stopCh <-chan struct{}) {
 
 	klog.Infof("Starting management-state-controller-" + c.operatorName)
 	defer klog.Infof("Shutting down management-state-controller-" + c.operatorName)
+	if !cache.WaitForCacheSync(stopCh, c.cachesToSync...) {
+		return
+	}
 
 	// doesn't matter what workers say, only start one.
 	go wait.Until(c.runWorker, time.Second, stopCh)

--- a/pkg/operator/resourcesynccontroller/resourcesync_controller_test.go
+++ b/pkg/operator/resourcesynccontroller/resourcesync_controller_test.go
@@ -100,7 +100,7 @@ func TestSyncSecret(t *testing.T) {
 		kubeClient.CoreV1(),
 		eventRecorder,
 	)
-	c.preRunCachesSynced = []cache.InformerSynced{
+	c.cachesToSync = []cache.InformerSynced{
 		secretInformers.Core().V1().Secrets().Informer().HasSynced,
 	}
 	c.configMapGetter = kubeClient.CoreV1()

--- a/pkg/operator/staticpod/controller/backingresource/backing_resource_controller.go
+++ b/pkg/operator/staticpod/controller/backingresource/backing_resource_controller.go
@@ -36,49 +36,45 @@ const (
 // service accounts and RBAC rules in the target namespace according to the bindata manifests
 // (templated with the config) if they differ.
 type BackingResourceController struct {
-	targetNamespace      string
-	operatorConfigClient v1helpers.OperatorClient
+	targetNamespace string
 
-	saListerSynced cache.InformerSynced
-	saLister       corelisterv1.ServiceAccountLister
+	operatorClient           v1helpers.OperatorClient
+	saLister                 corelisterv1.ServiceAccountLister
+	clusterRoleBindingLister rbaclisterv1.ClusterRoleBindingLister
+	kubeClient               kubernetes.Interface
 
-	clusterRoleBindingLister       rbaclisterv1.ClusterRoleBindingLister
-	clusterRoleBindingListerSynced cache.InformerSynced
-
-	// queue only ever has one item, but it has nice error handling backoff/retry semantics
-	queue workqueue.RateLimitingInterface
-
-	kubeClient    kubernetes.Interface
+	cachesToSync  []cache.InformerSynced
+	queue         workqueue.RateLimitingInterface
 	eventRecorder events.Recorder
 }
 
 // NewBackingResourceController creates a new backing resource controller.
 func NewBackingResourceController(
 	targetNamespace string,
-	operatorConfigClient v1helpers.OperatorClient,
+	operatorClient v1helpers.OperatorClient,
 	kubeInformersForTargetNamespace informers.SharedInformerFactory,
 	kubeClient kubernetes.Interface,
 	eventRecorder events.Recorder,
 ) *BackingResourceController {
 	c := &BackingResourceController{
-		targetNamespace:      targetNamespace,
-		operatorConfigClient: operatorConfigClient,
-		eventRecorder:        eventRecorder.WithComponentSuffix("backing-resource-controller"),
+		targetNamespace: targetNamespace,
+		operatorClient:  operatorClient,
 
-		saListerSynced: kubeInformersForTargetNamespace.Core().V1().ServiceAccounts().Informer().HasSynced,
-		saLister:       kubeInformersForTargetNamespace.Core().V1().ServiceAccounts().Lister(),
+		saLister:                 kubeInformersForTargetNamespace.Core().V1().ServiceAccounts().Lister(),
+		clusterRoleBindingLister: kubeInformersForTargetNamespace.Rbac().V1().ClusterRoleBindings().Lister(),
+		kubeClient:               kubeClient,
 
-		clusterRoleBindingListerSynced: kubeInformersForTargetNamespace.Core().V1().ServiceAccounts().Informer().HasSynced,
-		clusterRoleBindingLister:       kubeInformersForTargetNamespace.Rbac().V1().ClusterRoleBindings().Lister(),
-
-		queue:      workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "BackingResourceController"),
-		kubeClient: kubeClient,
+		queue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "BackingResourceController"),
+		eventRecorder: eventRecorder.WithComponentSuffix("backing-resource-controller"),
 	}
 
-	operatorConfigClient.Informer().AddEventHandler(c.eventHandler())
-
+	operatorClient.Informer().AddEventHandler(c.eventHandler())
 	kubeInformersForTargetNamespace.Core().V1().ServiceAccounts().Informer().AddEventHandler(c.eventHandler())
 	kubeInformersForTargetNamespace.Rbac().V1().ClusterRoleBindings().Informer().AddEventHandler(c.eventHandler())
+
+	c.cachesToSync = append(c.cachesToSync, operatorClient.Informer().HasSynced)
+	c.cachesToSync = append(c.cachesToSync, kubeInformersForTargetNamespace.Core().V1().ServiceAccounts().Informer().HasSynced)
+	c.cachesToSync = append(c.cachesToSync, kubeInformersForTargetNamespace.Rbac().V1().ClusterRoleBindings().Informer().HasSynced)
 
 	return c
 }
@@ -93,7 +89,7 @@ func (c BackingResourceController) mustTemplateAsset(name string) ([]byte, error
 }
 
 func (c BackingResourceController) sync() error {
-	operatorSpec, _, _, err := c.operatorConfigClient.GetOperatorState()
+	operatorSpec, _, _, err := c.operatorClient.GetOperatorState()
 	if err != nil {
 		return err
 	}
@@ -125,7 +121,7 @@ func (c BackingResourceController) sync() error {
 		cond.Reason = "Error"
 		cond.Message = err.Error()
 	}
-	if _, _, updateError := v1helpers.UpdateStatus(c.operatorConfigClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
+	if _, _, updateError := v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
 		if err == nil {
 			return updateError
 		}
@@ -141,10 +137,7 @@ func (c *BackingResourceController) Run(workers int, stopCh <-chan struct{}) {
 
 	klog.Infof("Starting BackingResourceController")
 	defer klog.Infof("Shutting down BackingResourceController")
-	if !cache.WaitForCacheSync(stopCh, c.saListerSynced) {
-		return
-	}
-	if !cache.WaitForCacheSync(stopCh, c.clusterRoleBindingListerSynced) {
+	if !cache.WaitForCacheSync(stopCh, c.cachesToSync...) {
 		return
 	}
 

--- a/pkg/operator/staticpod/controller/installer/installer_controller_test.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller_test.go
@@ -1054,17 +1054,17 @@ func TestInstallerController_manageInstallationPods(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &InstallerController{
-				targetNamespace:      tt.fields.targetNamespace,
-				staticPodName:        tt.fields.staticPodName,
-				configMaps:           tt.fields.configMaps,
-				secrets:              tt.fields.secrets,
-				command:              tt.fields.command,
-				operatorConfigClient: tt.fields.operatorConfigClient,
-				configMapsGetter:     tt.fields.kubeClient.CoreV1(),
-				podsGetter:           tt.fields.kubeClient.CoreV1(),
-				eventRecorder:        tt.fields.eventRecorder,
-				queue:                tt.fields.queue,
-				installerPodImageFn:  tt.fields.installerPodImageFn,
+				targetNamespace:     tt.fields.targetNamespace,
+				staticPodName:       tt.fields.staticPodName,
+				configMaps:          tt.fields.configMaps,
+				secrets:             tt.fields.secrets,
+				command:             tt.fields.command,
+				operatorClient:      tt.fields.operatorConfigClient,
+				configMapsGetter:    tt.fields.kubeClient.CoreV1(),
+				podsGetter:          tt.fields.kubeClient.CoreV1(),
+				eventRecorder:       tt.fields.eventRecorder,
+				queue:               tt.fields.queue,
+				installerPodImageFn: tt.fields.installerPodImageFn,
 			}
 			got, err := c.manageInstallationPods(tt.args.operatorSpec, tt.args.originalOperatorStatus, tt.args.resourceVersion)
 			if (err != nil) != tt.wantErr {

--- a/pkg/operator/staticpod/controller/monitoring/monitoring_resource_controller.go
+++ b/pkg/operator/staticpod/controller/monitoring/monitoring_resource_controller.go
@@ -37,50 +37,49 @@ type MonitoringResourceController struct {
 	serviceMonitorName string
 
 	clusterRoleBindingLister rbaclisterv1.ClusterRoleBindingLister
-	// preRunCachesSynced are the set of caches that must be synced before the controller will start doing work. This is normally
-	// the full set of listers and informers you use.
-	preRunCachesSynced []cache.InformerSynced
+	kubeClient               kubernetes.Interface
+	dynamicClient            dynamic.Interface
+	operatorClient           v1helpers.StaticPodOperatorClient
 
-	// queue only ever has one item, but it has nice error handling backoff/retry semantics
-	queue workqueue.RateLimitingInterface
-
-	kubeClient           kubernetes.Interface
-	dynamicClient        dynamic.Interface
-	operatorConfigClient v1helpers.StaticPodOperatorClient
-	eventRecorder        events.Recorder
+	cachesToSync  []cache.InformerSynced
+	queue         workqueue.RateLimitingInterface
+	eventRecorder events.Recorder
 }
 
 // NewMonitoringResourceController creates a new backing resource controller.
 func NewMonitoringResourceController(
 	targetNamespace string,
 	serviceMonitorName string,
-	operatorConfigClient v1helpers.StaticPodOperatorClient,
+	operatorClient v1helpers.StaticPodOperatorClient,
 	kubeInformersForTargetNamespace informers.SharedInformerFactory,
 	kubeClient kubernetes.Interface,
 	dynamicClient dynamic.Interface,
 	eventRecorder events.Recorder,
 ) *MonitoringResourceController {
 	c := &MonitoringResourceController{
-		targetNamespace:      targetNamespace,
-		operatorConfigClient: operatorConfigClient,
-		eventRecorder:        eventRecorder.WithComponentSuffix("monitoring-resource-controller"),
-		serviceMonitorName:   serviceMonitorName,
+		targetNamespace:    targetNamespace,
+		operatorClient:     operatorClient,
+		eventRecorder:      eventRecorder.WithComponentSuffix("monitoring-resource-controller"),
+		serviceMonitorName: serviceMonitorName,
 
 		clusterRoleBindingLister: kubeInformersForTargetNamespace.Rbac().V1().ClusterRoleBindings().Lister(),
-		preRunCachesSynced: []cache.InformerSynced{
+		cachesToSync: []cache.InformerSynced{
 			kubeInformersForTargetNamespace.Core().V1().ServiceAccounts().Informer().HasSynced,
-			operatorConfigClient.Informer().HasSynced,
+			operatorClient.Informer().HasSynced,
 		},
 
 		queue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "MonitoringResourceController"),
 		kubeClient:    kubeClient,
 		dynamicClient: dynamicClient,
 	}
-	operatorConfigClient.Informer().AddEventHandler(c.eventHandler())
 
+	operatorClient.Informer().AddEventHandler(c.eventHandler())
 	// TODO: We need a dynamic informer here to observe changes to ServiceMonitor resource.
-
 	kubeInformersForTargetNamespace.Rbac().V1().ClusterRoleBindings().Informer().AddEventHandler(c.eventHandler())
+
+	c.cachesToSync = append(c.cachesToSync, operatorClient.Informer().HasSynced)
+	c.cachesToSync = append(c.cachesToSync, kubeInformersForTargetNamespace.Rbac().V1().ClusterRoleBindings().Informer().HasSynced)
+
 	return c
 }
 
@@ -94,7 +93,7 @@ func (c MonitoringResourceController) mustTemplateAsset(name string) ([]byte, er
 }
 
 func (c MonitoringResourceController) sync() error {
-	operatorSpec, _, _, err := c.operatorConfigClient.GetStaticPodOperatorState()
+	operatorSpec, _, _, err := c.operatorClient.GetStaticPodOperatorState()
 	if err != nil {
 		return err
 	}
@@ -137,7 +136,7 @@ func (c MonitoringResourceController) sync() error {
 		cond.Reason = "Error"
 		cond.Message = err.Error()
 	}
-	if _, _, updateError := v1helpers.UpdateStaticPodStatus(c.operatorConfigClient, v1helpers.UpdateStaticPodConditionFn(cond)); updateError != nil {
+	if _, _, updateError := v1helpers.UpdateStaticPodStatus(c.operatorClient, v1helpers.UpdateStaticPodConditionFn(cond)); updateError != nil {
 		if err == nil {
 			return updateError
 		}
@@ -152,7 +151,7 @@ func (c *MonitoringResourceController) Run(workers int, stopCh <-chan struct{}) 
 
 	klog.Infof("Starting MonitoringResourceController")
 	defer klog.Infof("Shutting down MonitoringResourceController")
-	if !cache.WaitForCacheSync(stopCh, c.preRunCachesSynced...) {
+	if !cache.WaitForCacheSync(stopCh, c.cachesToSync...) {
 		return
 	}
 

--- a/pkg/operator/staticpod/controller/prune/prune_controller_test.go
+++ b/pkg/operator/staticpod/controller/prune/prune_controller_test.go
@@ -211,21 +211,21 @@ func TestPruneAPIResources(t *testing.T) {
 		}
 
 		c := &PruneController{
-			targetNamespace:      tc.targetNamespace,
-			podResourcePrefix:    "test-pod",
-			command:              []string{"/bin/true"},
-			configMapGetter:      kubeClient.CoreV1(),
-			secretGetter:         kubeClient.CoreV1(),
-			podGetter:            kubeClient.CoreV1(),
-			eventRecorder:        eventRecorder,
-			operatorConfigClient: fakeStaticPodOperatorClient,
+			targetNamespace:   tc.targetNamespace,
+			podResourcePrefix: "test-pod",
+			command:           []string{"/bin/true"},
+			configMapGetter:   kubeClient.CoreV1(),
+			secretGetter:      kubeClient.CoreV1(),
+			podGetter:         kubeClient.CoreV1(),
+			eventRecorder:     eventRecorder,
+			operatorClient:    fakeStaticPodOperatorClient,
 		}
 		c.ownerRefsFn = func(revision int32) ([]metav1.OwnerReference, error) {
 			return []metav1.OwnerReference{}, nil
 		}
 		c.prunerPodImageFn = func() string { return "docker.io/foo/bar" }
 
-		operatorSpec, _, _, err := c.operatorConfigClient.GetStaticPodOperatorState()
+		operatorSpec, _, _, err := c.operatorClient.GetStaticPodOperatorState()
 		if err != nil {
 			t.Fatalf("unexpected error %q", err)
 		}
@@ -423,21 +423,21 @@ func TestPruneDiskResources(t *testing.T) {
 			}
 
 			c := &PruneController{
-				targetNamespace:      "test",
-				podResourcePrefix:    "test-pod",
-				command:              []string{"/bin/true"},
-				configMapGetter:      kubeClient.CoreV1(),
-				secretGetter:         kubeClient.CoreV1(),
-				podGetter:            kubeClient.CoreV1(),
-				eventRecorder:        eventRecorder,
-				operatorConfigClient: fakeStaticPodOperatorClient,
+				targetNamespace:   "test",
+				podResourcePrefix: "test-pod",
+				command:           []string{"/bin/true"},
+				configMapGetter:   kubeClient.CoreV1(),
+				secretGetter:      kubeClient.CoreV1(),
+				podGetter:         kubeClient.CoreV1(),
+				eventRecorder:     eventRecorder,
+				operatorClient:    fakeStaticPodOperatorClient,
 			}
 			c.ownerRefsFn = func(revision int32) ([]metav1.OwnerReference, error) {
 				return []metav1.OwnerReference{}, nil
 			}
 			c.prunerPodImageFn = func() string { return "docker.io/foo/bar" }
 
-			operatorSpec, _, _, err := c.operatorConfigClient.GetStaticPodOperatorState()
+			operatorSpec, _, _, err := c.operatorClient.GetStaticPodOperatorState()
 			if err != nil {
 				t.Fatalf("unexpected error %q", err)
 			}

--- a/pkg/operator/staticpod/controller/revision/revision_controller.go
+++ b/pkg/operator/staticpod/controller/revision/revision_controller.go
@@ -39,13 +39,12 @@ type RevisionController struct {
 	// secrets is a list of secrets that are directly copied for the current values.  A different actor/controller modifies these.
 	secrets []RevisionResource
 
-	operatorConfigClient v1helpers.StaticPodOperatorClient
-	configMapGetter      corev1client.ConfigMapsGetter
-	secretGetter         corev1client.SecretsGetter
+	operatorClient  v1helpers.StaticPodOperatorClient
+	configMapGetter corev1client.ConfigMapsGetter
+	secretGetter    corev1client.SecretsGetter
 
-	// queue only ever has one item, but it has nice error handling backoff/retry semantics
-	queue workqueue.RateLimitingInterface
-
+	cachesToSync  []cache.InformerSynced
+	queue         workqueue.RateLimitingInterface
 	eventRecorder events.Recorder
 }
 
@@ -60,7 +59,7 @@ func NewRevisionController(
 	configMaps []RevisionResource,
 	secrets []RevisionResource,
 	kubeInformersForTargetNamespace informers.SharedInformerFactory,
-	operatorConfigClient v1helpers.StaticPodOperatorClient,
+	operatorClient v1helpers.StaticPodOperatorClient,
 	configMapGetter corev1client.ConfigMapsGetter,
 	secretGetter corev1client.SecretsGetter,
 	eventRecorder events.Recorder,
@@ -70,17 +69,21 @@ func NewRevisionController(
 		configMaps:      configMaps,
 		secrets:         secrets,
 
-		operatorConfigClient: operatorConfigClient,
-		configMapGetter:      configMapGetter,
-		secretGetter:         secretGetter,
-		eventRecorder:        eventRecorder.WithComponentSuffix("revision-controller"),
+		operatorClient:  operatorClient,
+		configMapGetter: configMapGetter,
+		secretGetter:    secretGetter,
+		eventRecorder:   eventRecorder.WithComponentSuffix("revision-controller"),
 
 		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "RevisionController"),
 	}
 
-	operatorConfigClient.Informer().AddEventHandler(c.eventHandler())
+	operatorClient.Informer().AddEventHandler(c.eventHandler())
 	kubeInformersForTargetNamespace.Core().V1().ConfigMaps().Informer().AddEventHandler(c.eventHandler())
 	kubeInformersForTargetNamespace.Core().V1().Secrets().Informer().AddEventHandler(c.eventHandler())
+
+	c.cachesToSync = append(c.cachesToSync, operatorClient.Informer().HasSynced)
+	c.cachesToSync = append(c.cachesToSync, kubeInformersForTargetNamespace.Core().V1().ConfigMaps().Informer().HasSynced)
+	c.cachesToSync = append(c.cachesToSync, kubeInformersForTargetNamespace.Core().V1().Secrets().Informer().HasSynced)
 
 	return c
 }
@@ -107,7 +110,7 @@ func (c RevisionController) createRevisionIfNeeded(operatorSpec *operatorv1.Stat
 			Reason:  "ContentCreationError",
 			Message: err.Error(),
 		}
-		if _, _, updateError := v1helpers.UpdateStaticPodStatus(c.operatorConfigClient, v1helpers.UpdateStaticPodConditionFn(cond)); updateError != nil {
+		if _, _, updateError := v1helpers.UpdateStaticPodStatus(c.operatorClient, v1helpers.UpdateStaticPodConditionFn(cond)); updateError != nil {
 			c.eventRecorder.Warningf("RevisionCreateFailed", "Failed to create revision %d: %v", nextRevision, err.Error())
 			return true, updateError
 		}
@@ -118,7 +121,7 @@ func (c RevisionController) createRevisionIfNeeded(operatorSpec *operatorv1.Stat
 		Type:   "RevisionControllerDegraded",
 		Status: operatorv1.ConditionFalse,
 	}
-	if _, updated, updateError := v1helpers.UpdateStaticPodStatus(c.operatorConfigClient, v1helpers.UpdateStaticPodConditionFn(cond), func(operatorStatus *operatorv1.StaticPodOperatorStatus) error {
+	if _, updated, updateError := v1helpers.UpdateStaticPodStatus(c.operatorClient, v1helpers.UpdateStaticPodConditionFn(cond), func(operatorStatus *operatorv1.StaticPodOperatorStatus) error {
 		if operatorStatus.LatestAvailableRevision == nextRevision {
 			klog.Warningf("revision %d is unexpectedly already the latest available revision. This is a possible race!", nextRevision)
 			return fmt.Errorf("conflicting latestAvailableRevision %d", operatorStatus.LatestAvailableRevision)
@@ -246,7 +249,7 @@ func (c RevisionController) createNewRevision(revision int32) error {
 }
 
 func (c RevisionController) sync() error {
-	operatorSpec, originalOperatorStatus, resourceVersion, err := c.operatorConfigClient.GetStaticPodOperatorStateWithQuorum()
+	operatorSpec, originalOperatorStatus, resourceVersion, err := c.operatorClient.GetStaticPodOperatorStateWithQuorum()
 	if err != nil {
 		return err
 	}
@@ -272,7 +275,7 @@ func (c RevisionController) sync() error {
 		cond.Reason = "Error"
 		cond.Message = err.Error()
 	}
-	if _, _, updateError := v1helpers.UpdateStaticPodStatus(c.operatorConfigClient, v1helpers.UpdateStaticPodConditionFn(cond)); updateError != nil {
+	if _, _, updateError := v1helpers.UpdateStaticPodStatus(c.operatorClient, v1helpers.UpdateStaticPodConditionFn(cond)); updateError != nil {
 		if err == nil {
 			return updateError
 		}
@@ -288,6 +291,9 @@ func (c *RevisionController) Run(workers int, stopCh <-chan struct{}) {
 
 	klog.Infof("Starting RevisionController")
 	defer klog.Infof("Shutting down RevisionController")
+	if !cache.WaitForCacheSync(stopCh, c.cachesToSync...) {
+		return
+	}
 
 	// doesn't matter what workers say, only start one.
 	go wait.Until(c.runWorker, time.Second, stopCh)

--- a/pkg/operator/staticpod/controller/staticpodstate/staticpodstate_controller.go
+++ b/pkg/operator/staticpod/controller/staticpodstate/staticpodstate_controller.go
@@ -36,14 +36,14 @@ type StaticPodStateController struct {
 	operandName       string
 	operatorNamespace string
 
-	operatorConfigClient v1helpers.StaticPodOperatorClient
-	configMapGetter      corev1client.ConfigMapsGetter
-	podsGetter           corev1client.PodsGetter
-	versionRecorder      status.VersionGetter
-	eventRecorder        events.Recorder
+	operatorClient  v1helpers.StaticPodOperatorClient
+	configMapGetter corev1client.ConfigMapsGetter
+	podsGetter      corev1client.PodsGetter
+	versionRecorder status.VersionGetter
 
-	// queue only ever has one item, but it has nice error handling backoff/retry semantics
-	queue workqueue.RateLimitingInterface
+	cachesToSync  []cache.InformerSynced
+	queue         workqueue.RateLimitingInterface
+	eventRecorder events.Recorder
 }
 
 // NewStaticPodStateController creates a controller that watches static pods and will produce a failing status if the
@@ -51,7 +51,7 @@ type StaticPodStateController struct {
 func NewStaticPodStateController(
 	targetNamespace, staticPodName, operatorNamespace, operandName string,
 	kubeInformersForTargetNamespace informers.SharedInformerFactory,
-	operatorConfigClient v1helpers.StaticPodOperatorClient,
+	operatorClient v1helpers.StaticPodOperatorClient,
 	configMapGetter corev1client.ConfigMapsGetter,
 	podsGetter corev1client.PodsGetter,
 	versionRecorder status.VersionGetter,
@@ -63,23 +63,26 @@ func NewStaticPodStateController(
 		operandName:       operandName,
 		operatorNamespace: operatorNamespace,
 
-		operatorConfigClient: operatorConfigClient,
-		configMapGetter:      configMapGetter,
-		podsGetter:           podsGetter,
-		versionRecorder:      versionRecorder,
-		eventRecorder:        eventRecorder.WithComponentSuffix("static-pod-state-controller"),
+		operatorClient:  operatorClient,
+		configMapGetter: configMapGetter,
+		podsGetter:      podsGetter,
+		versionRecorder: versionRecorder,
+		eventRecorder:   eventRecorder.WithComponentSuffix("static-pod-state-controller"),
 
 		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "StaticPodStateController"),
 	}
 
-	operatorConfigClient.Informer().AddEventHandler(c.eventHandler())
+	operatorClient.Informer().AddEventHandler(c.eventHandler())
 	kubeInformersForTargetNamespace.Core().V1().Pods().Informer().AddEventHandler(c.eventHandler())
+
+	c.cachesToSync = append(c.cachesToSync, operatorClient.Informer().HasSynced)
+	c.cachesToSync = append(c.cachesToSync, kubeInformersForTargetNamespace.Core().V1().Pods().Informer().HasSynced)
 
 	return c
 }
 
 func (c *StaticPodStateController) sync() error {
-	operatorSpec, originalOperatorStatus, _, err := c.operatorConfigClient.GetStaticPodOperatorState()
+	operatorSpec, originalOperatorStatus, _, err := c.operatorClient.GetStaticPodOperatorState()
 	if err != nil {
 		return err
 	}
@@ -150,7 +153,7 @@ func (c *StaticPodStateController) sync() error {
 		cond.Reason = "Error"
 		cond.Message = v1helpers.NewMultiLineAggregate(errs).Error()
 	}
-	if _, _, updateError := v1helpers.UpdateStaticPodStatus(c.operatorConfigClient, v1helpers.UpdateStaticPodConditionFn(cond), v1helpers.UpdateStaticPodConditionFn(cond)); updateError != nil {
+	if _, _, updateError := v1helpers.UpdateStaticPodStatus(c.operatorClient, v1helpers.UpdateStaticPodConditionFn(cond), v1helpers.UpdateStaticPodConditionFn(cond)); updateError != nil {
 		if err == nil {
 			return updateError
 		}
@@ -170,6 +173,9 @@ func (c *StaticPodStateController) Run(workers int, stopCh <-chan struct{}) {
 
 	klog.Infof("Starting StaticPodStateController")
 	defer klog.Infof("Shutting down StaticPodStateController")
+	if !cache.WaitForCacheSync(stopCh, c.cachesToSync...) {
+		return
+	}
 
 	// doesn't matter what workers say, only start one.
 	go wait.Until(c.runWorker, time.Second, stopCh)


### PR DESCRIPTION
Upgrades are flapping on revisions because the operator is getting redeployed and we don't wait for cache syncing. The specific instance is https://storage.googleapis.com/origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-4.0/1077/artifacts/e2e-aws-upgrade/events.json in the revision controller, but we had many that were missing because they all used to be live look ups.

@openshift/sig-master 