### PR TITLE
Generic crdgen

### DIFF
--- a/alpha-build-machinery/make/examples/multiple-binaries/Makefile
+++ b/alpha-build-machinery/make/examples/multiple-binaries/Makefile
@@ -6,8 +6,8 @@ include $(addprefix ../../, \
 )
 
 # Set crd-schema-gen variables
-CRD_SCHEMA_GEN_APIS :=$(addprefix ./pkg/apis/,v1 v1beta1)
-CRD_SCHEMA_GEN_VERSION :=v0.2.1
+CONTROLLER_GEN_VERSION :=v0.2.1
+CRD_APIS :=$(addprefix ./pkg/apis/,v1 v1beta1)
 
 # rpm wants build-id set
 GO_LD_EXTRAFLAGS +=-B 0x$$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n')
@@ -15,6 +15,12 @@ GO_LD_EXTRAFLAGS +=-B 0x$$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n')
 OUTPUT_DIR :=_output
 CROSS_BUILD_BINDIR :=$(OUTPUT_DIR)/bin
 RPM_EXTRAFLAGS :=--quiet --define 'version 2.42.0' --define 'dist .el7' --define 'release 6'
+
+# $1 - target name
+# $2 - apis
+# $3 - manifests
+# $4 - output
+$(call add-crd-gen,manifests,$(CRD_APIS),./manifests,./manifests)
 
 cross-build-darwin-amd64:
 	+@GOOS=darwin GOARCH=amd64 $(MAKE) --no-print-directory build GO_BUILD_BINDIR:=$(CROSS_BUILD_BINDIR)/darwin_amd64

--- a/alpha-build-machinery/make/examples/multiple-binaries/Makefile.test
+++ b/alpha-build-machinery/make/examples/multiple-binaries/Makefile.test
@@ -59,8 +59,9 @@ test-codegen:
 
 	$(MAKE) update-codegen-crds
 	$(MAKE) verify-codegen-crds
