### PR TITLE
Bug 1754042: Detect more retriable errors from general registry clients

### DIFF
--- a/pkg/image/registryclient/client.go
+++ b/pkg/image/registryclient/client.go
@@ -20,6 +20,7 @@ import (
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/manifest/schema1"
 	"github.com/docker/distribution/reference"
+	"github.com/docker/distribution/registry/api/errcode"
 	registryclient "github.com/docker/distribution/registry/client"
 	"github.com/docker/distribution/registry/client/auth"
 	"github.com/docker/distribution/registry/client/auth/challenge"
@@ -369,8 +370,20 @@ func isTemporaryHTTPError(err error) (time.Duration, bool) {
 	switch t := err.(type) {
 	case net.Error:
 		return time.Second, t.Temporary() || t.Timeout()
+	case errcode.ErrorCoder:
+		// note: we explicitly do not check errcode.ErrorCodeUnknown because that is used in
+		// a wide range of scenarios to convey "generic error", not "retryable error"
+		switch t.ErrorCode() {
+		case errcode.ErrorCodeUnavailable:
+			return 5 * time.Second, true
+		case errcode.ErrorCodeTooManyRequests:
+			return 2 * time.Second, true
+		}
 	case *registryclient.UnexpectedHTTPResponseError:
-		if t.StatusCode == http.StatusTooManyRequests {
+		switch t.StatusCode {
+		case http.StatusInternalServerError, http.StatusGatewayTimeout, http.StatusServiceUnavailable, http.StatusBadGateway:
+			return 5 * time.Second, true
+		case http.StatusTooManyRequests:
 			return 2 * time.Second, true
 		}
 	}


### PR DESCRIPTION
If we see a known 429 or 503 error, or an unknown 503 or 500 error,
we can retry.

Will allow broader retry behavior for cli commands.

Prereq for openshift/oc#112