### PR TITLE
Make image building to be more configurable and confirm to 4.x naming conventions

### DIFF
--- a/alpha-build-machinery/make/default.example.mk
+++ b/alpha-build-machinery/make/default.example.mk
@@ -20,12 +20,12 @@ CODEGEN_GROUPS_VERSION :=openshiftapiserver:v1alpha1
 #   $ make -n --print-data-base | grep ^CODEGEN
 
 # This will call a macro called "build-image" which will generate image specific targets based on the parameters:
-# $0 - macro name
-# $1 - target suffix
-# $2 - Dockerfile path
-# $3 - context directory for image build
+# $1 - target name
+# $2 - image ref
+# $3 - Dockerfile path
+# $4 - context
 # It will generate target "image-$(1)" for builing the image an binding it as a prerequisite to target "images".
-$(call build-image,origin-cluster-openshift-apiserver-operator,./Dockerfile,.)
+$(call build-image,ocp-cli,registry.svc.ci.openshift.org/ocp/4.2:cli,./images/cli/Dockerfile.rhel,.)
 
 # This will call a macro called "add-bindata" which will generate bindata specific targets based on the parameters:
 # $0 - macro name

--- a/alpha-build-machinery/make/default.example.mk.help.log
+++ b/alpha-build-machinery/make/default.example.mk.help.log
@@ -4,7 +4,7 @@ build
 clean
 clean-binaries
 help
-image-origin-cluster-openshift-apiserver-operator
+image-ocp-cli
 images
 test
 test-unit

--- a/alpha-build-machinery/make/operator.example.mk
+++ b/alpha-build-machinery/make/operator.example.mk
@@ -22,12 +22,12 @@ CODEGEN_GROUPS_VERSION :=openshiftapiserver:v1alpha1
 #   $ make -n --print-data-base | grep ^CODEGEN
 
 # This will call a macro called "build-image" which will generate image specific targets based on the parameters:
-# $0 - macro name
-# $1 - target suffix
-# $2 - Dockerfile path
-# $3 - context directory for image build
+# $1 - target name
+# $2 - image ref
+# $3 - Dockerfile path
+# $4 - context
 # It will generate target "image-$(1)" for builing the image an binding it as a prerequisite to target "images".
-$(call build-image,origin-cluster-openshift-apiserver-operator,./Dockerfile,.)
+$(call build-image,ocp-openshift-apiserver-operator,registry.svc.ci.openshift.org/ocp/4.2:openshift-apiserver-operator,./Dockerfile.rhel,.)
 
 # This will call a macro called "add-bindata" which will generate bindata specific targets based on the parameters:
 # $0 - macro name

--- a/alpha-build-machinery/make/operator.example.mk.help.log
+++ b/alpha-build-machinery/make/operator.example.mk.help.log
@@ -4,7 +4,7 @@ build
 clean
 clean-binaries
 help
-image-origin-cluster-openshift-apiserver-operator
+image-ocp-openshift-apiserver-operator
 images
 test
 test-unit

--- a/alpha-build-machinery/make/targets/openshift/images.mk
+++ b/alpha-build-machinery/make/targets/openshift/images.mk
@@ -1,19 +1,23 @@
-IMAGE_REGISTRY ?=
-IMAGE_ORG ?=openshift
-IMAGE_TAG ?=latest
-
-
 # IMAGE_BUILD_EXTRA_FLAGS lets you add extra flags for imagebuilder
 # e.g. to mount secrets and repo information into base image like:
 # make images IMAGE_BUILD_EXTRA_FLAGS='-mount ~/projects/origin-repos/4.2/:/etc/yum.repos.d/'
+IMAGE_BUILD_DEFAULT_FLAGS ?=--allow-pull
 IMAGE_BUILD_EXTRA_FLAGS ?=
 
-# $1 - image name
-# $2 - Dockerfile path
-# $3 - context
+# $1 - target name
+# $2 - image ref
+# $3 - Dockerfile path
+# $4 - context
 define build-image-internal
 image-$(1):
-	$(strip imagebuilder --allow-pull $(IMAGE_BUILD_EXTRA_FLAGS) -f $(2) -t $(addsuffix /,$(IMAGE_REGISTRY))$(addsuffix /,$(IMAGE_ORG))$(1)$(addprefix :,$(IMAGE_TAG)) $(3))
+	$(strip \
+		imagebuilder \
+		$(IMAGE_BUILD_DEFAULT_FLAGS) \
+		-t $(2)
+		-f $(3) \
+		$(IMAGE_BUILD_EXTRA_FLAGS) \
+		$(4) \
+	)
 .PHONY: image-$(1)
 
 images: image-$(1)
@@ -21,5 +25,5 @@ images: image-$(1)
 endef
 
 define build-image
-$(eval $(call build-image-internal,$(1),$(2),$(3)))
+$(eval $(call build-image-internal,$(1),$(2),$(3),$(4)))
 endef


### PR DESCRIPTION
We need this so we can build images with correct names especially for the case where that is a chained build.

E.g. we need to be able to match the image name in
```
FROM registry.svc.ci.openshift.org/ocp/4.2:cli
```

@openshift/openshift-team-master This need Makefile updated on first bump. (These targets are not exercised in CI so it won't fail.) 

/cc @sttts 