### PR TITLE
image: add missing docker types

### DIFF
--- a/pkg/image/dockerv1client/conversion.go
+++ b/pkg/image/dockerv1client/conversion.go
@@ -1,0 +1,26 @@
+package dockerv1client
+
+import "github.com/openshift/api/image/docker10"
+
+// Convert_DockerV1CompatibilityImage_to_DockerImageConfig takes a Docker registry digest
+// (schema 2.1) and converts it to the external API version of Image.
+func Convert_DockerV1CompatibilityImage_to_DockerImageConfig(in *DockerV1CompatibilityImage, out *DockerImageConfig) error {
+	*out = DockerImageConfig{
+		ID:              in.ID,
+		Parent:          in.Parent,
+		Comment:         in.Comment,
+		Created:         in.Created,
+		Container:       in.Container,
+		DockerVersion:   in.DockerVersion,
+		Author:          in.Author,
+		Architecture:    in.Architecture,
+		Size:            in.Size,
+		OS:              "linux",
+		ContainerConfig: in.ContainerConfig,
+	}
+	if in.Config != nil {
+		out.Config = &docker10.DockerConfig{}
+		*out.Config = *in.Config
+	}
+	return nil
+}

--- a/pkg/image/dockerv1client/types.go
+++ b/pkg/image/dockerv1client/types.go
@@ -1,5 +1,11 @@
 package dockerv1client
 
+import (
+	"time"
+
+	"github.com/openshift/api/image/docker10"
+)
+
 // TODO: Move these to openshift/api
 
 // DockerImageManifest represents the Docker v2 image format.
@@ -47,4 +53,39 @@ type Descriptor struct {
 	// Digest uniquely identifies the content. A byte stream can be verified
 	// against against this digest.
 	Digest string `json:"digest,omitempty"`
+}
+
+// DockerImageConfig stores the image configuration
+type DockerImageConfig struct {
+	ID              string                 `json:"id"`
+	Parent          string                 `json:"parent,omitempty"`
+	Comment         string                 `json:"comment,omitempty"`
+	Created         time.Time              `json:"created"`
+	Container       string                 `json:"container,omitempty"`
+	ContainerConfig docker10.DockerConfig  `json:"container_config,omitempty"`
+	DockerVersion   string                 `json:"docker_version,omitempty"`
+	Author          string                 `json:"author,omitempty"`
+	Config          *docker10.DockerConfig `json:"config,omitempty"`
+	Architecture    string                 `json:"architecture,omitempty"`
+	Size            int64                  `json:"size,omitempty"`
+	RootFS          *DockerConfigRootFS    `json:"rootfs,omitempty"`
+	History         []DockerConfigHistory  `json:"history,omitempty"`
+	OS              string                 `json:"os,omitempty"`
+	OSVersion       string                 `json:"os.version,omitempty"`
+	OSFeatures      []string               `json:"os.features,omitempty"`
+}
+
+// DockerConfigHistory stores build commands that were used to create an image
+type DockerConfigHistory struct {
+	Created    time.Time `json:"created"`
+	Author     string    `json:"author,omitempty"`
+	CreatedBy  string    `json:"created_by,omitempty"`
+	Comment    string    `json:"comment,omitempty"`
+	EmptyLayer bool      `json:"empty_layer,omitempty"`
+}
+
+// DockerConfigRootFS describes images root filesystem
+type DockerConfigRootFS struct {
+	Type    string   `json:"type"`
+	DiffIDs []string `json:"diff_ids,omitempty"`
 }

--- a/pkg/image/dockerv1client/types.go
+++ b/pkg/image/dockerv1client/types.go
@@ -38,6 +38,28 @@ type DockerHistory struct {
 	DockerV1Compatibility string `json:"v1Compatibility"`
 }
 
+// DockerV1CompatibilityImage represents the structured v1
+// compatibility information.
+type DockerV1CompatibilityImage struct {
+	ID              string                 `json:"id"`
+	Parent          string                 `json:"parent,omitempty"`
+	Comment         string                 `json:"comment,omitempty"`
+	Created         time.Time              `json:"created"`
+	Container       string                 `json:"container,omitempty"`
+	ContainerConfig docker10.DockerConfig  `json:"container_config,omitempty"`
+	DockerVersion   string                 `json:"docker_version,omitempty"`
+	Author          string                 `json:"author,omitempty"`
+	Config          *docker10.DockerConfig `json:"config,omitempty"`
+	Architecture    string                 `json:"architecture,omitempty"`
+	Size            int64                  `json:"size,omitempty"`
+}
+
+// DockerV1CompatibilityImageSize represents the structured v1
+// compatibility information for size
+type DockerV1CompatibilityImageSize struct {
+	Size int64 `json:"size,omitempty"`
+}
+
 // Descriptor describes targeted content. Used in conjunction with a blob
 // store, a descriptor can be used to fetch, store and target any kind of
 // blob. The struct also describes the wire protocol format. Fields should


### PR DESCRIPTION
These are missing in openshift/api, but are only needed by `oc` when manipulating with docker images. We can upstream all this to openshift/api, but this should get us started.