### PR TITLE
Add missing build name helper

### DIFF
--- a/pkg/build/naming/namer.go
+++ b/pkg/build/naming/namer.go
@@ -5,6 +5,13 @@ import (
 	"hash/fnv"
 
 	kvalidation "k8s.io/apimachinery/pkg/util/validation"
+
+	buildv1 "github.com/openshift/api/build/v1"
+)
+
+const (
+	// buildPodSuffix is the suffix used to append to a build pod name given a build name
+	buildPodSuffix = "build"
 )
 
 // GetName returns a name given a base ("deployment-5") and a suffix ("deploy")
@@ -44,6 +51,11 @@ func GetPodName(base, suffix string) string {
 // GetConfigMapName calls GetName with the length restriction for ConfigMaps
 func GetConfigMapName(base, suffix string) string {
 	return GetName(base, suffix, kvalidation.DNS1123SubdomainMaxLength)
+}
+
+// GetBuildPodName returns name of the build pod.
+func GetBuildPodName(build *buildv1.Build) string {
+	return GetPodName(build.Name, buildPodSuffix)
 }
 
 // max returns the greater of its 2 inputs

--- a/pkg/build/naming/namer_test.go
+++ b/pkg/build/naming/namer_test.go
@@ -4,7 +4,10 @@ import (
 	"math/rand"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kvalidation "k8s.io/apimachinery/pkg/util/validation"
+
+	buildv1 "github.com/openshift/api/build/v1"
 )
 
 func TestGetName(t *testing.T) {
@@ -98,4 +101,10 @@ func randSeq(n int) string {
 		b[i] = letters[rand.Intn(len(letters))]
 	}
 	return string(b)
+}
+
+func TestGetBuildPodName(t *testing.T) {
+	if expected, actual := "mybuild-build", GetBuildPodName(&buildv1.Build{ObjectMeta: metav1.ObjectMeta{Name: "mybuild"}}); expected != actual {
+		t.Errorf("Expected %s, got %s", expected, actual)
+	}
 }


### PR DESCRIPTION
This helper function exists in 2 copies (sic!) and is heavily used across apiserver, controller manager and cli.
/assign @deads2k @mfojtik 
