### PR TITLE
Re-enable OpenStack cloud provider

### DIFF
--- a/pkg/operator/configobserver/cloudprovider/observe_cloudprovider.go
+++ b/pkg/operator/configobserver/cloudprovider/observe_cloudprovider.go
@@ -151,8 +151,7 @@ func getPlatformName(platformType configv1.PlatformType, recorder events.Recorde
 		cloudProvider = "gce"
 	case configv1.LibvirtPlatformType:
 	case configv1.OpenStackPlatformType:
-		// TODO(flaper87): Enable this once we've figured out a way to write the cloud provider config in the master nodes
-		//cloudProvider = "openstack"
+		cloudProvider = "openstack"
 	case configv1.NonePlatformType:
 	default:
 		// the new doc on the infrastructure fields requires that we treat an unrecognized thing the same bare metal.

--- a/pkg/operator/configobserver/cloudprovider/observe_cloudprovider_test.go
+++ b/pkg/operator/configobserver/cloudprovider/observe_cloudprovider_test.go
@@ -63,7 +63,8 @@ func TestObserveCloudProviderNames(t *testing.T) {
 		cloudProviderCount: 0,
 	}, {
 		platform:           configv1.OpenStackPlatformType,
-		cloudProviderCount: 0,
+		expected:           "openstack",
+		cloudProviderCount: 1,
 	}, {
 		platform:           configv1.GCPPlatformType,
 		expected:           "gce",


### PR DESCRIPTION
After https://github.com/openshift/machine-config-operator/pull/964 is merged we can re-enable cloud provider again.