### PR TITLE
set operator version to match other operators

### DIFF
--- a/pkg/operator/staticpod/controller/staticpodstate/staticpodstate_controller.go
+++ b/pkg/operator/staticpod/controller/staticpodstate/staticpodstate_controller.go
@@ -135,6 +135,10 @@ func (c *StaticPodStateController) sync() error {
 			c.operandName,
 			status.VersionForOperandFromEnv(),
 		)
+		c.versionRecorder.SetVersion(
+			"operator",
+			status.VersionForOperatorFromEnv(),
+		)
 	}
 
 	// update failing condition

--- a/pkg/operator/status/version.go
+++ b/pkg/operator/status/version.go
@@ -18,7 +18,8 @@ type versionGetter struct {
 }
 
 const (
-	operandImageVersionEnvVarName = "OPERAND_IMAGE_VERSION"
+	operandImageVersionEnvVarName  = "OPERAND_IMAGE_VERSION"
+	operatorImageVersionEnvVarName = "OPERATOR_IMAGE_VERSION"
 )
 
 func NewVersionGetter() VersionGetter {
@@ -64,6 +65,10 @@ func (v *versionGetter) VersionChangedChannel() <-chan struct{} {
 
 func VersionForOperandFromEnv() string {
 	return os.Getenv(operandImageVersionEnvVarName)
+}
+
+func VersionForOperatorFromEnv() string {
+	return os.Getenv(operatorImageVersionEnvVarName)
 }
 
 func VersionForOperand(namespace, imagePullSpec string, configMapGetter corev1client.ConfigMapsGetter, eventRecorder events.Recorder) string {


### PR DESCRIPTION
/hold

hold for proof

This could resolve our operator version if the static pod operators set a different key.

proof in https://github.com/openshift/cluster-kube-apiserver-operator/pull/440