### PR TITLE
certs: add prometheus metrics for CA, signer and target certs

### DIFF
--- a/pkg/operator/certrotation/client_cert_rotation_controller.go
+++ b/pkg/operator/certrotation/client_cert_rotation_controller.go
@@ -140,6 +140,8 @@ func (c *CertRotationController) Run(workers int, stopCh <-chan struct{}) {
 	defer klog.Infof("Shutting down CertRotationController - %q", c.name)
 	c.WaitForReady(stopCh)
 
+	registerCertExpirationMetrics(c.CABundleRotation.Informer.Lister(), c.SigningRotation.Informer.Lister())
+
 	// doesn't matter what workers say, only start one.
 	go wait.Until(c.runWorker, time.Second, stopCh)
 

--- a/pkg/operator/certrotation/metrics.go
+++ b/pkg/operator/certrotation/metrics.go
@@ -1,0 +1,206 @@
+package certrotation
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/labels"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/util/cert"
+	"k8s.io/klog"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/openshift/library-go/pkg/crypto"
+)
+
+var (
+	defaultTimeNowFn = time.Now
+)
+
+var (
+	caBundleExpireHoursDesc = prometheus.NewDesc(
+		"cert_ca_bundle_expire_in_hours",
+		"Number of hours until certificates in given CA bundle expire",
+		[]string{"namespace", "name", "common_name", "signer_name", "index", "valid_from"}, nil)
+
+	signerExpireHoursDesc = prometheus.NewDesc(
+		"cert_signer_expire_in_hours",
+		"Number of hours until certificates in given signer expire",
+		[]string{"namespace", "name", "common_name", "signer_name", "index", "valid_from"}, nil)
+
+	targetExpireHoursDesc = prometheus.NewDesc(
+		"cert_target_expire_in_hours",
+		"Number of hours until certificates in given target expire",
+		[]string{"namespace", "name", "common_name", "signer_name", "index", "valid_from"}, nil)
+)
+
+type certExpirationMetricsCollector struct {
+	configLister corev1listers.ConfigMapLister
+	secretLister corev1listers.SecretLister
+
+	nowFn func() time.Time
+}
+
+// Describe implements the prometheus collector interface
+func (c *certExpirationMetricsCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- caBundleExpireHoursDesc
+	ch <- signerExpireHoursDesc
+	ch <- targetExpireHoursDesc
+}
+
+// Collect implements the prometheus collector interface
+func (c *certExpirationMetricsCollector) Collect(ch chan<- prometheus.Metric) {
+	// to speed up collection, do this in parallel
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { defer wg.Done(); c.collectCABundles(ch) }()
+	go func() { defer wg.Done(); c.collectSignersAndTarget(ch) }()
+	wg.Wait()
+}
+
+func (c *certExpirationMetricsCollector) collectSignersAndTarget(ch chan<- prometheus.Metric) {
+	secrets, err := c.secretLister.List(managedCertificateLabelSelector())
+	if err != nil {
+		klog.Warningf("Failed to list signer secrets: %v", err)
+		return
+	}
+
+	for _, secret := range secrets {
+		var targetDescType *prometheus.Desc
+
+		certType, err := CertificateTypeFromObject(secret)
+		if err != nil {
+			klog.Warningf("Error determining certificate type from secret %s/%s: %v", secret.Namespace, secret.Name, err)
+			continue
+		}
+		switch certType {
+		case CertificateTypeSigner:
+			targetDescType = signerExpireHoursDesc
+		case CertificateTypeTarget:
+			targetDescType = targetExpireHoursDesc
+		default:
+			klog.Warningf("Secret %s/%s has unknown certificate type: %q", secret.Namespace, secret.Name, secret.Labels[ManagedCertificateTypeLabelName])
+			continue
+		}
+		if secret.Data["tls.crt"] == nil || secret.Data["tls.key"] == nil {
+			klog.V(4).Infof("Secret %s/%s does not have 'tls.crt' or 'tls.key'", secret.Namespace, secret.Name)
+			continue
+		}
+
+		signingCertKeyPair, err := crypto.GetCAFromBytes(secret.Data["tls.crt"], secret.Data["tls.key"])
+		if err != nil {
+			continue
+		}
+
+		labelValues := []string{}
+		for i, certificate := range signingCertKeyPair.Config.Certs {
+			expireHours := certificate.NotAfter.UTC().Sub(c.nowFn().UTC()).Hours()
+			labelValues = append(labelValues, []string{
+				secret.Namespace,
+				secret.Name,
+				certificate.Subject.CommonName,
+				certificate.Issuer.CommonName,
+				fmt.Sprintf("%d", i),
+				fmt.Sprintf("%s", certificate.NotBefore.UTC()),
+			}...)
+
+			ch <- prometheus.MustNewConstMetric(
+				targetDescType,
+				prometheus.GaugeValue,
+				float64(expireHours),
+				labelValues...)
+		}
+	}
+}
+
+func (c *certExpirationMetricsCollector) collectCABundles(ch chan<- prometheus.Metric) {
+	configs, err := c.configLister.List(managedCertificateLabelSelector())
+	if err != nil {
+		klog.Warningf("Failed to list configmaps: %v", err)
+		return
+	}
+
+	for _, config := range configs {
+		fmt.Printf("processing %q\n", config.Name)
+		certType, err := CertificateTypeFromObject(config)
+		if err != nil {
+			klog.Warningf("Error determining certificate type from config map %s/%s: %v", config.Namespace, config.Name, err)
+		}
+
+		if certType != CertificateTypeCABundle {
+			klog.Warningf("ConfigMap %s/%s is not CA bundle type: %q", config.Namespace, config.Name, config.Labels[ManagedCertificateTypeLabelName])
+			continue
+		}
+
+		if _, exists := config.Data["ca-bundle.crt"]; !exists {
+			klog.V(4).Infof("ConfigMap %s/%s does not have 'ca-bundle.crt'", config.Namespace, config.Name)
+			continue
+		}
+
+		certificates, err := cert.ParseCertsPEM([]byte(config.Data["ca-bundle.crt"]))
+		if err != nil {
+			klog.V(2).Infof("ConfigMap %s/%s 'ca-bundle.crt' has invalid certificates: %v", config.Namespace, config.Name, err)
+			continue
+		}
+
+		for i, certificate := range certificates {
+			labelValues := []string{}
+			expireHours := certificate.NotAfter.UTC().Sub(c.nowFn().UTC()).Hours()
+			// Do not report negative hours, if cert expired, the hours to expiration is zero.
+			if expireHours < 0 {
+				expireHours = 0
+			}
+			labelValues = append(labelValues, []string{
+				config.Namespace,
+				config.Name,
+				certificate.Subject.CommonName,
+				certificate.Issuer.CommonName,
+				fmt.Sprintf("%d", i),
+				fmt.Sprintf("%s", certificate.NotBefore.UTC()),
+			}...)
+
+			sample := prometheus.MustNewConstMetric(
+				caBundleExpireHoursDesc,
+				prometheus.GaugeValue,
+				float64(expireHours),
+				labelValues...)
+
+			ch <- sample
+		}
+	}
+}
+
+// managedCertificateLabelSelector returns a label selector that can be used in list or watch to filter
+// only secrets or configmaps that are labeled as managed.
+func managedCertificateLabelSelector() labels.Selector {
+	selector, err := labels.Parse(fmt.Sprintf("%s in (%s)", ManagedCertificateTypeLabelName, strings.Join([]string{
+		string(CertificateTypeCABundle),
+		string(CertificateTypeTarget),
+		string(CertificateTypeSigner),
+	}, ",")))
+	if err != nil {
+		panic(err)
+	}
+	return selector
+}
+
+// registerOnce guarantee that this prometheus metric collector will only be registered once.
+// TODO: Provide more reliable metric registration system in future.
+var registerOnce sync.Once
+
+// registerCertExpirationMetrics registers certificate monitoring metrics.
+func registerCertExpirationMetrics(configMaps corev1listers.ConfigMapLister, secrets corev1listers.SecretLister) {
+	registerOnce.Do(func() {
+		collector := &certExpirationMetricsCollector{
+			configLister: configMaps,
+			secretLister: secrets,
+			nowFn:        defaultTimeNowFn,
+		}
+
+		prometheus.MustRegister(collector)
+		klog.Infof("Prometheus: Registered managed certificates monitoring metrics")
+	})
+}

