### PR TITLE
Generate cloud config for openstack cloud provider

### DIFF
--- a/pkg/operator/configobserver/cloudprovider/observe_cloudprovider.go
+++ b/pkg/operator/configobserver/cloudprovider/observe_cloudprovider.go
@@ -96,7 +96,7 @@ func (c *cloudProviderObserver) ObserveCloudProviderNames(genericListers configo
 	}
 
 	// we set cloudprovider configmap values only for some cloud providers.
-	validCloudProviders := sets.NewString("azure", "gce", "vsphere")
+	validCloudProviders := sets.NewString("azure", "gce", "openstack", "vsphere")
 	if !validCloudProviders.Has(cloudProvider) {
 		sourceCloudConfigMap = ""
 	}


### PR DESCRIPTION
OpenStack cloud provider requires a cloud config file to operate properly.