### PR TITLE
Add containerize macro

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,12 @@ include $(addprefix alpha-build-machinery/make/, \
 	golang.mk \
 	targets/openshift/deps.mk \
 	targets/openshift/bindata.mk \
+	targets/containerize.mk \
 )
 
 $(call add-bindata,backingresources,./pkg/operator/staticpod/controller/backingresource/manifests/...,bindata,bindata,./pkg/operator/staticpod/controller/backingresource/bindata/bindata.go)
 $(call add-bindata,monitoring,./pkg/operator/staticpod/controller/monitoring/manifests/...,bindata,bindata,./pkg/operator/staticpod/controller/monitoring/bindata/bindata.go)
 $(call add-bindata,installer,./pkg/operator/staticpod/controller/installer/manifests/...,bindata,bindata,./pkg/operator/staticpod/controller/installer/bindata/bindata.go)
 $(call add-bindata,staticpod,./pkg/operator/staticpod/controller/prune/manifests/...,bindata,bindata,./pkg/operator/staticpod/controller/prune/bindata/bindata.go)
+
+$(call containerize-targets,verify update,registry.svc.ci.openshift.org/openshift/release:golang-1.12,/go/src/$(GO_PACKAGE))

--- a/alpha-build-machinery/Makefile
+++ b/alpha-build-machinery/Makefile
@@ -1,3 +1,5 @@
+self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
+
 SHELL :=/bin/bash
 all: verify
 .PHONY: all
@@ -57,5 +59,13 @@ verify: verify-makefiles
 update: update-makefiles
 .PHONY: update
 
+# We need to be careful to expand all the paths before any include is done
+# or self_dir could be modified for the next include by the included file.
+# Also doing this at the end of the file allows us to user self_dir before it could be modified.
+include $(addprefix $(self_dir)/make/, \
+	targets/help.mk \
+	targets/containerize.mk \
+	lib/golang.mk \
+)
 
-include ./make/targets/help.mk
+$(call containerize-targets,verify update,registry.svc.ci.openshift.org/openshift/release:golang-1.12,/go/src/$(GO_PACKAGE))

--- a/alpha-build-machinery/make/targets/containerize.mk
+++ b/alpha-build-machinery/make/targets/containerize.mk
@@ -1,0 +1,18 @@
+CONTAINERIZE_RUNTIME ?=$(shell command -v podman || command -v docker || echo 'failed_to_detect_container_runtime')
+CONTAINERIZE_RUNOPTS ?=-i -t --rm
+
+define containerized-target-internal
+$(1)-containerized: CONTAINERIZE_IMAGE:=$(2)
+$(1)-containerized: CONTAINERIZE_MOUNTOPTS:=-v '$(shell pwd)/:$(3)/'
+$(1)-containerized:
+	'$$(CONTAINERIZE_RUNTIME)' run $$(CONTAINERIZE_RUNOPTS) $$(CONTAINERIZE_MOUNTOPTS) '$$(CONTAINERIZE_IMAGE)' bash -c "$(MAKE) -C '$(3)' '$(1)' MAKEFLAGS:=$$(MAKEFLAGS)"
+.PHONY: $(1)-containerized
+
+endef
+
+# $1 - image
+# $2 - targets (separated-by-space)
+# $3 - srcdir
+define containerize-targets
+$(foreach t,$(1),$(eval $(call containerized-target-internal,$(t),$(2),$(3))))
+endef


### PR DESCRIPTION
@openshift/sig-master now any target can be run in a container if you wish

@sttts @mfojtik hope that makes especially the Mac folks happy :)

Adds the same target with `-containerized` suffix making it run using podman (or docker if you set the envar to it). If in doubt, use `make help` to list the targets.