### PR TITLE
configobserver/cloudprovider: sync the cloud-config for GCP

### DIFF
--- a/pkg/operator/configobserver/cloudprovider/observe_cloudprovider.go
+++ b/pkg/operator/configobserver/cloudprovider/observe_cloudprovider.go
@@ -95,7 +95,7 @@ func (c *cloudProviderObserver) ObserveCloudProviderNames(genericListers configo
 	}
 
 	// we set cloudprovider configmap values only for some cloud providers.
-	validCloudProviders := sets.NewString("azure", "vsphere")
+	validCloudProviders := sets.NewString("azure", "gce", "vsphere")
 	if !validCloudProviders.Has(cloudProvider) {
 		sourceCloudConfigMap = ""
 	}


### PR DESCRIPTION
GCP cloud provider needs to be configured to be Regional and MultiZone so that it is looking for resources like instances in all Zones for the region it's deployed in.

/cc @csrwng 