### PR TITLE
controller: retry connection errors when getting extension-apiserver-authentication 

### DIFF
--- a/pkg/config/serving/server.go
+++ b/pkg/config/serving/server.go
@@ -1,17 +1,23 @@
 package serving
 
 import (
+	"context"
+	"time"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/util/wait"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	genericapiserveroptions "k8s.io/apiserver/pkg/server/options"
+	"k8s.io/klog"
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 )
 
-func ToServerConfig(servingInfo configv1.HTTPServingInfo, authenticationConfig operatorv1alpha1.DelegatedAuthentication, authorizationConfig operatorv1alpha1.DelegatedAuthorization, kubeConfigFile string) (*genericapiserver.Config, error) {
+func ToServerConfig(ctx context.Context, servingInfo configv1.HTTPServingInfo, authenticationConfig operatorv1alpha1.DelegatedAuthentication, authorizationConfig operatorv1alpha1.DelegatedAuthorization,
+	kubeConfigFile string) (*genericapiserver.Config, error) {
 	scheme := runtime.NewScheme()
 	metav1.AddToGroupVersion(scheme, metav1.SchemeGroupVersion)
 	config := genericapiserver.NewConfig(serializer.NewCodecFactory(scheme))
@@ -20,23 +26,51 @@ func ToServerConfig(servingInfo configv1.HTTPServingInfo, authenticationConfig o
 	if err != nil {
 		return nil, err
 	}
+
 	if err := servingOptions.ApplyTo(&config.SecureServing, &config.LoopbackClientConfig); err != nil {
 		return nil, err
 	}
 
+	var lastApplyErr error
+
+	pollCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
 	if !authenticationConfig.Disabled {
 		authenticationOptions := genericapiserveroptions.NewDelegatingAuthenticationOptions()
 		authenticationOptions.RemoteKubeConfigFile = kubeConfigFile
-		if err := authenticationOptions.ApplyTo(&config.Authentication, config.SecureServing, config.OpenAPIConfig); err != nil {
-			return nil, err
+
+		// In some cases the API server can return connection refused when getting the "extension-apiserver-authentication"
+		// config map.
+		err := wait.PollImmediateUntil(1*time.Second, func() (done bool, err error) {
+			lastApplyErr = authenticationOptions.ApplyTo(&config.Authentication, config.SecureServing, config.OpenAPIConfig)
+			if lastApplyErr != nil {
+				klog.V(4).Infof("Error initializing delegating authentication (will retry): %v", err)
+				return false, nil
+			}
+			return true, nil
+		}, pollCtx.Done())
+		if err != nil {
+			return nil, lastApplyErr
 		}
 	}
 
 	if !authorizationConfig.Disabled {
 		authorizationOptions := genericapiserveroptions.NewDelegatingAuthorizationOptions()
 		authorizationOptions.RemoteKubeConfigFile = kubeConfigFile
-		if err := authorizationOptions.ApplyTo(&config.Authorization); err != nil {
-			return nil, err
+
+		// In some cases the API server can return connection refused when getting the "extension-apiserver-authentication"
+		// config map.
+		err := wait.PollImmediateUntil(1*time.Second, func() (done bool, err error) {
+			lastApplyErr = authorizationOptions.ApplyTo(&config.Authorization)
+			if lastApplyErr != nil {
+				klog.V(4).Infof("Error initializing delegating authorization (will retry): %v", err)
+				return false, nil
+			}
+			return true, nil
+		}, pollCtx.Done())
+		if err != nil {
+			return nil, lastApplyErr
 		}
 	}
 

--- a/pkg/controller/controllercmd/builder.go
+++ b/pkg/controller/controllercmd/builder.go
@@ -199,7 +199,7 @@ func (b *ControllerBuilder) Run(config *unstructured.Unstructured, ctx context.C
 	if b.kubeAPIServerConfigFile != nil {
 		kubeConfig = *b.kubeAPIServerConfigFile
 	}
-	serverConfig, err := serving.ToServerConfig(*b.servingInfo, *b.authenticationConfig, *b.authorizationConfig, kubeConfig)
+	serverConfig, err := serving.ToServerConfig(ctx, *b.servingInfo, *b.authenticationConfig, *b.authorizationConfig, kubeConfig)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Add retry to prevent being fatal:

`Get https://172.30.0.1:443/api/v1/namespaces/kube-system/configmaps/extension-apiserver-authentication: dial tcp 172.30.0.1:443: connect: connection refused`

Best I can think of to address https://bugzilla.redhat.com/show_bug.cgi?id=1702104 (but I suspect there might be other components failing due to races).

/cc @deads2k 