### PR TITLE
pkg/apps: introduce apps.openshift.io helpers

### DIFF
--- a/pkg/apps/decode/decode.go
+++ b/pkg/apps/decode/decode.go
@@ -1,0 +1,54 @@
+package decode
+
+import (
+	"fmt"
+	"reflect"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/diff"
+
+	appsv1 "github.com/openshift/api/apps/v1"
+	"github.com/openshift/library-go/pkg/apps/scheme"
+)
+
+// DecodeDeploymentConfig decodes a DeploymentConfig from controller using annotation codec.
+// An error is returned if the controller doesn't contain an encoded config or decoding fail.
+func DecodeDeploymentConfig(controller metav1.ObjectMetaAccessor) (*appsv1.DeploymentConfig, error) {
+	encodedConfig, exists := controller.GetObjectMeta().GetAnnotations()[appsv1.DeploymentEncodedConfigAnnotation]
+	if !exists {
+		return nil, fmt.Errorf("object %s does not have encoded deployment config annotation", controller.GetObjectMeta().GetName())
+	}
+	config, err := runtime.Decode(scheme.AnnotationDecoder, []byte(encodedConfig))
+	if err != nil {
+		return nil, err
+	}
+	externalConfig, ok := config.(*appsv1.DeploymentConfig)
+	if !ok {
+		return nil, fmt.Errorf("object %+v is not v1.DeploymentConfig", config)
+	}
+	return externalConfig, nil
+}
+
+// HasLatestPodTemplate checks for differences between current deployment config
+// template and deployment config template encoded in the latest replication
+// controller. If they are different it will return an string diff containing
+// the change.
+func HasLatestPodTemplate(currentConfig *appsv1.DeploymentConfig, rc *v1.ReplicationController) (bool, string, error) {
+	latestConfig, err := DecodeDeploymentConfig(rc)
+	if err != nil {
+		return true, "", err
+	}
+	// The latestConfig represents an encoded DC in the latest deployment (RC).
+	// TODO: This diverges from the upstream behavior where we compare deployment
+	// template vs. replicaset template. Doing that will disallow any
+	// modifications to the RC the deployment config controller create and manage
+	// as a change to the RC will cause the DC to be reconciled and ultimately
+	// trigger a new rollout because of skew between latest RC template and DC
+	// template.
+	if reflect.DeepEqual(currentConfig.Spec.Template, latestConfig.Spec.Template) {
+		return true, "", nil
+	}
+	return false, diff.ObjectReflectDiff(currentConfig.Spec.Template, latestConfig.Spec.Template), nil
+}

--- a/pkg/apps/encode/encode.go
+++ b/pkg/apps/encode/encode.go
@@ -1,0 +1,130 @@
+package encode
+
+import (
+	"strconv"
+	"strings"
+
+	appsv1 "github.com/openshift/api/apps/v1"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/openshift/library-go/pkg/apps/scheme"
+	"github.com/openshift/library-go/pkg/apps/util"
+)
+
+var (
+	// deploymentConfigControllerRefKind contains the schema.GroupVersionKind for the
+	// deployment config. This is used in the ownerRef and GC client picks the appropriate
+	// client to get the deployment config.
+	deploymentConfigControllerRefKind = appsv1.GroupVersion.WithKind("DeploymentConfig")
+)
+
+func newControllerRef(config *appsv1.DeploymentConfig) *metav1.OwnerReference {
+	blockOwnerDeletion := true
+	isController := true
+	return &metav1.OwnerReference{
+		APIVersion:         deploymentConfigControllerRefKind.GroupVersion().String(),
+		Kind:               deploymentConfigControllerRefKind.Kind,
+		Name:               config.Name,
+		UID:                config.UID,
+		BlockOwnerDeletion: &blockOwnerDeletion,
+		Controller:         &isController,
+	}
+}
+
+// MakeDeployment creates a deployment represented as a ReplicationController and based on the given DeploymentConfig.
+// The controller replica count will be zero.
+func MakeDeployment(config *appsv1.DeploymentConfig) (*v1.ReplicationController, error) {
+	// EncodeDeploymentConfig encodes config as a string using codec.
+	encodedConfig, err := runtime.Encode(scheme.AnnotationEncoder, config)
+	if err != nil {
+		return nil, err
+	}
+
+	deploymentName := util.LatestDeploymentNameForConfig(config)
+	podSpec := config.Spec.Template.Spec.DeepCopy()
+
+	// Fix trailing and leading whitespace in the image field
+	// This is needed to sanitize old deployment configs where spaces were permitted but
+	// kubernetes 3.7 (#47491) tightened the validation of container image fields.
+	for i := range podSpec.Containers {
+		podSpec.Containers[i].Image = strings.TrimSpace(podSpec.Containers[i].Image)
+	}
+
+	controllerLabels := make(labels.Set)
+	for k, v := range config.Labels {
+		controllerLabels[k] = v
+	}
+	// Correlate the deployment with the config.
+	// TODO: Using the annotation constant for now since the value is correct
+	// but we could consider adding a new constant to the public types.
+	controllerLabels[appsv1.DeploymentConfigAnnotation] = config.Name
+
+	// Ensure that pods created by this deployment controller can be safely associated back
+	// to the controller, and that multiple deployment controllers for the same config don't
+	// manipulate each others' pods.
+	selector := map[string]string{}
+	for k, v := range config.Spec.Selector {
+		selector[k] = v
+	}
+	selector[util.DeploymentConfigLabel] = config.Name
+	selector[util.DeploymentLabel] = deploymentName
+
+	podLabels := make(labels.Set)
+	for k, v := range config.Spec.Template.Labels {
+		podLabels[k] = v
+	}
+	podLabels[util.DeploymentConfigLabel] = config.Name
+	podLabels[util.DeploymentLabel] = deploymentName
+
+	podAnnotations := make(labels.Set)
+	for k, v := range config.Spec.Template.Annotations {
+		podAnnotations[k] = v
+	}
+	podAnnotations[appsv1.DeploymentAnnotation] = deploymentName
+	podAnnotations[appsv1.DeploymentConfigAnnotation] = config.Name
+	podAnnotations[appsv1.DeploymentVersionAnnotation] = strconv.FormatInt(config.Status.LatestVersion, 10)
+
+	controllerRef := newControllerRef(config)
+	zero := int32(0)
+	deployment := &v1.ReplicationController{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      deploymentName,
+			Namespace: config.Namespace,
+			Annotations: map[string]string{
+				appsv1.DeploymentConfigAnnotation:        config.Name,
+				appsv1.DeploymentEncodedConfigAnnotation: string(encodedConfig),
+				appsv1.DeploymentStatusAnnotation:        string(appsv1.DeploymentStatusNew),
+				appsv1.DeploymentVersionAnnotation:       strconv.FormatInt(config.Status.LatestVersion, 10),
+				// This is the target replica count for the new deployment.
+				appsv1.DesiredReplicasAnnotation:  strconv.Itoa(int(config.Spec.Replicas)),
+				util.DeploymentReplicasAnnotation: strconv.Itoa(0),
+			},
+			Labels:          controllerLabels,
+			OwnerReferences: []metav1.OwnerReference{*controllerRef},
+		},
+		Spec: v1.ReplicationControllerSpec{
+			// The deployment should be inactive initially
+			Replicas:        &zero,
+			Selector:        selector,
+			MinReadySeconds: config.Spec.MinReadySeconds,
+			Template: &v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:      podLabels,
+					Annotations: podAnnotations,
+				},
+				Spec: *podSpec,
+			},
+		},
+	}
+	if config.Status.Details != nil && len(config.Status.Details.Message) > 0 {
+		deployment.Annotations[appsv1.DeploymentStatusReasonAnnotation] = config.Status.Details.Message
+	}
+	if value, ok := config.Annotations[util.DeploymentIgnorePodAnnotation]; ok {
+		deployment.Annotations[util.DeploymentIgnorePodAnnotation] = value
+	}
+
+	return deployment, nil
+}

