### PR TITLE
fileobserver: do not hash empty string

### DIFF
--- a/pkg/controller/controllercmd/cmd.go
+++ b/pkg/controller/controllercmd/cmd.go
@@ -100,7 +100,12 @@ func (c *ControllerCommandConfig) NewCommandWithContext(ctx context.Context) *co
 				}
 				files := map[string][]byte{}
 				for _, fn := range c.basicFlags.TerminateOnFiles {
-					files[fn], _ = ioutil.ReadFile(fn) // intentionally ignore error
+					fileBytes, err := ioutil.ReadFile(fn)
+					if err != nil {
+						klog.Warningf("Unable to read initial content of %q: %v", fn, err)
+						continue // intentionally ignore errors
+					}
+					files[fn] = fileBytes
 				}
 				obs.AddReactor(func(filename string, action fileobserver.ActionType) error {
 					klog.Infof("exiting because %q changed", filename)

--- a/pkg/controller/fileobserver/observer_polling.go
+++ b/pkg/controller/fileobserver/observer_polling.go
@@ -38,6 +38,16 @@ func (o *pollingObserver) AddReactor(reaction ReactorFn, startingFileContent map
 
 		if startingContent, ok := startingFileContent[f]; ok {
 			klog.V(3).Infof("Starting from specified content for file %q", f)
+			// if empty starting content is specified, do not hash the empty string but just return it the same
+			// way as calculateFileHash() does in that case.
+			// in case the file exists and is empty, we don't care about the initial content anyway, because we
+			// are only going to react when the file content change.
+			// in case the file does not exists but empty string is specified as initial content, without this
+			// the content will be hashed and reaction will trigger as if the content changed.
+			if len(startingContent) == 0 {
+				o.files[f] = ""
+				continue
+			}
 			o.files[f], err = calculateHash(bytes.NewBuffer(startingContent))
 			if err != nil {
 				panic(fmt.Sprintf("unexpected error while adding reactor for %#v: %v", files, err))

--- a/pkg/controller/fileobserver/observer_polling_test.go
+++ b/pkg/controller/fileobserver/observer_polling_test.go
@@ -150,7 +150,7 @@ func TestObserverSimpleContentSpecified(t *testing.T) {
 	o.AddReactor(
 		testReaction,
 		map[string][]byte{
-			testFile: {},
+			testFile: []byte("bar"),
 		},
 		testFile)
 


### PR DESCRIPTION
Inside auth operator, we read the trusted ca bundle file but we ignore the error when the file does not exists. In that case the starting content for that file is empty string. Without this fix, the fileobserver will hash the empty string (`e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`) and then after the binary/operator run, the `calculateFileHash()` return "" as hash if the file does not exists.

That will trigger immediate restart/termination because the content change.

NOTE: This is blocking 4.1 -> 4.2 upgrade test, this was found in the logs:

```
 1 observer_polling.go:78] Observed change: file:/var/run/configmaps/trusted-ca-bundle/ca-bundle.crt (current: "", lastKnown: "e3b0c44298fc1c149af....
```