### PR TITLE
Revert "Re-enable OpenStack cloud provider"

### DIFF
--- a/pkg/operator/configobserver/cloudprovider/observe_cloudprovider.go
+++ b/pkg/operator/configobserver/cloudprovider/observe_cloudprovider.go
@@ -152,7 +152,8 @@ func getPlatformName(platformType configv1.PlatformType, recorder events.Recorde
 		cloudProvider = "gce"
 	case configv1.LibvirtPlatformType:
 	case configv1.OpenStackPlatformType:
-		cloudProvider = "openstack"
+		// TODO(flaper87): Enable this once we've figured out a way to write the cloud provider config in the master nodes
+		//cloudProvider = "openstack"
 	case configv1.NonePlatformType:
 	default:
 		// the new doc on the infrastructure fields requires that we treat an unrecognized thing the same bare metal.

--- a/pkg/operator/configobserver/cloudprovider/observe_cloudprovider_test.go
+++ b/pkg/operator/configobserver/cloudprovider/observe_cloudprovider_test.go
@@ -63,8 +63,7 @@ func TestObserveCloudProviderNames(t *testing.T) {
 		cloudProviderCount: 0,
 	}, {
 		platform:           configv1.OpenStackPlatformType,
-		expected:           "openstack",
-		cloudProviderCount: 1,
+		cloudProviderCount: 0,
 	}, {
 		platform:           configv1.GCPPlatformType,
 		expected:           "gce",


### PR DESCRIPTION
This reverts commit 5d216395e5dfb57ea13f4d5eab3e20f8b116034c from #488 

Cloud provider requires a path to a valid kubeconfig file in its configuration, but for all components using the provider we have the same configuration, generated by the installer with the kubeconfig path equals to `/var/lib/kubelet/kubeconfig`
https://github.com/openshift/installer/blob/master/pkg/asset/manifests/openstack/cloudproviderconfig.go#L33

If we try to use this configuration with other components, CP cannot start. For instance, for cluster-kube-controller-manager it should be /etc/kubernetes/static-pod-resources/configmaps/controller-manager-kubeconfig/kubeconfig

Until this issue is solved we should temporarily disable CP.