### PR TITLE
move scopes and groupification out

### DIFF
--- a/pkg/authorization/scopemetadata/clusterrole_describers.go
+++ b/pkg/authorization/scopemetadata/clusterrole_describers.go
@@ -1,0 +1,86 @@
+package scopelibrary
+
+import (
+	"fmt"
+	"strings"
+)
+
+// role:<clusterrole name>:<namespace to allow the cluster role, * means all>
+type ClusterRoleEvaluator struct{}
+
+var clusterRoleEvaluatorInstance = ClusterRoleEvaluator{}
+
+func (ClusterRoleEvaluator) Handles(scope string) bool {
+	return ClusterRoleEvaluatorHandles(scope)
+}
+
+func (e ClusterRoleEvaluator) Validate(scope string) error {
+	_, _, _, err := ClusterRoleEvaluatorParseScope(scope)
+	return err
+}
+
+func (e ClusterRoleEvaluator) Describe(scope string) (string, string, error) {
+	roleName, scopeNamespace, escalating, err := ClusterRoleEvaluatorParseScope(scope)
+	if err != nil {
+		return "", "", err
+	}
+
+	// Anything you can do [in project "foo" | server-wide] that is also allowed by the "admin" role[, except access escalating resources like secrets]
+
+	scopePhrase := ""
+	if scopeNamespace == scopesAllNamespaces {
+		scopePhrase = "server-wide"
+	} else {
+		scopePhrase = fmt.Sprintf("in project %q", scopeNamespace)
+	}
+
+	warning := ""
+	escalatingPhrase := ""
+	if escalating {
+		warning = fmt.Sprintf("Includes access to escalating resources like secrets")
+	} else {
+		escalatingPhrase = ", except access escalating resources like secrets"
+	}
+
+	description := fmt.Sprintf("Anything you can do %s that is also allowed by the %q role%s", scopePhrase, roleName, escalatingPhrase)
+
+	return description, warning, nil
+}
+
+func ClusterRoleEvaluatorHandles(scope string) bool {
+	return strings.HasPrefix(scope, clusterRoleIndicator)
+}
+
+// ClusterRoleEvaluatorParseScope parses the requested scope, determining the requested role name, namespace, and if
+// access to escalating objects is required.  It will return an error if it doesn't parse cleanly
+func ClusterRoleEvaluatorParseScope(scope string) (string /*role name*/, string /*namespace*/, bool /*escalating*/, error) {
+	if !ClusterRoleEvaluatorHandles(scope) {
+		return "", "", false, fmt.Errorf("bad format for scope %v", scope)
+	}
+	return parseClusterRoleScope(scope)
+}
+
+func parseClusterRoleScope(scope string) (string /*role name*/, string /*namespace*/, bool /*escalating*/, error) {
+	if !strings.HasPrefix(scope, clusterRoleIndicator) {
+		return "", "", false, fmt.Errorf("bad format for scope %v", scope)
+	}
+	escalating := false
+	if strings.HasSuffix(scope, ":!") {
+		escalating = true
+		// clip that last segment before parsing the rest
+		scope = scope[:strings.LastIndex(scope, ":")]
+	}
+
+	tokens := strings.SplitN(scope, ":", 2)
+	if len(tokens) != 2 {
+		return "", "", false, fmt.Errorf("bad format for scope %v", scope)
+	}
+
+	// namespaces can't have colons, but roles can.  pick last.
+	lastColonIndex := strings.LastIndex(tokens[1], ":")
+	if lastColonIndex <= 0 || lastColonIndex == (len(tokens[1])-1) {
+		return "", "", false, fmt.Errorf("bad format for scope %v", scope)
+	}
+
+	return tokens[1][0:lastColonIndex], tokens[1][lastColonIndex+1:], escalating, nil
+}

--- a/pkg/authorization/scopemetadata/describers.go
+++ b/pkg/authorization/scopemetadata/describers.go
@@ -1,0 +1,17 @@
+package scopelibrary
+
+// ScopeDescriber takes a scope and returns metadata about it
+type ScopeDescriber interface {
+	// Handles returns true if this evaluator can evaluate this scope
+	Handles(scope string) bool
+	// Validate returns an error if the scope is malformed
+	Validate(scope string) error
+	// Describe returns a description, warning (typically used to warn about escalation dangers), or an error if the scope is malformed
+	Describe(scope string) (description string, warning string, err error)
+}
+
+// ScopeDescribers map prefixes to a function that handles that prefix
+var ScopeDescribers = []ScopeDescriber{
+	UserEvaluator{},
+	ClusterRoleEvaluator{},
+}

