### PR TITLE
resourcemerge: add pruning helpers when creating a ConfigMap

### DIFF
--- a/pkg/operator/resource/resourcemerge/generic_config_merger.go
+++ b/pkg/operator/resource/resourcemerge/generic_config_merger.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"k8s.io/klog"
+	"sigs.k8s.io/yaml"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -17,7 +18,14 @@ import (
 // MergeConfigMap takes a configmap, the target key, special overlay funcs a list of config configs to overlay on top of each other
 // It returns the resultant configmap and a bool indicating if any changes were made to the configmap
 func MergeConfigMap(configMap *corev1.ConfigMap, configKey string, specialCases map[string]MergeFunc, configYAMLs ...[]byte) (*corev1.ConfigMap, bool, error) {
-	configBytes, err := MergeProcessConfig(specialCases, configYAMLs...)
+	return MergePrunedConfigMap(nil, configMap, configKey, specialCases, configYAMLs...)
+}
+
+// MergePrunedConfigMap takes a configmap, the target key, special overlay funcs a list of config configs to overlay on top of each other
+// It returns the resultant configmap and a bool indicating if any changes were made to the configmap.
+// It roundtrips the config through the given schema.
+func MergePrunedConfigMap(schema runtime.Object, configMap *corev1.ConfigMap, configKey string, specialCases map[string]MergeFunc, configYAMLs ...[]byte) (*corev1.ConfigMap, bool, error) {
+	configBytes, err := MergePrunedProcessConfig(schema, specialCases, configYAMLs...)
 	if err != nil {
 		return nil, false, err
 	}
@@ -85,6 +93,44 @@ func MergeProcessConfig(specialCases map[string]MergeFunc, configYAMLs ...[]byte
 	return currentConfigYAML, nil
 }
 
+// MergePrunedProcessConfig merges a series of config yaml files together with each later one overlaying all previous.
+// The result is roundtripped through the given schema if it is non-nil.
+func MergePrunedProcessConfig(schema runtime.Object, specialCases map[string]MergeFunc, configYAMLs ...[]byte) ([]byte, error) {
+	bs, err := MergeProcessConfig(specialCases, configYAMLs...)
+	if err != nil {
+		return nil, err
+	}
+
+	if schema == nil {
+		return bs, nil
+	}
+
+	// roundtrip through the schema
+	typed := schema.DeepCopyObject()
+	if err := yaml.Unmarshal(bs, typed); err != nil {
+		return nil, err
+	}
+	typedBytes, err := json.Marshal(typed)
+	if err != nil {
+		return nil, err
+	}
+	var untypedJSON map[string]interface{}
+	if err := json.Unmarshal(typedBytes, &untypedJSON); err != nil {
+		return nil, err
+	}
+
+	// and intersect output with input because we cannot rely on omitempty in the schema
+	inputBytes, err := yaml.YAMLToJSON(bs)
+	if err != nil {
+		return nil, err
+	}
+	var inputJSON map[string]interface{}
+	if err := json.Unmarshal(inputBytes, &inputJSON); err != nil {
+		return nil, err
+	}
+	return json.Marshal(intersectJSON(inputJSON, untypedJSON))
+}
+
 type MergeFunc func(dst, src interface{}, currentPath string) (interface{}, error)
 
 // mergeConfig overwrites entries in curr by additional.  It modifies curr.
@@ -131,4 +177,54 @@ func mergeConfig(curr, additional map[string]interface{}, currentPath string, sp
 	}
 
 	return nil
+}
+
+// jsonIntersection returns the intersection of both JSON object,
+// preferring the values of the first argument.
+func intersectJSON(x1, x2 map[string]interface{}) map[string]interface{} {
+	if x1 == nil || x2 == nil {
+		return nil
+	}
+	ret := map[string]interface{}{}
+	for k, v1 := range x1 {
+		v2, ok := x2[k]
+		if !ok {
+			continue
+		}
+		ret[k] = intersectValue(v1, v2)
+	}
+	return ret
+}
+
+func intersectArray(x1, x2 []interface{}) []interface{} {
+	if x1 == nil || x2 == nil {
+		return nil
+	}
+	ret := make([]interface{}, 0, len(x1))
+	for i := range x1 {
+		if i >= len(x2) {
+			break
+		}
+		ret = append(ret, intersectValue(x1, x2))
+	}
+	return ret
+}
+
+func intersectValue(x1, x2 interface{}) interface{} {
+	switch x1 := x1.(type) {
+	case map[string]interface{}:
+		x2, ok := x2.(map[string]interface{})
+		if !ok {
+			return x1
+		}
+		return intersectJSON(x1, x2)
+	case []interface{}:
+		x2, ok := x2.([]interface{})
+		if !ok {
+			return x1
+		}
+		return intersectArray(x1, x2)
+	default:
+		return x1
+	}
 }

--- a/pkg/operator/resource/resourcemerge/generic_config_merger_test.go
+++ b/pkg/operator/resource/resourcemerge/generic_config_merger_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/diff"
+
+	controlplanev1 "github.com/openshift/api/kubecontrolplane/v1"
 )
 
 func TestMergeConfig(t *testing.T) {
@@ -190,6 +192,53 @@ bravo: two
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			actual, err := MergeProcessConfig(test.specialCases, []byte(test.curr), []byte(test.additional))
+			switch {
+			case err == nil && len(test.expectedErr) == 0:
+			case err == nil && len(test.expectedErr) != 0:
+				t.Fatalf("missing %q", test.expectedErr)
+			case err != nil && len(test.expectedErr) == 0:
+				t.Fatal(err)
+			case err != nil && len(test.expectedErr) != 0 && !strings.Contains(err.Error(), test.expectedErr):
+				t.Fatalf("expected %q, got %q", test.expectedErr, err)
+			}
+			if err != nil {
+				return
+			}
+
+			if test.expected != string(actual) {
+				t.Error(diff.StringDiff(test.expected, string(actual)))
+			}
+		})
+	}
+}
+
+func TestMergePrunedConfig(t *testing.T) {
+	tests := []struct {
+		name         string
+		curr         string
+		additional   string
+		specialCases map[string]MergeFunc
+
+		expected    string
+		expectedErr string
+	}{
+		{
+			name: "prune unknown values",
+			curr: `
+apiVersion: foo
+kind: the-kind
+alpha: first
+`,
+			additional: `
+consolePublicURL: http://foo/bar
+`,
+			expected: `{"apiVersion":"foo","consolePublicURL":"http://foo/bar","kind":"the-kind"}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual, err := MergePrunedProcessConfig(&controlplanev1.KubeAPIServerConfig{}, test.specialCases, []byte(test.curr), []byte(test.additional))
 			switch {
 			case err == nil && len(test.expectedErr) == 0:
 			case err == nil && len(test.expectedErr) != 0:


### PR DESCRIPTION
This adds a variant of the ConfigMap resourcemerge funcs which prunes fields that do not show up in a given `runtime.Object`. This will be used to prune configs for operands from mistyped values and from operator internal fields.