### PR TITLE
file-watcher-watchdog: add command to kill the operand process on file changes

### DIFF
--- a/pkg/operator/watchdog/cmd.go
+++ b/pkg/operator/watchdog/cmd.go
@@ -1,0 +1,345 @@
+package watchdog
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/server"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog"
+
+	"github.com/openshift/library-go/pkg/config/client"
+	"github.com/openshift/library-go/pkg/controller/fileobserver"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/retry"
+)
+
+type FileWatcherOptions struct {
+	// ProcessName is the name of the process we will send SIGTERM
+	ProcessName string
+
+	// Files lists all files we want to monitor for changes
+	Files      []string
+	KubeConfig string
+
+	// Namespace to report events to
+	Namespace string
+	recorder  events.Recorder
+
+	// Interval specifies how aggressive we want to be in file checks
+	Interval time.Duration
+
+	// Time to give the process to terminate gracefully
+	TerminationGracePeriod time.Duration
+
+	// for unit-test to mock getting the process PID (unit-test)
+	findPidByNameFn func(name string) (int, bool, error)
+
+	// processExistsFn to mock checking the process PID (unit-test)
+	processExistsFn func(int) (bool, error)
+
+	// for unit-test to mock sending UNIX signals
+	handleTerminationFn func(pid int) error
+
+	handleKillFn func(pid int) error
+
+	// for unit-test to mock prefixing files (/proc/PID/root)
+	addProcPrefixToFilesFn func([]string, int) []string
+
+	// lastTerminatedPid is used track the value of a PID that we already terminated
+	lastTerminatedPid int
+}
+
+func NewFileWatcherOptions() *FileWatcherOptions {
+	return &FileWatcherOptions{
+		findPidByNameFn:        FindProcessByName,
+		processExistsFn:        ProcessExists,
+		addProcPrefixToFilesFn: addProcPrefixToFiles,
+		handleTerminationFn: func(pid int) error {
+			return syscall.Kill(pid, syscall.SIGTERM)
+		},
+		handleKillFn: func(pid int) error {
+			return syscall.Kill(pid, syscall.SIGKILL)
+		},
+	}
+}
+
+// NewFileWatcherWatchdog return the file watcher watchdog command.
+// This command should be used as a side-car to a container which will react to file changes in the main container
+// and terminate the main container process in case a change is observed.
+// TODO: If the main container start before the watchdog side-car container (image pull) there might be a case
+// 		 the watchdog won't react to a changed file (simply because it is not running yet). In that case the main process
+//       will not be reloaded. However, the operator image should be pulled on master node and therefore chances to hit this
+//       case are minimal.
+func NewFileWatcherWatchdog() *cobra.Command {
+	o := NewFileWatcherOptions()
+
+	cmd := &cobra.Command{
+		Use:   "file-watcher-watchdog",
+		Short: "Watch files on the disk and terminate the specified process on change",
+		Run: func(cmd *cobra.Command, args []string) {
+			klog.V(1).Info(cmd.Flags())
+			klog.V(1).Info(spew.Sdump(o))
+
+			// Handle shutdown
+			termHandler := server.SetupSignalHandler()
+			ctx, shutdown := context.WithCancel(context.TODO())
+			go func() {
+				defer shutdown()
+				<-termHandler
+			}()
+
+			if err := o.Complete(); err != nil {
+				klog.Fatal(err)
+			}
+			if err := o.Validate(); err != nil {
+				klog.Fatal(err)
+			}
+
+			if err := o.Run(ctx); err != nil {
+				klog.Fatal(err)
+			}
+		},
+	}
+
+	o.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+func (o *FileWatcherOptions) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&o.ProcessName, "process-name", "", "name of the process to send TERM signal to on file change (eg. 'hyperkube').")
+	fs.StringSliceVar(&o.Files, "files", o.Files, "comma separated list of file names to monitor for changes")
+	fs.StringVar(&o.KubeConfig, "kubeconfig", o.KubeConfig, "kubeconfig file or empty")
+	fs.StringVar(&o.Namespace, "namespace", o.Namespace, "namespace to report the watchdog events")
+	fs.DurationVar(&o.Interval, "interval", 5*time.Second, "interval specifying how aggressive the file checks should be")
+	fs.DurationVar(&o.TerminationGracePeriod, "termination-grace-period", 30*time.Second, "interval specifying how long to wait until sending KILL signal to the process")
+}
+
+func (o *FileWatcherOptions) Complete() error {
+	clientConfig, err := client.GetKubeConfigOrInClusterConfig(o.KubeConfig, nil)
+	if err != nil {
+		return err
+	}
+	kubeClient, err := kubernetes.NewForConfig(clientConfig)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
+	defer cancel()
+
+	// Get event recorder.
+	// Retry on connection errors for 10s, but don't error out, instead fallback to the namespace.
+	var eventTarget *v1.ObjectReference
+	err = retry.RetryOnConnectionErrors(ctx, func(context.Context) (bool, error) {
+		var clientErr error
+		eventTarget, clientErr = events.GetControllerReferenceForCurrentPod(kubeClient, o.Namespace, nil)
+		if clientErr != nil {
+			return false, clientErr
+		}
+		return true, nil
+	})
+	if err != nil {
+		klog.Warningf("unable to get owner reference (falling back to namespace): %v", err)
+	}
+	o.recorder = events.NewRecorder(kubeClient.CoreV1().Events(o.Namespace), "file-change-watchdog", eventTarget)
+
+	return nil
+}
+
+func (o *FileWatcherOptions) Validate() error {
+	if len(o.ProcessName) == 0 {
+		return fmt.Errorf("process name must be specified")
+	}
+	if len(o.Files) == 0 {
+		return fmt.Errorf("at least one file to observe must be specified")
+	}
+	if len(o.Namespace) == 0 && len(os.Getenv("POD_NAMESPACE")) == 0 {
+		return fmt.Errorf("either namespace flag or POD_NAMESPACE environment variable must be specified")
+	}
+	return nil
+}
+
+// runPidObserver runs a loop that observes changes to the PID of the process we send signals after change is detected.
+func (o *FileWatcherOptions) runPidObserver(ctx context.Context, pidObservedCh chan int) {
+	defer close(pidObservedCh)
+	currentPID := 0
+	retries := 0
+	pollErr := wait.PollImmediateUntil(1*time.Second, func() (done bool, err error) {
+		retries++
+		// attempt to find the PID by process name via /proc
+		observedPID, found, err := o.findPidByNameFn(o.ProcessName)
+		if !found || err != nil {
+			klog.Warningf("Unable to determine PID for %q (retry: %d, err: %v)", o.ProcessName, retries, err)
+			return false, nil
+		}
+
+		if currentPID == 0 {
+			currentPID = observedPID
+			// notify runWatchdog when the PID is initially observed (we need the PID to mutate file paths).
+			pidObservedCh <- observedPID
+		}
+
+		// watch for PID changes, when observed restart the observer and wait for the new PID to appear.
+		if currentPID != observedPID {
+			return true, nil
+		}
+
+		return false, nil
+	}, ctx.Done())
+
+	// These are not fatal errors, but we still want to log them out
+	if pollErr != nil && pollErr != wait.ErrWaitTimeout {
+		klog.Warningf("Unexpected error: %v", pollErr)
+	}
+}
+
+// readInitialFileContent reads the content of files specified.
+// This is needed by file observer.
+func readInitialFileContent(files []string) (map[string][]byte, error) {
+	initialContent := map[string][]byte{}
+	for _, name := range files {
+		// skip files that does not exists (yet)
+		if _, err := os.Stat(name); os.IsNotExist(err) {
+			continue
+		}
+		content, err := ioutil.ReadFile(name)
+		if err != nil {
+			return nil, err
+		}
+		initialContent[name] = content
+	}
+	return initialContent, nil
+}
+
+// addProcPrefixToFiles mutates the file list and prefix every file with /proc/PID/root.
+// With shared pid namespace, we are able to access the target container filesystem via /proc.
+func addProcPrefixToFiles(oldFiles []string, pid int) []string {
+	files := []string{}
+	for _, file := range oldFiles {
+		files = append(files, filepath.Join("/proc", fmt.Sprintf("%d", pid), "root", file))
+	}
+	return files
+}
+
+// Run the main watchdog loop.
+func (o *FileWatcherOptions) Run(ctx context.Context) error {
+	for {
+		{
+			o.lastTerminatedPid = 0
+			instanceCtx, shutdown := context.WithCancel(ctx)
+			defer shutdown()
+			select {
+			case <-ctx.Done():
+				// exit(0)
+				shutdown()
+				return nil
+			default:
+			}
+			if err := o.runWatchdog(instanceCtx); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (o *FileWatcherOptions) terminateGracefully(pid int) error {
+	// Send SIGTERM to the process
+	klog.Infof("Sending TERM signal to %d ...", pid)
+	if err := o.handleTerminationFn(pid); err != nil {
+		return err
+	}
+	// Wait TerminationGracePeriodSeconds or until the process is not removed from /proc
+	pollErr := wait.PollImmediate(500*time.Millisecond, o.TerminationGracePeriod, func() (done bool, err error) {
+		if exists, err := o.processExistsFn(pid); !exists && err == nil {
+			return true, nil
+		} else if err != nil {
+			return true, err
+		}
+		return false, nil
+	})
+	// If the process still exists and the TerminationGracePeriodSeconds passed, send kill signal and return
+	if pollErr == wait.ErrWaitTimeout {
+		klog.Infof("Sending KILL signal to %d ...", pid)
+		return o.handleKillFn(pid)
+	}
+	return pollErr
+}
+
+// runWatchdog run single instance of watchdog.
+func (o *FileWatcherOptions) runWatchdog(ctx context.Context) error {
+	watchdogCtx, shutdown := context.WithCancel(ctx)
+	defer shutdown()
+
+	// Handle watchdog shutdown
+	go func() {
+		defer shutdown()
+		<-ctx.Done()
+	}()
+
+	pidObservedCh := make(chan int)
+	go o.runPidObserver(watchdogCtx, pidObservedCh)
+
+	// Wait while we get the initial PID for the process
+	klog.Infof("Waiting for process %q PID ...", o.ProcessName)
+	currentPID := <-pidObservedCh
+
+	// Mutate path for specified files as '/proc/PID/root/<original path>'
+	// This means side-car container don't have to duplicate the mounts from main container.
+	// This require shared PID namespace feature.
+	filesToWatch := o.addProcPrefixToFilesFn(o.Files, currentPID)
+	klog.Infof("Watching for changes in: %s", spew.Sdump(filesToWatch))
+
+	// Read initial file content. If shared PID namespace does not work, this will error.
+	initialContent, err := readInitialFileContent(filesToWatch)
+	if err != nil {
+		// TODO: remove this once we get aggregated logging
+		o.recorder.Warningf("FileChangeWatchdogFailed", "Reading initial file content failed: %v", err)
+		return fmt.Errorf("unable to read initial file content: %v", err)
+	}
+
+	o.recorder.Eventf("FileChangeWatchdogStarted", "Started watching files for process %s[%d]", o.ProcessName, currentPID)
+
+	observer, err := fileobserver.NewObserver(o.Interval)
+	if err != nil {
+		o.recorder.Warningf("ObserverFailed", "Failed to start to file observer: %v", err)
+		return fmt.Errorf("unable to start file observer: %v", err)
+	}
+
+	observer.AddReactor(func(file string, action fileobserver.ActionType) error {
+		// We already signalled this PID to terminate and the process is being gracefully terminated now.
+		// Do not duplicate termination process for PID we already terminated, but wait for the new PID to appear.
+		if currentPID == o.lastTerminatedPid {
+			return nil
+		}
+
+		o.lastTerminatedPid = currentPID
+		defer shutdown()
+
+		o.recorder.Eventf("FileChangeObserved", "Observed change in file %q, gracefully terminating process %s[%d]", file, o.ProcessName, currentPID)
+
+		if err := o.terminateGracefully(currentPID); err != nil {
+			o.recorder.Warningf("SignalFailed", "Failed to terminate process %s[%d] gracefully: %v", o.ProcessName, currentPID, err)
+			return err
+		}
+
+		return nil
+	}, initialContent, filesToWatch...)
+
+	go observer.Run(watchdogCtx.Done())
+
+	<-watchdogCtx.Done()
+	return nil
+}

--- a/pkg/operator/watchdog/cmd_test.go
+++ b/pkg/operator/watchdog/cmd_test.go
@@ -1,0 +1,152 @@
+package watchdog
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/openshift/library-go/pkg/operator/events/eventstesting"
+)
+
+func TestPidObserver(t *testing.T) {
+	var currentPIDMutex = sync.Mutex{}
+	currentPID := 1
+
+	getProcessPIDByName := func(name string) (int, bool, error) {
+		currentPIDMutex.Lock()
+		defer currentPIDMutex.Unlock()
+		return currentPID, true, nil
+	}
+
+	watcher := &FileWatcherOptions{
+		findPidByNameFn: getProcessPIDByName,
+	}
+
+	pidObservedCh := make(chan int)
+	monitorTerminated := make(chan struct{})
+
+	go func() {
+		defer close(monitorTerminated)
+		watcher.runPidObserver(context.TODO(), pidObservedCh)
+	}()
+
+	// We should receive the initial PID
+	select {
+	case pid := <-pidObservedCh:
+		if pid != 1 {
+			t.Fatalf("expected PID 1, got %d", pid)
+		}
+		t.Log("initial PID observed")
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout (observing initial PID)")
+	}
+
+	// We changed the PID, the monitor should gracefully terminate
+	currentPIDMutex.Lock()
+	currentPID = 10
+	currentPIDMutex.Unlock()
+
+	select {
+	case <-monitorTerminated:
+		t.Log("monitor successfully terminated")
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout (terminating monitor)")
+	}
+}
+
+func TestWatchdogRun(t *testing.T) {
+	signalTermRecv := make(chan int)
+	signalKillRecv := make(chan int)
+
+	// Make temporary file we are going to watch and write changes
+	testDir, err := ioutil.TempDir("", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(testDir)
+	if err := ioutil.WriteFile(filepath.Join(testDir, "testfile"), []byte("starting"), os.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := &FileWatcherOptions{
+		ProcessName: "test",
+		Files:       []string{filepath.Join(testDir, "testfile")},
+		handleTerminationFn: func(pid int) error {
+			signalTermRecv <- pid
+			return nil
+		},
+		handleKillFn: func(pid int) error {
+			signalKillRecv <- pid
+			return nil
+		},
+		findPidByNameFn: func(name string) (int, bool, error) {
+			return 10, true, nil
+		},
+		processExistsFn: func(int) (bool, error) {
+			return true, nil
+		},
+		addProcPrefixToFilesFn: func(files []string, i int) []string {
+			return files
+		},
+		Interval:               200 * time.Millisecond,
+		TerminationGracePeriod: 1 * time.Second,
+		recorder:               eventstesting.NewTestingEventRecorder(t),
+	}
+
+	// commandCtx is context used for the Run() method
+	commandCtx, shutdown := context.WithTimeout(context.TODO(), 1*time.Minute)
+	defer shutdown()
+
+	commandTerminatedCh := make(chan struct{})
+	go func() {
+		defer close(commandTerminatedCh)
+		if err := opts.Run(commandCtx); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// Give file watcher time to observe the file
+	time.Sleep(1 * time.Second)
+
+	// Modify the monitored file
+	if err := ioutil.WriteFile(filepath.Join(testDir, "testfile"), []byte("changed"), os.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case pid := <-signalTermRecv:
+		if pid != 10 {
+			t.Errorf("expected received PID to be 10, got %d", pid)
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatal("timeout (waiting for PID)")
+	}
+
+	select {
+	case pid := <-signalKillRecv:
+		if pid != 10 {
+			t.Errorf("expected received PID to be 10, got %d", pid)
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatal("timeout (waiting for PID)")
+	}
+
+	select {
+	case <-commandTerminatedCh:
+		t.Fatal("run command is not expected to terminate")
+	default:
+	}
+
+	// Test the shutdown sequence
+	shutdown()
+	select {
+	case <-commandTerminatedCh:
+	case <-time.After(20 * time.Second):
+		t.Fatal("run command failed to terminate")
+	}
+
+}

--- a/pkg/operator/watchdog/proc.go
+++ b/pkg/operator/watchdog/proc.go
@@ -1,0 +1,76 @@
+package watchdog
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"syscall"
+)
+
+// FindProcessByName find the process name specified by name and return the PID of that process.
+// If the process is not found, the bool is false.
+// NOTE: This require container with shared process namespace (if run as side-car).
+func FindProcessByName(name string) (int, bool, error) {
+	files, err := ioutil.ReadDir("/proc")
+	if err != nil {
+		return 0, false, err
+	}
+	// sort means we start with the directories with numbers
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].Name() < files[j].Name()
+	})
+	for _, file := range files {
+		if !file.IsDir() {
+			continue
+		}
+		// only scan process directories (eg. /proc/1234)
+		pid, err := strconv.Atoi(file.Name())
+		if err != nil {
+			continue
+		}
+		// read the /proc/123/exe symlink that points to a process
+		linkTarget := readlink(filepath.Join("/proc", file.Name(), "exe"))
+		if path.Base(linkTarget) != name {
+			continue
+		}
+		return pid, true, nil
+	}
+	return 0, false, nil
+}
+
+// ProcessExists checks if the process specified by a PID exists in the /proc filesystem.
+// Error is returned when the stat on the /proc dir fail (permission issue).
+func ProcessExists(pid int) (bool, error) {
+	procDir, err := os.Stat(fmt.Sprintf("/proc/%d", pid))
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if procDir.IsDir() {
+		return true, nil
+	} else {
+		return false, fmt.Errorf("unexpected error: /proc/%d is file, not directory", pid)
+	}
+}
+
+// readlink is copied from the os.Readlink() but does not return error when the target path does not exists.
+// This is used to read broken links as in case of share PID namespace, the /proc/1/exe points to a binary
+// that does not exists from the source container.
+func readlink(name string) string {
+	for l := 128; ; l *= 2 {
+		b := make([]byte, l)
+		n, _ := syscall.Readlink(name, b)
+		if n < 0 {
+			n = 0
+		}
+		if n < l {
+			return string(b[0:n])
+		}
+	}
+}

--- a/pkg/operator/watchdog/proc_test.go
+++ b/pkg/operator/watchdog/proc_test.go
@@ -1,0 +1,96 @@
+package watchdog
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadLink(t *testing.T) {
+	tests := []struct {
+		name       string
+		evalResult func(string, string, string, *testing.T)
+		preRun     func(t *testing.T) (target, linkPath, dirName string)
+		postRun    func(linkPath, dirName string, t *testing.T)
+	}{
+		{
+			name: "target exists",
+			evalResult: func(target, link, result string, t *testing.T) {
+				if result != target {
+					t.Errorf("expected %q to match %q", result, target)
+				}
+			},
+			preRun: func(t *testing.T) (string, string, string) {
+				tmpDir, err := ioutil.TempDir("", "existing")
+				if err != nil {
+					t.Fatalf("unable to create temp dir: %v", err)
+				}
+				if err := ioutil.WriteFile(filepath.Join(tmpDir, "testfile"), []byte{1}, os.ModePerm); err != nil {
+					t.Fatalf("unable to write file: %v", err)
+				}
+				if err := os.Symlink(filepath.Join(tmpDir, "testfile"), filepath.Join(tmpDir, "newfile")); err != nil {
+					t.Fatalf("unable to make symlink: %v", err)
+				}
+				return filepath.Join(tmpDir, "testfile"), filepath.Join(tmpDir, "newfile"), tmpDir
+			},
+			postRun: func(linkPath, dirName string, t *testing.T) {
+				if err := os.RemoveAll(dirName); err != nil {
+					t.Fatalf("unable to remove %q: %v", dirName, err)
+				}
+			},
+		},
+		{
+			name: "target does not exists",
+			evalResult: func(target, link, result string, t *testing.T) {
+				if result != target {
+					t.Errorf("expected %q to match %q", result, target)
+				}
+			},
+			preRun: func(t *testing.T) (string, string, string) {
+				tmpDir, err := ioutil.TempDir("", "broken")
+				if err != nil {
+					t.Fatalf("unable to create temp dir: %v", err)
+				}
+				if err := os.Symlink(filepath.Join(tmpDir, "testfile"), filepath.Join(tmpDir, "newfile")); err != nil {
+					t.Fatalf("unable to make symlink: %v", err)
+				}
+				return filepath.Join(tmpDir, "testfile"), filepath.Join(tmpDir, "newfile"), tmpDir
+			},
+			postRun: func(linkPath, dirName string, t *testing.T) {
+				if err := os.RemoveAll(dirName); err != nil {
+					t.Fatalf("unable to remove %q: %v", dirName, err)
+				}
+			},
+		},
+		{
+			name: "source does not exists",
+			evalResult: func(target, link, result string, t *testing.T) {
+				if len(result) > 0 {
+					t.Errorf("expected result be empty, got: %q", result)
+				}
+			},
+			preRun: func(t *testing.T) (string, string, string) {
+				tmpDir, err := ioutil.TempDir("", "broken-source")
+				if err != nil {
+					t.Fatalf("unable to create temp dir: %v", err)
+				}
+				return filepath.Join(tmpDir, "testfile"), filepath.Join(tmpDir, "newfile"), tmpDir
+			},
+			postRun: func(linkPath, dirName string, t *testing.T) {
+				if err := os.RemoveAll(dirName); err != nil {
+					t.Fatalf("unable to remove %q: %v", dirName, err)
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			target, link, tempDir := test.preRun(t)
+			result := readlink(link)
+			test.evalResult(target, link, result, t)
+			test.postRun(link, tempDir, t)
+		})
+	}
+}


### PR DESCRIPTION
The purpose of this package is to live aside to an operand container (side-car). If the operand pod runs with `shareProcessNamespace: true` the watchdog can send SIGTERM to the operand to trigger graceful shutdown.

The watchdog use the fileobserver to detect changes in files (`--files`) and in reaction to a change it will send TERM signal to a process specified by name `--process-name`.