### PR TITLE
certsyncpod: default namespace to POD_NAMESPACE env var

### DIFF
--- a/pkg/operator/staticpod/certsyncpod/certsync_cmd.go
+++ b/pkg/operator/staticpod/certsyncpod/certsync_cmd.go
@@ -49,7 +49,7 @@ func NewCertSyncControllerCommand(configmaps, secrets []revision.RevisionResourc
 	}
 
 	cmd.Flags().StringVar(&o.DestinationDir, "destination-dir", o.DestinationDir, "Directory to write to")
-	cmd.Flags().StringVarP(&o.Namespace, "namespace", "n", o.Namespace, "Namespace to read from")
+	cmd.Flags().StringVarP(&o.Namespace, "namespace", "n", o.Namespace, "Namespace to read from (default to 'POD_NAMESPACE' environment variable)")
 	cmd.Flags().StringVar(&o.KubeConfigFile, "kubeconfig", o.KubeConfigFile, "Location of the master configuration file to run from.")
 
 	return cmd
@@ -102,6 +102,10 @@ func (o *CertSyncControllerOptions) Complete() error {
 	kubeConfig, err := client.GetKubeConfigOrInClusterConfig(o.KubeConfigFile, nil)
 	if err != nil {
 		return err
+	}
+
+	if len(o.Namespace) == 0 && len(os.Getenv("POD_NAMESPACE")) > 0 {
+		o.Namespace = os.Getenv("POD_NAMESPACE")
 	}
 
 	protoKubeConfig := rest.CopyConfig(kubeConfig)


### PR DESCRIPTION
We pass the `POD_NAMESPACE` using the env var to args, but that seems like not properly expanded:

`Failed to list *v1.ConfigMap: configmaps is forbidden: User "system:kube-controller-manager" cannot list resource "configmaps" in API group "" in the namespace "${POD_NAMESPACE}"\nW0502`

```
   command: ["cluster-kube-controller-manager-operator", "cert-syncer"]
    args:
      - --kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/kube-controller-cert-syncer-kubeconfig/kubeconfig
      - --namespace=${POD_NAMESPACE}
      - --destination-dir=/etc/kubernetes/static-pod-certs
```

This change will make use of the env var default and allow to override via args.