### PR TITLE
Fix API registration for 1.16

### DIFF
--- a/pkg/operator/resource/resourceapply/apiregistration.go
+++ b/pkg/operator/resource/resourceapply/apiregistration.go
@@ -27,6 +27,14 @@ func ApplyAPIService(client apiregistrationv1client.APIServicesGetter, recorder 
 	modified := resourcemerge.BoolPtr(false)
 	existingCopy := existing.DeepCopy()
 
+	// Since the required object does not specify a service port, and
+	// the port in the existing object is likely to be defaulted to
+	// 443, avoid thrashing by ensuring that the port is not
+	// considered when determining equality.
+	if required.Spec.Service != nil && existingCopy.Spec.Service != nil {
+		required.Spec.Service.Port = existingCopy.Spec.Service.Port
+	}
+
 	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
 	serviceSame := equality.Semantic.DeepEqual(existingCopy.Spec.Service, required.Spec.Service)
 	prioritySame := existingCopy.Spec.VersionPriority == required.Spec.VersionPriority && existingCopy.Spec.GroupPriorityMinimum == required.Spec.GroupPriorityMinimum


### PR DESCRIPTION
`APIService.Spec.Service.Port` was added in 1.15 (https://github.com/kubernetes/kubernetes/pull/74855) and defaults to 443. This was causing api registration to continually update APIService resources due to the expected form lacking a port and the serialized form having a default value of 443, resulting in thrashing and API instability. The fix is to not consider the service port when determining if an APIService is current.

This PR blocks cluster-openshift-apiserver-operator's bump to 1.16: https://github.com/openshift/cluster-openshift-apiserver-operator/pull/233