### PR TITLE
operator: fix named queue names to prevent prometheus errors

### DIFF
--- a/pkg/operator/certrotation/client_cert_rotation_controller.go
+++ b/pkg/operator/certrotation/client_cert_rotation_controller.go
@@ -2,6 +2,7 @@ package certrotation
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -64,7 +65,7 @@ func NewCertRotationController(
 		TargetRotation:   targetRotation,
 		OperatorClient:   operatorClient,
 
-		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), name),
+		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), strings.Replace(name, "-", "_", -1)),
 	}
 
 	signingRotation.Informer.Informer().AddEventHandler(c.eventHandler())

--- a/pkg/operator/management/management_state_controller.go
+++ b/pkg/operator/management/management_state_controller.go
@@ -2,6 +2,7 @@ package management
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"k8s.io/klog"
@@ -44,7 +45,7 @@ func NewOperatorManagementStateController(
 		operatorClient: operatorClient,
 		eventRecorder:  recorder,
 
-		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "ManagementStateController-"+name),
+		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "ManagementStateController_"+strings.Replace(name, "-", "_", -1)),
 	}
 
 	operatorClient.Informer().AddEventHandler(c.eventHandler())

--- a/pkg/operator/status/status_controller.go
+++ b/pkg/operator/status/status_controller.go
@@ -2,6 +2,7 @@ package status
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"k8s.io/klog"
@@ -70,7 +71,7 @@ func NewClusterOperatorStatusController(
 		operatorClient:        operatorClient,
 		eventRecorder:         recorder.WithComponentSuffix("status-controller"),
 
-		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "StatusSyncer-"+name),
+		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "StatusSyncer_"+strings.Replace(name, "-", "_", -1)),
 	}
 
 	operatorClient.Informer().AddEventHandler(c.eventHandler())


### PR DESCRIPTION
Seeing a lot of:

`
E0520 09:21:27.184580       1 workqueue_metrics.go:129] failed to register depth metric StatusSyncer-kube-controller-manager: descriptor Desc{fqName: "StatusSyncer-kube-controller-manager_depth", help: "(Deprecated) Current depth of workqueue: StatusSyncer-kube-controll│
er-manager", constLabels: {}, variableLabels: []} is invalid: "StatusSyncer-kube-controller-manager_depth" is not a valid metric name
`

Which means the prometheus metrics for queues are not being published. I think this happened after we bumped the client-go in library-go. Starting fixing in library-go and then move to operators.

/cc @deads2k 
/cc @soltysh 