### PR TITLE
add dependency magnet files for go mod and build-machinery

### DIFF
--- a/alpha-build-machinery/doc.go
+++ b/alpha-build-machinery/doc.go
@@ -1,0 +1,14 @@
+// required for gomod to pull in packages.
+
+package alpha_build_machinery
+
+// this is a dependency magnet to make it easier to pull in the build-machinery.  We want a single import to pull all of it in.
+import (
+	_ "github.com/openshift/library-go/alpha-build-machinery/make"
+	_ "github.com/openshift/library-go/alpha-build-machinery/make/lib"
+	_ "github.com/openshift/library-go/alpha-build-machinery/make/targets"
+	_ "github.com/openshift/library-go/alpha-build-machinery/make/targets/golang"
+	_ "github.com/openshift/library-go/alpha-build-machinery/make/targets/openshift"
+	_ "github.com/openshift/library-go/alpha-build-machinery/make/targets/openshift/operator"
+	_ "github.com/openshift/library-go/alpha-build-machinery/scripts"
+)

--- a/alpha-build-machinery/make/doc.go
+++ b/alpha-build-machinery/make/doc.go
@@ -1,0 +1,3 @@
+// required for gomod to pull in packages.
+
+package alpha_build_machinery

--- a/alpha-build-machinery/make/lib/doc.go
+++ b/alpha-build-machinery/make/lib/doc.go
@@ -1,0 +1,3 @@
+// required for gomod to pull in packages.
+
+package alpha_build_machinery

--- a/alpha-build-machinery/make/targets/doc.go
+++ b/alpha-build-machinery/make/targets/doc.go
@@ -1,0 +1,3 @@
+// required for gomod to pull in packages.
+
+package alpha_build_machinery

--- a/alpha-build-machinery/make/targets/golang/doc.go
+++ b/alpha-build-machinery/make/targets/golang/doc.go
@@ -1,0 +1,3 @@
+// required for gomod to pull in packages.
+
+package alpha_build_machinery

--- a/alpha-build-machinery/make/targets/openshift/doc.go
+++ b/alpha-build-machinery/make/targets/openshift/doc.go
@@ -1,0 +1,3 @@
+// required for gomod to pull in packages.
+
+package alpha_build_machinery

--- a/alpha-build-machinery/make/targets/openshift/operator/doc.go
+++ b/alpha-build-machinery/make/targets/openshift/operator/doc.go
@@ -1,0 +1,3 @@
+// required for gomod to pull in packages.
+
+package alpha_build_machinery

--- a/alpha-build-machinery/scripts/doc.go
+++ b/alpha-build-machinery/scripts/doc.go
@@ -1,0 +1,3 @@
+// required for gomod to pull in packages.
+
+package alpha_build_machinery


### PR DESCRIPTION
`go mod` prunes all packages not used.  You cannot rely on a non-go package, but we need our build machinery.  This allows us to use `go mod` by creating a dependency magnet we can use from other repos.

/assign @tnozicka @soltysh 