### PR TITLE
observe proxy: don't change target in noconfig -> noconfig case

### DIFF
--- a/pkg/operator/configobserver/proxy/observe_proxy.go
+++ b/pkg/operator/configobserver/proxy/observe_proxy.go
@@ -56,7 +56,7 @@ func (f *observeProxyFlags) ObserveProxyConfig(genericListers configobserver.Lis
 	}
 
 	newProxyMap := proxyToMap(proxyConfig)
-	if len(newProxyMap) > 0 {
+	if newProxyMap != nil {
 		if err := unstructured.SetNestedStringMap(observedConfig, newProxyMap, f.configPath...); err != nil {
 			errs = append(errs, err)
 		}
@@ -82,6 +82,10 @@ func proxyToMap(proxy *configv1.Proxy) map[string]string {
 
 	if httpsProxy := proxy.Spec.HTTPSProxy; len(httpsProxy) > 0 {
 		proxyMap["HTTPS_PROXY"] = httpsProxy
+	}
+
+	if len(proxyMap) == 0 {
+		return nil
 	}
 
 	return proxyMap

--- a/pkg/operator/configobserver/proxy/observe_proxy_test.go
+++ b/pkg/operator/configobserver/proxy/observe_proxy_test.go
@@ -33,10 +33,12 @@ func TestObserveProxyConfig(t *testing.T) {
 	configPath := []string{"openshift", "proxy"}
 
 	tests := []struct {
-		name          string
-		proxySpec     configv1.ProxySpec
-		expected      map[string]interface{}
-		expectedError []error
+		name           string
+		proxySpec      configv1.ProxySpec
+		previous       map[string]string
+		expected       map[string]interface{}
+		expectedError  []error
+		eventsExpected int
 	}{
 		{
 			name:          "all unset",
@@ -60,7 +62,8 @@ func TestObserveProxyConfig(t *testing.T) {
 					},
 				},
 			},
-			expectedError: []error{},
+			expectedError:  []error{},
+			eventsExpected: 1,
 		},
 	}
 	for _, tt := range tests {
@@ -85,6 +88,9 @@ func TestObserveProxyConfig(t *testing.T) {
 			}
 			if !reflect.DeepEqual(errorsGot, tt.expectedError) {
 				t.Errorf("observeProxyFlags.ObserveProxyConfig() errorsGot = %v, want %v", errorsGot, tt.expectedError)
+			}
+			if events := eventRecorder.Events(); len(events) != tt.eventsExpected {
+				t.Errorf("expected %d events, but got %d: %v", tt.eventsExpected, len(events), events)
 			}
 		})
 	}


### PR DESCRIPTION
causes trouble in https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_cluster-kube-apiserver-operator/530/pull-ci-openshift-cluster-kube-apiserver-operator-master-e2e-aws/2467/artifacts/e2e-aws/pods/openshift-kube-apiserver-operator_kube-apiserver-operator-564769bd4f-p8s98_kube-apiserver-operator.log