### PR TITLE
configmerge: fix stack smash

### DIFF
--- a/pkg/operator/resource/resourcemerge/generic_config_merger.go
+++ b/pkg/operator/resource/resourcemerge/generic_config_merger.go
@@ -205,7 +205,7 @@ func intersectArray(x1, x2 []interface{}) []interface{} {
 		if i >= len(x2) {
 			break
 		}
-		ret = append(ret, intersectValue(x1, x2))
+		ret = append(ret, intersectValue(x1[i], x2[i]))
 	}
 	return ret
 }

--- a/pkg/operator/resource/resourcemerge/generic_config_merger_test.go
+++ b/pkg/operator/resource/resourcemerge/generic_config_merger_test.go
@@ -234,6 +234,19 @@ consolePublicURL: http://foo/bar
 `,
 			expected: `{"apiVersion":"foo","consolePublicURL":"http://foo/bar","kind":"the-kind"}`,
 		},
+		{
+			name: "prune unknown values with array",
+			curr: `
+apiVersion: foo
+kind: the-kind
+corsAllowedOrigins:
+- (?i)//openshift(:|\z)
+`,
+			additional: `
+consolePublicURL: http://foo/bar
+`,
+			expected: `{"apiVersion":"foo","consolePublicURL":"http://foo/bar","corsAllowedOrigins":["(?i)//openshift(:|\\z)"],"kind":"the-kind"}`,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
intersectArray() was trying to intersect the input array again
instead of the elements of the array, in a recursive loop.