### PR TITLE
pkg/asset/create: Add Update options to patch existing resources

### DIFF
--- a/pkg/assets/create/testdata/operator-config.yaml
+++ b/pkg/assets/create/testdata/operator-config.yaml
@@ -4,3 +4,5 @@ metadata:
   name: instance
 spec:
   managementState: Managed
+status:
+  observedGeneration: 2


### PR DESCRIPTION
Allows consumers to switch between current behavior of skipping already existing objects in cluster
and updating the objects in cluster to desired specification in the manifest file

Also extends the default create to PUT status subresource when status field is set for a manifest.