### PR TITLE
reports `NotReady` status of master nodes

### DIFF
--- a/pkg/crypto/crypto.go
+++ b/pkg/crypto/crypto.go
@@ -35,6 +35,7 @@ var versions = map[string]uint16{
 	"VersionTLS10": tls.VersionTLS10,
 	"VersionTLS11": tls.VersionTLS11,
 	"VersionTLS12": tls.VersionTLS12,
+	"VersionTLS13": tls.VersionTLS13,
 }
 
 // TLSVersionToNameOrDie given a tls version as an int, return its readable name

--- a/pkg/operator/condition/condition.go
+++ b/pkg/operator/condition/condition.go
@@ -25,7 +25,7 @@ const (
 	// This condition is set to false when the operator can successfully synchronize installer SA and CRB.
 	BackingResourceControllerDegradedConditionType = "BackingResourceControllerDegraded"
 
-	// ManagementStateDegradedConditionType is true when the operator observe errors when installing the new revision static pods.
+	// StaticPodsDegradedConditionType is true when the operator observe errors when installing the new revision static pods.
 	// This condition report Error reason when the pods are terminated or not ready or waiting during which the operand quality of service is degraded.
 	// This condition is set to False when the pods change state to running and are observed ready.
 	StaticPodsDegradedConditionType = "StaticPodsDegraded"
@@ -59,4 +59,8 @@ const (
 	// the operator attempted to created required resource(s) (secrets, configmaps, ...).
 	// This condition mean no new revision will be created.
 	RevisionControllerDegradedConditionType = "RevisionControllerDegraded"
+
+	// NodeControllerDegradedConditionType is true when the operator observed a master node that is not ready.
+	// Note that a node is not ready when its Condition.NodeReady wasn't set to true
+	NodeControllerDegradedConditionType = "NodeControllerDegraded"
 )

--- a/pkg/operator/staticpod/controller/node/node_controller.go
+++ b/pkg/operator/staticpod/controller/node/node_controller.go
@@ -2,13 +2,10 @@ package node
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
-	"github.com/openshift/library-go/pkg/operator/v1helpers"
-
-	"k8s.io/klog"
-
-	"k8s.io/apimachinery/pkg/api/equality"
+	coreapiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -17,9 +14,12 @@ import (
 	corelisterv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/library-go/pkg/operator/condition"
 	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
 
 const nodeControllerWorkQueueKey = "key"
@@ -59,11 +59,10 @@ func NewNodeController(
 }
 
 func (c NodeController) sync() error {
-	_, originalOperatorStatus, resourceVersion, err := c.operatorClient.GetStaticPodOperatorState()
+	_, originalOperatorStatus, _, err := c.operatorClient.GetStaticPodOperatorState()
 	if err != nil {
 		return err
 	}
-	operatorStatus := originalOperatorStatus.DeepCopy()
 
 	selector, err := labels.NewRequirement("node-role.kubernetes.io/master", selection.Equals, []string{""})
 	if err != nil {
@@ -106,13 +105,52 @@ func (c NodeController) sync() error {
 		newTargetNodeStates = append(newTargetNodeStates, operatorv1.NodeStatus{NodeName: node.Name})
 	}
 
-	operatorStatus.NodeStatuses = newTargetNodeStates
-	if !equality.Semantic.DeepEqual(originalOperatorStatus, operatorStatus) {
-		if _, updateError := c.operatorClient.UpdateStaticPodOperatorStatus(resourceVersion, operatorStatus); updateError != nil {
-			return updateError
+	// detect and report master nodes that are not ready
+	notReadyNodes := []string{}
+	for _, node := range nodes {
+		for _, con := range node.Status.Conditions {
+			if con.Type == coreapiv1.NodeReady && con.Status != coreapiv1.ConditionTrue {
+				notReadyNodes = append(notReadyNodes, node.Name)
+			}
 		}
 	}
+	newCondition := operatorv1.OperatorCondition{
+		Type: condition.NodeControllerDegradedConditionType,
+	}
+	if len(notReadyNodes) > 0 {
+		newCondition.Status = operatorv1.ConditionTrue
+		newCondition.Reason = "MasterNodesReady"
+		newCondition.Message = fmt.Sprintf("The master node(s) %q not ready", strings.Join(notReadyNodes, ","))
+	} else {
+		newCondition.Status = operatorv1.ConditionFalse
+		newCondition.Reason = "MasterNodesReady"
+		newCondition.Message = "All master node(s) are ready"
+	}
 
+	oldStatus := &operatorv1.StaticPodOperatorStatus{}
+	_, updated, updateError := v1helpers.UpdateStaticPodStatus(c.operatorClient, v1helpers.UpdateStaticPodConditionFn(newCondition), func(status *operatorv1.StaticPodOperatorStatus) error {
+		status.NodeStatuses = newTargetNodeStates
+		return nil
+	}, func(status *operatorv1.StaticPodOperatorStatus) error {
+		//a hack for storing the old status (before the update)
+		oldStatus = status
+		return nil
+	})
+
+	if updateError != nil {
+		return updateError
+	}
+
+	if !updated {
+		return nil
+	}
+
+	for _, oldCondition := range oldStatus.Conditions {
+		if oldCondition.Type == condition.NodeControllerDegradedConditionType && oldCondition.Message != newCondition.Message {
+			c.eventRecorder.Eventf("MasterNodesReadyChanged", newCondition.Message)
+			break
+		}
+	}
 	return nil
 }
 

--- a/pkg/operator/staticpod/controller/node/node_controller_test.go
+++ b/pkg/operator/staticpod/controller/node/node_controller_test.go
@@ -5,25 +5,158 @@ import (
 	"testing"
 	"time"
 
-	"github.com/openshift/library-go/pkg/operator/v1helpers"
-
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/library-go/pkg/operator/condition"
 	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
 
-func fakeMasterNode(name string) *v1.Node {
-	n := &v1.Node{}
+func fakeMasterNode(name string) *corev1.Node {
+	n := &corev1.Node{}
 	n.Name = name
 	n.Labels = map[string]string{
 		"node-role.kubernetes.io/master": "",
 	}
 
 	return n
+}
+
+func makeNodeNotReady(node *corev1.Node) *corev1.Node {
+	con := corev1.NodeCondition{}
+	con.Type = corev1.NodeReady
+	con.Status = corev1.ConditionFalse
+	node.Status.Conditions = append(node.Status.Conditions, con)
+	return node
+}
+
+func validateCommonNodeControllerDegradedCondtion(con operatorv1.OperatorCondition) error {
+	if con.Type != condition.NodeControllerDegradedConditionType {
+		return fmt.Errorf("incorrect condition.type, expected NodeControllerDegraded, got %s", con.Type)
+	}
+	if con.Reason != "MasterNodesReady" {
+		return fmt.Errorf("incorrect condition.reason, expected MasterNodesReady, got %s", con.Reason)
+	}
+	return nil
+}
+
+func TestNodeControllerDegradedConditionType(t *testing.T) {
+	scenarios := []struct {
+		name               string
+		masterNodes        []runtime.Object
+		evaluateNodeStatus func([]operatorv1.OperatorCondition) error
+	}{
+		// scenario 1
+		{
+			name:        "scenario 1: one unhealthy master node is reported",
+			masterNodes: []runtime.Object{makeNodeNotReady(fakeMasterNode("test-node-1")), fakeMasterNode("test-node-2")},
+			evaluateNodeStatus: func(conditions []operatorv1.OperatorCondition) error {
+				if len(conditions) != 1 {
+					return fmt.Errorf("expected exaclty 1 condition, got %d", len(conditions))
+				}
+
+				con := conditions[0]
+				if err := validateCommonNodeControllerDegradedCondtion(con); err != nil {
+					return err
+				}
+				if con.Status != operatorv1.ConditionTrue {
+					return fmt.Errorf("incorrect condition.status, expected %v, got %v", operatorv1.ConditionTrue, con.Status)
+				}
+				expectedMsg := "The master node(s) \"test-node-1\" not ready"
+				if con.Message != expectedMsg {
+					return fmt.Errorf("incorrect condition.message, expected %s, got %s", expectedMsg, con.Message)
+				}
+				return nil
+			},
+		},
+
+		// scenario 2
+		{
+			name:        "scenario 2: all master nodes are healthy",
+			masterNodes: []runtime.Object{fakeMasterNode("test-node-1"), fakeMasterNode("test-node-2")},
+			evaluateNodeStatus: func(conditions []operatorv1.OperatorCondition) error {
+				if len(conditions) != 1 {
+					return fmt.Errorf("expected exaclty 1 condition, got %d", len(conditions))
+				}
+
+				con := conditions[0]
+				if err := validateCommonNodeControllerDegradedCondtion(con); err != nil {
+					return err
+				}
+				if con.Status != operatorv1.ConditionFalse {
+					return fmt.Errorf("incorrect condition.status, expected %v, got %v", operatorv1.ConditionFalse, con.Status)
+				}
+				expectedMsg := "All master node(s) are ready"
+				if con.Message != expectedMsg {
+					return fmt.Errorf("incorrect condition.message, expected %s, got %s", expectedMsg, con.Message)
+				}
+				return nil
+			},
+		},
+
+		// scenario 3
+		{
+			name:        "scenario 3: multiple master nodes are unhealthy",
+			masterNodes: []runtime.Object{makeNodeNotReady(fakeMasterNode("test-node-1")), fakeMasterNode("test-node-2"), makeNodeNotReady(fakeMasterNode("test-node-3"))},
+			evaluateNodeStatus: func(conditions []operatorv1.OperatorCondition) error {
+				if len(conditions) != 1 {
+					return fmt.Errorf("expected exaclty 1 condition, got %d", len(conditions))
+				}
+
+				con := conditions[0]
+				if err := validateCommonNodeControllerDegradedCondtion(con); err != nil {
+					return err
+				}
+				if con.Status != operatorv1.ConditionTrue {
+					return fmt.Errorf("incorrect condition.status, expected %v, got %v", operatorv1.ConditionTrue, con.Status)
+				}
+				expectedMsg := "The master node(s) \"test-node-1,test-node-3\" not ready"
+				if con.Message != expectedMsg {
+					return fmt.Errorf("incorrect condition.message, expected %s, got %s", expectedMsg, con.Message)
+				}
+				return nil
+			},
+		},
+	}
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			kubeClient := fake.NewSimpleClientset(scenario.masterNodes...)
+			fakeLister := v1helpers.NewFakeNodeLister(kubeClient)
+			kubeInformers := informers.NewSharedInformerFactory(kubeClient, 1*time.Minute)
+			fakeStaticPodOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(
+				&operatorv1.StaticPodOperatorSpec{
+					OperatorSpec: operatorv1.OperatorSpec{
+						ManagementState: operatorv1.Managed,
+					},
+				},
+				&operatorv1.StaticPodOperatorStatus{
+					LatestAvailableRevision: 1,
+				},
+				nil,
+				nil,
+			)
+
+			eventRecorder := events.NewRecorder(kubeClient.CoreV1().Events("test"), "test-operator", &corev1.ObjectReference{})
+
+			c := NewNodeController(fakeStaticPodOperatorClient, kubeInformers, eventRecorder)
+			// override the lister so we don't have to run the informer to list nodes
+			c.nodeLister = fakeLister
+			if err := c.sync(); err != nil {
+				t.Fatal(err)
+			}
+
+			_, status, _, _ := fakeStaticPodOperatorClient.GetStaticPodOperatorState()
+
+			if err := scenario.evaluateNodeStatus(status.OperatorStatus.Conditions); err != nil {
+				t.Errorf("%s: failed to evaluate operator conditions: %v", scenario.name, err)
+			}
+		})
+
+	}
 }
 
 func TestNewNodeController(t *testing.T) {
@@ -118,7 +251,7 @@ func TestNewNodeController(t *testing.T) {
 				nil,
 			)
 
-			eventRecorder := events.NewRecorder(kubeClient.CoreV1().Events("test"), "test-operator", &v1.ObjectReference{})
+			eventRecorder := events.NewRecorder(kubeClient.CoreV1().Events("test"), "test-operator", &corev1.ObjectReference{})
 
 			c := NewNodeController(fakeStaticPodOperatorClient, kubeInformers, eventRecorder)
 			// override the lister so we don't have to run the informer to list nodes


### PR DESCRIPTION
extends node controller to examine `Node.Status.Ready` field and to report unhealthy status.
the status is reported by the controller as a new condition of type `NodeControllerDegraded` that is added to `StaticPodOperatorStatus`

closes https://jira.coreos.com/browse/MSTR-404