### PR TITLE
Ignore nested vendor/ folders in gofmt

### DIFF
--- a/alpha-build-machinery/make/lib/golang.mk
+++ b/alpha-build-machinery/make/lib/golang.mk
@@ -12,7 +12,7 @@ GOFMT ?=gofmt
 GOFMT_FLAGS ?=-s -l
 GOLINT ?=golint
 
-GO_FILES ?=$(shell find . -name '*.go' -not -path './vendor/*' -print)
+GO_FILES ?=$(shell find . -name '*.go' -not -path '*/vendor/*' -print)
 GO_PACKAGES ?=./...
 GO_TEST_PACKAGES ?=$(GO_PACKAGES)
 


### PR DESCRIPTION
ignore nested `vendor` folders for gofmt. although we strip vendor folder there are legal usecases like `alpha-build-machinery` examples

/cc @sttts 