### PR TITLE
auth: add impersonating client

### DIFF
--- a/pkg/authentication/impersonatingclient/impersonate.go
+++ b/pkg/authentication/impersonatingclient/impersonate.go
@@ -1,0 +1,88 @@
+package impersonatingclient
+
+import (
+	"net/http"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apiserver/pkg/authentication/user"
+	kclientset "k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/transport"
+	"k8s.io/client-go/util/flowcontrol"
+)
+
+// NewImpersonatingConfig wraps the config's transport to impersonate a user, including user, groups, and scopes
+func NewImpersonatingConfig(user user.Info, config restclient.Config) restclient.Config {
+	oldWrapTransport := config.WrapTransport
+	if oldWrapTransport == nil {
+		oldWrapTransport = func(rt http.RoundTripper) http.RoundTripper { return rt }
+	}
+	newConfig := transport.ImpersonationConfig{
+		UserName: user.GetName(),
+		Groups:   user.GetGroups(),
+		Extra:    user.GetExtra(),
+	}
+	config.WrapTransport = func(rt http.RoundTripper) http.RoundTripper {
+		return transport.NewImpersonatingRoundTripper(newConfig, oldWrapTransport(rt))
+	}
+	return config
+}
+
+// NewImpersonatingKubernetesClientset returns a Kubernetes clientset that will impersonate a user, including user, groups, and scopes
+func NewImpersonatingKubernetesClientset(user user.Info, config restclient.Config) (kclientset.Interface, error) {
+	impersonatingConfig := NewImpersonatingConfig(user, config)
+	return kclientset.NewForConfig(&impersonatingConfig)
+}
+
+// impersonatingRESTClient sets impersonating user, groups, and scopes headers per request
+type impersonatingRESTClient struct {
+	user     user.Info
+	delegate restclient.Interface
+}
+
+func NewImpersonatingRESTClient(user user.Info, client restclient.Interface) restclient.Interface {
+	return &impersonatingRESTClient{user: user, delegate: client}
+}
+
+// Verb does the impersonation per request by setting the proper headers
+func (c *impersonatingRESTClient) impersonate(req *restclient.Request) *restclient.Request {
+	req.SetHeader(transport.ImpersonateUserHeader, c.user.GetName())
+	req.SetHeader(transport.ImpersonateGroupHeader, c.user.GetGroups()...)
+	for k, vv := range c.user.GetExtra() {
+		req.SetHeader(transport.ImpersonateUserExtraHeaderPrefix+k, vv...)
+	}
+	return req
+}
+
+func (c *impersonatingRESTClient) Verb(verb string) *restclient.Request {
+	return c.impersonate(c.delegate.Verb(verb))
+}
+
+func (c *impersonatingRESTClient) Post() *restclient.Request {
+	return c.impersonate(c.delegate.Post())
+}
+
+func (c *impersonatingRESTClient) Put() *restclient.Request {
+	return c.impersonate(c.delegate.Put())
+}
+
+func (c *impersonatingRESTClient) Patch(pt types.PatchType) *restclient.Request {
+	return c.impersonate(c.delegate.Patch(pt))
+}
+
+func (c *impersonatingRESTClient) Get() *restclient.Request {
+	return c.impersonate(c.delegate.Get())
+}
+
+func (c *impersonatingRESTClient) Delete() *restclient.Request {
+	return c.impersonate(c.delegate.Delete())
+}
+
+func (c *impersonatingRESTClient) APIVersion() schema.GroupVersion {
+	return c.delegate.APIVersion()
+}
+
+func (c *impersonatingRESTClient) GetRateLimiter() flowcontrol.RateLimiter {
+	return c.delegate.GetRateLimiter()
+}

--- a/pkg/authentication/impersonatingclient/impersonate_rbac.go
+++ b/pkg/authentication/impersonatingclient/impersonate_rbac.go
@@ -1,0 +1,19 @@
+package impersonatingclient
+
+import (
+	"context"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	rbacv1 "k8s.io/client-go/kubernetes/typed/rbac/v1"
+	"k8s.io/client-go/rest"
+)
+
+// NewImpersonatingRBACFromContext returns an impersonated RBAC client with the user of the context.
+func NewImpersonatingRBACFromContext(ctx context.Context, restclient rest.Interface) (rbacv1.RbacV1Interface, error) {
+	user, ok := request.UserFrom(ctx)
+	if !ok {
+		return nil, apierrors.NewBadRequest("user missing from context")
+	}
+	return rbacv1.New(NewImpersonatingRESTClient(user, restclient)), nil
+}


### PR DESCRIPTION
Used by integration and openshift apiserver (apiserver and admission).

This is the last dependency in tests that point to openshift-apiserver.

/cc @deads2k 