### PR TITLE
fileobserver: deprecate ExitOnChangeReactor in favor of TerminateOnChangeReactor

### DIFF
--- a/pkg/controller/fileobserver/observer_polling.go
+++ b/pkg/controller/fileobserver/observer_polling.go
@@ -16,14 +16,14 @@ import (
 
 type pollingObserver struct {
 	interval time.Duration
-	reactors map[string][]reactorFn
+	reactors map[string][]ReactorFn
 	files    map[string]string
 
 	reactorsMutex sync.RWMutex
 }
 
 // AddReactor will add new reactor to this observer.
-func (o *pollingObserver) AddReactor(reaction reactorFn, startingFileContent map[string][]byte, files ...string) Observer {
+func (o *pollingObserver) AddReactor(reaction ReactorFn, startingFileContent map[string][]byte, files ...string) Observer {
 	o.reactorsMutex.Lock()
 	defer o.reactorsMutex.Unlock()
 	for _, f := range files {

--- a/pkg/operator/staticpod/certsyncpod/certsync_cmd.go
+++ b/pkg/operator/staticpod/certsyncpod/certsync_cmd.go
@@ -62,10 +62,12 @@ func (o *CertSyncControllerOptions) Run() error {
 		return err
 	}
 
-	initialContent, _ := ioutil.ReadFile(o.KubeConfigFile)
-	observer.AddReactor(fileobserver.ExitOnChangeReactor, map[string][]byte{o.KubeConfigFile: initialContent}, o.KubeConfigFile)
-
 	stopCh := make(chan struct{})
+
+	initialContent, _ := ioutil.ReadFile(o.KubeConfigFile)
+	observer.AddReactor(fileobserver.TerminateOnChangeReactor(func() {
+		close(stopCh)
+	}), map[string][]byte{o.KubeConfigFile: initialContent}, o.KubeConfigFile)
 
 	kubeInformers := informers.NewSharedInformerFactoryWithOptions(o.kubeClient, 10*time.Minute, informers.WithNamespace(o.Namespace))
 


### PR DESCRIPTION
The `ExitOnChangeReactor` is dangerous because it calls `os.Exit(0)` directly which kills the process immediately without proper shutdown. 
The `TerminateOnChangeReactor` allow consumer to pass the termination function.

The `ExitOnChangeReactor` is not removed as somebody might be using it, but marked as deprecated.

/cc @sttts 