### PR TITLE
installer: fix pending revision error message to include target revision

### DIFF
--- a/pkg/operator/staticpod/controller/installer/installer_controller.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller.go
@@ -540,7 +540,7 @@ func (c *InstallerController) newNodeStateForInstallInProgress(currNodeState *op
 			// stop early, don't wait for ready static pod because a new revision is waiting
 			ret.LastFailedRevision = currNodeState.TargetRevision
 			ret.TargetRevision = 0
-			ret.LastFailedRevisionErrors = []string{"static pod of revision has been installed, but is not ready while new revision % is pending"}
+			ret.LastFailedRevisionErrors = []string{fmt.Sprintf("static pod of revision has been installed, but is not ready while new revision %d is pending", currNodeState.TargetRevision)}
 			return ret, false, "new revision pending", nil
 		}
 


### PR DESCRIPTION
Fixes:

```
2019-08-30T06:34:04.422583209Z   (string) (len=91) "static pod of revision has been installed, but is not ready while new revision % is pending"
```