### PR TITLE
monitoring: make service monitor CRD unavailability produce less noise

### DIFF
--- a/pkg/operator/staticpod/controller/monitoring/monitoring_resource_controller.go
+++ b/pkg/operator/staticpod/controller/monitoring/monitoring_resource_controller.go
@@ -5,11 +5,9 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/openshift/library-go/pkg/operator/management"
-	"github.com/openshift/library-go/pkg/operator/v1helpers"
-
 	"k8s.io/klog"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
@@ -20,10 +18,13 @@ import (
 	"k8s.io/client-go/util/workqueue"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
+
 	"github.com/openshift/library-go/pkg/assets"
 	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/management"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/openshift/library-go/pkg/operator/staticpod/controller/monitoring/bindata"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
 
 const (
@@ -31,6 +32,8 @@ const (
 	controllerWorkQueueKey                             = "key"
 	manifestDir                                        = "pkg/operator/staticpod/controller/monitoring"
 )
+
+var syntheticRequeueError = fmt.Errorf("synthetic requeue request")
 
 type MonitoringResourceController struct {
 	targetNamespace    string
@@ -119,7 +122,14 @@ func (c MonitoringResourceController) sync() error {
 		errs = append(errs, fmt.Errorf("manifests/service-monitor.yaml: %v", err))
 	} else {
 		_, serviceMonitorErr := resourceapply.ApplyServiceMonitor(c.dynamicClient, c.eventRecorder, serviceMonitorBytes)
-		errs = append(errs, serviceMonitorErr)
+		// This is to handle 'the server could not find the requested resource' which occurs when the CRD is not available
+		// yet (the CRD is provided by prometheus operator). This produce noise and plenty of events.
+		if errors.IsNotFound(serviceMonitorErr) {
+			klog.V(4).Infof("Unable to apply service monitor: %v", err)
+			return syntheticRequeueError
+		} else if serviceMonitorErr != nil {
+			errs = append(errs, serviceMonitorErr)
+		}
 	}
 
 	err = v1helpers.NewMultiLineAggregate(errs)
@@ -179,7 +189,10 @@ func (c *MonitoringResourceController) processNextWorkItem() bool {
 		return true
 	}
 
-	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", dsKey, err))
+	if err != syntheticRequeueError {
+		utilruntime.HandleError(fmt.Errorf("%v failed with : %v", dsKey, err))
+	}
+
 	c.queue.AddRateLimited(dsKey)
 
 	return true


### PR DESCRIPTION
There is plenty of these errors in the log and dozen of events generated:

`│2019-04-28T19:12:41.659900979Z I0428 19:12:41.659847       1 event.go:221] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-apiserver-operator", Name:"kube-apiserver-operator", UID:"149d03e3-69e9-11e9-a91d-124681ba4ffe", APIVersion:"apps/v1", ResourceVersion:"", Field│
│2019-04-28T19:12:41.673928052Z E0428 19:12:41.673873       1 monitoring_resource_controller.go:182] key failed with : the server could not find the requested resource`

The reason described in the comment.