### PR TITLE
split valid and enabled TLS versions

### DIFF
--- a/pkg/config/validation/serving_info.go
+++ b/pkg/config/validation/serving_info.go
@@ -59,7 +59,7 @@ func ValidateServingInfo(info configv1.ServingInfo, certificatesRequired bool, f
 	}
 
 	if _, err := crypto.TLSVersion(info.MinTLSVersion); err != nil {
-		validationResults.AddErrors(field.NotSupported(fldPath.Child("minTLSVersion"), info.MinTLSVersion, crypto.ValidTLSVersions()))
+		validationResults.AddErrors(field.NotSupported(fldPath.Child("minTLSVersion"), info.MinTLSVersion, crypto.SupportedTLSVersions()))
 	}
 	for i, cipher := range info.CipherSuites {
 		if _, err := crypto.CipherSuite(cipher); err != nil {

--- a/pkg/crypto/crypto.go
+++ b/pkg/crypto/crypto.go
@@ -31,11 +31,19 @@ import (
 	"k8s.io/client-go/util/cert"
 )
 
+// TLS versions that are known to golang. Go 1.12 adds TLS 1.3 support with a build flag.
 var versions = map[string]uint16{
 	"VersionTLS10": tls.VersionTLS10,
 	"VersionTLS11": tls.VersionTLS11,
 	"VersionTLS12": tls.VersionTLS12,
 	"VersionTLS13": tls.VersionTLS13,
+}
+
+// TLS versions that are enabled.
+var supportedVersions = map[string]uint16{
+	"VersionTLS10": tls.VersionTLS10,
+	"VersionTLS11": tls.VersionTLS11,
+	"VersionTLS12": tls.VersionTLS12,
 }
 
 // TLSVersionToNameOrDie given a tls version as an int, return its readable name
@@ -72,6 +80,18 @@ func TLSVersionOrDie(versionName string) uint16 {
 	}
 	return version
 }
+
+// Returns the build enabled TLS versions.
+func SupportedTLSVersions() []string {
+	supported := []string{}
+	for k := range supportedVersions {
+		supported = append(supported, k)
+	}
+	sort.Strings(supported)
+	return supported
+}
+
+// TLS versions that are known to golang, but may not necessarily be enabled.
 func ValidTLSVersions() []string {
 	validVersions := []string{}
 	for k := range versions {

--- a/pkg/crypto/crypto_test.go
+++ b/pkg/crypto/crypto_test.go
@@ -51,6 +51,13 @@ func TestConstantMaps(t *testing.T) {
 			t.Errorf("versions map has %s not in tls package", k)
 		}
 	}
+
+	for k := range supportedVersions {
+		if _, ok := discoveredVersions[k]; !ok {
+			t.Errorf("supported versions map has %s not in tls package", k)
+		}
+	}
+
 }
 
 func TestCrypto(t *testing.T) {


### PR DESCRIPTION
We need to discern between the package-valid TLS versions (with go1.12 this now includes tls1.3) and the server enabled versions (which only goes up to tls1.2). Currently some origin tests assume that the package-valid versions above the default are automatically supported, but tls1.3 is opt-in at build time.