### PR TITLE
operator/certrotation: make rotation methods public

### DIFF
--- a/pkg/operator/certrotation/cabundle.go
+++ b/pkg/operator/certrotation/cabundle.go
@@ -32,7 +32,7 @@ type CABundleRotation struct {
 	EventRecorder events.Recorder
 }
 
-func (c CABundleRotation) ensureConfigMapCABundle(signingCertKeyPair *crypto.CA) ([]*x509.Certificate, error) {
+func (c CABundleRotation) EnsureConfigMapCABundle(signingCertKeyPair *crypto.CA) ([]*x509.Certificate, error) {
 	// by this point we have current signing cert/key pair.  We now need to make sure that the ca-bundle configmap has this cert and
 	// doesn't have any expired certs
 	originalCABundleConfigMap, err := c.Lister.ConfigMaps(c.Namespace).Get(c.Name)

--- a/pkg/operator/certrotation/cabundle_test.go
+++ b/pkg/operator/certrotation/cabundle_test.go
@@ -235,7 +235,7 @@ func TestEnsureConfigMapCABundle(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			_, err = c.ensureConfigMapCABundle(newCA)
+			_, err = c.EnsureConfigMapCABundle(newCA)
 			switch {
 			case err != nil && len(test.expectedError) == 0:
 				t.Error(err)

--- a/pkg/operator/certrotation/client_cert_rotation_controller.go
+++ b/pkg/operator/certrotation/client_cert_rotation_controller.go
@@ -99,17 +99,17 @@ func (c CertRotationController) sync() error {
 }
 
 func (c CertRotationController) syncWorker() error {
-	signingCertKeyPair, err := c.SigningRotation.ensureSigningCertKeyPair()
+	signingCertKeyPair, err := c.SigningRotation.EnsureSigningCertKeyPair()
 	if err != nil {
 		return err
 	}
 
-	cabundleCerts, err := c.CABundleRotation.ensureConfigMapCABundle(signingCertKeyPair)
+	cabundleCerts, err := c.CABundleRotation.EnsureConfigMapCABundle(signingCertKeyPair)
 	if err != nil {
 		return err
 	}
 
-	if err := c.TargetRotation.ensureTargetCertKeyPair(signingCertKeyPair, cabundleCerts); err != nil {
+	if err := c.TargetRotation.EnsureTargetCertKeyPair(signingCertKeyPair, cabundleCerts); err != nil {
 		return err
 	}
 

--- a/pkg/operator/certrotation/signer.go
+++ b/pkg/operator/certrotation/signer.go
@@ -30,7 +30,7 @@ type SigningRotation struct {
 	EventRecorder events.Recorder
 }
 
-func (c SigningRotation) ensureSigningCertKeyPair() (*crypto.CA, error) {
+func (c SigningRotation) EnsureSigningCertKeyPair() (*crypto.CA, error) {
 	originalSigningCertKeyPairSecret, err := c.Lister.Secrets(c.Namespace).Get(c.Name)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return nil, err

--- a/pkg/operator/certrotation/signer_test.go
+++ b/pkg/operator/certrotation/signer_test.go
@@ -116,7 +116,7 @@ func TestEnsureSigningCertKeyPair(t *testing.T) {
 				EventRecorder: events.NewInMemoryRecorder("test"),
 			}
 
-			_, err := c.ensureSigningCertKeyPair()
+			_, err := c.EnsureSigningCertKeyPair()
 			switch {
 			case err != nil && len(test.expectedError) == 0:
 				t.Error(err)

--- a/pkg/operator/certrotation/target.go
+++ b/pkg/operator/certrotation/target.go
@@ -48,7 +48,7 @@ type TargetCertRechecker interface {
 	RecheckChannel() <-chan struct{}
 }
 
-func (c TargetRotation) ensureTargetCertKeyPair(signingCertKeyPair *crypto.CA, caBundleCerts []*x509.Certificate) error {
+func (c TargetRotation) EnsureTargetCertKeyPair(signingCertKeyPair *crypto.CA, caBundleCerts []*x509.Certificate) error {
 	// at this point our trust bundle has been updated.  We don't know for sure that consumers have updated, but that's why we have a second
 	// validity percentage.  We always check to see if we need to sign.  Often we are signing with an old key or we have no target
 	// and need to mint one

--- a/pkg/operator/certrotation/target_test.go
+++ b/pkg/operator/certrotation/target_test.go
@@ -200,7 +200,7 @@ func TestEnsureTargetCertKeyPair(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = c.ensureTargetCertKeyPair(newCA, newCA.Config.Certs)
+			err = c.EnsureTargetCertKeyPair(newCA, newCA.Config.Certs)
 			switch {
 			case err != nil && len(test.expectedError) == 0:
 				t.Error(err)
@@ -393,7 +393,7 @@ func TestEnsureTargetSignerCertKeyPair(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = c.ensureTargetCertKeyPair(newCA, newCA.Config.Certs)
+			err = c.EnsureTargetCertKeyPair(newCA, newCA.Config.Certs)
 			switch {
 			case err != nil && len(test.expectedError) == 0:
 				t.Error(err)


### PR DESCRIPTION
They're useful outside of the static-pod operators.