--- a/pkg/authorization/scopemetadata/user_describers.go
+++ b/pkg/authorization/scopemetadata/user_describers.go
@@ -1,0 +1,68 @@
+package scopelibrary
+
+import (
+	"fmt"
+)
+
+// these must agree with the scope authorizer, but it's an API we cannot realistically change
+const (
+	scopesAllNamespaces = "*"
+
+	userIndicator        = "user:"
+	clusterRoleIndicator = "role:"
+
+	userInfo        = userIndicator + "info"
+	userAccessCheck = userIndicator + "check-access"
+
+	// UserListScopedProjects gives explicit permission to see the projects that this token can see.
+	userListScopedProjects = userIndicator + "list-scoped-projects"
+
+	// UserListAllProjects gives explicit permission to see the projects a user can see.  This is often used to prime secondary ACL systems
+	// unrelated to openshift and to display projects for selection in a secondary UI.
+	userListAllProjects = userIndicator + "list-projects"
+
+	// UserFull includes all permissions of the user
+	userFull = userIndicator + "full"
+)
+
+// user:<scope name>
+type UserEvaluator struct{}
+
+func (UserEvaluator) Handles(scope string) bool {
+	return UserEvaluatorHandles(scope)
+}
+
+func (e UserEvaluator) Validate(scope string) error {
+	if e.Handles(scope) {
+		return nil
+	}
+
+	return fmt.Errorf("unrecognized scope: %v", scope)
+}
+
+var defaultSupportedScopesMap = map[string]string{
+	userInfo:               "Read-only access to your user information (including username, identities, and group membership)",
+	userAccessCheck:        `Read-only access to view your privileges (for example, "can I create builds?")`,
+	userListScopedProjects: `Read-only access to list your projects viewable with this token and view their metadata (display name, description, etc.)`,
+	userListAllProjects:    `Read-only access to list your projects and view their metadata (display name, description, etc.)`,
+	userFull:               `Full read/write access with all of your permissions`,
+}
+
+func (UserEvaluator) Describe(scope string) (string, string, error) {
+	switch scope {
+	case userInfo, userAccessCheck, userListScopedProjects, userListAllProjects:
+		return defaultSupportedScopesMap[scope], "", nil
+	case userFull:
+		return defaultSupportedScopesMap[scope], `Includes any access you have to escalating resources like secrets`, nil
+	default:
+		return "", "", fmt.Errorf("unrecognized scope: %v", scope)
+	}
+}
+
+func UserEvaluatorHandles(scope string) bool {
+	switch scope {
+	case userFull, userInfo, userAccessCheck, userListScopedProjects, userListAllProjects:
+		return true
+	}
+	return false
+}

