### PR TITLE
Update observe proxy to use Status NoProxy

### DIFF
--- a/pkg/operator/configobserver/proxy/observe_proxy.go
+++ b/pkg/operator/configobserver/proxy/observe_proxy.go
@@ -72,7 +72,7 @@ func (f *observeProxyFlags) ObserveProxyConfig(genericListers configobserver.Lis
 func proxyToMap(proxy *configv1.Proxy) map[string]string {
 	proxyMap := map[string]string{}
 
-	if noProxy := proxy.Spec.NoProxy; len(noProxy) > 0 {
+	if noProxy := proxy.Status.NoProxy; len(noProxy) > 0 {
 		proxyMap["NO_PROXY"] = noProxy
 	}
 

--- a/pkg/operator/configobserver/proxy/observe_proxy_test.go
+++ b/pkg/operator/configobserver/proxy/observe_proxy_test.go
@@ -35,6 +35,7 @@ func TestObserveProxyConfig(t *testing.T) {
 	tests := []struct {
 		name           string
 		proxySpec      configv1.ProxySpec
+		proxyStatus    configv1.ProxyStatus
 		previous       map[string]string
 		expected       map[string]interface{}
 		expectedError  []error
@@ -43,12 +44,18 @@ func TestObserveProxyConfig(t *testing.T) {
 		{
 			name:          "all unset",
 			proxySpec:     configv1.ProxySpec{},
+			proxyStatus:   configv1.ProxyStatus{},
 			expected:      map[string]interface{}{},
 			expectedError: []error{},
 		},
 		{
 			name: "all set",
 			proxySpec: configv1.ProxySpec{
+				HTTPProxy:  "http://someplace.it",
+				HTTPSProxy: "https://someplace.it",
+				NoProxy:    "127.0.0.1",
+			},
+			proxyStatus: configv1.ProxyStatus{
 				HTTPProxy:  "http://someplace.it",
 				HTTPSProxy: "https://someplace.it",
 				NoProxy:    "127.0.0.1",
@@ -72,6 +79,7 @@ func TestObserveProxyConfig(t *testing.T) {
 			indexer.Add(&configv1.Proxy{
 				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
 				Spec:       tt.proxySpec,
+				Status:     tt.proxyStatus,
 			})
 			listers := testLister{
 				lister: configlistersv1.NewProxyLister(indexer),


### PR DESCRIPTION
When the installer creates the Proxy manifest
Status NoProxy contains the list of cluster urls and
ip address(es) that should not be proxied.  Spec noProxy
only contains the user provided list.