### PR TITLE
Fix install races

### DIFF
--- a/pkg/filelock/filelock.go
+++ b/pkg/filelock/filelock.go
@@ -1,0 +1,73 @@
+package filelock
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/klog"
+)
+
+type lock struct {
+	path string
+}
+
+func NewLock(path string) *lock {
+	return &lock{
+		path: path,
+	}
+}
+
+func (l *lock) TryLock() (bool, error) {
+	f, err := os.OpenFile(l.path, os.O_CREATE|os.O_EXCL, 644)
+	if err != nil {
+		if errors.IsAlreadyExists(err) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("failed to create lock file %q: %v", l.path, err)
+	}
+	defer func() {
+		err := f.Close()
+		if err != nil {
+			klog.Error(err)
+		}
+	}()
+
+	_, err = f.Write([]byte(strconv.Itoa(os.Getpid())))
+	if err != nil {
+		// We have already acquired the lock so we shouldn't fail on additional info
+		klog.Error(err)
+	}
+
+	return true, nil
+}
+
+func (l *lock) IsLocked() (bool, error) {
+	_, err := os.Stat(l.path)
+	if err == nil {
+		return true, nil
+	}
+
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+
+	// The bool return value doesn't matter but if someone was ignoring the error
+	// it is safer to assume the file is locked.
+	return true, fmt.Errorf("failed to determine if lock file %q is present: %v", l.path, err)
+}
+
+func (l *lock) Unlock() error {
+	err := os.Remove(l.path)
+	if err != nil {
+		return fmt.Errorf("failed to remove lock file %q: %v", l.path, err)
+	}
+
+	return nil
+}
+
+func (l *lock) Path() string {
+	return l.path
+}

--- a/pkg/filelock/filelock_test.go
+++ b/pkg/filelock/filelock_test.go
@@ -1,0 +1,82 @@
+package filelock
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestIsLocked(t *testing.T) {
+	dir, err := ioutil.TempDir("", "test-is-locked")
+	if err != nil {
+		t.Fatalf("failed to create tmp dir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	l := NewLock(filepath.Join(dir, "lock_file"))
+	locked, err := l.IsLocked()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if locked {
+		t.Fatal("With no file present it shouldn't be locked")
+	}
+
+	// First lock should succeed
+	locked, err = l.TryLock()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if !locked {
+		t.Fatal("Locking failed.")
+	}
+
+	locked, err = l.IsLocked()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if !locked {
+		t.Fatal("With lock file present it should be locked")
+	}
+
+	// Second lock should fail
+	locked, err = l.TryLock()
+	expErr := fmt.Errorf("failed to create lock file %q: open %s: file exists", l.Path(), l.Path())
+	if !reflect.DeepEqual(err, expErr) {
+		t.Fatalf("Expected error %#v, got %#v", expErr, err)
+	}
+	if locked {
+		t.Fatal("Locking should have failed")
+	}
+
+	locked, err = l.IsLocked()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if !locked {
+		t.Fatal("With lock file present it should be locked")
+	}
+
+	err = l.Unlock()
+	if err != nil {
+		t.Errorf("Failed to unlock file: %v", err)
+	}
+
+	locked, err = l.IsLocked()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if locked {
+		t.Fatal("With no lock file present it should be unlocked")
+	}
+
+	// Unlocking unlocked (not present file lock) should fail
+	err = l.Unlock()
+	expErr = fmt.Errorf("failed to remove lock file %q: remove %s: no such file or directory", l.Path(), l.Path())
+	if !reflect.DeepEqual(err, expErr) {
+		t.Fatalf("Expected error %#v, got %#v", expErr, err)
+	}
+}

--- a/pkg/operator/staticpod/certsyncpod/certsync_cmd.go
+++ b/pkg/operator/staticpod/certsyncpod/certsync_cmd.go
@@ -23,6 +23,7 @@ type CertSyncControllerOptions struct {
 	KubeConfigFile string
 	Namespace      string
 	DestinationDir string
+	PodManifestDir string
 
 	configMaps []revision.RevisionResource
 	secrets    []revision.RevisionResource
@@ -49,6 +50,7 @@ func NewCertSyncControllerCommand(configmaps, secrets []revision.RevisionResourc
 	}
 
 	cmd.Flags().StringVar(&o.DestinationDir, "destination-dir", o.DestinationDir, "Directory to write to")
+	cmd.Flags().StringVar(&o.PodManifestDir, "pod-manifest-dir", o.PodManifestDir, "Directory for the static pod manifest")
 	cmd.Flags().StringVarP(&o.Namespace, "namespace", "n", o.Namespace, "Namespace to read from (default to 'POD_NAMESPACE' environment variable)")
 	cmd.Flags().StringVar(&o.KubeConfigFile, "kubeconfig", o.KubeConfigFile, "Location of the master configuration file to run from.")
 
@@ -81,6 +83,7 @@ func (o *CertSyncControllerOptions) Run() error {
 
 	controller, err := NewCertSyncController(
 		o.DestinationDir,
+		o.PodManifestDir,
 		o.Namespace,
 		o.configMaps,
 		o.secrets,

--- a/pkg/operator/staticpod/hold/hold.go
+++ b/pkg/operator/staticpod/hold/hold.go
@@ -1,0 +1,13 @@
+package hold
+
+import (
+	"path/filepath"
+)
+
+var (
+	installerHoldFile = "INSTALLER_HOLD"
+)
+
+func InstallerFile(podManifestDir string) string {
+	return filepath.Join(podManifestDir, installerHoldFile)
+}


### PR DESCRIPTION
Description and prove of use in https://github.com/openshift/cluster-kube-apiserver-operator/pull/483

When bumping dependent repos this needs pod manifests dir exposed to cert-syncer.

/cc @deads2k 