--- a/pkg/apps/encode/encode_test.go
+++ b/pkg/apps/encode/encode_test.go
@@ -1,0 +1,120 @@
+package encode
+
+import (
+	"testing"
+	"time"
+
+	appsv1 "github.com/openshift/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/library-go/pkg/apps/util"
+	appstest "github.com/openshift/library-go/pkg/apps/util/test"
+)
+
+func TestRolloutExceededTimeoutSeconds(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name                   string
+		config                 *appsv1.DeploymentConfig
+		deploymentCreationTime time.Time
+		expectTimeout          bool
+	}{
+		// Recreate strategy with deployment running for 20s (exceeding 10s timeout)
+		{
+			name: "recreate timeout",
+			config: func(timeoutSeconds int64) *appsv1.DeploymentConfig {
+				config := appstest.OkDeploymentConfig(1)
+				config.Spec.Strategy.RecreateParams.TimeoutSeconds = &timeoutSeconds
+				return config
+			}(int64(10)),
+			deploymentCreationTime: now.Add(-20 * time.Second),
+			expectTimeout:          true,
+		},
+		// Recreate strategy with no timeout
+		{
+			name: "recreate no timeout",
+			config: func(timeoutSeconds int64) *appsv1.DeploymentConfig {
+				config := appstest.OkDeploymentConfig(1)
+				config.Spec.Strategy.RecreateParams.TimeoutSeconds = &timeoutSeconds
+				return config
+			}(int64(0)),
+			deploymentCreationTime: now.Add(-700 * time.Second),
+			expectTimeout:          false,
+		},
+
+		// Rolling strategy with deployment running for 20s (exceeding 10s timeout)
+		{
+			name: "rolling timeout",
+			config: func(timeoutSeconds int64) *appsv1.DeploymentConfig {
+				config := appstest.OkDeploymentConfig(1)
+				config.Spec.Strategy = appstest.OkRollingStrategy()
+				config.Spec.Strategy.RollingParams.TimeoutSeconds = &timeoutSeconds
+				return config
+			}(int64(10)),
+			deploymentCreationTime: now.Add(-20 * time.Second),
+			expectTimeout:          true,
+		},
+		// Rolling strategy with deployment with no timeout specified.
+		{
+			name: "rolling using default timeout",
+			config: func(timeoutSeconds int64) *appsv1.DeploymentConfig {
+				config := appstest.OkDeploymentConfig(1)
+				config.Spec.Strategy = appstest.OkRollingStrategy()
+				config.Spec.Strategy.RollingParams.TimeoutSeconds = nil
+				return config
+			}(0),
+			deploymentCreationTime: now.Add(-20 * time.Second),
+			expectTimeout:          false,
+		},
+		// Recreate strategy with deployment with no timeout specified.
+		{
+			name: "recreate using default timeout",
+			config: func(timeoutSeconds int64) *appsv1.DeploymentConfig {
+				config := appstest.OkDeploymentConfig(1)
+				config.Spec.Strategy.RecreateParams.TimeoutSeconds = nil
+				return config
+			}(0),
+			deploymentCreationTime: now.Add(-20 * time.Second),
+			expectTimeout:          false,
+		},
+		// Custom strategy with deployment with no timeout specified.
+		{
+			name: "custom using default timeout",
+			config: func(timeoutSeconds int64) *appsv1.DeploymentConfig {
+				config := appstest.OkDeploymentConfig(1)
+				config.Spec.Strategy = appstest.OkCustomStrategy()
+				return config
+			}(0),
+			deploymentCreationTime: now.Add(-20 * time.Second),
+			expectTimeout:          false,
+		},
+		// Custom strategy use default timeout exceeding it.
+		{
+			name: "custom using default timeout timing out",
+			config: func(timeoutSeconds int64) *appsv1.DeploymentConfig {
+				config := appstest.OkDeploymentConfig(1)
+				config.Spec.Strategy = appstest.OkCustomStrategy()
+				return config
+			}(0),
+			deploymentCreationTime: now.Add(-700 * time.Second),
+			expectTimeout:          true,
+		},
+	}
+
+	for _, tc := range tests {
+		config := tc.config
+		deployment, err := MakeDeployment(config)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		deployment.ObjectMeta.CreationTimestamp = metav1.Time{Time: tc.deploymentCreationTime}
+		gotTimeout := util.RolloutExceededTimeoutSeconds(config, deployment)
+		if tc.expectTimeout && !gotTimeout {
+			t.Errorf("[%s]: expected timeout, but got no timeout", tc.name)
+		}
+		if !tc.expectTimeout && gotTimeout {
+			t.Errorf("[%s]: expected no timeout, but got timeout", tc.name)
+		}
+
+	}
+}

--- a/pkg/apps/scheme/scheme.go
+++ b/pkg/apps/scheme/scheme.go
@@ -1,0 +1,30 @@
+package scheme
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
+	appsv1 "github.com/openshift/api/apps/v1"
+)
+
+var (
+	// for decoding, we want to be tolerant of groupified and non-groupified
+	annotationDecodingScheme = runtime.NewScheme()
+	AnnotationDecoder        runtime.Decoder
+
+	// for encoding, we want to be strict on groupified
+	annotationEncodingScheme = runtime.NewScheme()
+	AnnotationEncoder        runtime.Encoder
+)
+
+func init() {
+	utilruntime.Must(appsv1.Install(annotationDecodingScheme))
+	utilruntime.Must(appsv1.DeprecatedInstallWithoutGroup(annotationDecodingScheme))
+	annotationDecoderCodecFactory := serializer.NewCodecFactory(annotationDecodingScheme)
+	AnnotationDecoder = annotationDecoderCodecFactory.UniversalDecoder(appsv1.GroupVersion)
+
+	utilruntime.Must(appsv1.Install(annotationEncodingScheme))
+	annotationEncoderCodecFactory := serializer.NewCodecFactory(annotationEncodingScheme)
+	AnnotationEncoder = annotationEncoderCodecFactory.LegacyCodec(appsv1.GroupVersion)
+}

