### PR TITLE
installer: fire event on missing required certs

### DIFF
--- a/pkg/operator/staticpod/controller/installer/installer_controller.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller.go
@@ -741,6 +741,7 @@ func (c InstallerController) ensureCerts() error {
 		return nil
 	}
 
+	c.eventRecorder.Eventf("RequiredCertsMissing", strings.Join(missing, ","))
 	return fmt.Errorf("missing: %v", strings.Join(missing, ","))
 }
 

--- a/pkg/operator/staticpod/controller/installer/installer_controller_test.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller_test.go
@@ -21,6 +21,7 @@ import (
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/events/eventstesting"
 	"github.com/openshift/library-go/pkg/operator/staticpod/controller/revision"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
@@ -1378,6 +1379,7 @@ func TestEnsureCert(t *testing.T) {
 				targetNamespace: "ns",
 				certConfigMaps:  test.certConfigMaps,
 				certSecrets:     test.certSecrets,
+				eventRecorder:   eventstesting.NewTestingEventRecorder(t),
 
 				configMapsGetter: client.CoreV1(),
 				secretsGetter:    client.CoreV1(),


### PR DESCRIPTION
The "missing: secrets/serving-cert should be logged by event.