### PR TITLE
Introduce gosec for security checks

### DIFF
--- a/alpha-build-machinery/make/default.example.mk.help.log
+++ b/alpha-build-machinery/make/default.example.mk.help.log
@@ -15,6 +15,7 @@ update-deps
 update-deps-overrides
 update-generated
 update-gofmt
+update-gosec
 verify
 verify-bindata
 verify-codegen
@@ -22,4 +23,5 @@ verify-deps
 verify-generated
 verify-gofmt
 verify-golint
+verify-gosec
 verify-govet

--- a/alpha-build-machinery/make/golang.example.mk.help.log
+++ b/alpha-build-machinery/make/golang.example.mk.help.log
@@ -8,7 +8,9 @@ test
 test-unit
 update
 update-gofmt
+update-gosec
 verify
 verify-gofmt
 verify-golint
+verify-gosec
 verify-govet

--- a/alpha-build-machinery/make/golang.mk
+++ b/alpha-build-machinery/make/golang.mk
@@ -6,6 +6,7 @@ self_dir := $(dir $(lastword $(MAKEFILE_LIST)))
 
 verify: verify-gofmt
 verify: verify-govet
+verify: verify-gosec
 .PHONY: verify
 
 update: update-gofmt

--- a/alpha-build-machinery/make/lib/golang.mk
+++ b/alpha-build-machinery/make/lib/golang.mk
@@ -11,6 +11,10 @@ GOEXE ?=$(shell $(GO) env GOEXE)
 GOFMT ?=gofmt
 GOFMT_FLAGS ?=-s -l
 GOLINT ?=golint
+GOSEC ?=gosec
+GOSEC_SEVERITY ?=high
+GOSEC_CONFIDENCE ?=high
+GOSEC_EXCLUDE ?=G304
 
 GO_FILES ?=$(shell find . -name '*.go' -not -path '*/vendor/*' -not -path '*/_output/*' -print)
 GO_PACKAGES ?=./...

--- a/alpha-build-machinery/make/operator.example.mk.help.log
+++ b/alpha-build-machinery/make/operator.example.mk.help.log
@@ -15,6 +15,7 @@ update-deps
 update-deps-overrides
 update-generated
 update-gofmt
+update-gosec
 verify
 verify-bindata
 verify-codegen
@@ -22,4 +23,5 @@ verify-deps
 verify-generated
 verify-gofmt
 verify-golint
+verify-gosec
 verify-govet

--- a/pkg/image/dockerv1client/client.go
+++ b/pkg/image/dockerv1client/client.go
@@ -223,6 +223,7 @@ func newConnection(url url.URL, dialTimeout time.Duration, allowInsecure, enable
 
 	var rt http.RoundTripper
 	if allowInsecure {
+		//#nosec
 		rt = knet.SetTransportDefaults(&http.Transport{
 			Dial: (&net.Dialer{
 				Timeout:   dialTimeout,


### PR DESCRIPTION
gosec does static code analysis and checks for common security issues in
golang codebases.

This PR introduces the tool, and sets it up as a test target in the Makefile.