--- a/pkg/apps/scheme/scheme_test.go
+++ b/pkg/apps/scheme/scheme_test.go
@@ -1,0 +1,47 @@
+package scheme
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/davecgh/go-spew/spew"
+
+	appsv1 "github.com/openshift/api/apps/v1"
+)
+
+const legacyDC = `{
+  "apiVersion": "v1",
+  "kind": "DeploymentConfig",
+  "metadata": {
+    "name": "sinatra-app-example-a"
+  }
+}
+`
+
+func TestLegacyDecoding(t *testing.T) {
+	result, err := runtime.Decode(AnnotationDecoder, []byte(legacyDC))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.(*appsv1.DeploymentConfig).Name != "sinatra-app-example-a" {
+		t.Fatal(spew.Sdump(result))
+	}
+
+	groupfiedBytes, err := runtime.Encode(AnnotationEncoder, result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(groupfiedBytes), "apps.openshift.io/v1") {
+		t.Fatal(string(groupfiedBytes))
+	}
+
+	result2, err := runtime.Decode(AnnotationDecoder, groupfiedBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result2.(*appsv1.DeploymentConfig).Name != "sinatra-app-example-a" {
+		t.Fatal(spew.Sdump(result2))
+	}
+}

--- a/pkg/apps/util/const.go
+++ b/pkg/apps/util/const.go
@@ -1,0 +1,60 @@
+package util
+
+const (
+	// FailedRcCreateReason is added in a deployment config when it cannot create a new replication
+	// controller.
+	FailedRcCreateReason = "ReplicationControllerCreateError"
+	// NewReplicationControllerReason is added in a deployment config when it creates a new replication
+	// controller.
+	NewReplicationControllerReason = "NewReplicationControllerCreated"
+	// NewRcAvailableReason is added in a deployment config when its newest replication controller is made
+	// available ie. the number of new pods that have passed readiness checks and run for at least
+	// minReadySeconds is at least the minimum available pods that need to run for the deployment config.
+	NewRcAvailableReason = "NewReplicationControllerAvailable"
+	// TimedOutReason is added in a deployment config when its newest replication controller fails to show
+	// any progress within the given deadline (progressDeadlineSeconds).
+	TimedOutReason = "ProgressDeadlineExceeded"
+	// PausedConfigReason is added in a deployment config when it is paused. Lack of progress shouldn't be
+	// estimated once a deployment config is paused.
+	PausedConfigReason = "DeploymentConfigPaused"
+	// CancelledRolloutReason is added in a deployment config when its newest rollout was
+	// interrupted by cancellation.
+	CancelledRolloutReason = "RolloutCancelled"
+
+	// DeploymentConfigLabel is the name of a label used to correlate a deployment with the
+	DeploymentConfigLabel = "deploymentconfig"
+
+	// DeploymentLabel is the name of a label used to correlate a deployment with the Pod created
+	DeploymentLabel = "deployment"
+
+	// MaxDeploymentDurationSeconds represents the maximum duration that a deployment is allowed to run.
+	// This is set as the default value for ActiveDeadlineSeconds for the deployer pod.
+	// Currently set to 6 hours.
+	MaxDeploymentDurationSeconds int64 = 21600
+
+	// DefaultRecreateTimeoutSeconds is the default TimeoutSeconds for RecreateDeploymentStrategyParams.
+	// Used by strategies:
+	DefaultRecreateTimeoutSeconds int64 = 10 * 60
+	DefaultRollingTimeoutSeconds  int64 = 10 * 60
+
+	// PreHookPodSuffix is the suffix added to all pre hook pods
+	PreHookPodSuffix = "hook-pre"
+	// MidHookPodSuffix is the suffix added to all mid hook pods
+	MidHookPodSuffix = "hook-mid"
+	// PostHookPodSuffix is the suffix added to all post hook pods
+	PostHookPodSuffix = "hook-post"
+
+	// Used only internally by utils:
+
+	// DeploymentStatusReasonAnnotation represents the reason for deployment being in a given state
+	// Used for specifying the reason for cancellation or failure of a deployment
+	DeploymentIgnorePodAnnotation = "deploy.openshift.io/deployer-pod.ignore"
+	DeploymentReplicasAnnotation  = "openshift.io/deployment.replicas"
+
+	DeploymentFailedUnrelatedDeploymentExists = "unrelated pod with the same name as this deployment is already running"
+	DeploymentFailedUnableToCreateDeployerPod = "unable to create deployer pod"
+	DeploymentFailedDeployerPodNoLongerExists = "deployer pod no longer exists"
+
+	deploymentCancelledByUser                = "cancelled by the user"
+	deploymentCancelledNewerDeploymentExists = "newer deployment was found running"
+)

--- a/pkg/apps/util/test/ok.go
+++ b/pkg/apps/util/test/ok.go
@@ -1,0 +1,268 @@
+package test
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/api/legacyscheme"
+
+	appsv1 "github.com/openshift/api/apps/v1"
+)
+
+const (
+	ImageStreamName      = "test-image-stream"
+	ImageID              = "0000000000000000000000000000000000000000000000000000000000000001"
+	DockerImageReference = "registry:5000/openshift/test-image-stream@sha256:0000000000000000000000000000000000000000000000000000000000000001"
+)
+
+func OkDeploymentConfig(version int64) *appsv1.DeploymentConfig {
+	return &appsv1.DeploymentConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "config",
+			Namespace: corev1.NamespaceDefault,
+			SelfLink:  "/apis/apps.openshift.io/v1/deploymentConfig/config",
+		},
+		Spec:   OkDeploymentConfigSpec(),
+		Status: OkDeploymentConfigStatus(version),
+	}
+}
+
+func OkDeploymentConfigSpec() appsv1.DeploymentConfigSpec {
+	return appsv1.DeploymentConfigSpec{
+		Replicas: 1,
+		Selector: OkSelector(),
+		Strategy: OkStrategy(),
+		Template: OkPodTemplate(),
+		Triggers: []appsv1.DeploymentTriggerPolicy{
+			OkImageChangeTrigger(),
+			OkConfigChangeTrigger(),
+		},
+	}
+}
+
+func OkDeploymentConfigStatus(version int64) appsv1.DeploymentConfigStatus {
+	return appsv1.DeploymentConfigStatus{
+		LatestVersion: version,
+	}
+}
+
+func OkImageChangeDetails() *appsv1.DeploymentDetails {
+	return &appsv1.DeploymentDetails{
+		Causes: []appsv1.DeploymentCause{{
+			Type: appsv1.DeploymentTriggerOnImageChange,
+			ImageTrigger: &appsv1.DeploymentCauseImageTrigger{
+				From: corev1.ObjectReference{
+					Name: ImageStreamName + ":latest",
+					Kind: "ImageStreamTag",
+				}}}}}
+}
+
+func OkConfigChangeDetails() *appsv1.DeploymentDetails {
+	return &appsv1.DeploymentDetails{
+		Causes: []appsv1.DeploymentCause{{
+			Type: appsv1.DeploymentTriggerOnConfigChange,
+		}}}
+}
+
+func OkStrategy() appsv1.DeploymentStrategy {
+	return appsv1.DeploymentStrategy{
+		Type: appsv1.DeploymentStrategyTypeRecreate,
+		Resources: corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				corev1.ResourceName(corev1.ResourceCPU):    resource.MustParse("10"),
+				corev1.ResourceName(corev1.ResourceMemory): resource.MustParse("10G"),
+			},
+		},
+		RecreateParams: &appsv1.RecreateDeploymentStrategyParams{
+			TimeoutSeconds: mkintp(20),
+		},
+		ActiveDeadlineSeconds: mkintp(21600),
+	}
+}
+
+func OkCustomStrategy() appsv1.DeploymentStrategy {
+	return appsv1.DeploymentStrategy{
+		Type:         appsv1.DeploymentStrategyTypeCustom,
+		CustomParams: OkCustomParams(),
+		Resources: corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				corev1.ResourceName(corev1.ResourceCPU):    resource.MustParse("10"),
+				corev1.ResourceName(corev1.ResourceMemory): resource.MustParse("10G"),
+			},
+		},
+	}
+}
+
+func OkCustomParams() *appsv1.CustomDeploymentStrategyParams {
+	return &appsv1.CustomDeploymentStrategyParams{
+		Image: "openshift/origin-deployer",
+		Environment: []corev1.EnvVar{
+			{
+				Name:  "ENV1",
+				Value: "VAL1",
+			},
+		},
+		Command: []string{"/bin/echo", "hello", "world"},
+	}
+}
+
+func mkintp(i int) *int64 {
+	v := int64(i)
+	return &v
+}
+
+func OkRollingStrategy() appsv1.DeploymentStrategy {
+	return appsv1.DeploymentStrategy{
+		Type: appsv1.DeploymentStrategyTypeRolling,
+		RollingParams: &appsv1.RollingDeploymentStrategyParams{
+			UpdatePeriodSeconds: mkintp(1),
+			IntervalSeconds:     mkintp(1),
+			TimeoutSeconds:      mkintp(20),
+		},
+		Resources: corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				corev1.ResourceName(corev1.ResourceCPU):    resource.MustParse("10"),
+				corev1.ResourceName(corev1.ResourceMemory): resource.MustParse("10G"),
+			},
+		},
+	}
+}
+
+func OkSelector() map[string]string {
+	return map[string]string{"a": "b"}
+}
+
+func OkPodTemplate() *corev1.PodTemplateSpec {
+	one := int64(1)
+	return &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "container1",
+					Image: "registry:8080/repo1:ref1",
+					Env: []corev1.EnvVar{
+						{
+							Name:  "ENV1",
+							Value: "VAL1",
+						},
+					},
+					ImagePullPolicy:          corev1.PullIfNotPresent,
+					TerminationMessagePath:   "/dev/termination-log",
+					TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+				},
+				{
+					Name:                     "container2",
+					Image:                    "registry:8080/repo1:ref2",
+					ImagePullPolicy:          corev1.PullIfNotPresent,
+					TerminationMessagePath:   "/dev/termination-log",
+					TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+				},
+			},
+			RestartPolicy:                 corev1.RestartPolicyAlways,
+			DNSPolicy:                     corev1.DNSClusterFirst,
+			TerminationGracePeriodSeconds: &one,
+			SchedulerName:                 corev1.DefaultSchedulerName,
+			SecurityContext:               &corev1.PodSecurityContext{},
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: OkSelector(),
+		},
+	}
+}
+
+func OkPodTemplateChanged() *corev1.PodTemplateSpec {
+	template := OkPodTemplate()
+	template.Spec.Containers[0].Image = DockerImageReference
+	return template
+}
+
+func OkPodTemplateMissingImage(missing ...string) *corev1.PodTemplateSpec {
+	set := sets.NewString(missing...)
+	template := OkPodTemplate()
+	for i, c := range template.Spec.Containers {
+		if set.Has(c.Name) {
+			// remember that slices use copies, so have to ref array entry explicitly
+			template.Spec.Containers[i].Image = ""
+		}
+	}
+	return template
+}
+
+func OkConfigChangeTrigger() appsv1.DeploymentTriggerPolicy {
+	return appsv1.DeploymentTriggerPolicy{
+		Type: appsv1.DeploymentTriggerOnConfigChange,
+	}
+}
+
+func OkImageChangeTrigger() appsv1.DeploymentTriggerPolicy {
+	return appsv1.DeploymentTriggerPolicy{
+		Type: appsv1.DeploymentTriggerOnImageChange,
+		ImageChangeParams: &appsv1.DeploymentTriggerImageChangeParams{
+			Automatic: true,
+			ContainerNames: []string{
+				"container1",
+			},
+			From: corev1.ObjectReference{
+				Kind: "ImageStreamTag",
+				Name: ImageStreamName + ":latest",
+			},
+		},
+	}
+}
+
+func OkTriggeredImageChange() appsv1.DeploymentTriggerPolicy {
+	ict := OkImageChangeTrigger()
+	ict.ImageChangeParams.LastTriggeredImage = DockerImageReference
+	return ict
+}
+
+func OkNonAutomaticICT() appsv1.DeploymentTriggerPolicy {
+	ict := OkImageChangeTrigger()
+	ict.ImageChangeParams.Automatic = false
+	return ict
+}
+
+func OkTriggeredNonAutomatic() appsv1.DeploymentTriggerPolicy {
+	ict := OkNonAutomaticICT()
+	ict.ImageChangeParams.LastTriggeredImage = DockerImageReference
+	return ict
+}
+
+func TestDeploymentConfig(config *appsv1.DeploymentConfig) *appsv1.DeploymentConfig {
+	config.Spec.Test = true
+	return config
+}
+
+func RemoveTriggerTypes(config *appsv1.DeploymentConfig, triggerTypes ...appsv1.DeploymentTriggerType) {
+	types := sets.NewString()
+	for _, triggerType := range triggerTypes {
+		types.Insert(string(triggerType))
+	}
+
+	remaining := []appsv1.DeploymentTriggerPolicy{}
+	for _, trigger := range config.Spec.Triggers {
+		if types.Has(string(trigger.Type)) {
+			continue
+		}
+		remaining = append(remaining, trigger)
+	}
+
+	config.Spec.Triggers = remaining
+}
+
+func RoundTripConfig(t *testing.T, config *appsv1.DeploymentConfig) *appsv1.DeploymentConfig {
+	versioned, err := legacyscheme.Scheme.ConvertToVersion(config, appsv1.SchemeGroupVersion)
+	if err != nil {
+		t.Errorf("unexpected conversion error: %v", err)
+		return nil
+	}
+	defaulted, err := legacyscheme.Scheme.ConvertToVersion(versioned, appsv1.SchemeGroupVersion)
+	if err != nil {
+		t.Errorf("unexpected conversion error: %v", err)
+		return nil
+	}
+	return defaulted.(*appsv1.DeploymentConfig)
+}