--- a/pkg/authorization/scopemetadata/validation.go
+++ b/pkg/authorization/scopemetadata/validation.go
@@ -1,0 +1,152 @@
+package scopelibrary
+
+import (
+	"fmt"
+
+	kutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	oauthv1 "github.com/openshift/api/oauth/v1"
+)
+
+func ValidateScopes(scopes []string, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if len(scopes) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath, "may not be empty"))
+	}
+
+	for i, scope := range scopes {
+		illegalCharacter := false
+		// https://tools.ietf.org/html/rfc6749#section-3.3 (full list of allowed chars is %x21 / %x23-5B / %x5D-7E)
+		// for those without an ascii table, that's `!`, `#-[`, `]-~` inclusive.
+		for _, ch := range scope {
+			switch {
+			case ch == '!':
+			case ch >= '#' && ch <= '[':
+			case ch >= ']' && ch <= '~':
+			default:
+				allErrs = append(allErrs, field.Invalid(fldPath.Index(i), scope, fmt.Sprintf("%v not allowed", ch)))
+				illegalCharacter = true
+			}
+		}
+		if illegalCharacter {
+			continue
+		}
+
+		found := false
+		for _, evaluator := range ScopeDescribers {
+			if !evaluator.Handles(scope) {
+				continue
+			}
+
+			found = true
+			if err := evaluator.Validate(scope); err != nil {
+				allErrs = append(allErrs, field.Invalid(fldPath.Index(i), scope, err.Error()))
+				break
+			}
+		}
+
+		if !found {
+			allErrs = append(allErrs, field.Invalid(fldPath.Index(i), scope, "no scope handler found"))
+		}
+	}
+
+	return allErrs
+}
+
+func ValidateScopeRestrictions(client *oauthv1.OAuthClient, scopes ...string) error {
+	if len(scopes) == 0 {
+		return fmt.Errorf("%s may not request unscoped tokens", client.Name)
+	}
+
+	if len(client.ScopeRestrictions) == 0 {
+		return nil
+	}
+
+	errs := []error{}
+	for _, scope := range scopes {
+		if err := validateScopeRestrictions(client, scope); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return kutilerrors.NewAggregate(errs)
+}
+
+func validateScopeRestrictions(client *oauthv1.OAuthClient, scope string) error {
+	errs := []error{}
+
+	for _, restriction := range client.ScopeRestrictions {
+		if len(restriction.ExactValues) > 0 {
+			if err := validateLiteralScopeRestrictions(scope, restriction.ExactValues); err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			return nil
+		}
+
+		if restriction.ClusterRole != nil {
+			if !ClusterRoleEvaluatorHandles(scope) {
+				continue
+			}
+			if err := validateClusterRoleScopeRestrictions(scope, *restriction.ClusterRole); err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			return nil
+		}
+	}
+
+	// if we got here, then nothing matched.   If we already have errors, do nothing, otherwise add one to make it report failed.
+	if len(errs) == 0 {
+		errs = append(errs, fmt.Errorf("%v did not match any scope restriction", scope))
+	}
+
+	return kutilerrors.NewAggregate(errs)
+}
+
+func validateLiteralScopeRestrictions(scope string, literals []string) error {
+	for _, literal := range literals {
+		if literal == scope {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("%v not found in %v", scope, literals)
+}
+
+func validateClusterRoleScopeRestrictions(scope string, restriction oauthv1.ClusterRoleScopeRestriction) error {
+	role, namespace, escalating, err := ClusterRoleEvaluatorParseScope(scope)
+	if err != nil {
+		return err
+	}
+
+	foundName := false
+	for _, restrictedRoleName := range restriction.RoleNames {
+		if restrictedRoleName == "*" || restrictedRoleName == role {
+			foundName = true
+			break
+		}
+	}
+	if !foundName {
+		return fmt.Errorf("%v does not use an approved name", scope)
+	}
+
+	foundNamespace := false
+	for _, restrictedNamespace := range restriction.Namespaces {
+		if restrictedNamespace == "*" || restrictedNamespace == namespace {
+			foundNamespace = true
+			break
+		}
+	}
+	if !foundNamespace {
+		return fmt.Errorf("%v does not use an approved namespace", scope)
+	}
+
+	if escalating && !restriction.AllowEscalation {
+		return fmt.Errorf("%v is not allowed to escalate", scope)
+	}
+
+	return nil
+}

--- a/pkg/authorization/scopemetadata/validation_test.go
+++ b/pkg/authorization/scopemetadata/validation_test.go
@@ -1,0 +1,141 @@
+package scopelibrary
+
+import (
+	"strings"
+	"testing"
+
+	oauthv1 "github.com/openshift/api/oauth/v1"
+)
+
+func TestValidateScopeRestrictions(t *testing.T) {
+	testCases := []struct {
+		name   string
+		scopes []string
+		client *oauthv1.OAuthClient
+
+		expectedErrors []string
+	}{
+		{
+			name:   "unrestricted allows any",
+			scopes: []string{"one"},
+			client: &oauthv1.OAuthClient{},
+		},
+		{
+			name:   "unrestricted allows empty",
+			scopes: []string{""},
+			client: &oauthv1.OAuthClient{},
+		},
+		{
+			name:           "missing scopes check precedes unrestricted",
+			scopes:         []string{},
+			client:         &oauthv1.OAuthClient{},
+			expectedErrors: []string{"may not request unscoped tokens"},
+		},
+		{
+			name:   "simple literal",
+			scopes: []string{"one"},
+			client: &oauthv1.OAuthClient{
+				ScopeRestrictions: []oauthv1.ScopeRestriction{{ExactValues: []string{"two", "one"}}},
+			},
+		},
+		{
+			name:   "simple must match",
+			scopes: []string{"missing"},
+			client: &oauthv1.OAuthClient{
+				ScopeRestrictions: []oauthv1.ScopeRestriction{{ExactValues: []string{"two", "one"}}},
+			},
+			expectedErrors: []string{`missing not found in [two one]`},
+		},
+		{
+			name:   "cluster role name must match",
+			scopes: []string{clusterRoleIndicator + "three:alfa"},
+			client: &oauthv1.OAuthClient{
+				ScopeRestrictions: []oauthv1.ScopeRestriction{{ClusterRole: &oauthv1.ClusterRoleScopeRestriction{
+					RoleNames:       []string{"one", "two"},
+					Namespaces:      []string{"alfa", "bravo"},
+					AllowEscalation: false,
+				}}},
+			},
+			expectedErrors: []string{`role:three:alfa does not use an approved name`},
+		},
+		{
+			name:   "cluster role namespace must match",
+			scopes: []string{clusterRoleIndicator + "two:charlie"},
+			client: &oauthv1.OAuthClient{
+				ScopeRestrictions: []oauthv1.ScopeRestriction{{ClusterRole: &oauthv1.ClusterRoleScopeRestriction{
+					RoleNames:       []string{"one", "two"},
+					Namespaces:      []string{"alfa", "bravo"},
+					AllowEscalation: false,
+				}}},
+			},
+			expectedErrors: []string{`role:two:charlie does not use an approved namespace`},
+		},
+		{
+			name:   "cluster role escalation must match",
+			scopes: []string{clusterRoleIndicator + "two:bravo:!"},
+			client: &oauthv1.OAuthClient{
+				ScopeRestrictions: []oauthv1.ScopeRestriction{{ClusterRole: &oauthv1.ClusterRoleScopeRestriction{
+					RoleNames:       []string{"one", "two"},
+					Namespaces:      []string{"alfa", "bravo"},
+					AllowEscalation: false,
+				}}},
+			},
+			expectedErrors: []string{`role:two:bravo:! is not allowed to escalate`},
+		},
+		{
+			name:   "cluster role matches",
+			scopes: []string{clusterRoleIndicator + "two:bravo:!"},
+			client: &oauthv1.OAuthClient{
+				ScopeRestrictions: []oauthv1.ScopeRestriction{{ClusterRole: &oauthv1.ClusterRoleScopeRestriction{
+					RoleNames:       []string{"one", "two"},
+					Namespaces:      []string{"alfa", "bravo"},
+					AllowEscalation: true,
+				}}},
+			},
+		},
+		{
+			name:   "cluster role matches 2",
+			scopes: []string{clusterRoleIndicator + "two:bravo"},
+			client: &oauthv1.OAuthClient{
+				ScopeRestrictions: []oauthv1.ScopeRestriction{{ClusterRole: &oauthv1.ClusterRoleScopeRestriction{
+					RoleNames:       []string{"one", "two"},
+					Namespaces:      []string{"alfa", "bravo"},
+					AllowEscalation: false,
+				}}},
+			},
+		},
+		{
+			name:   "cluster role star matches",
+			scopes: []string{clusterRoleIndicator + "two:bravo"},
+			client: &oauthv1.OAuthClient{
+				ScopeRestrictions: []oauthv1.ScopeRestriction{{ClusterRole: &oauthv1.ClusterRoleScopeRestriction{
+					RoleNames:       []string{"one", "two", "*"},
+					Namespaces:      []string{"alfa", "bravo", "*"},
+					AllowEscalation: true,
+				}}},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		err := ValidateScopeRestrictions(tc.client, tc.scopes...)
+		if err != nil && len(tc.expectedErrors) == 0 {
+			t.Errorf("%s: unexpected error: %v", tc.name, err)
+			continue
+		}
+		if err == nil && len(tc.expectedErrors) > 0 {
+			t.Errorf("%s: missing error: %v", tc.name, tc.expectedErrors)
+			continue
+		}
+		if err == nil && len(tc.expectedErrors) == 0 {
+			continue
+		}
+
+		for _, expectedErr := range tc.expectedErrors {
+			if !strings.Contains(err.Error(), expectedErr) {
+				t.Errorf("%s: error %v missing %v", tc.name, err, expectedErr)
+			}
+		}
+	}
+
+}

--- a/pkg/legacyapi/legacygroupification/groupification.go
+++ b/pkg/legacyapi/legacygroupification/groupification.go
@@ -1,0 +1,228 @@
+package legacygroupification
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	appsv1 "github.com/openshift/api/apps/v1"
+	authorizationv1 "github.com/openshift/api/authorization/v1"
+	buildv1 "github.com/openshift/api/build/v1"
+	imagev1 "github.com/openshift/api/image/v1"
+	networkv1 "github.com/openshift/api/network/v1"
+	oauthv1 "github.com/openshift/api/oauth/v1"
+	projectv1 "github.com/openshift/api/project/v1"
+	quotav1 "github.com/openshift/api/quota/v1"
+	routev1 "github.com/openshift/api/route/v1"
+	securityv1 "github.com/openshift/api/security/v1"
+	templatev1 "github.com/openshift/api/template/v1"
+	userv1 "github.com/openshift/api/user/v1"
+)
+
+// deprecated
+func IsOAPI(gvk schema.GroupVersionKind) bool {
+	if len(gvk.Group) > 0 {
+		return false
+	}
+
+	_, ok := oapiKindsToGroup[gvk.Kind]
+	return ok
+}
+
+// deprecated
+func OAPIToGroupifiedGVK(gvk *schema.GroupVersionKind) {
+	if len(gvk.Group) > 0 {
+		return
+	}
+
+	newGroup, ok := oapiKindsToGroup[gvk.Kind]
+	if !ok {
+		return
+	}
+	gvk.Group = newGroup
+}
+
+// deprecated
+func OAPIToGroupified(uncast runtime.Object, gvk *schema.GroupVersionKind) {
+	if len(gvk.Group) > 0 {
+		return
+	}
+
+	switch obj := uncast.(type) {
+	case *unstructured.Unstructured:
+		newGroup := fixOAPIGroupKindInTopLevelUnstructured(obj.Object)
+		if len(newGroup) > 0 {
+			gvk.Group = newGroup
+			uncast.GetObjectKind().SetGroupVersionKind(*gvk)
+		}
+	case *unstructured.UnstructuredList:
+		newGroup := fixOAPIGroupKindInTopLevelUnstructured(obj.Object)
+		if len(newGroup) > 0 {
+			gvk.Group = newGroup
+			uncast.GetObjectKind().SetGroupVersionKind(*gvk)
+		}
+
+	case *appsv1.DeploymentConfig, *appsv1.DeploymentConfigList,
+		*appsv1.DeploymentConfigRollback,
+		*appsv1.DeploymentLog,
+		*appsv1.DeploymentRequest:
+		gvk.Group = appsv1.GroupName
+		uncast.GetObjectKind().SetGroupVersionKind(*gvk)
+
+	case *authorizationv1.ClusterRoleBinding, *authorizationv1.ClusterRoleBindingList,
+		*authorizationv1.ClusterRole, *authorizationv1.ClusterRoleList,
+		*authorizationv1.Role, *authorizationv1.RoleList,
+		*authorizationv1.RoleBinding, *authorizationv1.RoleBindingList,
+		*authorizationv1.RoleBindingRestriction, *authorizationv1.RoleBindingRestrictionList,
+		*authorizationv1.SubjectRulesReview, *authorizationv1.SelfSubjectRulesReview,
+		*authorizationv1.ResourceAccessReview, *authorizationv1.LocalResourceAccessReview,
+		*authorizationv1.SubjectAccessReview, *authorizationv1.LocalSubjectAccessReview:
+		gvk.Group = authorizationv1.GroupName
+		uncast.GetObjectKind().SetGroupVersionKind(*gvk)
+
+	case *buildv1.BuildConfig, *buildv1.BuildConfigList,
+		*buildv1.Build, *buildv1.BuildList,
+		*buildv1.BuildLog,
+		*buildv1.BuildRequest,
+		*buildv1.BinaryBuildRequestOptions:
+		gvk.Group = buildv1.GroupName
+		uncast.GetObjectKind().SetGroupVersionKind(*gvk)
+
+	case *imagev1.Image, *imagev1.ImageList,
+		*imagev1.ImageSignature,
+		*imagev1.ImageStreamImage,
+		*imagev1.ImageStreamImport,
+		*imagev1.ImageStreamMapping,
+		*imagev1.ImageStream, *imagev1.ImageStreamList,
+		*imagev1.ImageStreamTag:
+		gvk.Group = imagev1.GroupName
+		uncast.GetObjectKind().SetGroupVersionKind(*gvk)
+
+	case *networkv1.ClusterNetwork, *networkv1.ClusterNetworkList,
+		*networkv1.NetNamespace, *networkv1.NetNamespaceList,
+		*networkv1.HostSubnet, *networkv1.HostSubnetList,
+		*networkv1.EgressNetworkPolicy, *networkv1.EgressNetworkPolicyList:
+		gvk.Group = networkv1.GroupName
+		uncast.GetObjectKind().SetGroupVersionKind(*gvk)
+
+	case *projectv1.Project, *projectv1.ProjectList,
+		*projectv1.ProjectRequest:
+		gvk.Group = projectv1.GroupName
+		uncast.GetObjectKind().SetGroupVersionKind(*gvk)
+
+	case *quotav1.ClusterResourceQuota, *quotav1.ClusterResourceQuotaList,
+		*quotav1.AppliedClusterResourceQuota, *quotav1.AppliedClusterResourceQuotaList:
+		gvk.Group = quotav1.GroupName
+		uncast.GetObjectKind().SetGroupVersionKind(*gvk)
+
+	case *oauthv1.OAuthAuthorizeToken, *oauthv1.OAuthAuthorizeTokenList,
+		*oauthv1.OAuthClientAuthorization, *oauthv1.OAuthClientAuthorizationList,
+		*oauthv1.OAuthClient, *oauthv1.OAuthClientList,
+		*oauthv1.OAuthAccessToken, *oauthv1.OAuthAccessTokenList:
+		gvk.Group = oauthv1.GroupName
+		uncast.GetObjectKind().SetGroupVersionKind(*gvk)
+
+	case *routev1.Route, *routev1.RouteList:
+		gvk.Group = routev1.GroupName
+		uncast.GetObjectKind().SetGroupVersionKind(*gvk)
+
+	case *securityv1.SecurityContextConstraints, *securityv1.SecurityContextConstraintsList,
+		*securityv1.PodSecurityPolicySubjectReview,
+		*securityv1.PodSecurityPolicySelfSubjectReview,
+		*securityv1.PodSecurityPolicyReview:
+		gvk.Group = securityv1.GroupName
+		uncast.GetObjectKind().SetGroupVersionKind(*gvk)
+
+	case *templatev1.Template, *templatev1.TemplateList:
+		gvk.Group = templatev1.GroupName
+		uncast.GetObjectKind().SetGroupVersionKind(*gvk)
+
+	case *userv1.Group, *userv1.GroupList,
+		*userv1.Identity, *userv1.IdentityList,
+		*userv1.UserIdentityMapping,
+		*userv1.User, *userv1.UserList:
+		gvk.Group = userv1.GroupName
+		uncast.GetObjectKind().SetGroupVersionKind(*gvk)
+
+	}
+}
+
+var oapiKindsToGroup = map[string]string{
+	"DeploymentConfigRollback": "apps.openshift.io",
+	"DeploymentConfig":         "apps.openshift.io", "DeploymentConfigList": "apps.openshift.io",
+	"DeploymentLog":      "apps.openshift.io",
+	"DeploymentRequest":  "apps.openshift.io",
+	"ClusterRoleBinding": "authorization.openshift.io", "ClusterRoleBindingList": "authorization.openshift.io",
+	"ClusterRole": "authorization.openshift.io", "ClusterRoleList": "authorization.openshift.io",
+	"RoleBindingRestriction": "authorization.openshift.io", "RoleBindingRestrictionList": "authorization.openshift.io",
+	"RoleBinding": "authorization.openshift.io", "RoleBindingList": "authorization.openshift.io",
+	"Role": "authorization.openshift.io", "RoleList": "authorization.openshift.io",
+	"SubjectRulesReview": "authorization.openshift.io", "SelfSubjectRulesReview": "authorization.openshift.io",
+	"ResourceAccessReview": "authorization.openshift.io", "LocalResourceAccessReview": "authorization.openshift.io",
+	"SubjectAccessReview": "authorization.openshift.io", "LocalSubjectAccessReview": "authorization.openshift.io",
+	"BuildConfig": "build.openshift.io", "BuildConfigList": "build.openshift.io",
+	"Build": "build.openshift.io", "BuildList": "build.openshift.io",
+	"BinaryBuildRequestOptions": "build.openshift.io",
+	"BuildLog":                  "build.openshift.io",
+	"BuildRequest":              "build.openshift.io",
+	"Image":                     "image.openshift.io", "ImageList": "image.openshift.io",
+	"ImageSignature":     "image.openshift.io",
+	"ImageStreamImage":   "image.openshift.io",
+	"ImageStreamImport":  "image.openshift.io",
+	"ImageStreamMapping": "image.openshift.io",
+	"ImageStream":        "image.openshift.io", "ImageStreamList": "image.openshift.io",
+	"ImageStreamTag": "image.openshift.io", "ImageStreamTagList": "image.openshift.io",
+	"ClusterNetwork": "network.openshift.io", "ClusterNetworkList": "network.openshift.io",
+	"EgressNetworkPolicy": "network.openshift.io", "EgressNetworkPolicyList": "network.openshift.io",
+	"HostSubnet": "network.openshift.io", "HostSubnetList": "network.openshift.io",
+	"NetNamespace": "network.openshift.io", "NetNamespaceList": "network.openshift.io",
+	"OAuthAccessToken": "oauth.openshift.io", "OAuthAccessTokenList": "oauth.openshift.io",
+	"OAuthAuthorizeToken": "oauth.openshift.io", "OAuthAuthorizeTokenList": "oauth.openshift.io",
+	"OAuthClientAuthorization": "oauth.openshift.io", "OAuthClientAuthorizationList": "oauth.openshift.io",
+	"OAuthClient": "oauth.openshift.io", "OAuthClientList": "oauth.openshift.io",
+	"Project": "project.openshift.io", "ProjectList": "project.openshift.io",
+	"ProjectRequest":       "project.openshift.io",
+	"ClusterResourceQuota": "quota.openshift.io", "ClusterResourceQuotaList": "quota.openshift.io",
+	"AppliedClusterResourceQuota": "quota.openshift.io", "AppliedClusterResourceQuotaList": "quota.openshift.io",
+	"Route": "route.openshift.io", "RouteList": "route.openshift.io",
+	"SecurityContextConstraints": "security.openshift.io", "SecurityContextConstraintsList": "security.openshift.io",
+	"PodSecurityPolicySubjectReview":     "security.openshift.io",
+	"PodSecurityPolicySelfSubjectReview": "security.openshift.io",
+	"PodSecurityPolicyReview":            "security.openshift.io",
+	"Template":                           "template.openshift.io", "TemplateList": "template.openshift.io",
+	"Group": "user.openshift.io", "GroupList": "user.openshift.io",
+	"Identity": "user.openshift.io", "IdentityList": "user.openshift.io",
+	"UserIdentityMapping": "user.openshift.io",
+	"User":                "user.openshift.io", "UserList": "user.openshift.io",
+}
+
+func fixOAPIGroupKindInTopLevelUnstructured(obj map[string]interface{}) string {
+	kind, ok := obj["kind"]
+	if !ok {
+		return ""
+	}
+	kindStr, ok := kind.(string)
+	if !ok {
+		return ""
+	}
+	newGroup, ok := oapiKindsToGroup[kindStr]
+	if !ok {
+		return ""
+	}
+
+	apiVersion, ok := obj["apiVersion"]
+	if !ok {
+		return newGroup
+	}
+	apiVersionStr, ok := apiVersion.(string)
+	if !ok {
+		return newGroup
+	}
+
+	if apiVersionStr != "v1" {
+		return newGroup
+	}
+	obj["apiVersion"] = newGroup + "/v1"
+
+	return newGroup
+}


### PR DESCRIPTION
shared by oauthserver, kube-apiserver, openshift-apiserver, and library-go.