### PR TITLE
Bug 1748280: resourceapply: sync ConfigMap binaryData as well

### DIFF
--- a/pkg/operator/resource/resourceapply/core.go
+++ b/pkg/operator/resource/resourceapply/core.go
@@ -1,6 +1,7 @@
 package resourceapply
 
 import (
+	"bytes"
 	"fmt"
 	"sort"
 	"strings"
@@ -168,9 +169,19 @@ func ApplyConfigMap(client coreclientv1.ConfigMapsGetter, recorder events.Record
 			modifiedKeys = append(modifiedKeys, "data."+existingCopyKey)
 		}
 	}
+	for existingCopyKey, existingCopyBinValue := range existingCopy.BinaryData {
+		if requiredBinValue, ok := required.BinaryData[existingCopyKey]; !ok || !bytes.Equal(existingCopyBinValue, requiredBinValue) {
+			modifiedKeys = append(modifiedKeys, "binaryData."+existingCopyKey)
+		}
+	}
 	for requiredKey := range required.Data {
 		if _, ok := existingCopy.Data[requiredKey]; !ok {
 			modifiedKeys = append(modifiedKeys, "data."+requiredKey)
+		}
+	}
+	for requiredBinKey := range required.BinaryData {
+		if _, ok := existingCopy.BinaryData[requiredBinKey]; !ok {
+			modifiedKeys = append(modifiedKeys, "binaryData."+requiredBinKey)
 		}
 	}
 
@@ -179,6 +190,7 @@ func ApplyConfigMap(client coreclientv1.ConfigMapsGetter, recorder events.Record
 		return existingCopy, false, nil
 	}
 	existingCopy.Data = required.Data
+	existingCopy.BinaryData = required.BinaryData
 
 	actual, err := client.ConfigMaps(required.Namespace).Update(existingCopy)
 

--- a/pkg/operator/resource/resourceapply/core_test.go
+++ b/pkg/operator/resource/resourceapply/core_test.go
@@ -139,6 +139,52 @@ func TestApplyConfigMap(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "update on mismatch binary data",
+			existing: []runtime.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "one-ns", Name: "foo", Labels: map[string]string{"extra": "leave-alone"}},
+					Data: map[string]string{
+						"configmap": "value",
+					},
+				},
+			},
+			input: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "one-ns", Name: "foo"},
+				Data: map[string]string{
+					"configmap": "value",
+				},
+				BinaryData: map[string][]byte{
+					"binconfigmap": []byte("value"),
+				},
+			},
+
+			expectedModified: true,
+			verifyActions: func(actions []clienttesting.Action, t *testing.T) {
+				if len(actions) != 2 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("get", "configmaps") || actions[0].(clienttesting.GetAction).GetName() != "foo" {
+					t.Error(spew.Sdump(actions))
+				}
+				if !actions[1].Matches("update", "configmaps") {
+					t.Error(spew.Sdump(actions))
+				}
+				expected := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "one-ns", Name: "foo", Labels: map[string]string{"extra": "leave-alone"}},
+					Data: map[string]string{
+						"configmap": "value",
+					},
+					BinaryData: map[string][]byte{
+						"binconfigmap": []byte("value"),
+					},
+				}
+				actual := actions[1].(clienttesting.UpdateAction).GetObject().(*corev1.ConfigMap)
+				if !equality.Semantic.DeepEqual(expected, actual) {
+					t.Error(JSONPatch(expected, actual))
+				}
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
We weren't syncing the binaryData which resulted in failures for the console operator. This fixes it.