--- a/pkg/apps/util/util.go
+++ b/pkg/apps/util/util.go
@@ -1,0 +1,587 @@
+package util
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	intstrutil "k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	appsv1 "github.com/openshift/api/apps/v1"
+
+	"github.com/openshift/library-go/pkg/build/naming"
+)
+
+// RolloutExceededTimeoutSeconds returns true if the current deployment exceeded
+// the timeoutSeconds defined for its strategy.
+// Note that this is different than activeDeadlineSeconds which is the timeout
+// set for the deployer pod. In some cases, the deployer pod cannot be created
+// (like quota, etc...). In that case deployer controller use this function to
+// measure if the created deployment (RC) exceeded the timeout.
+func RolloutExceededTimeoutSeconds(config *appsv1.DeploymentConfig, latestRC *v1.ReplicationController) bool {
+	timeoutSeconds := GetTimeoutSecondsForStrategy(config)
+	// If user set the timeoutSeconds to 0, we assume there should be no timeout.
+	if timeoutSeconds <= 0 {
+		return false
+	}
+	return int64(time.Since(latestRC.CreationTimestamp.Time).Seconds()) > timeoutSeconds
+}
+
+// GetTimeoutSecondsForStrategy returns the timeout in seconds defined in the
+// deployment config strategy.
+func GetTimeoutSecondsForStrategy(config *appsv1.DeploymentConfig) int64 {
+	var timeoutSeconds int64
+	switch config.Spec.Strategy.Type {
+	case appsv1.DeploymentStrategyTypeRolling:
+		timeoutSeconds = DefaultRollingTimeoutSeconds
+		if t := config.Spec.Strategy.RollingParams.TimeoutSeconds; t != nil {
+			timeoutSeconds = *t
+		}
+	case appsv1.DeploymentStrategyTypeRecreate:
+		timeoutSeconds = DefaultRecreateTimeoutSeconds
+		if t := config.Spec.Strategy.RecreateParams.TimeoutSeconds; t != nil {
+			timeoutSeconds = *t
+		}
+	case appsv1.DeploymentStrategyTypeCustom:
+		timeoutSeconds = DefaultRecreateTimeoutSeconds
+	}
+	return timeoutSeconds
+}
+
+// DeployerPodNameForDeployment returns the name of a pod for a given deployment
+func DeployerPodNameForDeployment(deployment string) string {
+	return naming.GetPodName(deployment, "deploy")
+}
+
+// NewDeploymentCondition creates a new deployment condition.
+func NewDeploymentCondition(condType appsv1.DeploymentConditionType, status v1.ConditionStatus, reason string, message string) *appsv1.DeploymentCondition {
+	return &appsv1.DeploymentCondition{
+		Type:               condType,
+		Status:             status,
+		LastUpdateTime:     metav1.Now(),
+		LastTransitionTime: metav1.Now(),
+		Reason:             reason,
+		Message:            message,
+	}
+}
+
+// SetDeploymentCondition updates the deployment to include the provided condition. If the condition that
+// we are about to add already exists and has the same status and reason then we are not going to update.
+func SetDeploymentCondition(status *appsv1.DeploymentConfigStatus, condition appsv1.DeploymentCondition) {
+	currentCond := GetDeploymentCondition(*status, condition.Type)
+	if currentCond != nil && currentCond.Status == condition.Status && currentCond.Reason == condition.Reason {
+		return
+	}
+	// Preserve lastTransitionTime if we are not switching between statuses of a condition.
+	if currentCond != nil && currentCond.Status == condition.Status {
+		condition.LastTransitionTime = currentCond.LastTransitionTime
+	}
+
+	newConditions := filterOutCondition(status.Conditions, condition.Type)
+	status.Conditions = append(newConditions, condition)
+}
+
+// RemoveDeploymentCondition removes the deployment condition with the provided type.
+func RemoveDeploymentCondition(status *appsv1.DeploymentConfigStatus, condType appsv1.DeploymentConditionType) {
+	status.Conditions = filterOutCondition(status.Conditions, condType)
+}
+
+// filterOutCondition returns a new slice of deployment conditions without conditions with the provided type.
+func filterOutCondition(conditions []appsv1.DeploymentCondition, condType appsv1.DeploymentConditionType) []appsv1.DeploymentCondition {
+	var newConditions []appsv1.DeploymentCondition
+	for _, c := range conditions {
+		if c.Type == condType {
+			continue
+		}
+		newConditions = append(newConditions, c)
+	}
+	return newConditions
+}
+
+// IsOwnedByConfig checks whether the provided replication controller is part of a
+// deployment configuration.
+// TODO: Switch to use owner references once we got those working.
+func IsOwnedByConfig(obj metav1.Object) bool {
+	_, ok := obj.GetAnnotations()[appsv1.DeploymentConfigAnnotation]
+	return ok
+}
+
+// DeploymentsForCleanup determines which deployments for a configuration are relevant for the
+// revision history limit quota
+func DeploymentsForCleanup(configuration *appsv1.DeploymentConfig, deployments []*v1.ReplicationController) []v1.ReplicationController {
+	// if the past deployment quota has been exceeded, we need to prune the oldest deployments
+	// until we are not exceeding the quota any longer, so we sort oldest first
+	sort.Sort(sort.Reverse(ByLatestVersionDesc(deployments)))
+
+	relevantDeployments := []v1.ReplicationController{}
+	activeDeployment := ActiveDeployment(deployments)
+	if activeDeployment == nil {
+		// if cleanup policy is set but no successful deployments have happened, there will be
+		// no active deployment. We can consider all of the deployments in this case except for
+		// the latest one
+		for i := range deployments {
+			deployment := deployments[i]
+			if deploymentVersionFor(deployment) != configuration.Status.LatestVersion {
+				relevantDeployments = append(relevantDeployments, *deployment)
+			}
+		}
+	} else {
+		// if there is an active deployment, we need to filter out any deployments that we don't
+		// care about, namely the active deployment and any newer deployments
+		for i := range deployments {
+			deployment := deployments[i]
+			if deployment != activeDeployment && deploymentVersionFor(deployment) < deploymentVersionFor(activeDeployment) {
+				relevantDeployments = append(relevantDeployments, *deployment)
+			}
+		}
+	}
+
+	return relevantDeployments
+}
+
+// RecordConfigChangeCause sets a deployment config cause for config change.
+func RecordConfigChangeCause(config *appsv1.DeploymentConfig) {
+	config.Status.Details = &appsv1.DeploymentDetails{
+		Causes: []appsv1.DeploymentCause{
+			{
+				Type: appsv1.DeploymentTriggerOnConfigChange,
+			},
+		},
+		Message: "config change",
+	}
+}
+
+// RecordImageChangeCauses sets a deployment config cause for image change. It
+// takes a list of changed images and record an cause for each image.
+func RecordImageChangeCauses(config *appsv1.DeploymentConfig, imageNames []string) {
+	config.Status.Details = &appsv1.DeploymentDetails{
+		Message: "image change",
+	}
+	for _, imageName := range imageNames {
+		config.Status.Details.Causes = append(config.Status.Details.Causes, appsv1.DeploymentCause{
+			Type:         appsv1.DeploymentTriggerOnImageChange,
+			ImageTrigger: &appsv1.DeploymentCauseImageTrigger{From: v1.ObjectReference{Kind: "DockerImage", Name: imageName}},
+		})
+	}
+}
+
+// HasUpdatedImages indicates if the deployment configuration images were updated.
+func HasUpdatedImages(dc *appsv1.DeploymentConfig, rc *v1.ReplicationController) (bool, []string) {
+	updatedImages := []string{}
+	rcImages := sets.NewString()
+	for _, c := range rc.Spec.Template.Spec.Containers {
+		rcImages.Insert(c.Image)
+	}
+	for _, c := range dc.Spec.Template.Spec.Containers {
+		if !rcImages.Has(c.Image) {
+			updatedImages = append(updatedImages, c.Image)
+		}
+	}
+	if len(updatedImages) == 0 {
+		return false, nil
+	}
+	return true, updatedImages
+}
+
+// IsProgressing expects a state deployment config and its updated status in order to
+// determine if there is any progress.
+func IsProgressing(config *appsv1.DeploymentConfig, newStatus *appsv1.DeploymentConfigStatus) bool {
+	oldStatusOldReplicas := config.Status.Replicas - config.Status.UpdatedReplicas
+	newStatusOldReplicas := newStatus.Replicas - newStatus.UpdatedReplicas
+
+	return (newStatus.UpdatedReplicas > config.Status.UpdatedReplicas) || (newStatusOldReplicas < oldStatusOldReplicas)
+}
+
+// LabelForDeployment builds a string identifier for a Deployment.
+func LabelForDeployment(deployment *v1.ReplicationController) string {
+	return fmt.Sprintf("%s/%s", deployment.Namespace, deployment.Name)
+}
+
+// LabelForDeploymentConfig builds a string identifier for a DeploymentConfig.
+func LabelForDeploymentConfig(config runtime.Object) string {
+	accessor, _ := meta.Accessor(config)
+	return fmt.Sprintf("%s/%s", accessor.GetNamespace(), accessor.GetName())
+}
+
+// DeploymentDesiredReplicas returns number of desired replica for the given replication controller
+func DeploymentDesiredReplicas(obj runtime.Object) (int32, bool) {
+	return int32AnnotationFor(obj, appsv1.DesiredReplicasAnnotation)
+}
+
+// LatestDeploymentNameForConfig returns a stable identifier for deployment config
+func LatestDeploymentNameForConfig(config *appsv1.DeploymentConfig) string {
+	return LatestDeploymentNameForConfigAndVersion(config.Name, config.Status.LatestVersion)
+}
+
+// DeploymentNameForConfigVersion returns the name of the version-th deployment
+// for the config that has the provided name
+func DeploymentNameForConfigVersion(name string, version int64) string {
+	return fmt.Sprintf("%s-%d", name, version)
+}
+
+// LatestDeploymentNameForConfigAndVersion returns a stable identifier for config based on its version.
+func LatestDeploymentNameForConfigAndVersion(name string, version int64) string {
+	return fmt.Sprintf("%s-%d", name, version)
+}
+
+func DeployerPodNameFor(obj runtime.Object) string {
+	return AnnotationFor(obj, appsv1.DeploymentPodAnnotation)
+}
+
+func DeploymentConfigNameFor(obj runtime.Object) string {
+	return AnnotationFor(obj, appsv1.DeploymentConfigAnnotation)
+}
+
+func DeploymentStatusReasonFor(obj runtime.Object) string {
+	return AnnotationFor(obj, appsv1.DeploymentStatusReasonAnnotation)
+}
+
+func DeleteStatusReasons(rc *v1.ReplicationController) {
+	delete(rc.Annotations, appsv1.DeploymentStatusReasonAnnotation)
+	delete(rc.Annotations, appsv1.DeploymentCancelledAnnotation)
+}
+
+func SetCancelledByUserReason(rc *v1.ReplicationController) {
+	rc.Annotations[appsv1.DeploymentCancelledAnnotation] = "true"
+	rc.Annotations[appsv1.DeploymentStatusReasonAnnotation] = deploymentCancelledByUser
+}
+
+func SetCancelledByNewerDeployment(rc *v1.ReplicationController) {
+	rc.Annotations[appsv1.DeploymentCancelledAnnotation] = "true"
+	rc.Annotations[appsv1.DeploymentStatusReasonAnnotation] = deploymentCancelledNewerDeploymentExists
+}
+
+// HasSynced checks if the provided deployment config has been noticed by the deployment
+// config controller.
+func HasSynced(dc *appsv1.DeploymentConfig, generation int64) bool {
+	return dc.Status.ObservedGeneration >= generation
+}
+
+// HasChangeTrigger returns whether the provided deployment configuration has
+// a config change trigger or not
+func HasChangeTrigger(config *appsv1.DeploymentConfig) bool {
+	for _, trigger := range config.Spec.Triggers {
+		if trigger.Type == appsv1.DeploymentTriggerOnConfigChange {
+			return true
+		}
+	}
+	return false
+}
+
+// HasTrigger returns whether the provided deployment configuration has any trigger
+// defined or not.
+func HasTrigger(config *appsv1.DeploymentConfig) bool {
+	return HasChangeTrigger(config) || HasImageChangeTrigger(config)
+}
+
+// HasLastTriggeredImage returns whether all image change triggers in provided deployment
+// configuration has the lastTriggerImage field set (iow. all images were updated for
+// them). Returns false if deployment configuration has no image change trigger defined.
+func HasLastTriggeredImage(config *appsv1.DeploymentConfig) bool {
+	hasImageTrigger := false
+	for _, trigger := range config.Spec.Triggers {
+		if trigger.Type == appsv1.DeploymentTriggerOnImageChange {
+			hasImageTrigger = true
+			if len(trigger.ImageChangeParams.LastTriggeredImage) == 0 {
+				return false
+			}
+		}
+	}
+	return hasImageTrigger
+}
+
+// IsInitialDeployment returns whether the deployment configuration is the first version
+// of this configuration.
+func IsInitialDeployment(config *appsv1.DeploymentConfig) bool {
+	return config.Status.LatestVersion == 0
+}
+
+// IsRollingConfig returns true if the strategy type is a rolling update.
+func IsRollingConfig(config *appsv1.DeploymentConfig) bool {
+	return config.Spec.Strategy.Type == appsv1.DeploymentStrategyTypeRolling
+}
+
+// ResolveFenceposts is copy from k8s deployment_utils to avoid unnecessary imports
+func ResolveFenceposts(maxSurge, maxUnavailable *intstrutil.IntOrString, desired int32) (int32, int32, error) {
+	surge, err := intstrutil.GetValueFromIntOrPercent(maxSurge, int(desired), true)
+	if err != nil {
+		return 0, 0, err
+	}
+	unavailable, err := intstrutil.GetValueFromIntOrPercent(maxUnavailable, int(desired), false)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	if surge == 0 && unavailable == 0 {
+		// Validation should never allow the user to explicitly use zero values for both maxSurge
+		// maxUnavailable. Due to rounding down maxUnavailable though, it may resolve to zero.
+		// If both fenceposts resolve to zero, then we should set maxUnavailable to 1 on the
+		// theory that surge might not work due to quota.
+		unavailable = 1
+	}
+
+	return int32(surge), int32(unavailable), nil
+}
+
+// MaxUnavailable returns the maximum unavailable pods a rolling deployment config can take.
+func MaxUnavailable(config *appsv1.DeploymentConfig) int32 {
+	if !IsRollingConfig(config) {
+		return int32(0)
+	}
+	// Error caught by validation
+	_, maxUnavailable, _ := ResolveFenceposts(config.Spec.Strategy.RollingParams.MaxSurge, config.Spec.Strategy.RollingParams.MaxUnavailable, config.Spec.Replicas)
+	return maxUnavailable
+}
+
+// MaxSurge returns the maximum surge pods a rolling deployment config can take.
+func MaxSurge(config appsv1.DeploymentConfig) int32 {
+	if !IsRollingConfig(&config) {
+		return int32(0)
+	}
+	// Error caught by validation
+	maxSurge, _, _ := ResolveFenceposts(config.Spec.Strategy.RollingParams.MaxSurge, config.Spec.Strategy.RollingParams.MaxUnavailable, config.Spec.Replicas)
+	return maxSurge
+}
+
+// AnnotationFor returns the annotation with key for obj.
+func AnnotationFor(obj runtime.Object, key string) string {
+	objectMeta, err := meta.Accessor(obj)
+	if err != nil {
+		return ""
+	}
+	if objectMeta == nil || reflect.ValueOf(objectMeta).IsNil() {
+		return ""
+	}
+	return objectMeta.GetAnnotations()[key]
+}
+
+// ActiveDeployment returns the latest complete deployment, or nil if there is
+// no such deployment. The active deployment is not always the same as the
+// latest deployment.
+func ActiveDeployment(input []*v1.ReplicationController) *v1.ReplicationController {
+	var activeDeployment *v1.ReplicationController
+	var lastCompleteDeploymentVersion int64 = 0
+	for i := range input {
+		deployment := input[i]
+		deploymentVersion := DeploymentVersionFor(deployment)
+		if IsCompleteDeployment(deployment) && deploymentVersion > lastCompleteDeploymentVersion {
+			activeDeployment = deployment
+			lastCompleteDeploymentVersion = deploymentVersion
+		}
+	}
+	return activeDeployment
+}
+
+// ConfigSelector returns a label Selector which can be used to find all
+// deployments for a DeploymentConfig.
+//
+// TODO: Using the annotation constant for now since the value is correct
+// but we could consider adding a new constant to the public types.
+func ConfigSelector(name string) labels.Selector {
+	return labels.SelectorFromValidatedSet(labels.Set{appsv1.DeploymentConfigAnnotation: name})
+}
+
+// IsCompleteDeployment returns true if the passed deployment is in state complete.
+func IsCompleteDeployment(deployment runtime.Object) bool {
+	return DeploymentStatusFor(deployment) == appsv1.DeploymentStatusComplete
+}
+
+// IsFailedDeployment returns true if the passed deployment failed.
+func IsFailedDeployment(deployment runtime.Object) bool {
+	return DeploymentStatusFor(deployment) == appsv1.DeploymentStatusFailed
+}
+
+// IsTerminatedDeployment returns true if the passed deployment has terminated (either
+// complete or failed).
+func IsTerminatedDeployment(deployment runtime.Object) bool {
+	return IsCompleteDeployment(deployment) || IsFailedDeployment(deployment)
+}
+
+func IsDeploymentCancelled(deployment runtime.Object) bool {
+	value := AnnotationFor(deployment, appsv1.DeploymentCancelledAnnotation)
+	return strings.EqualFold(value, "true")
+}
+
+// DeployerPodSelector returns a label Selector which can be used to find all
+// deployer pods associated with a deployment with name.
+func DeployerPodSelector(name string) labels.Selector {
+	return labels.SelectorFromValidatedSet(labels.Set{appsv1.DeployerPodForDeploymentLabel: name})
+}
+
+func DeploymentStatusFor(deployment runtime.Object) appsv1.DeploymentStatus {
+	return appsv1.DeploymentStatus(AnnotationFor(deployment, appsv1.DeploymentStatusAnnotation))
+}
+
+func SetDeploymentLatestVersionAnnotation(rc *v1.ReplicationController, version string) {
+	if rc.Annotations == nil {
+		rc.Annotations = map[string]string{}
+	}
+	rc.Annotations[appsv1.DeploymentVersionAnnotation] = version
+}
+
+func DeploymentVersionFor(obj runtime.Object) int64 {
+	v, err := strconv.ParseInt(AnnotationFor(obj, appsv1.DeploymentVersionAnnotation), 10, 64)
+	if err != nil {
+		return -1
+	}
+	return v
+}
+
+func DeploymentNameFor(obj runtime.Object) string {
+	return AnnotationFor(obj, appsv1.DeploymentAnnotation)
+}
+
+func deploymentVersionFor(obj runtime.Object) int64 {
+	v, err := strconv.ParseInt(AnnotationFor(obj, appsv1.DeploymentVersionAnnotation), 10, 64)
+	if err != nil {
+		return -1
+	}
+	return v
+}
+
+// LatestDeploymentInfo returns info about the latest deployment for a config,
+// or nil if there is no latest deployment. The latest deployment is not
+// always the same as the active deployment.
+func LatestDeploymentInfo(config *appsv1.DeploymentConfig, deployments []*v1.ReplicationController) (bool, *v1.ReplicationController) {
+	if config.Status.LatestVersion == 0 || len(deployments) == 0 {
+		return false, nil
+	}
+	sort.Sort(ByLatestVersionDesc(deployments))
+	candidate := deployments[0]
+	return deploymentVersionFor(candidate) == config.Status.LatestVersion, candidate
+}
+
+// GetDeploymentCondition returns the condition with the provided type.
+func GetDeploymentCondition(status appsv1.DeploymentConfigStatus, condType appsv1.DeploymentConditionType) *appsv1.DeploymentCondition {
+	for i := range status.Conditions {
+		c := status.Conditions[i]
+		if c.Type == condType {
+			return &c
+		}
+	}
+	return nil
+}
+
+// GetReplicaCountForDeployments returns the sum of all replicas for the
+// given deployments.
+func GetReplicaCountForDeployments(deployments []*v1.ReplicationController) int32 {
+	totalReplicaCount := int32(0)
+	for _, deployment := range deployments {
+		count := deployment.Spec.Replicas
+		if count == nil {
+			continue
+		}
+		totalReplicaCount += *count
+	}
+	return totalReplicaCount
+}
+
+// GetStatusReplicaCountForDeployments returns the sum of the replicas reported in the
+// status of the given deployments.
+func GetStatusReplicaCountForDeployments(deployments []*v1.ReplicationController) int32 {
+	totalReplicaCount := int32(0)
+	for _, deployment := range deployments {
+		totalReplicaCount += deployment.Status.Replicas
+	}
+	return totalReplicaCount
+}
+
+// GetReadyReplicaCountForReplicationControllers returns the number of ready pods corresponding to
+// the given replication controller.
+func GetReadyReplicaCountForReplicationControllers(replicationControllers []*v1.ReplicationController) int32 {
+	totalReadyReplicas := int32(0)
+	for _, rc := range replicationControllers {
+		if rc != nil {
+			totalReadyReplicas += rc.Status.ReadyReplicas
+		}
+	}
+	return totalReadyReplicas
+}
+
+// GetAvailableReplicaCountForReplicationControllers returns the number of available pods corresponding to
+// the given replication controller.
+func GetAvailableReplicaCountForReplicationControllers(replicationControllers []*v1.ReplicationController) int32 {
+	totalAvailableReplicas := int32(0)
+	for _, rc := range replicationControllers {
+		if rc != nil {
+			totalAvailableReplicas += rc.Status.AvailableReplicas
+		}
+	}
+	return totalAvailableReplicas
+}
+
+// HasImageChangeTrigger returns whether the provided deployment configuration has
+// an image change trigger or not.
+func HasImageChangeTrigger(config *appsv1.DeploymentConfig) bool {
+	for _, trigger := range config.Spec.Triggers {
+		if trigger.Type == appsv1.DeploymentTriggerOnImageChange {
+			return true
+		}
+	}
+	return false
+}
+
+// CanTransitionPhase returns whether it is allowed to go from the current to the next phase.
+func CanTransitionPhase(current, next appsv1.DeploymentStatus) bool {
+	switch current {
+	case appsv1.DeploymentStatusNew:
+		switch next {
+		case appsv1.DeploymentStatusPending,
+			appsv1.DeploymentStatusRunning,
+			appsv1.DeploymentStatusFailed,
+			appsv1.DeploymentStatusComplete:
+			return true
+		}
+	case appsv1.DeploymentStatusPending:
+		switch next {
+		case appsv1.DeploymentStatusRunning,
+			appsv1.DeploymentStatusFailed,
+			appsv1.DeploymentStatusComplete:
+			return true
+		}
+	case appsv1.DeploymentStatusRunning:
+		switch next {
+		case appsv1.DeploymentStatusFailed, appsv1.DeploymentStatusComplete:
+			return true
+		}
+	}
+	return false
+}
+
+func int32AnnotationFor(obj runtime.Object, key string) (int32, bool) {
+	s := AnnotationFor(obj, key)
+	if len(s) == 0 {
+		return 0, false
+	}
+	i, err := strconv.ParseInt(s, 10, 32)
+	if err != nil {
+		return 0, false
+	}
+	return int32(i), true
+}
+
+type ByLatestVersionAsc []*v1.ReplicationController
+
+func (d ByLatestVersionAsc) Len() int      { return len(d) }
+func (d ByLatestVersionAsc) Swap(i, j int) { d[i], d[j] = d[j], d[i] }
+func (d ByLatestVersionAsc) Less(i, j int) bool {
+	return DeploymentVersionFor(d[i]) < DeploymentVersionFor(d[j])
+}
+
+// ByLatestVersionDesc sorts deployments by LatestVersion descending.
+type ByLatestVersionDesc []*v1.ReplicationController
+
+func (d ByLatestVersionDesc) Len() int      { return len(d) }
+func (d ByLatestVersionDesc) Swap(i, j int) { d[i], d[j] = d[j], d[i] }
+func (d ByLatestVersionDesc) Less(i, j int) bool {
+	return DeploymentVersionFor(d[j]) < DeploymentVersionFor(d[i])
+}

