### PR TITLE
Fix bitbucket and glide

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -3,6 +3,7 @@ updated: 2019-06-25T17:09:36.178129217+02:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
+  vcs: hg
 - name: github.com/Azure/go-ansiterm
   version: d6e3b3328b783f23731bc4d058875b0371ff8109
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -62,3 +62,8 @@ import:
   version: da3951ba2e9e02bc0e7642150b3e265aed7e1df3 # matching origin 4.2 level
 - package: github.com/docker/distribution
   version: 16128bbac47f75050e82f7e91b04df33775e0c23 # level currently used in origin to base the origin patches on.  See https://github.com/openshift/image-registry/pull/126/commits/eb32acef7827ac2227c3aeaddc444880ed98edb3 leading to https://github.com/openshift/docker-distribution/commits/image-registry-3.11
+
+# VCS issues
+- package: bitbucket.org/ww/goautoneg
+  vcs: hg
+


### PR DESCRIPTION
Fixes https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_library-go/468/pull-ci-openshift-library-go-master-verify-deps/1254

(I didn't want to couple bump into it. I don't think the hash mismatch matters.)


@openshift/sig-master fyi, this may be needed in other repos where verify-deps is rightfully failing and also you would not be able to bump deps otherwise