### PR TITLE
Fix up crd-schema-gen verify

### DIFF
--- a/alpha-build-machinery/make/examples/multiple-binaries/Makefile.test.log
+++ b/alpha-build-machinery/make/examples/multiple-binaries/Makefile.test.log
@@ -142,21 +142,7 @@ chmod +x '_output/tools/bin/yq';
 '_output/tools/src/sigs.k8s.io/controller-tools/controller-gen' \
 	schemapatch:manifests="./manifests" \
 	paths="./pkg/apis/v1;./pkg/apis/v1beta1" \
-_output/tools/bin/yq m -i './manifests/operator.openshift.io_myoperatorresources.crd.yaml' './manifests/operator.openshift.io_myoperatorresources.crd.yaml-merge-patch'
---- 
-@@ -9,11 +9,6 @@ spec:
-     kind: MyOperatorResource
-     plural: myoperatorresources
-   scope: ""
--  validation:
--    openAPIV3Schema:
--      properties:
--        apiVersion:
--          pattern: ^(test|TEST)$
- status:
-   acceptedNames:
-     kind: ""
---- 
+--- ./manifests/operator.openshift.io_myotheroperatorresources.crd.yaml
 @@ -11,9 +11,39 @@ spec:
    scope: ""
    version: v1beta1
@@ -216,7 +202,6 @@ Using existing yq from "_output/tools/bin/yq"
 '_output/tools/src/sigs.k8s.io/controller-tools/controller-gen' \
 	schemapatch:manifests="./manifests" \
 	paths="./pkg/apis/v1;./pkg/apis/v1beta1" \
-_output/tools/bin/yq m -i './manifests/operator.openshift.io_myoperatorresources.crd.yaml' './manifests/operator.openshift.io_myoperatorresources.crd.yaml-merge-patch'
 ! diff -Naup ./testing/manifests/initial/ ./manifests/ 2>/dev/null
 diff -Naup ./testing/manifests/initial/operator.openshift.io_myoperatorresources.crd.yaml ./manifests/operator.openshift.io_myoperatorresources.crd.yaml
 --- ./testing/manifests/initial/operator.openshift.io_myoperatorresources.crd.yaml


### PR DESCRIPTION
This fixes up #526 to only check the diff of CRD manifests, instead of the entire manifest folder, the latter of which causes errors because we do not copy the entire manifests folder to the temp dir.

The other option of course *is* copying the entire manifests folder to the temp dir, however that creates a lot of ugly silenced errors when we call `cp` for just update:

```
$ make update-codegen
Using existing controller-gen from "_output/tools/src/sigs.k8s.io/controller-tools/controller-gen"
Using existing yq from "_output/tools/bin/yq"
'_output/tools/src/sigs.k8s.io/controller-tools/controller-gen' \
		schemapatch:manifests="./manifests" \
		paths="./vendor/github.com/openshift/api/operator/v1" \
		output:dir="./manifests"
cp -n ./manifests/* './manifests/' || true  # FIXME: centos
cp: ./manifests/0000_20_kube-apiserver-operator_00_namespace.yaml and ./manifests/0000_20_kube-apiserver-operator_00_namespace.yaml are identical (not copied).
cp: ./manifests/0000_20_kube-apiserver-operator_00_scc-anyuid.json and ./manifests/0000_20_kube-apiserver-operator_00_scc-anyuid.json are identical (not copied).
cp: ./manifests/0000_20_kube-apiserver-operator_00_scc-hostaccess.json and ./manifests/0000_20_kube-apiserver-operator_00_scc-hostaccess.json are identical (not copied).
cp: ./manifests/0000_20_kube-apiserver-operator_00_scc-hostmount-anyuid.json and ./manifests/0000_20_kube-apiserver-operator_00_scc-hostmount-anyuid.json are identical (not copied).
cp: ./manifests/0000_20_kube-apiserver-operator_00_scc-hostnetwork.json and ./manifests/0000_20_kube-apiserver-operator_00_scc-hostnetwork.json are identical (not copied).
cp: ./manifests/0000_20_kube-apiserver-operator_00_scc-nonroot.json and ./manifests/0000_20_kube-apiserver-operator_00_scc-nonroot.json are identical (not copied).
cp: ./manifests/0000_20_kube-apiserver-operator_00_scc-privileged.json and ./manifests/0000_20_kube-apiserver-operator_00_scc-privileged.json are identical (not copied).
cp: ./manifests/0000_20_kube-apiserver-operator_00_scc-restricted.json and ./manifests/0000_20_kube-apiserver-operator_00_scc-restricted.json are identical (not copied).
cp: ./manifests/0000_20_kube-apiserver-operator_01_config.crd.yaml and ./manifests/0000_20_kube-apiserver-operator_01_config.crd.yaml are identical (not copied).
cp: ./manifests/0000_20_kube-apiserver-operator_01_config.crd.yaml-merge-patch and ./manifests/0000_20_kube-apiserver-operator_01_config.crd.yaml-merge-patch are identical (not copied).
cp: ./manifests/0000_20_kube-apiserver-operator_01_operator.cr.yaml and ./manifests/0000_20_kube-apiserver-operator_01_operator.cr.yaml are identical (not copied).
cp: ./manifests/0000_20_kube-apiserver-operator_02_service.yaml and ./manifests/0000_20_kube-apiserver-operator_02_service.yaml are identical (not copied).
cp: ./manifests/0000_20_kube-apiserver-operator_03_configmap.yaml and ./manifests/0000_20_kube-apiserver-operator_03_configmap.yaml are identical (not copied).
cp: ./manifests/0000_20_kube-apiserver-operator_04_clusterrolebinding.yaml and ./manifests/0000_20_kube-apiserver-operator_04_clusterrolebinding.yaml are identical (not copied).
cp: ./manifests/0000_20_kube-apiserver-operator_05_serviceaccount.yaml and ./manifests/0000_20_kube-apiserver-operator_05_serviceaccount.yaml are identical (not copied).
cp: ./manifests/0000_20_kube-apiserver-operator_06_deployment.yaml and ./manifests/0000_20_kube-apiserver-operator_06_deployment.yaml are identical (not copied).
cp: ./manifests/0000_20_kube-apiserver-operator_07_clusteroperator.yaml and ./manifests/0000_20_kube-apiserver-operator_07_clusteroperator.yaml are identical (not copied).
cp: ./manifests/0000_90_kube-apiserver-operator_01_prometheusrole.yaml and ./manifests/0000_90_kube-apiserver-operator_01_prometheusrole.yaml are identical (not copied).
cp: ./manifests/0000_90_kube-apiserver-operator_02_prometheusrolebinding.yaml and ./manifests/0000_90_kube-apiserver-operator_02_prometheusrolebinding.yaml are identical (not copied).
cp: ./manifests/0000_90_kube-apiserver-operator_03_servicemonitor.yaml and ./manifests/0000_90_kube-apiserver-operator_03_servicemonitor.yaml are identical (not copied).
cp: ./manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml and ./manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml are identical (not copied).
cp: ./manifests/image-references and ./manifests/image-references are identical (not copied).
_output/tools/bin/yq m -i './manifests/0000_20_kube-apiserver-operator_01_config.crd.yaml' './manifests/0000_20_kube-apiserver-operator_01_config.crd.yaml-merge-patch
```

So, this is hacky, but the output is more readable. 

This PR also updates a line in verify to make sure that yaml-merge-patches are appropriately applied to the temp directory. Using the global variable, the temp directory for CRD_SCHEMA_GEN_OUTPUT wasn't properly passed through to update-codegen, meaning the patches didn't get applied to the temp dir