### PR TITLE
build-machinery: Fix and simplify GO_PACKAGE detection

### DIFF
--- a/alpha-build-machinery/make/lib/golang.mk
+++ b/alpha-build-machinery/make/lib/golang.mk
@@ -1,9 +1,6 @@
 GO ?=go
 GOPATH ?=$(shell $(GO) env GOPATH)
-gopath_list :=$(subst :, ,$(strip $(GOPATH)))
-# Use every path in GOPATH to try to remove it as a prefix of current dir to determine the package name.
-# If the prefix is not removed on subtitution, filter-out unchanged paths.
-GO_PACKAGE ?=$(strip $(filter-out $(abspath .),$(foreach p,$(gopath_list),$(patsubst $(p)/src/%,%,$(abspath .)))))
+GO_PACKAGE ?=$(shell $(GO) list -e -f '{{ .ImportPath }}' . || echo 'no_package_detected')
 
 GOOS ?=$(shell $(GO) env GOOS)
 GOHOSTOS ?=$(shell $(GO) env GOHOSTOS)


### PR DESCRIPTION
I found that when building rpms (special gopath / multiple gopath) this failed. Looks like `go list` can do it as well and I have more confidence in it.

/cc @sttts 