### PR TITLE
loglevel: rework setting the log level using flags

### DIFF
--- a/pkg/operator/events/recorder_in_memory.go
+++ b/pkg/operator/events/recorder_in_memory.go
@@ -38,7 +38,10 @@ func (r *inMemoryEventRecorder) ComponentName() string {
 }
 
 func (r *inMemoryEventRecorder) ForComponent(component string) Recorder {
-	return &inMemoryEventRecorder{events: []*corev1.Event{}, source: component}
+	r.Lock()
+	defer r.Unlock()
+	r.source = component
+	return r
 }
 
 func (r *inMemoryEventRecorder) WithComponentSuffix(suffix string) Recorder {

--- a/pkg/operator/loglevel/logging_controller_test.go
+++ b/pkg/operator/loglevel/logging_controller_test.go
@@ -1,0 +1,68 @@
+package loglevel
+
+import (
+	"testing"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+func TestClusterOperatorLoggingController(t *testing.T) {
+	if err := SetVerbosityValue(operatorv1.Normal); err != nil {
+		t.Fatal(err)
+	}
+
+	operatorSpec := &operatorv1.OperatorSpec{
+		ManagementState:  operatorv1.Managed,
+		OperatorLogLevel: operatorv1.Normal,
+	}
+
+	fakeStaticPodOperatorClient := v1helpers.NewFakeOperatorClient(
+		operatorSpec,
+		&operatorv1.OperatorStatus{},
+		nil,
+	)
+
+	recorder := events.NewInMemoryRecorder("")
+
+	controller := NewClusterOperatorLoggingController(fakeStaticPodOperatorClient, recorder)
+
+	// no-op, desired == current
+	if err := controller.sync(); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(recorder.Events()) > 0 {
+		t.Fatalf("expected zero events, got %d", len(recorder.Events()))
+	}
+
+	// change the log level to trace should 1 emit event
+	operatorSpec.OperatorLogLevel = operatorv1.Trace
+	if err := controller.sync(); err != nil {
+		t.Fatal(err)
+	}
+
+	if operatorEvents := recorder.Events(); len(operatorEvents) == 1 {
+		expectedEventMessage := `Operator log level changed from "Normal" to "Trace"`
+		if message := operatorEvents[0].Message; message != expectedEventMessage {
+			t.Fatalf("expected event message %q, got %q", expectedEventMessage, message)
+		}
+	} else {
+		t.Fatalf("expected 1 event, got %d", len(operatorEvents))
+	}
+
+	// next sync should not produce any extra event
+	if err := controller.sync(); err != nil {
+		t.Fatal(err)
+	}
+
+	if operatorEvents := recorder.Events(); len(operatorEvents) != 1 {
+		t.Fatalf("expected 1 event recorded, got %d", len(operatorEvents))
+	}
+
+	if current := CurrentLogLevel(); current != operatorv1.Trace {
+		t.Fatalf("expected log level 'Trace', got %v", current)
+	}
+}

--- a/pkg/operator/loglevel/util.go
+++ b/pkg/operator/loglevel/util.go
@@ -1,7 +1,15 @@
 package loglevel
 
-import operatorv1 "github.com/openshift/api/operator/v1"
+import (
+	"flag"
+	"fmt"
 
+	"k8s.io/klog"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+)
+
+// LogLevelToKlog transforms operator log level to a klog numeric verbosity level.
 func LogLevelToKlog(logLevel operatorv1.LogLevel) int {
 	switch logLevel {
 	case operatorv1.Normal:
@@ -15,4 +23,67 @@ func LogLevelToKlog(logLevel operatorv1.LogLevel) int {
 	default:
 		return 2
 	}
+}
+
+// CurrentLogLevel attempts to guess the current log level that is used by klog.
+// We can use flags here as well, but this is less ugly ano more programmatically correct than flags.
+func CurrentLogLevel() operatorv1.LogLevel {
+	switch {
+	case klog.V(8) == true:
+		return operatorv1.TraceAll
+	case klog.V(6) == true:
+		return operatorv1.Trace
+	case klog.V(4) == true:
+		return operatorv1.Debug
+	case klog.V(2) == true:
+		return operatorv1.Normal
+	default:
+		return operatorv1.Normal
+	}
+}
+
+// SetVerbosityValue is a nasty hack and attempt to manipulate the global flags as klog does not expose
+// a way to dynamically change the loglevel in runtime.
+func SetVerbosityValue(logLevel operatorv1.LogLevel) error {
+	if logLevel == CurrentLogLevel() {
+		return nil
+	}
+
+	var level *klog.Level
+
+	// Convert operator loglevel to klog numeric string
+	desiredLevelValue := fmt.Sprintf("%d", LogLevelToKlog(logLevel))
+
+	// First, if the '-v' was specified in command line, attempt to acquire the level pointer from it.
+	if f := flag.CommandLine.Lookup("v"); f != nil {
+		if flagValue, ok := f.Value.(*klog.Level); ok {
+			level = flagValue
+		}
+	}
+
+	// Second, if the '-v' was not set but is still present in flags defined for the command, attempt to acquire it
+	// by visiting all flags.
+	if level == nil {
+		flag.VisitAll(func(f *flag.Flag) {
+			if level != nil {
+				return
+			}
+			if levelFlag, ok := f.Value.(*klog.Level); ok {
+				level = levelFlag
+			}
+		})
+	}
+
+	if level != nil {
+		return level.Set(desiredLevelValue)
+	}
+
+	// Third, if modifying the flag value (which is recommended by klog) fails, then fallback to modifying
+	// the internal state of klog using the empty new level.
+	var newLevel klog.Level
+	if err := newLevel.Set(desiredLevelValue); err != nil {
+		return fmt.Errorf("failed set klog.logging.verbosity %s: %v", desiredLevelValue, err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
The recommended way (from klog) to set the loglevel is go trough flags and use the flag.Value to mutate the current verbosity. I added that before we fallback to mutate the global logging var directly.

Added helper to determine what is the current logging verbosity and added a test to prove it works.

/cc @deads2k 