### PR TITLE
Fix tests

### DIFF
--- a/alpha-build-machinery/Makefile
+++ b/alpha-build-machinery/Makefile
@@ -14,6 +14,7 @@ examples :=$(wildcard ./make/examples/*/Makefile.test)
 # Delete lines referencing temporary files and directories
 # Unify make error output between versions
 # Ignore old cp errors on centos7
+# Ignore different make output with `-k` option
 define update-makefile-log
 mkdir -p "$(3)"
 set -o pipefail; $(MAKE) -j 1 -C "$(dir $(1))" -f "$(notdir $(1))" --no-print-directory --warn-undefined-variables $(2) 2>&1 | \
@@ -24,6 +25,7 @@ set -o pipefail; $(MAKE) -j 1 -C "$(dir $(1))" -f "$(notdir $(1))" --no-print-di
    sed -E 's~^[<> ]*((\+\+\+|\-\-\-) \./(testing/)?manifests/.*.yaml).*~\1~' | \
    sed -E 's/^(make\[2\]: \*\*\* \[).*: (.*\] Error 1)/\1\2/' | \
    grep -v 'are the same file' | \
+   grep -E -v -e '^make\[2\]: Target `.*'"'"' not remade because of errors\.$$' | \
    tee "$(3)"/"$(notdir $(1))"$(subst ..,.,.$(2).log)
 
 endef

--- a/alpha-build-machinery/make/examples/multiple-binaries/Makefile.test
+++ b/alpha-build-machinery/make/examples/multiple-binaries/Makefile.test
@@ -27,7 +27,7 @@ test-build:
 
 test-cross-build:
 	[[ ! -d ./_output/ ]] || (ls -l ./_output/ && false)
-	$(MAKE) cross-build
+	$(MAKE) cross-build SOURCE_GIT_TAG=v42.43.44 SOURCE_GIT_COMMIT=aaa SOURCE_GIT_TREE_STATE=clean
 	[[ ! -f ./openshift ]]
 	[[ ! -f ./oc ]]
 	[[ -f ./_output/bin/darwin_amd64/openshift ]]
@@ -43,7 +43,7 @@ test-cross-build:
 test-rpm:
 	[[ ! -d ./_output/ ]] || (ls -l ./_output/ && false)
 
-	$(MAKE) rpm-build
+	$(MAKE) rpm-build SOURCE_GIT_TAG=v42.43.44 SOURCE_GIT_COMMIT=aaa SOURCE_GIT_TREE_STATE=clean
 	[[ -f ./_output/rpms/x86_64/openshift-2.42.0-6.el7.x86_64.rpm ]]
 	[[ -f ./_output/srpms/openshift-2.42.0-6.el7.src.rpm ]]
 

--- a/alpha-build-machinery/make/examples/multiple-binaries/Makefile.test.log
+++ b/alpha-build-machinery/make/examples/multiple-binaries/Makefile.test.log
@@ -40,15 +40,11 @@ if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_outpu
 rm -f -r '_output/bin'
 if [ -d '_output' ]; then rmdir --ignore-fail-on-non-empty '_output'; fi
 [[ ! -d ./_output/ ]] || (ls -l ./_output/ && false)
-make cross-build
-fatal: No names found, cannot describe anything.
-fatal: No names found, cannot describe anything.
+make cross-build SOURCE_GIT_TAG=v42.43.44 SOURCE_GIT_COMMIT=aaa SOURCE_GIT_TREE_STATE=clean
 mkdir -p '_output/bin/darwin_amd64'
 go build -ldflags "-s -w -X github.com/openshift/library-go/alpha-build-machinery/make/examples/multiple-binaries/pkg/version.versionFromGit="<redacted_for_diff>" -X github.com/openshift/library-go/alpha-build-machinery/make/examples/multiple-binaries/pkg/version.commitFromGit="<redacted_for_diff>" -X github.com/openshift/library-go/alpha-build-machinery/make/examples/multiple-binaries/pkg/version.gitTreeState="<redacted_for_diff>" -X github.com/openshift/library-go/alpha-build-machinery/make/examples/multiple-binaries/pkg/version.buildDate="<redacted_for_diff>" -B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n')" -o '_output/bin/darwin_amd64/oc' github.com/openshift/library-go/alpha-build-machinery/make/examples/multiple-binaries/cmd/oc
 mkdir -p '_output/bin/darwin_amd64'
 go build -ldflags "-s -w -X github.com/openshift/library-go/alpha-build-machinery/make/examples/multiple-binaries/pkg/version.versionFromGit="<redacted_for_diff>" -X github.com/openshift/library-go/alpha-build-machinery/make/examples/multiple-binaries/pkg/version.commitFromGit="<redacted_for_diff>" -X github.com/openshift/library-go/alpha-build-machinery/make/examples/multiple-binaries/pkg/version.gitTreeState="<redacted_for_diff>" -X github.com/openshift/library-go/alpha-build-machinery/make/examples/multiple-binaries/pkg/version.buildDate="<redacted_for_diff>" -B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n')" -o '_output/bin/darwin_amd64/openshift' github.com/openshift/library-go/alpha-build-machinery/make/examples/multiple-binaries/cmd/openshift
-fatal: No names found, cannot describe anything.
-fatal: No names found, cannot describe anything.
 mkdir -p '_output/bin/windows_amd64'
 go build -ldflags "-s -w -X github.com/openshift/library-go/alpha-build-machinery/make/examples/multiple-binaries/pkg/version.versionFromGit="<redacted_for_diff>" -X github.com/openshift/library-go/alpha-build-machinery/make/examples/multiple-binaries/pkg/version.commitFromGit="<redacted_for_diff>" -X github.com/openshift/library-go/alpha-build-machinery/make/examples/multiple-binaries/pkg/version.gitTreeState="<redacted_for_diff>" -X github.com/openshift/library-go/alpha-build-machinery/make/examples/multiple-binaries/pkg/version.buildDate="<redacted_for_diff>" -B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n')" -o '_output/bin/windows_amd64/oc.exe' github.com/openshift/library-go/alpha-build-machinery/make/examples/multiple-binaries/cmd/oc
 mkdir -p '_output/bin/windows_amd64'
@@ -85,10 +81,8 @@ if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_outpu
 rm -f -r '_output/bin'
 if [ -d '_output' ]; then rmdir --ignore-fail-on-non-empty '_output'; fi
 [[ ! -d ./_output/ ]] || (ls -l ./_output/ && false)
-make rpm-build
+make rpm-build SOURCE_GIT_TAG=v42.43.44 SOURCE_GIT_COMMIT=aaa SOURCE_GIT_TREE_STATE=clean
 rpmbuild -ba --define "_topdir /github.com/openshift/library-go/alpha-build-machinery/make/examples/multiple-binaries" --define "go_package github.com/openshift/library-go/alpha-build-machinery/make/examples/multiple-binaries" --quiet --define 'version 2.42.0' --define 'dist .el7' --define 'release 6' ocp.spec
-fatal: No names found, cannot describe anything.
-fatal: No names found, cannot describe anything.
 [[ -f ./_output/rpms/x86_64/openshift-2.42.0-6.el7.x86_64.rpm ]]
 [[ -f ./_output/srpms/openshift-2.42.0-6.el7.src.rpm ]]
 make clean


### PR DESCRIPTION
- make tests not depending on git describe (makes the output stable and fixes the change if you mount only a subdir into a container)
- ignore `-k` adding a line in error case that makes test logs not match if you run update without `-k` option

/cc @damemi 