### PR TITLE
add helpers shared with e2e tests

### DIFF
--- a/pkg/image/imageutil/helpers.go
+++ b/pkg/image/imageutil/helpers.go
@@ -1,6 +1,7 @@
 package imageutil
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"sort"
@@ -8,7 +9,10 @@ import (
 
 	"github.com/blang/semver"
 
+	"github.com/openshift/api/image/docker10"
+	imagev1 "github.com/openshift/api/image/v1"
 	digestinternal "github.com/openshift/library-go/pkg/image/internal/digest"
+	imagereference "github.com/openshift/library-go/pkg/image/reference"
 )
 
 const (
@@ -198,5 +202,137 @@ func PrioritizeTags(tags []string) {
 	sort.Sort(ptags)
 	for i, pt := range ptags {
 		tags[i] = pt.tag
+	}
+}
+
+// StatusHasTag returns named tag from image stream's status and boolean whether one was found.
+func StatusHasTag(stream *imagev1.ImageStream, name string) (imagev1.NamedTagEventList, bool) {
+	for _, tag := range stream.Status.Tags {
+		if tag.Tag == name {
+			return tag, true
+		}
+	}
+	return imagev1.NamedTagEventList{}, false
+}
+
+// LatestTaggedImage returns the most recent TagEvent for the specified image
+// repository and tag. Will resolve lookups for the empty tag. Returns nil
+// if tag isn't present in stream.status.tags.
+func LatestTaggedImage(stream *imagev1.ImageStream, tag string) *imagev1.TagEvent {
+	if len(tag) == 0 {
+		tag = imagev1.DefaultImageTag
+	}
+
+	// find the most recent tag event with an image reference
+	t, ok := StatusHasTag(stream, tag)
+	if ok {
+		if len(t.Items) == 0 {
+			return nil
+		}
+		return &t.Items[0]
+	}
+
+	return nil
+}
+
+// ImageWithMetadata mutates the given image. It parses raw DockerImageManifest data stored in the image and
+// fills its DockerImageMetadata and other fields.
+// Copied from github.com/openshift/image-registry/pkg/origin-common/util/util.go
+func ImageWithMetadata(image *imagev1.Image) error {
+	// Check if the metadata are already filled in for this image.
+	meta, hasMetadata := image.DockerImageMetadata.Object.(*docker10.DockerImage)
+	if hasMetadata && meta.Size > 0 {
+		return nil
+	}
+
+	version := image.DockerImageMetadataVersion
+	if len(version) == 0 {
+		version = "1.0"
+	}
+
+	obj := &docker10.DockerImage{}
+	if len(image.DockerImageMetadata.Raw) != 0 {
+		if err := json.Unmarshal(image.DockerImageMetadata.Raw, obj); err != nil {
+			return err
+		}
+		image.DockerImageMetadata.Object = obj
+	}
+
+	image.DockerImageMetadataVersion = version
+
+	return nil
+}
+
+func ImageWithMetadataOrDie(image *imagev1.Image) {
+	if err := ImageWithMetadata(image); err != nil {
+		panic(err)
+	}
+}
+
+// ResolveLatestTaggedImage returns the appropriate pull spec for a given tag in
+// the image stream, handling the tag's reference policy if necessary to return
+// a resolved image. Callers that transform an ImageStreamTag into a pull spec
+// should use this method instead of LatestTaggedImage.
+func ResolveLatestTaggedImage(stream *imagev1.ImageStream, tag string) (string, bool) {
+	if len(tag) == 0 {
+		tag = imagev1.DefaultImageTag
+	}
+	return resolveTagReference(stream, tag, LatestTaggedImage(stream, tag))
+}
+
+// ResolveTagReference applies the tag reference rules for a stream, tag, and tag event for
+// that tag. It returns true if the tag is
+func resolveTagReference(stream *imagev1.ImageStream, tag string, latest *imagev1.TagEvent) (string, bool) {
+	if latest == nil {
+		return "", false
+	}
+	return resolveReferenceForTagEvent(stream, tag, latest), true
+}
+
+// SpecHasTag returns named tag from image stream's spec and boolean whether one was found.
+func SpecHasTag(stream *imagev1.ImageStream, name string) (imagev1.TagReference, bool) {
+	for _, tag := range stream.Spec.Tags {
+		if tag.Name == name {
+			return tag, true
+		}
+	}
+	return imagev1.TagReference{}, false
+}
+
+// ResolveReferenceForTagEvent applies the tag reference rules for a stream, tag, and tag event for
+// that tag.
+func resolveReferenceForTagEvent(stream *imagev1.ImageStream, tag string, latest *imagev1.TagEvent) string {
+	// retrieve spec policy - if not found, we use the latest spec
+	ref, ok := SpecHasTag(stream, tag)
+	if !ok {
+		return latest.DockerImageReference
+	}
+
+	switch ref.ReferencePolicy.Type {
+	// the local reference policy attempts to use image pull through on the integrated
+	// registry if possible
+	case imagev1.LocalTagReferencePolicy:
+		local := stream.Status.DockerImageRepository
+		if len(local) == 0 || len(latest.Image) == 0 {
+			// fallback to the originating reference if no local docker registry defined or we
+			// lack an image ID
+			return latest.DockerImageReference
+		}
+
+		// we must use imageapi's helper since we're calling Exact later on, which produces string
+		ref, err := imagereference.Parse(local)
+		if err != nil {
+			// fallback to the originating reference if the reported local repository spec is not valid
+			return latest.DockerImageReference
+		}
+
+		// create a local pullthrough URL
+		ref.Tag = ""
+		ref.ID = latest.Image
+		return ref.Exact()
+
+	// the default policy is to use the originating image
+	default:
+		return latest.DockerImageReference
 	}
 }


### PR DESCRIPTION
These two are needed by e2e tests and having them here avoids copying.