### PR TITLE
installer: ensure the etcd-client secret is available

### DIFF
--- a/pkg/operator/staticpod/controller/installer/installer_controller.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller.go
@@ -87,16 +87,16 @@ type InstallerController struct {
 // InstallerPodMutationFunc is a function that has a chance at changing the installer pod before it is created
 type InstallerPodMutationFunc func(pod *corev1.Pod, nodeName string, operatorSpec *operatorv1.StaticPodOperatorSpec, revision int32) error
 
-func (o *InstallerController) WithInstallerPodMutationFn(installerPodMutationFn InstallerPodMutationFunc) *InstallerController {
-	o.installerPodMutationFns = append(o.installerPodMutationFns, installerPodMutationFn)
-	return o
+func (c *InstallerController) WithInstallerPodMutationFn(installerPodMutationFn InstallerPodMutationFunc) *InstallerController {
+	c.installerPodMutationFns = append(c.installerPodMutationFns, installerPodMutationFn)
+	return c
 }
 
-func (o *InstallerController) WithCerts(certDir string, certConfigMaps, certSecrets []revision.RevisionResource) *InstallerController {
-	o.certDir = certDir
-	o.certConfigMaps = certConfigMaps
-	o.certSecrets = certSecrets
-	return o
+func (c *InstallerController) WithCerts(certDir string, certConfigMaps, certSecrets []revision.RevisionResource) *InstallerController {
+	c.certDir = certDir
+	c.certConfigMaps = certConfigMaps
+	c.certSecrets = certSecrets
+	return c
 }
 
 // staticPodState is the status of a static pod that has been installed to a node.
@@ -196,14 +196,14 @@ func nodeToStartRevisionWith(getStaticPodState func(nodeName string) (state stat
 	oldestNotReadyRevision := math.MaxInt32
 	for i := range nodes {
 		currNodeState := &nodes[i]
-		state, revision, _, err := getStaticPodState(currNodeState.NodeName)
+		state, currentRevision, _, err := getStaticPodState(currNodeState.NodeName)
 		if err != nil && apierrors.IsNotFound(err) {
 			return i, nil
 		}
 		if err != nil {
 			return 0, err
 		}
-		revisionNum, err := strconv.Atoi(revision)
+		revisionNum, err := strconv.Atoi(currentRevision)
 		if err != nil {
 			return i, nil
 		}
@@ -221,11 +221,11 @@ func nodeToStartRevisionWith(getStaticPodState func(nodeName string) (state stat
 	oldestPodRevision := math.MaxInt32
 	for i := range nodes {
 		currNodeState := &nodes[i]
-		_, revision, _, err := getStaticPodState(currNodeState.NodeName)
+		_, currentRevision, _, err := getStaticPodState(currNodeState.NodeName)
 		if err != nil {
 			return 0, err
 		}
-		revisionNum, err := strconv.Atoi(revision)
+		revisionNum, err := strconv.Atoi(currentRevision)
 		if err != nil {
 			return i, nil
 		}
@@ -441,9 +441,9 @@ func setAvailableProgressingNodeInstallerFailingConditions(newStatus *operatorv1
 	}
 
 	revisionStrings := []string{}
-	for _, revision := range Int32KeySet(counts).List() {
-		count := counts[revision]
-		revisionStrings = append(revisionStrings, fmt.Sprintf("%d nodes are at revision %d", count, revision))
+	for _, currentRevision := range Int32KeySet(counts).List() {
+		count := counts[currentRevision]
+		revisionStrings = append(revisionStrings, fmt.Sprintf("%d nodes are at revision %d", count, currentRevision))
 	}
 	// if we are progressing and no nodes have achieved that level, we should indicate
 	if numProgressing > 0 && counts[newStatus.LatestAvailableRevision] == 0 {
@@ -532,12 +532,12 @@ func (c *InstallerController) newNodeStateForInstallInProgress(currNodeState *op
 			break
 		}
 
-		state, revision, failedErrors, err := c.getStaticPodState(currNodeState.NodeName)
+		state, currentRevision, failedErrors, err := c.getStaticPodState(currNodeState.NodeName)
 		if err != nil {
 			return nil, false, err
 		}
 
-		if revision != strconv.Itoa(int(currNodeState.TargetRevision)) {
+		if currentRevision != strconv.Itoa(int(currNodeState.TargetRevision)) {
 			// new updated pod to be launched
 			break
 		}


### PR DESCRIPTION
A high rate of failed installer pods on revision `1` observed via CI. Caused by missing `etcd-client-1` secret which is part of the "required" secrets.

```
I0429 20:43:28.093507       1 cmd.go:246] Creating target resource directory "/etc/kubernetes/static-pod-resources/kube-apiserver-pod-1" ...
I0429 20:43:28.093861       1 cmd.go:171] Creating target resource directory "/etc/kubernetes/static-pod-resources/kube-apiserver-pod-1" ...
I0429 20:43:28.093951       1 cmd.go:179] Getting secrets ...
I0429 20:43:28.096810       1 copy.go:24] Failed to get secret openshift-kube-apiserver/etcd-client-1: secrets "etcd-client-1" not found
F0429 20:43:28.101133       1 cmd.go:89] failed to copy: secrets "etcd-client-1" not found
```

We already have mechanism to ensure some (cert) required secrets and configs are available at the time we run the pod, this add all required secrets and configs to the check as the installer pod will always fail when those does not exists and we should rather wait in the operator than creating and failing the installer pod?

Also improving the error message to see the namespace (not always obvious in tests).

Proof: https://github.com/openshift/cluster-kube-apiserver-operator/pull/446

/cc @deads2k 
/cc @damemi 