### PR TITLE
configobserver/cloudprovider: add GCP to known platforms

### DIFF
--- a/pkg/operator/configobserver/cloudprovider/observe_cloudprovider.go
+++ b/pkg/operator/configobserver/cloudprovider/observe_cloudprovider.go
@@ -147,6 +147,8 @@ func getPlatformName(platformType configv1.PlatformType, recorder events.Recorde
 	case configv1.VSpherePlatformType:
 		cloudProvider = "vsphere"
 	case configv1.BareMetalPlatformType:
+	case configv1.GCPPlatformType:
+		cloudProvider = "gce"
 	case configv1.LibvirtPlatformType:
 	case configv1.OpenStackPlatformType:
 		// TODO(flaper87): Enable this once we've figured out a way to write the cloud provider config in the master nodes

--- a/pkg/operator/configobserver/cloudprovider/observe_cloudprovider_test.go
+++ b/pkg/operator/configobserver/cloudprovider/observe_cloudprovider_test.go
@@ -66,7 +66,8 @@ func TestObserveCloudProviderNames(t *testing.T) {
 		cloudProviderCount: 0,
 	}, {
 		platform:           configv1.GCPPlatformType,
-		cloudProviderCount: 0,
+		expected:           "gce",
+		cloudProviderCount: 1,
 	}, {
 		platform:           configv1.NonePlatformType,
 		cloudProviderCount: 0,


### PR DESCRIPTION
The cloud provider name for GCP platform is `gce` [1]

[1]: https://github.com/kubernetes/kubernetes/blob/844a0c9a10cd52367ec7c05f5a8c176535dcef38/staging/src/k8s.io/legacy-cloud-providers/gce/gce.go#L59