### PR TITLE
pkg/asset/create: run UpdateSatus for resources that have status field set

### DIFF
--- a/pkg/assets/create/create_test.go
+++ b/pkg/assets/create/create_test.go
@@ -149,6 +149,14 @@ func TestCreate(t *testing.T) {
 	testConfigMap.SetName("aggregator-client-ca")
 	testConfigMap.SetNamespace("openshift-kube-apiserver")
 
+	testOperatorConfig := &unstructured.Unstructured{}
+	testOperatorConfig.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "kubeapiserver.operator.openshift.io",
+		Version: "v1alpha1",
+		Kind:    "KubeAPIServerOperatorConfig",
+	})
+	testOperatorConfig.SetName("instance")
+
 	tests := []struct {
 		name              string
 		discovery         []*restmapper.APIGroupResources
@@ -173,6 +181,27 @@ func TestCreate(t *testing.T) {
 			name:            "create all resources",
 			discovery:       resources,
 			existingObjects: []runtime.Object{testConfigMap},
+		},
+		{
+			name:            "create all resources",
+			discovery:       resources,
+			existingObjects: []runtime.Object{testOperatorConfig},
+			evalActions: func(t *testing.T, actions []ktesting.Action) {
+				if got, exp := len(actions), 7; got != exp {
+					t.Errorf("expected %d actions, found %d", exp, got)
+					return
+				}
+
+				ups, ok := actions[5].(ktesting.UpdateAction)
+				if !ok {
+					t.Errorf("expecting Update action for actions[5], got %T", actions[5])
+					return
+				}
+				if got, exp := ups.GetSubresource(), "status"; got != exp {
+					t.Errorf("ecpecting the subresource to be %q, got %q", exp, got)
+					return
+				}
+			},
 		},
 	}
 

--- a/pkg/assets/create/create_test.go
+++ b/pkg/assets/create/create_test.go
@@ -157,6 +157,17 @@ func TestCreate(t *testing.T) {
 	})
 	testOperatorConfig.SetName("instance")
 
