### PR TITLE
Report detailed revision reason as installer pod annotation

### DIFF
--- a/pkg/operator/staticpod/controller/installer/installer_controller_test.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller_test.go
@@ -460,7 +460,7 @@ func TestEnsureInstallerPod(t *testing.T) {
 			c.ownerRefsFn = func(revision int32) ([]metav1.OwnerReference, error) {
 				return []metav1.OwnerReference{}, nil
 			}
-			err := c.ensureInstallerPod("test-node-1", &operatorv1.StaticPodOperatorSpec{}, 1)
+			err := c.ensureInstallerPod("test-node-1", &operatorv1.StaticPodOperatorSpec{}, 1, "")
 			if err != nil {
 				if tt.expectedErr == "" {
 					t.Errorf("InstallerController.ensureInstallerPod() expected no error, got = %v", err)

--- a/vendor/github.com/openshift/api/operator/v1/types.go
+++ b/vendor/github.com/openshift/api/operator/v1/types.go
@@ -185,6 +185,10 @@ type StaticPodOperatorStatus struct {
 	// +optional
 	LatestAvailableRevision int32 `json:"latestAvailableRevision,omitEmpty"`
 
+	// latestAvailableRevisionReason describe the reason the latest available revision was updated
+	// +optional
+	LatestAvailableRevisionReason string `json:"latestAvailableRevisionReason,emitEmpty"`
+
 	// nodeStatuses track the deployment values and errors across individual nodes
 	// +optional
 	NodeStatuses []NodeStatus `json:"nodeStatuses,omitempty"`


### PR DESCRIPTION
Knowing why revision N was triggered means somebody have to dig trough events or operator logs.
As we dump all pods in CI, if we store the detailed reason (what changed and how) inside the installer pod annotation, we can understand why given revision (and installer pod) was created.

/cc @deads2k 
/cc @sttts 

NOTE: This include illegal bump to openshift/api as we might need new API field if we want to do this,.