--- a/pkg/operator/certrotation/metrics_test.go
+++ b/pkg/operator/certrotation/metrics_test.go
@@ -1,0 +1,241 @@
+package certrotation
+
+import (
+	"crypto/x509/pkix"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kcorelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/openshift/library-go/pkg/crypto"
+)
+
+func makeCABundleConfigMap(name string, certs *crypto.CA, t *testing.T) *v1.ConfigMap {
+	caBundleConfigMap := v1.ConfigMap{}
+	caBundleConfigMap.Namespace = "test"
+	caBundleConfigMap.Name = name
+	caBundleConfigMap.Labels = map[string]string{
+		ManagedCertificateTypeLabelName: string(CertificateTypeCABundle),
+	}
+	if certs != nil {
+		caBytes, err := crypto.EncodeCertificates(certs.Config.Certs[0], certs.Config.Certs[0])
+		if err != nil {
+			t.Fatal(err)
+		}
+		caBundleConfigMap.Data = map[string]string{}
+		caBundleConfigMap.Data["ca-bundle.crt"] = string(caBytes)
+	}
+
+	return &caBundleConfigMap
+}
+
+func parseMetricOrDie(metric prometheus.Metric) dto.Metric {
+	var out dto.Metric
+	if err := metric.Write(&out); err != nil {
+		panic(err)
+	}
+	return out
+}
+
+func findMetricByName(name string, metrics []prometheus.Metric) *dto.Metric {
+	for _, m := range metrics {
+		parsed := parseMetricOrDie(m)
+		for _, label := range parsed.GetLabel() {
+			if label.GetName() == "name" && label.GetValue() == name {
+				return &parsed
+			}
+		}
+	}
+	return nil
+}
+
+func evaluateLabelValue(name, observed, expected string, t *testing.T) {
+	if len(expected) == 0 {
+		return
+	}
+	if observed != expected {
+		t.Errorf("expected label %q to have value %q, got %q", name, expected, observed)
+	}
+}
+
+func evaluateLabelPairs(labels []*dto.LabelPair, t *testing.T, common_name, name, namespace, signer_name, valid_from string) {
+	if len(labels) != 6 {
+		t.Errorf("expected 6 labels, got %d", len(labels))
+		return
+	}
+	for _, label := range labels {
+		switch label.GetName() {
+		case "common_name":
+			evaluateLabelValue(label.GetName(), label.GetValue(), common_name, t)
+		case "name":
+			evaluateLabelValue(label.GetName(), label.GetValue(), name, t)
+		case "namespace":
+			evaluateLabelValue(label.GetName(), label.GetValue(), namespace, t)
+		case "signer_name":
+			evaluateLabelValue(label.GetName(), label.GetValue(), signer_name, t)
+		case "valid_from":
+			evaluateLabelValue(label.GetName(), label.GetValue(), valid_from, t)
+		case "index":
+		default:
+			t.Errorf("untested label name %q found", label.GetName())
+		}
+	}
+}
+
+func defaultEmptySecrets() []*v1.Secret {
+	return []*v1.Secret{}
+}
+
+func TestCertExpirationMetricsCollector(t *testing.T) {
+	testCases := []struct {
+		name           string
+		initialConfigs func() []*v1.ConfigMap
+		initialSecrets func() []*v1.Secret
+
+		evaluateMetrics         func([]prometheus.Metric, *testing.T)
+		expectedMetricCollected int
+	}{
+		{
+			name: "CA bundle config map with single certs expiring in 1 hour",
+			initialConfigs: func() []*v1.ConfigMap {
+				certs, err := newTestCACertificate(pkix.Name{CommonName: "signer-tests"}, int64(1), metav1.Duration{Duration: time.Hour}, time.Now)
+				if err != nil {
+					t.Error(err)
+				}
+				return []*v1.ConfigMap{makeCABundleConfigMap("test-ca", certs, t)}
+			},
+			initialSecrets:          defaultEmptySecrets,
+			expectedMetricCollected: 1,
+			evaluateMetrics: func(metrics []prometheus.Metric, t *testing.T) {
+				caMetric := parseMetricOrDie(metrics[0])
+				if value := math.Round(caMetric.GetGauge().GetValue()); value != 1.0 {
+					t.Errorf("expected validatity 1 (hour), got %f", value)
+				}
+				evaluateLabelPairs(caMetric.GetLabel(), t, "signer-tests", "test-ca", "test", "signer-tests", "")
+			},
+		},
+		{
+			name: "CA bundle config maps with single cert",
+			initialConfigs: func() []*v1.ConfigMap {
+				oneHourCert, err := newTestCACertificate(pkix.Name{CommonName: "maciej"}, int64(1), metav1.Duration{Duration: time.Hour}, time.Now)
+				if err != nil {
+					t.Error(err)
+				}
+				oneDayCert, err := newTestCACertificate(pkix.Name{CommonName: "stefan"}, int64(1), metav1.Duration{Duration: 24 * time.Hour}, time.Now)
+				if err != nil {
+					t.Error(err)
+				}
+				expiredCert, err := newTestCACertificate(pkix.Name{CommonName: "david"}, int64(1), metav1.Duration{Duration: time.Hour}, func() time.Time {
+					return time.Now().Add(-24 * time.Hour)
+				})
+				if err != nil {
+					t.Error(err)
+				}
+				return []*v1.ConfigMap{
+					makeCABundleConfigMap("test-ca-1-hour", oneHourCert, t),
+					makeCABundleConfigMap("test-ca-1-day", oneDayCert, t),
+					makeCABundleConfigMap("test-ca-expired", expiredCert, t),
+				}
+			},
+			initialSecrets:          defaultEmptySecrets,
+			expectedMetricCollected: 6,
+			evaluateMetrics: func(metrics []prometheus.Metric, t *testing.T) {
+				caOneHourMetric := findMetricByName("test-ca-1-hour", metrics)
+				if caOneHourMetric == nil {
+					t.Errorf("test-ca-1-hour metric not found")
+				}
+				if value := math.Round(caOneHourMetric.GetGauge().GetValue()); value != 1.0 {
+					t.Errorf("expected hours to expire 1, got %f", value)
+				}
+				evaluateLabelPairs(caOneHourMetric.GetLabel(), t, "maciej", "test-ca-1-hour", "test", "maciej", "")
+
+				caOneDayMetric := findMetricByName("test-ca-1-day", metrics)
+				if caOneDayMetric == nil {
+					t.Errorf("test-ca-1-day metric not found")
+				}
+				if value := math.Round(caOneDayMetric.GetGauge().GetValue()); value != 24.0 {
+					t.Errorf("expected hours to expire 24, got %f", value)
+				}
+				evaluateLabelPairs(caOneDayMetric.GetLabel(), t, "stefan", "test-ca-1-day", "test", "stefan", "")
+
+				caExpiredMetric := findMetricByName("test-ca-expired", metrics)
+				if caExpiredMetric == nil {
+					t.Errorf("test-ca-expired metric not found")
+				}
+				if value := math.Round(caExpiredMetric.GetGauge().GetValue()); value != 0.0 {
+					t.Errorf("expected hours to expire be zero, got %f", value)
+				}
+				evaluateLabelPairs(caExpiredMetric.GetLabel(), t, "david", "test-ca-expired", "test", "david", "")
+			},
+		},
+		{
+			name: "CA bundle config map with empty cert",
+			initialConfigs: func() []*v1.ConfigMap {
+				config := makeCABundleConfigMap("test-ca", nil, t)
+				return []*v1.ConfigMap{config}
+			},
+			initialSecrets:          defaultEmptySecrets,
+			expectedMetricCollected: 0,
+			evaluateMetrics:         func(metrics []prometheus.Metric, t *testing.T) {},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			secretIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			configIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			for _, config := range tc.initialConfigs() {
+				if err := configIndexer.Add(config); err != nil {
+					t.Fatal(err)
+				}
+			}
+			for _, secret := range tc.initialSecrets() {
+				if err := secretIndexer.Add(secret); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			c := &certExpirationMetricsCollector{
+				configLister: kcorelisters.NewConfigMapLister(configIndexer),
+				secretLister: kcorelisters.NewSecretLister(secretIndexer),
+				nowFn:        defaultTimeNowFn,
+			}
+
+			// start metric collection, wait until expected metric count is reached
+			collectedMetrics := []prometheus.Metric{}
+			collectionChan := make(chan prometheus.Metric)
+
+			stopChan := make(chan struct{})
+			go func() {
+				defer close(collectionChan)
+				c.Collect(collectionChan)
+				<-stopChan
+			}()
+
+			for {
+				select {
+				case m := <-collectionChan:
+					collectedMetrics = append(collectedMetrics, m)
+				case <-time.After(time.Second * 5):
+					if len(collectedMetrics) != tc.expectedMetricCollected {
+						t.Fatalf("timeout receiving expected results (got %d, expected %d)", len(collectedMetrics), tc.expectedMetricCollected)
+					}
+				}
+
+				if len(collectedMetrics) == tc.expectedMetricCollected {
+					close(stopChan)
+					break
+				}
+			}
+
+			tc.evaluateMetrics(collectedMetrics, t)
+		})
+	}
+
+}


### PR DESCRIPTION
Attempt number two to introduce certificate expiration prometheus metrics. There are three metrics, all with low cardinality:

* `cert_ca_bundle_expire_in_hours` is a gauge that tracks the number of hours before the certs inside the CA bundle reach their expiration. 
* `cert_signer_expire_in_hours` is a gauge that tracks the number of hours before the signer cert reach its expiration.
* `cert_target_expire_in_hours` is a guage that tracks the number of hours before the target cert expire.

The collector tracks all secrets and config maps provided by the lister. The labels and types are already being set on secrets and configs we produce.

This version add unit test and fixes some logic errors inside the collector. Also fixes the "double" registration bug which caused this to explode before 4.1 release.

/cc @deads2k 
/cc @sttts 