### PR TITLE
tighten leader election defaults

### DIFF
--- a/pkg/config/leaderelection/leaderelection.go
+++ b/pkg/config/leaderelection/leaderelection.go
@@ -75,13 +75,13 @@ func LeaderElectionDefaulting(config configv1.LeaderElection, defaultNamespace, 
 	ret := *(&config).DeepCopy()
 
 	if ret.LeaseDuration.Duration == 0 {
-		ret.LeaseDuration.Duration = 120 * time.Second
+		ret.LeaseDuration.Duration = 60 * time.Second
 	}
 	if ret.RenewDeadline.Duration == 0 {
-		ret.RenewDeadline.Duration = 90 * time.Second
+		ret.RenewDeadline.Duration = 35 * time.Second
 	}
 	if ret.RetryPeriod.Duration == 0 {
-		ret.RetryPeriod.Duration = 20 * time.Second
+		ret.RetryPeriod.Duration = 10 * time.Second
 	}
 	if len(ret.Namespace) == 0 {
 		if len(defaultNamespace) > 0 {


### PR DESCRIPTION
Because we have serial updates, the time it takes to acquire a lease is a significant percentage of upgrade time.  In 1.14 we get a graceful release of leases, but until then let's tune this down.

/assign @smarterclayton 