--- a/pkg/apps/util/util_test.go
+++ b/pkg/apps/util/util_test.go
@@ -1,0 +1,425 @@
+package util
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	appsv1 "github.com/openshift/api/apps/v1"
+)
+
+func TestPodName(t *testing.T) {
+	deployment := &corev1.ReplicationController{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "testName",
+		},
+	}
+	expected := "testName-deploy"
+	actual := DeployerPodNameForDeployment(deployment.Name)
+	if expected != actual {
+		t.Errorf("Unexpected pod name for deployment. Expected: %s Got: %s", expected, actual)
+	}
+}
+
+func TestCanTransitionPhase(t *testing.T) {
+	tests := []struct {
+		name          string
+		current, next appsv1.DeploymentStatus
+		expected      bool
+	}{
+		{
+			name:     "New->New",
+			current:  appsv1.DeploymentStatusNew,
+			next:     appsv1.DeploymentStatusNew,
+			expected: false,
+		},
+		{
+			name:     "New->Pending",
+			current:  appsv1.DeploymentStatusNew,
+			next:     appsv1.DeploymentStatusPending,
+			expected: true,
+		},
+		{
+			name:     "New->Running",
+			current:  appsv1.DeploymentStatusNew,
+			next:     appsv1.DeploymentStatusRunning,
+			expected: true,
+		},
+		{
+			name:     "New->Complete",
+			current:  appsv1.DeploymentStatusNew,
+			next:     appsv1.DeploymentStatusComplete,
+			expected: true,
+		},
+		{
+			name:     "New->Failed",
+			current:  appsv1.DeploymentStatusNew,
+			next:     appsv1.DeploymentStatusFailed,
+			expected: true,
+		},
+		{
+			name:     "Pending->New",
+			current:  appsv1.DeploymentStatusPending,
+			next:     appsv1.DeploymentStatusNew,
+			expected: false,
+		},
+		{
+			name:     "Pending->Pending",
+			current:  appsv1.DeploymentStatusPending,
+			next:     appsv1.DeploymentStatusPending,
+			expected: false,
+		},
+		{
+			name:     "Pending->Running",
+			current:  appsv1.DeploymentStatusPending,
+			next:     appsv1.DeploymentStatusRunning,
+			expected: true,
+		},
+		{
+			name:     "Pending->Failed",
+			current:  appsv1.DeploymentStatusPending,
+			next:     appsv1.DeploymentStatusFailed,
+			expected: true,
+		},
+		{
+			name:     "Pending->Complete",
+			current:  appsv1.DeploymentStatusPending,
+			next:     appsv1.DeploymentStatusComplete,
+			expected: true,
+		},
+		{
+			name:     "Running->New",
+			current:  appsv1.DeploymentStatusRunning,
+			next:     appsv1.DeploymentStatusNew,
+			expected: false,
+		},
+		{
+			name:     "Running->Pending",
+			current:  appsv1.DeploymentStatusRunning,
+			next:     appsv1.DeploymentStatusPending,
+			expected: false,
+		},
+		{
+			name:     "Running->Running",
+			current:  appsv1.DeploymentStatusRunning,
+			next:     appsv1.DeploymentStatusRunning,
+			expected: false,
+		},
+		{
+			name:     "Running->Failed",
+			current:  appsv1.DeploymentStatusRunning,
+			next:     appsv1.DeploymentStatusFailed,
+			expected: true,
+		},
+		{
+			name:     "Running->Complete",
+			current:  appsv1.DeploymentStatusRunning,
+			next:     appsv1.DeploymentStatusComplete,
+			expected: true,
+		},
+		{
+			name:     "Complete->New",
+			current:  appsv1.DeploymentStatusComplete,
+			next:     appsv1.DeploymentStatusNew,
+			expected: false,
+		},
+		{
+			name:     "Complete->Pending",
+			current:  appsv1.DeploymentStatusComplete,
+			next:     appsv1.DeploymentStatusPending,
+			expected: false,
+		},
+		{
+			name:     "Complete->Running",
+			current:  appsv1.DeploymentStatusComplete,
+			next:     appsv1.DeploymentStatusRunning,
+			expected: false,
+		},
+		{
+			name:     "Complete->Failed",
+			current:  appsv1.DeploymentStatusComplete,
+			next:     appsv1.DeploymentStatusFailed,
+			expected: false,
+		},
+		{
+			name:     "Complete->Complete",
+			current:  appsv1.DeploymentStatusComplete,
+			next:     appsv1.DeploymentStatusComplete,
+			expected: false,
+		},
+		{
+			name:     "Failed->New",
+			current:  appsv1.DeploymentStatusFailed,
+			next:     appsv1.DeploymentStatusNew,
+			expected: false,
+		},
+		{
+			name:     "Failed->Pending",
+			current:  appsv1.DeploymentStatusFailed,
+			next:     appsv1.DeploymentStatusPending,
+			expected: false,
+		},
+		{
+			name:     "Failed->Running",
+			current:  appsv1.DeploymentStatusFailed,
+			next:     appsv1.DeploymentStatusRunning,
+			expected: false,
+		},
+		{
+			name:     "Failed->Complete",
+			current:  appsv1.DeploymentStatusFailed,
+			next:     appsv1.DeploymentStatusComplete,
+			expected: false,
+		},
+		{
+			name:     "Failed->Failed",
+			current:  appsv1.DeploymentStatusFailed,
+			next:     appsv1.DeploymentStatusFailed,
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		got := CanTransitionPhase(test.current, test.next)
+		if got != test.expected {
+			t.Errorf("%s: expected %t, got %t", test.name, test.expected, got)
+		}
+	}
+}
+
+var (
+	now     = metav1.Now()
+	later   = metav1.Time{Time: now.Add(time.Minute)}
+	earlier = metav1.Time{Time: now.Add(-time.Minute)}
+
+	condProgressing = func() appsv1.DeploymentCondition {
+		return appsv1.DeploymentCondition{
+			Type:               appsv1.DeploymentProgressing,
+			Status:             corev1.ConditionTrue,
+			LastTransitionTime: now,
+		}
+	}
+
+	condProgressingDifferentTime = func() appsv1.DeploymentCondition {
+		return appsv1.DeploymentCondition{
+			Type:               appsv1.DeploymentProgressing,
+			Status:             corev1.ConditionTrue,
+			LastTransitionTime: later,
+		}
+	}
+
+	condProgressingDifferentReason = func() appsv1.DeploymentCondition {
+		return appsv1.DeploymentCondition{
+			Type:               appsv1.DeploymentProgressing,
+			Status:             corev1.ConditionTrue,
+			LastTransitionTime: later,
+			Reason:             NewReplicationControllerReason,
+		}
+	}
+
+	condNotProgressing = func() appsv1.DeploymentCondition {
+		return appsv1.DeploymentCondition{
+			Type:               appsv1.DeploymentProgressing,
+			Status:             corev1.ConditionFalse,
+			LastUpdateTime:     earlier,
+			LastTransitionTime: earlier,
+		}
+	}
+
+	condAvailable = func() appsv1.DeploymentCondition {
+		return appsv1.DeploymentCondition{
+			Type:   appsv1.DeploymentAvailable,
+			Status: corev1.ConditionTrue,
+		}
+	}
+)
+
+func TestGetCondition(t *testing.T) {
+	exampleStatus := func() appsv1.DeploymentConfigStatus {
+		return appsv1.DeploymentConfigStatus{
+			Conditions: []appsv1.DeploymentCondition{condProgressing(), condAvailable()},
+		}
+	}
+
+	tests := []struct {
+		name string
+
+		status     appsv1.DeploymentConfigStatus
+		condType   appsv1.DeploymentConditionType
+		condStatus corev1.ConditionStatus
+
+		expected bool
+	}{
+		{
+			name: "condition exists",
+
+			status:   exampleStatus(),
+			condType: appsv1.DeploymentAvailable,
+
+			expected: true,
+		},
+		{
+			name: "condition does not exist",
+
+			status:   exampleStatus(),
+			condType: appsv1.DeploymentReplicaFailure,
+
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		cond := GetDeploymentCondition(test.status, test.condType)
+		exists := cond != nil
+		if exists != test.expected {
+			t.Errorf("%s: expected condition to exist: %t, got: %t", test.name, test.expected, exists)
+		}
+	}
+}
+
+func TestSetCondition(t *testing.T) {
+	tests := []struct {
+		name string
+
+		status *appsv1.DeploymentConfigStatus
+		cond   appsv1.DeploymentCondition
+
+		expectedStatus *appsv1.DeploymentConfigStatus
+	}{
+		{
+			name: "set for the first time",
+
+			status: &appsv1.DeploymentConfigStatus{},
+			cond:   condAvailable(),
+
+			expectedStatus: &appsv1.DeploymentConfigStatus{
+				Conditions: []appsv1.DeploymentCondition{
+					condAvailable(),
+				},
+			},
+		},
+		{
+			name: "simple set",
+
+			status: &appsv1.DeploymentConfigStatus{
+				Conditions: []appsv1.DeploymentCondition{
+					condProgressing(),
+				},
+			},
+			cond: condAvailable(),
+
+			expectedStatus: &appsv1.DeploymentConfigStatus{
+				Conditions: []appsv1.DeploymentCondition{
+					condProgressing(), condAvailable(),
+				},
+			},
+		},
+		{
+			name: "replace if status changes",
+
+			status: &appsv1.DeploymentConfigStatus{
+				Conditions: []appsv1.DeploymentCondition{
+					condNotProgressing(),
+				},
+			},
+			cond: condProgressing(),
+
+			expectedStatus: &appsv1.DeploymentConfigStatus{Conditions: []appsv1.DeploymentCondition{condProgressing()}},
+		},
+		{
+			name: "replace if reason changes",
+
+			status: &appsv1.DeploymentConfigStatus{
+				Conditions: []appsv1.DeploymentCondition{
+					condProgressing(),
+				},
+			},
+			cond: condProgressingDifferentReason(),
+
+			expectedStatus: &appsv1.DeploymentConfigStatus{
+				Conditions: []appsv1.DeploymentCondition{
+					{
+						Type:   appsv1.DeploymentProgressing,
+						Status: corev1.ConditionTrue,
+						// Note that LastTransitionTime stays the same.
+						LastTransitionTime: now,
+						// Only the reason changes.
+						Reason: NewReplicationControllerReason,
+					},
+				},
+			},
+		},
+		{
+			name: "don't replace if status and reason don't change",
+
+			status: &appsv1.DeploymentConfigStatus{
+				Conditions: []appsv1.DeploymentCondition{
+					condProgressing(),
+				},
+			},
+			cond: condProgressingDifferentTime(),
+
+			expectedStatus: &appsv1.DeploymentConfigStatus{Conditions: []appsv1.DeploymentCondition{condProgressing()}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Logf("running test %q", test.name)
+		SetDeploymentCondition(test.status, test.cond)
+		if !reflect.DeepEqual(test.status, test.expectedStatus) {
+			t.Errorf("expected status: %v, got: %v", test.expectedStatus, test.status)
+		}
+	}
+}
+
+func TestRemoveCondition(t *testing.T) {
+	exampleStatus := func() *appsv1.DeploymentConfigStatus {
+		return &appsv1.DeploymentConfigStatus{
+			Conditions: []appsv1.DeploymentCondition{condProgressing(), condAvailable()},
+		}
+	}
+
+	tests := []struct {
+		name string
+
+		status   *appsv1.DeploymentConfigStatus
+		condType appsv1.DeploymentConditionType
+
+		expectedStatus *appsv1.DeploymentConfigStatus
+	}{
+		{
+			name: "remove from empty status",
+
+			status:   &appsv1.DeploymentConfigStatus{},
+			condType: appsv1.DeploymentProgressing,
+
+			expectedStatus: &appsv1.DeploymentConfigStatus{},
+		},
+		{
+			name: "simple remove",
+
+			status:   &appsv1.DeploymentConfigStatus{Conditions: []appsv1.DeploymentCondition{condProgressing()}},
+			condType: appsv1.DeploymentProgressing,
+
+			expectedStatus: &appsv1.DeploymentConfigStatus{},
+		},
+		{
+			name: "doesn't remove anything",
+
+			status:   exampleStatus(),
+			condType: appsv1.DeploymentReplicaFailure,
+
+			expectedStatus: exampleStatus(),
+		},
+	}
+
+	for _, test := range tests {
+		RemoveDeploymentCondition(test.status, test.condType)
+		if !reflect.DeepEqual(test.status, test.expectedStatus) {
+			t.Errorf("%s: expected status: %v, got: %v", test.name, test.expectedStatus, test.status)
+		}
+	}
+}


### PR DESCRIPTION
Summary of changes:

* Removed `rcMapper` and `NewReplicationControllerScaleClient` (they depend on k8s.io/kubernetes)
* Split decoding, encoding and schema installation to separate packages
* Mechanical move of other utils.