### PR TITLE
look for service serving certs in correct location

### DIFF
--- a/pkg/controller/controllercmd/cmd.go
+++ b/pkg/controller/controllercmd/cmd.go
@@ -133,7 +133,7 @@ func hasServiceServingCerts(certDir string) bool {
 // you do not need to customize the controller builder. This method modifies config with self-signed default cert locations if
 // necessary.
 func (c *ControllerCommandConfig) AddDefaultRotationToConfig(config *operatorv1alpha1.GenericOperatorConfig, configContent []byte) (map[string][]byte, []string, error) {
-	certDir := "/var/run/secrets/serving-cert"
+	certDir := "/var/run/secrets/service-network-serving-certkey"
 
 	observedFiles := []string{
 		c.basicFlags.ConfigFile,


### PR DESCRIPTION
If a user overrides the default serving certs, the user provided cert might no longer contain the SANs needed when serving on the service network. Look for the service network serving certs in the `service-network-serving-certkey` directory instead which, if it exists, should contain the operator managed service network serving certs.