### PR TITLE
fileobserver: allow to specify start time for file observer

### DIFF
--- a/pkg/controller/fileobserver/observer.go
+++ b/pkg/controller/fileobserver/observer.go
@@ -57,3 +57,12 @@ func NewObserver(interval time.Duration) (Observer, error) {
 		files:    map[string]string{},
 	}, nil
 }
+
+func NewObserverWithStartTime(interval time.Duration, startTime time.Time) (Observer, error) {
+	observer, err := NewObserver(interval)
+	if err != nil {
+		return nil, err
+	}
+	observer.(*pollingObserver).startTimestamp = &startTime
+	return observer, nil
+}


### PR DESCRIPTION
In some cases, we need to trigger a modified reaction when the file modification timestamp is never than a process consuming the modification. Such case exists when a file watch dog is not running yet (image pull?) but the main process is already started. In that case, there is some time when we don't react to file changes (because we don't run).

If we are able to read the timestamp of the process and use that timestamp when initializing the observer, we might trigger when the files we observing are "newer" than that process.