-	! diff -Naup ./testing/manifests/initial/ ./manifests/ 2>/dev/null
-	diff -Naup ./testing/manifests/updated/ ./manifests/ 2>/dev/null
+	cp -r ./testing/manifests/initial/*.crd.yaml-merge-patch ./manifests/
+	! diff -Naup ./testing/manifests/initial/ ./manifests/ 2>/dev/null 1>&2
+	diff -Naup ./testing/manifests/updated/ ./manifests/
 
 	$(MAKE) clean
 	[[ ! -d ./_output/ ]] || (ls -l ./_output/ && false)

--- a/alpha-build-machinery/make/examples/multiple-binaries/Makefile.test.log
+++ b/alpha-build-machinery/make/examples/multiple-binaries/Makefile.test.log
@@ -133,9 +133,6 @@ Installing yq into '_output/tools/bin/yq'
 mkdir -p '_output/tools/bin/'
 curl -s -f -L https://github.com/mikefarah/yq/releases/download/2.4.0/yq_linux_amd64 -o '_output/tools/bin/yq'
 chmod +x '_output/tools/bin/yq';
-'_output/tools/src/sigs.k8s.io/controller-tools/controller-gen' \
-	schemapatch:manifests="./manifests" \
-	paths="./pkg/apis/v1;./pkg/apis/v1beta1" \
 --- ./manifests/operator.openshift.io_myotheroperatorresources.crd.yaml
 @@ -9,6 +9,40 @@ spec:
      kind: MyOtherOperatorResource
@@ -178,85 +175,19 @@ chmod +x '_output/tools/bin/yq';
    version: v1beta1
    versions:
    - name: v1beta1
-make[2]: *** [verify-codegen-crds] Error 1
+make[2]: *** [verify-codegen-crds-manifests] Error 1
 make update-codegen-crds
 Using existing controller-gen from "_output/tools/src/sigs.k8s.io/controller-tools/controller-gen"
 Using existing yq from "_output/tools/bin/yq"
-'_output/tools/src/sigs.k8s.io/controller-tools/controller-gen' \
-	schemapatch:manifests="./manifests" \
-	paths="./pkg/apis/v1;./pkg/apis/v1beta1" \
-	output:dir="./manifests"
-cp -n ./manifests/operator.openshift.io_myotheroperatorresources.crd.yaml-merge-patch './manifests/' || true  # FIXME: centos
+'_output/tools/src/sigs.k8s.io/controller-tools/controller-gen' schemapatch:manifests="./manifests" paths="./pkg/apis/v1;./pkg/apis/v1beta1" output:dir="./manifests"
 _output/tools/bin/yq m -i -x './manifests/operator.openshift.io_myotheroperatorresources.crd.yaml' './manifests/operator.openshift.io_myotheroperatorresources.crd.yaml-merge-patch'
-cp -n ./manifests/operator.openshift.io_myoperatorresources.crd.yaml-merge-patch './manifests/' || true  # FIXME: centos
 _output/tools/bin/yq m -i -x './manifests/operator.openshift.io_myoperatorresources.crd.yaml' './manifests/operator.openshift.io_myoperatorresources.crd.yaml-merge-patch'
 make verify-codegen-crds
 Using existing controller-gen from "_output/tools/src/sigs.k8s.io/controller-tools/controller-gen"
 Using existing yq from "_output/tools/bin/yq"
-'_output/tools/src/sigs.k8s.io/controller-tools/controller-gen' \
-	schemapatch:manifests="./manifests" \
-	paths="./pkg/apis/v1;./pkg/apis/v1beta1" \
-! diff -Naup ./testing/manifests/initial/ ./manifests/ 2>/dev/null
-diff -Naup ./testing/manifests/initial/operator.openshift.io_myoperatorresources.crd.yaml ./manifests/operator.openshift.io_myoperatorresources.crd.yaml
---- ./testing/manifests/initial/operator.openshift.io_myoperatorresources.crd.yaml
-+++ ./manifests/operator.openshift.io_myoperatorresources.crd.yaml
-@@ -9,6 +9,11 @@ spec:
-     kind: MyOperatorResource
-     plural: myoperatorresources
-   scope: ""
-+  validation:
-+    openAPIV3Schema:
-+      properties:
-+        apiVersion:
-+          pattern: ^(test|TEST)$
- status:
-   acceptedNames:
-     kind: ""
-diff -Naup ./testing/manifests/initial/operator.openshift.io_myotheroperatorresources.crd.yaml ./manifests/operator.openshift.io_myotheroperatorresources.crd.yaml
---- ./testing/manifests/initial/operator.openshift.io_myotheroperatorresources.crd.yaml
-+++ ./manifests/operator.openshift.io_myotheroperatorresources.crd.yaml
-@@ -9,6 +9,40 @@ spec:
-     kind: MyOtherOperatorResource
-     plural: myotheroperatorresources
-   scope: ""
-+  validation:
-+    openAPIV3Schema:
-+      description: MyOtherOperatorResource is an example operator configuration type
-+      properties:
-+        apiVersion:
-+          description: 'APIVersion defines the versioned schema of this representation
-+            of an object. Servers should convert recognized schemas to the latest
-+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-+          type: string
-+        kind:
-+          description: 'Kind is a string value representing the REST resource this
-+            object represents. Servers may infer this from the endpoint the client
-+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-+          type: string
-+        metadata:
-+          type: object
-+        spec:
-+          properties:
-+            deprecatedField:
-+              type: string
-+            name:
-+              type: string
-+            overwritePattern:
-+              pattern: ^(Managed|Unmanaged)$
-+              type: string
-+          required:
-+          - deprecatedField
-+          - name
-+          - overwritePattern
-+          type: object
-+      required:
-+      - metadata
-+      - spec
-+      type: object
-   version: v1beta1
-   versions:
-   - name: v1beta1
-diff -Naup ./testing/manifests/updated/ ./manifests/ 2>/dev/null
+cp -r ./testing/manifests/initial/*.crd.yaml-merge-patch ./manifests/
+! diff -Naup ./testing/manifests/initial/ ./manifests/ 2>/dev/null 1>&2
+diff -Naup ./testing/manifests/updated/ ./manifests/
 make clean
 rm -f oc openshift
 rm -f -r '/github.com/openshift/library-go/alpha-build-machinery/make/examples/multiple-binaries/_output/srpms'

--- a/alpha-build-machinery/make/targets/openshift/crd-schema-gen.mk
+++ b/alpha-build-machinery/make/targets/openshift/crd-schema-gen.mk
@@ -1,27 +1,55 @@
 self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
 
-CRD_SCHEMA_GEN_APIS ?=$(error CRD_SCHEMA_GEN_APIS is required)
-CRD_SCHEMA_GEN_MANIFESTS ?=./manifests
-CRD_SCHEMA_GEN_OUTPUT ?=./manifests
-
-crd_patches =$(subst $(CRD_SCHEMA_GEN_MANIFESTS),$(CRD_SCHEMA_GEN_OUTPUT),$(wildcard $(CRD_SCHEMA_GEN_MANIFESTS)/*.crd.yaml-merge-patch))
-
 # $1 - crd file
 # $2 - patch file
 define patch-crd
-	cp -n $(CRD_SCHEMA_GEN_MANIFESTS)/$(notdir $2) '$(CRD_SCHEMA_GEN_OUTPUT)/' || true  # FIXME: centos
 	$(YQ) m -i -x '$(1)' '$(2)'
 
 endef
 
 empty :=
-update-codegen-crds: ensure-controller-gen ensure-yq
+
+define diff-file
+	diff -Naup '$(1)' '$(2)'
+
+endef
+
+# $1 - apis
+# $2 - manifests
+# $3 - output
+define run-crd-gen
 	'$(CONTROLLER_GEN)' \
-		schemapatch:manifests="$(CRD_SCHEMA_GEN_MANIFESTS)" \
-		paths="$(subst $(empty) ,;,$(CRD_SCHEMA_GEN_APIS))" \
-		output:dir="$(CRD_SCHEMA_GEN_OUTPUT)"
-	$(foreach p,$(crd_patches),$(call patch-crd,$(basename $(p)).yaml,$(p)))
+		schemapatch:manifests="$(2)" \
+		paths="$(subst $(empty) ,;,$(1))" \
+		output:dir="$(3)"
+	$$(foreach p,$$(wildcard $(2)/*.crd.yaml-merge-patch),$$(call patch-crd,$$(subst $(2),$(3),$$(basename $$(p))).yaml,$$(p)))
+endef
+
+
+# $1 - target name
+# $2 - apis
+# $3 - manifests
+# $4 - output
+define add-crd-gen-internal
+
+update-codegen-crds-$(1): ensure-controller-gen ensure-yq
+	$(call run-crd-gen,$(2),$(3),$(4))
+.PHONY: update-codegen-crds-$(1)
+
+update-codegen-crds: update-codegen-crds-$(1)
 .PHONY: update-codegen-crds
+
+verify-codegen-crds-$(1): VERIFY_CODEGEN_CRD_TMP_DIR:=$(shell mktemp -d)
+verify-codegen-crds-$(1): ensure-controller-gen ensure-yq
+	$(call run-crd-gen,$(2),$(3),$$(VERIFY_CODEGEN_CRD_TMP_DIR))
+	$$(foreach p,$$(wildcard $(3)/*.crd.yaml),$$(call diff-file,$$(p),$$(subst $(3),$$(VERIFY_CODEGEN_CRD_TMP_DIR),$$(p))))
+.PHONY: verify-codegen-crds-$(1)
+
+verify-codegen-crds: verify-codegen-crds-$(1)
+.PHONY: verify-codegen-crds
+
+endef
+
 
 update-generated: update-codegen-crds
 .PHONY: update-generated
@@ -29,23 +57,16 @@ update-generated: update-codegen-crds
 update: update-generated
 .PHONY: update
 
-# $1 - manifest (actual) crd
-# $2 - temp crd
-define diff-crd
-	diff -Naup $(1) $(2)
-
-endef
-
-verify-codegen-crds: CRD_SCHEMA_GEN_OUTPUT :=$(shell mktemp -d)
-verify-codegen-crds: update-codegen-crds
-	$(foreach p,$(wildcard $(CRD_SCHEMA_GEN_MANIFESTS)/*.crd.yaml),$(call diff-crd,$(p),$(subst $(CRD_SCHEMA_GEN_MANIFESTS),$(CRD_SCHEMA_GEN_OUTPUT),$(p))))
-.PHONY: verify-codegen-crds
-
 verify-generated: verify-codegen-crds
 .PHONY: verify-generated
 
 verify: verify-generated
 .PHONY: verify
+
+
+define add-crd-gen
+$(eval $(call add-crd-gen-internal,$(1),$(2),$(3),$(4)))
+endef
 
 
 # We need to be careful to expand all the paths before any include is done


### PR DESCRIPTION
`openshift/api` needs to generate CRDs in multiple different directories so we need to macro so it can be instantiated multiple times