### PR TITLE
cmd: run terminate-on-files observer

### DIFF
--- a/pkg/controller/controllercmd/cmd.go
+++ b/pkg/controller/controllercmd/cmd.go
@@ -89,21 +89,27 @@ func (c *ControllerCommandConfig) NewCommandWithContext(ctx context.Context) *co
 				klog.Fatal(err)
 			}
 
-			// setup file observer to terminate when given files change
-			obs, err := fileobserver.NewObserver(10 * time.Second)
-			if err != nil {
-				klog.Fatal(err)
-			}
 			ctx, terminate := context.WithCancel(shutdownCtx)
-			files := map[string][]byte{}
-			for _, fn := range c.basicFlags.TerminateOnFiles {
-				files[fn], _ = ioutil.ReadFile(fn) // intentionally ignore error
+			defer terminate()
+
+			if len(c.basicFlags.TerminateOnFiles) > 0 {
+				// setup file observer to terminate when given files change
+				obs, err := fileobserver.NewObserver(10 * time.Second)
+				if err != nil {
+					klog.Fatal(err)
+				}
+				files := map[string][]byte{}
+				for _, fn := range c.basicFlags.TerminateOnFiles {
+					files[fn], _ = ioutil.ReadFile(fn) // intentionally ignore error
+				}
+				obs.AddReactor(func(filename string, action fileobserver.ActionType) error {
+					klog.Infof("exiting because %q changed", filename)
+					terminate()
+					return nil
+				}, files, c.basicFlags.TerminateOnFiles...)
+
+				go obs.Run(shutdownHandler)
 			}
-			obs.AddReactor(func(filename string, action fileobserver.ActionType) error {
-				klog.Infof("exiting because %q changed", filename)
-				terminate()
-				return nil
-			}, files, c.basicFlags.TerminateOnFiles...)
 
 			if err := c.StartController(ctx); err != nil {
 				klog.Fatal(err)


### PR DESCRIPTION
This fixes a bug where if `--terminate-on-files` is used we never run the file observer (just create it). It also starts the observer only if this flag is specified.

This should unblock the auth operator.