### PR TITLE
make targets: Fix broken update-bindata

### DIFF
--- a/alpha-build-machinery/make/targets/openshift/bindata.mk
+++ b/alpha-build-machinery/make/targets/openshift/bindata.mk
@@ -3,7 +3,7 @@ TMP_GOPATH :=$(shell mktemp -d)
 
 .ensure-go-bindata:
 	ln -s $(abspath ./vendor) "$(TMP_GOPATH)/src"
-	export GOPATH=$(TMP_GOPATH) && go install "./vendor/github.com/jteeuwen/go-bindata/..."
+	export GOPATH=$(TMP_GOPATH) && export GOBIN=$(TMP_GOPATH)/bin && go install "./vendor/github.com/jteeuwen/go-bindata/..."
 
 # $1 - input dirs
 # $2 - prefix


### PR DESCRIPTION
If someone has GOBIN set, `go install` only compiles into the
folder specified by this variable, which causes the make target
to fail and a potential unwanted install of the binary to the user's
GOBIN folder.