### PR TITLE
staticpod: prune installer pods for removed masters

### DIFF
--- a/pkg/operator/staticpod/controller/installer/installer_controller.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller.go
@@ -615,6 +615,14 @@ func getInstallerPodName(revision int32, nodeName string) string {
 func (c *InstallerController) ensureInstallerPod(nodeName string, operatorSpec *operatorv1.StaticPodOperatorSpec, revision int32) error {
 	pod := resourceread.ReadPodV1OrDie(bindata.MustAsset(filepath.Join(manifestDir, manifestInstallerPodPath)))
 
+	if pod.Labels == nil {
+		pod.Labels = map[string]string{}
+	}
+
+	// Add nodename to make label queries possible
+	pod.Labels["operator.openshift.io/node"] = nodeName
+	pod.Labels["operator.openshift.io/role"] = "installer"
+
 	pod.Namespace = c.targetNamespace
 	pod.Name = getInstallerPodName(revision, nodeName)
 	pod.Spec.NodeName = nodeName

--- a/pkg/operator/staticpod/controller/node/node_controller_test.go
+++ b/pkg/operator/staticpod/controller/node/node_controller_test.go
@@ -120,7 +120,7 @@ func TestNewNodeController(t *testing.T) {
 
 			eventRecorder := events.NewRecorder(kubeClient.CoreV1().Events("test"), "test-operator", &v1.ObjectReference{})
 
-			c := NewNodeController(fakeStaticPodOperatorClient, kubeInformers, eventRecorder)
+			c := NewNodeController("fake-namespace", kubeClient.CoreV1(), fakeStaticPodOperatorClient, kubeInformers, eventRecorder)
 			// override the lister so we don't have to run the informer to list nodes
 			c.nodeLister = fakeLister
 			if err := c.sync(); err != nil {

--- a/pkg/operator/staticpod/controllers.go
+++ b/pkg/operator/staticpod/controllers.go
@@ -3,17 +3,12 @@ package staticpod
 import (
 	"fmt"
 
-	"github.com/openshift/library-go/pkg/operator/loglevel"
-
-	"github.com/openshift/library-go/pkg/operator/unsupportedconfigoverridescontroller"
-
 	"k8s.io/apimachinery/pkg/util/errors"
-
-	"github.com/openshift/library-go/pkg/operator/status"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/loglevel"
 	"github.com/openshift/library-go/pkg/operator/staticpod/controller/backingresource"
 	"github.com/openshift/library-go/pkg/operator/staticpod/controller/installer"
 	"github.com/openshift/library-go/pkg/operator/staticpod/controller/monitoring"
@@ -21,6 +16,8 @@ import (
 	"github.com/openshift/library-go/pkg/operator/staticpod/controller/prune"
 	"github.com/openshift/library-go/pkg/operator/staticpod/controller/revision"
 	"github.com/openshift/library-go/pkg/operator/staticpod/controller/staticpodstate"
+	"github.com/openshift/library-go/pkg/operator/status"
+	"github.com/openshift/library-go/pkg/operator/unsupportedconfigoverridescontroller"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
 
@@ -204,6 +201,8 @@ func (b *staticPodOperatorControllerBuilder) ToControllers() (*staticPodOperator
 	}
 
 	controllers.nodeController = node.NewNodeController(
+		b.operandNamespace,
+		podClient,
 		b.staticPodOperatorClient,
 		clusterInformers,
 		eventRecorder,


### PR DESCRIPTION
This fixes an edge case when the master node is removed but some if the installer pods for that master were in "new" or "pending" state. In such case, the installer pod will never succeed because the node selector won't match any node.

The change here will cause all installer pods for the removed node being deleted when we observe master node removed (all pods, not just pending, as there is no reason keeping them around?).

/cc @deads2k 
/cc @sanchezl 