+	testOperatorConfigWithStatus := &unstructured.Unstructured{}
+	testOperatorConfigWithStatus.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "kubeapiserver.operator.openshift.io",
+		Version: "v1alpha1",
+		Kind:    "KubeAPIServerOperatorConfig",
+	})
+	testOperatorConfigWithStatus.SetName("instance")
+	testOperatorConfigStatusVal := make(map[string]interface{})
+	testOperatorConfigStatusVal["initializedValue"] = "something before"
+	unstructured.SetNestedField(testOperatorConfigWithStatus.Object, testOperatorConfigStatusVal, "status")
+
 	tests := []struct {
 		name              string
 		discovery         []*restmapper.APIGroupResources
@@ -199,6 +210,17 @@ func TestCreate(t *testing.T) {
 				}
 				if got, exp := ups.GetSubresource(), "status"; got != exp {
 					t.Errorf("ecpecting the subresource to be %q, got %q", exp, got)
+					return
+				}
+			},
+		},
+		{
+			name:            "create all resources",
+			discovery:       resources,
+			existingObjects: []runtime.Object{testOperatorConfigWithStatus},
+			evalActions: func(t *testing.T, actions []ktesting.Action) {
+				if got, exp := len(actions), 6; got != exp {
+					t.Errorf("expected %d actions, found %d", exp, got)
 					return
 				}
 			},

--- a/pkg/assets/create/create_test.go
+++ b/pkg/assets/create/create_test.go
@@ -184,7 +184,7 @@ func TestCreate(t *testing.T) {
 		{
 			name:              "fail to create kube apiserver operator config",
 			discovery:         resourcesWithoutKubeAPIServer,
-			expectFailedCount: 1,
+			expectFailedCount: 2,
 			expectError:       true,
 			expectReload:      true,
 		},
@@ -198,12 +198,12 @@ func TestCreate(t *testing.T) {
 			discovery:       resources,
 			existingObjects: []runtime.Object{testOperatorConfig},
 			evalActions: func(t *testing.T, actions []ktesting.Action) {
-				if got, exp := len(actions), 7; got != exp {
+				if got, exp := len(actions), 8; got != exp {
 					t.Errorf("expected %d actions, found %d", exp, got)
 					return
 				}
 
-				ups, ok := actions[5].(ktesting.UpdateAction)
+				ups, ok := actions[6].(ktesting.UpdateAction)
 				if !ok {
 					t.Errorf("expecting Update action for actions[5], got %T", actions[5])
 					return
@@ -219,7 +219,7 @@ func TestCreate(t *testing.T) {
 			discovery:       resources,
 			existingObjects: []runtime.Object{testOperatorConfigWithStatus},
 			evalActions: func(t *testing.T, actions []ktesting.Action) {
-				if got, exp := len(actions), 6; got != exp {
+				if got, exp := len(actions), 7; got != exp {
 					t.Errorf("expected %d actions, found %d", exp, got)
 					return
 				}
@@ -281,7 +281,7 @@ func TestLoad(t *testing.T) {
 		{
 			name:                  "read all manifests",
 			assetDir:              "testdata",
-			expectedManifestCount: 5,
+			expectedManifestCount: 6,
 		},
 		{
 			name:        "handle missing dir",

--- a/pkg/assets/create/creater.go
+++ b/pkg/assets/create/creater.go
@@ -163,13 +163,19 @@ func create(ctx context.Context, manifests map[string]*unstructured.Unstructured
 			continue
 		}
 
+		var resource dynamic.ResourceInterface
 		if mappings.Scope.Name() == meta.RESTScopeNameRoot {
-			_, err = client.Resource(mappings.Resource).Create(manifests[path], metav1.CreateOptions{})
+			resource = client.Resource(mappings.Resource)
 		} else {
-			_, err = client.Resource(mappings.Resource).Namespace(manifests[path].GetNamespace()).Create(manifests[path], metav1.CreateOptions{})
+			resource = client.Resource(mappings.Resource).Namespace(manifests[path].GetNamespace())
 		}
-
 		resourceString := mappings.Resource.Resource + "." + mappings.Resource.Version + "." + mappings.Resource.Group + "/" + manifests[path].GetName() + " -n " + manifests[path].GetNamespace()
+
+		incluster, err := resource.Create(manifests[path], metav1.CreateOptions{})
+
+		if err == nil && options.Verbose {
+			fmt.Fprintf(options.StdErr, "Created %q %s\n", path, resourceString)
+		}
 
 		// Resource already exists means we already succeeded
 		// This should never happen as we remove already created items from the manifest list, unless the resource existed beforehand.
@@ -177,22 +183,38 @@ func create(ctx context.Context, manifests map[string]*unstructured.Unstructured
 			if options.Verbose {
 				fmt.Fprintf(options.StdErr, "Skipped %q %s as it already exists\n", path, resourceString)
 			}
-			delete(manifests, path)
-			continue
+			incluster, err = resource.Get(manifests[path].GetName(), metav1.GetOptions{})
+			if err != nil {
+				if options.Verbose {
+					fmt.Fprintf(options.StdErr, "Failed to get already existing %q %s: %v\n", path, resourceString, err)
+				}
+				errs[path] = fmt.Errorf("failed to get %s: %v", resourceString, err)
+				continue
+			}
 		}
 
 		if err != nil {
 			if options.Verbose {
 				fmt.Fprintf(options.StdErr, "Failed to create %q %s: %v\n", path, resourceString, err)
 			}
-			errs[path] = fmt.Errorf("failed to create: %v", err)
+			errs[path] = fmt.Errorf("failed to create %s: %v", resourceString, err)
 			continue
 		}
 
-		if options.Verbose {
-			fmt.Fprintf(options.StdErr, "Created %q %s\n", path, resourceString)
+		if _, ok := manifests[path].Object["status"]; ok {
+			unstructured.SetNestedMap(incluster.Object, manifests[path].Object["status"].(map[string]interface{}), "status")
+			incluster, err = resource.UpdateStatus(incluster, metav1.UpdateOptions{})
+			if err != nil && !kerrors.IsNotFound(err) {
+				if options.Verbose {
+					fmt.Fprintf(options.StdErr, "Failed to update the  %q %s: %v\n", path, resourceString, err)
+				}
+				errs[path] = fmt.Errorf("failed to update status for %s: %v", resourceString, err)
+				continue
+			}
+			if options.Verbose {
+				fmt.Fprintf(options.StdErr, "Updated status for %q %s\n", path, resourceString)
+			}
 		}
-
 		// Creation succeeded lets remove the manifest from the list to avoid creating it second time
 		delete(manifests, path)
 	}

--- a/pkg/assets/create/creater.go
+++ b/pkg/assets/create/creater.go
@@ -202,25 +202,18 @@ func create(ctx context.Context, manifests map[string]*unstructured.Unstructured
 		}
 
 		if _, ok := manifests[path].Object["status"]; ok {
-			_, found, err := unstructured.NestedMap(incluster.Object, "status")
-			if err != nil {
-				if options.Verbose {
-					fmt.Fprintf(options.StdErr, "Failed to find status field %q %s: %v\n", path, resourceString, err)
-				}
-				errs[path] = fmt.Errorf("failed to find status field %s: %v", resourceString, err)
-				continue
-			}
+			_, found := incluster.Object["status"]
 			if !found {
-				unstructured.SetNestedMap(incluster.Object, manifests[path].Object["status"].(map[string]interface{}), "status")
+				incluster.Object["status"] = manifests[path].Object["status"]
 				incluster, err = resource.UpdateStatus(incluster, metav1.UpdateOptions{})
 				if err != nil && !kerrors.IsNotFound(err) {
 					if options.Verbose {
-						fmt.Fprintf(options.StdErr, "Failed to update the  %q %s: %v\n", path, resourceString, err)
+						fmt.Fprintf(options.StdErr, "Failed to update status for the %q %s: %v\n", path, resourceString, err)
 					}
 					errs[path] = fmt.Errorf("failed to update status for %s: %v", resourceString, err)
 					continue
 				}
-				if options.Verbose {
+				if err == nil && options.Verbose {
 					fmt.Fprintf(options.StdErr, "Updated status for %q %s\n", path, resourceString)
 				}
 			}

--- a/pkg/assets/create/testdata/operator-config-empty-status.yaml
+++ b/pkg/assets/create/testdata/operator-config-empty-status.yaml
@@ -1,0 +1,7 @@
+apiVersion: kubeapiserver.operator.openshift.io/v1alpha1
+kind: KubeAPIServerOperatorConfig
+metadata:
+  name: instance-empty-status
+spec:
+  managementState: Managed
+status:

--- a/pkg/assets/create/testdata/operator-config.yaml
+++ b/pkg/assets/create/testdata/operator-config.yaml
@@ -4,3 +4,5 @@ metadata:
   name: instance
 spec:
   managementState: Managed
+status:
+  initializedValue: something


### PR DESCRIPTION
Resources like proxies.config.openshift.io that have a status subresource require extra call to UpdateStatus to ensure that the status
contents of the manifest are applied to the cluster.

/cc @deads2k @sttts 