### PR TITLE
Bug 1719188: fix IsOperatorAlwaysManaged check so operator conditions are set to u…

### DIFF
--- a/pkg/operator/status/status_controller.go
+++ b/pkg/operator/status/status_controller.go
@@ -124,7 +124,10 @@ func (c StatusSyncer) sync() error {
 	}
 	clusterOperatorObj := originalClusterOperatorObj.DeepCopy()
 
-	if detailedSpec.ManagementState == operatorv1.Unmanaged && !management.IsOperatorAlwaysManaged() {
+	// management.IsOperatorAlwaysManaged() means the operator can't be set to unmanaged state.
+	// so if a cluster admin sets an operator as unmanaged when it can't be unmanaged, then we set the
+	// conditions to unknown, as we are now in an indeterminate state
+	if detailedSpec.ManagementState == operatorv1.Unmanaged && management.IsOperatorAlwaysManaged() {
 		clusterOperatorObj.Status = configv1.ClusterOperatorStatus{}
 
 		configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorAvailable, Status: configv1.ConditionUnknown, Reason: "Unmanaged"})


### PR DESCRIPTION
…nknown if unmanaged is NOT supported

Now, are operators which want only to support managed, and not unmanaged etc. already calling SetOperatorAlwaysManaged() at 
https://github.com/gabemontero/library-go/blob/master/pkg/operator/management/management_state.go#L25-L27

Or are they not calling that method and getting desired behavior by accident?

Do we have a precise list of operator who need to be "always managed"