### PR TITLE
installer: add controller that watch pending installer pods

### DIFF
--- a/pkg/operator/staticpod/controller/installerstate/installer_state_controller.go
+++ b/pkg/operator/staticpod/controller/installerstate/installer_state_controller.go
@@ -1,0 +1,254 @@
+package installerstate
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+const installerStateControllerWorkQueueKey = "key"
+
+// maxToleratedPodPendingDuration is the maximum time we tolerate installer pod in pending state
+var maxToleratedPodPendingDuration = 5 * time.Minute
+
+type InstallerStateController struct {
+	podsGetter      corev1client.PodsGetter
+	eventsGetter    corev1client.EventsGetter
+	queue           workqueue.RateLimitingInterface
+	cachesToSync    []cache.InformerSynced
+	targetNamespace string
+	operatorClient  v1helpers.StaticPodOperatorClient
+	eventRecorder   events.Recorder
+
+	timeNowFn func() time.Time
+}
+
+func NewInstallerStateController(kubeInformersForTargetNamespace informers.SharedInformerFactory,
+	podsGetter corev1client.PodsGetter,
+	eventsGetter corev1client.EventsGetter,
+	operatorClient v1helpers.StaticPodOperatorClient,
+	targetNamespace string,
+	recorder events.Recorder,
+) *InstallerStateController {
+	c := &InstallerStateController{
+		podsGetter:      podsGetter,
+		eventsGetter:    eventsGetter,
+		targetNamespace: targetNamespace,
+		operatorClient:  operatorClient,
+		eventRecorder:   recorder.WithComponentSuffix("installer-state-controller"),
+		queue:           workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "InstallerStateController"),
+		timeNowFn:       time.Now,
+	}
+
+	c.cachesToSync = append(c.cachesToSync, kubeInformersForTargetNamespace.Core().V1().Pods().Informer().HasSynced)
+	kubeInformersForTargetNamespace.Core().V1().Pods().Informer().AddEventHandler(c.eventHandler())
+
+	return c
+}
+
+func (c *InstallerStateController) eventHandler() cache.ResourceEventHandler {
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { c.queue.Add(installerStateControllerWorkQueueKey) },
+		UpdateFunc: func(old, new interface{}) { c.queue.Add(installerStateControllerWorkQueueKey) },
+		DeleteFunc: func(obj interface{}) { c.queue.Add(installerStateControllerWorkQueueKey) },
+	}
+}
+
+// degradedConditionNames lists all supported condition types.
+var degradedConditionNames = []string{
+	"InstallerPodPendingDegraded",
+	"InstallerPodContainerWaitingDegraded",
+	"InstallerPodNetworkingDegraded",
+}
+
+func (c *InstallerStateController) sync() error {
+	pods, err := c.podsGetter.Pods(c.targetNamespace).List(metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(labels.Set{"app": "installer"}).String(),
+	})
+	if err != nil {
+		return err
+	}
+
+	// collect all startingObjects that are in pending state for longer than maxToleratedPodPendingDuration
+	pendingPods := []*v1.Pod{}
+	for _, pod := range pods.Items {
+		if pod.Status.Phase != v1.PodPending || pod.Status.StartTime == nil {
+			continue
+		}
+		if c.timeNowFn().Sub(pod.Status.StartTime.Time) >= maxToleratedPodPendingDuration {
+			pendingPods = append(pendingPods, pod.DeepCopy())
+		}
+	}
+
+	// in theory, there should never be two installer startingObjects pending as we don't roll new installer pod
+	// until the previous/existing pod has finished its job.
+	foundConditions := []operatorv1.OperatorCondition{}
+	foundConditions = append(foundConditions, c.handlePendingInstallerPods(pendingPods)...)
+
+	// handle networking conditions that are based on events
+	networkConditions, err := c.handlePendingInstallerPodsNetworkEvents(pendingPods)
+	if err != nil {
+		return err
+	}
+	foundConditions = append(foundConditions, networkConditions...)
+
+	updateConditionFuncs := []v1helpers.UpdateStaticPodStatusFunc{}
+
+	// check the supported degraded foundConditions and check if any pending pod matching them.
+	for _, degradedConditionName := range degradedConditionNames {
+		// clean up existing foundConditions
+		updatedCondition := operatorv1.OperatorCondition{
+			Type:   degradedConditionName,
+			Status: operatorv1.ConditionFalse,
+		}
+		if condition := v1helpers.FindOperatorCondition(foundConditions, degradedConditionName); condition != nil {
+			updatedCondition = *condition
+		}
+		updateConditionFuncs = append(updateConditionFuncs, v1helpers.UpdateStaticPodConditionFn(updatedCondition))
+	}
+
+	if _, _, err := v1helpers.UpdateStaticPodStatus(c.operatorClient, updateConditionFuncs...); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *InstallerStateController) handlePendingInstallerPodsNetworkEvents(pods []*v1.Pod) ([]operatorv1.OperatorCondition, error) {
+	conditions := []operatorv1.OperatorCondition{}
+	if len(pods) == 0 {
+		return conditions, nil
+	}
+	namespaceEvents, err := c.eventsGetter.Events(c.targetNamespace).List(metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	for _, event := range namespaceEvents.Items {
+		if event.InvolvedObject.Kind != "Pod" {
+			continue
+		}
+		if !strings.Contains(event.Message, "failed to create pod network") {
+			continue
+		}
+		for _, pod := range pods {
+			if pod.Name != event.InvolvedObject.Name {
+				continue
+			}
+			// If we already find the pod that is pending because of the networking problem, skip other pods.
+			// This will reduce the events we fire.
+			if v1helpers.FindOperatorCondition(conditions, "InstallerPodNetworkingDegraded") != nil {
+				break
+			}
+			condition := operatorv1.OperatorCondition{
+				Type:    "InstallerPodNetworkingDegraded",
+				Status:  operatorv1.ConditionTrue,
+				Reason:  event.Reason,
+				Message: fmt.Sprintf("Pod %q on node %q observed degraded networking: %s", pod.Name, pod.Spec.NodeName, event.Message),
+			}
+			conditions = append(conditions, condition)
+			c.eventRecorder.Warningf(condition.Reason, condition.Message)
+		}
+	}
+	return conditions, nil
+}
+
+func (c *InstallerStateController) handlePendingInstallerPods(pods []*v1.Pod) []operatorv1.OperatorCondition {
+	conditions := []operatorv1.OperatorCondition{}
+	for _, pod := range pods {
+		// at this point we already know the pod is pending for longer than expected
+		pendingTime := c.timeNowFn().Sub(pod.Status.StartTime.Time)
+
+		// the pod is in the pending state for longer than maxToleratedPodPendingDuration, report the reason and message
+		// as degraded condition for the operator.
+		if len(pod.Status.Reason) > 0 {
+			condition := operatorv1.OperatorCondition{
+				Type:    "InstallerPodPendingDegraded",
+				Reason:  pod.Status.Reason,
+				Status:  operatorv1.ConditionTrue,
+				Message: fmt.Sprintf("Pod %q on node %q is Pending for %s because %s", pod.Name, pod.Spec.NodeName, pendingTime, pod.Status.Message),
+			}
+			conditions = append(conditions, condition)
+			c.eventRecorder.Warningf(condition.Reason, condition.Message)
+		}
+
+		// one or more containers are in waiting state for longer than maxToleratedPodPendingDuration, report the reason and message
+		// as degraded condition for the operator.
+		for _, containerStatus := range pod.Status.ContainerStatuses {
+			if containerStatus.State.Waiting == nil {
+				continue
+			}
+			if state := containerStatus.State.Waiting; len(state.Reason) > 0 {
+				condition := operatorv1.OperatorCondition{
+					Type:    "InstallerPodContainerWaitingDegraded",
+					Reason:  state.Reason,
+					Status:  operatorv1.ConditionTrue,
+					Message: fmt.Sprintf("Pod %q on node %q container %q is waiting for %s because %s", pod.Name, pod.Spec.NodeName, containerStatus.Name, pendingTime, state.Message),
+				}
+				conditions = append(conditions, condition)
+				c.eventRecorder.Warningf(condition.Reason, condition.Message)
+			}
+		}
+	}
+
+	return conditions
+}
+
+// Run starts the kube-apiserver and blocks until stopCh is closed.
+func (c *InstallerStateController) Run(workers int, stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	klog.Infof("Starting InstallerStateController")
+	defer klog.Infof("Shutting down InstallerStateController")
+	if !cache.WaitForCacheSync(stopCh, c.cachesToSync...) {
+		return
+	}
+
+	// doesn't matter what workers say, only start one.
+	go wait.Until(c.runWorker, time.Second, stopCh)
+
+	// add time based trigger
+	go wait.Until(func() { c.queue.Add(installerStateControllerWorkQueueKey) }, time.Minute, stopCh)
+
+	<-stopCh
+}
+
+func (c *InstallerStateController) runWorker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+func (c *InstallerStateController) processNextWorkItem() bool {
+	dsKey, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(dsKey)
+
+	err := c.sync()
+	if err == nil {
+		c.queue.Forget(dsKey)
+		return true
+	}
+
+	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", dsKey, err))
+	c.queue.AddRateLimited(dsKey)
+
+	return true
+}

--- a/pkg/operator/staticpod/controller/installerstate/installer_state_controller_test.go
+++ b/pkg/operator/staticpod/controller/installerstate/installer_state_controller_test.go
@@ -1,0 +1,177 @@
+package installerstate
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/storage/names"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	"github.com/openshift/library-go/pkg/operator/events/eventstesting"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+func newInstallerPod(name string, mutateStatusFn func(*corev1.PodStatus)) *corev1.Pod {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "test",
+			Labels:    map[string]string{"app": "installer"},
+		},
+		Spec:   corev1.PodSpec{},
+		Status: corev1.PodStatus{},
+	}
+	mutateStatusFn(&pod.Status)
+	return pod
+}
+
+func newInstallerPodNetworkEvent(mutateFn func(*corev1.Event)) *corev1.Event {
+	event := &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      names.SimpleNameGenerator.GenerateName("test"),
+			Namespace: "test",
+		},
+		InvolvedObject: corev1.ObjectReference{
+			Kind: "Pod",
+			Name: "installer-1",
+		},
+		Reason: "FailedCreatePodSandBox",
+		Message: `'(combined from similar events): Failed create pod sandbox: rpc error:
+    code = Unknown desc = failed to create pod network sandbox k8s_installer-5-control-plane-1_openshift-kube-apiserver_900db7f3-d2ce-11e9-8fc8-005056be0641_0(121698f4862fd67157ca586cab18aefb048fe5d7b3bd87516098ac0e91a90a13):
+    Multus: Err adding pod to network "openshift-sdn": Multus: error in invoke Delegate
+    add - "openshift-sdn": failed to send CNI request: Post http://dummy/: dial unix
+    /var/run/openshift-sdn/cniserver/socket: connect: connection refused'`,
+	}
+	if mutateFn != nil {
+		mutateFn(event)
+	}
+	return event
+}
+
+func TestInstallerStateController(t *testing.T) {
+	tests := []struct {
+		name            string
+		startingObjects []runtime.Object
+		evalConditions  func(t *testing.T, conditions []operatorv1.OperatorCondition)
+	}{
+		{
+			name: "should report pending pod",
+			startingObjects: []runtime.Object{
+				newInstallerPod("installer-1", func(status *corev1.PodStatus) {
+					status.Phase = corev1.PodPending
+					status.Reason = "PendingReason"
+					status.Message = "PendingMessage"
+					status.StartTime = &metav1.Time{Time: time.Now().Add(-(maxToleratedPodPendingDuration + 5*time.Minute))}
+				}),
+			},
+			evalConditions: func(t *testing.T, conditions []operatorv1.OperatorCondition) {
+				podPendingCondition := v1helpers.FindOperatorCondition(conditions, "InstallerPodPendingDegraded")
+				if podPendingCondition.Status != operatorv1.ConditionTrue {
+					t.Errorf("expected InstallerPodPendingDegraded condition to be True")
+				}
+				podContainerWaitingCondition := v1helpers.FindOperatorCondition(conditions, "InstallerPodContainerWaitingDegraded")
+				if podContainerWaitingCondition.Status != operatorv1.ConditionFalse {
+					t.Errorf("expected InstallerPodPendingDegraded condition to be False")
+				}
+			},
+		},
+		{
+			name: "should report pod with failing networking",
+			startingObjects: []runtime.Object{
+				newInstallerPod("installer-1", func(status *corev1.PodStatus) {
+					status.Phase = corev1.PodPending
+					status.Reason = "PendingReason"
+					status.Message = "PendingMessage"
+					status.StartTime = &metav1.Time{Time: time.Now().Add(-(maxToleratedPodPendingDuration + 5*time.Minute))}
+				}),
+				newInstallerPodNetworkEvent(nil),
+				newInstallerPodNetworkEvent(nil),
+				newInstallerPodNetworkEvent(nil),
+			},
+			evalConditions: func(t *testing.T, conditions []operatorv1.OperatorCondition) {
+				podPendingCondition := v1helpers.FindOperatorCondition(conditions, "InstallerPodNetworkingDegraded")
+				if podPendingCondition.Status != operatorv1.ConditionTrue {
+					t.Errorf("expected InstallerPodNetworkingDegraded condition to be True")
+				}
+			},
+		},
+		{
+			name: "should report pending pod with waiting container",
+			startingObjects: []runtime.Object{
+				newInstallerPod("installer-1", func(status *corev1.PodStatus) {
+					status.Phase = corev1.PodPending
+					status.Reason = "PendingReason"
+					status.Message = "PendingMessage"
+					status.StartTime = &metav1.Time{Time: time.Now().Add(-(maxToleratedPodPendingDuration + 5*time.Minute))}
+					status.ContainerStatuses = append(status.ContainerStatuses, corev1.ContainerStatus{Name: "test", State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{
+						Reason:  "PodInitializing",
+						Message: "initializing error",
+					}}})
+				}),
+			},
+			evalConditions: func(t *testing.T, conditions []operatorv1.OperatorCondition) {
+				podPendingCondition := v1helpers.FindOperatorCondition(conditions, "InstallerPodPendingDegraded")
+				if podPendingCondition.Status != operatorv1.ConditionTrue {
+					t.Errorf("expected InstallerPodPendingDegraded condition to be True")
+				}
+				podContainerWaitingCondition := v1helpers.FindOperatorCondition(conditions, "InstallerPodContainerWaitingDegraded")
+				if podContainerWaitingCondition.Status != operatorv1.ConditionTrue {
+					t.Errorf("expected InstallerPodPendingDegraded condition to be True")
+				}
+			},
+		},
+		{
+			name: "should report false when no pending startingObjects",
+			startingObjects: []runtime.Object{
+				newInstallerPod("installer-1", func(status *corev1.PodStatus) {
+					status.Phase = corev1.PodRunning
+					status.StartTime = &metav1.Time{Time: time.Now().Add(-(maxToleratedPodPendingDuration + 5*time.Minute))}
+				}),
+			},
+			evalConditions: func(t *testing.T, conditions []operatorv1.OperatorCondition) {
+				podPendingCondition := v1helpers.FindOperatorCondition(conditions, "InstallerPodPendingDegraded")
+				if podPendingCondition.Status != operatorv1.ConditionFalse {
+					t.Errorf("expected InstallerPodPendingDegraded condition to be False")
+				}
+				podContainerWaitingCondition := v1helpers.FindOperatorCondition(conditions, "InstallerPodContainerWaitingDegraded")
+				if podContainerWaitingCondition.Status != operatorv1.ConditionFalse {
+					t.Errorf("expected InstallerPodPendingDegraded condition to be False")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kubeClient := fake.NewSimpleClientset(tt.startingObjects...)
+			kubeInformers := informers.NewSharedInformerFactoryWithOptions(kubeClient, 1*time.Minute, informers.WithNamespace("test"))
+			stopCh := make(chan struct{})
+			go kubeInformers.Start(stopCh)
+			defer close(stopCh)
+
+			fakeStaticPodOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(&operatorv1.StaticPodOperatorSpec{}, &operatorv1.StaticPodOperatorStatus{}, nil, nil)
+			eventRecorder := eventstesting.NewTestingEventRecorder(t)
+			controller := NewInstallerStateController(kubeInformers, kubeClient.CoreV1(), kubeClient.CoreV1(), fakeStaticPodOperatorClient, "test", eventRecorder)
+			if err := controller.sync(); err != nil {
+				t.Error(err)
+				return
+			}
+
+			_, status, _, err := fakeStaticPodOperatorClient.GetOperatorState()
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			if tt.evalConditions != nil {
+				tt.evalConditions(t, status.Conditions)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
This will add controller that watches the installer pods in `Pending` state that are in this state for longer then 5 minutes. If such pods are found, the controller will then make the operator go to Degraded and report the reason and message found for such pod/container state.

This will help improve debugging and triaging bugs caused by slow networking or kubelet that prevents rolling updates to static pod based operators.

/cc @deads2k 
/cc @sttts 