### PR TITLE
add IMAGE_REGISTRY flag to default.example.mk

### DIFF
--- a/alpha-build-machinery/make/default.example.mk
+++ b/alpha-build-machinery/make/default.example.mk
@@ -19,13 +19,17 @@ CODEGEN_GROUPS_VERSION :=openshiftapiserver:v1alpha1
 # You can list all codegen related variables by:
 #   $ make -n --print-data-base | grep ^CODEGEN
 
+IMAGE_REGISTRY?=registry.svc.ci.openshift.org
+IMAGE_REPO?=$(IMAGE_REGISTRY)/ocp/4.3
+IMAGE_TAG?=$(IMAGE_REPO):openshift-apiserver
+
 # This will call a macro called "build-image" which will generate image specific targets based on the parameters:
 # $1 - target name
 # $2 - image ref
 # $3 - Dockerfile path
 # $4 - context
 # It will generate target "image-$(1)" for builing the image an binding it as a prerequisite to target "images".
-$(call build-image,ocp-cli,registry.svc.ci.openshift.org/ocp/4.2:cli,./images/cli/Dockerfile.rhel,.)
+$(call build-image,ocp-openshift-apiserver,$(IMAGE_TAG),./images/Dockerfile.rhel,.)
 
 # This will call a macro called "add-bindata" which will generate bindata specific targets based on the parameters:
 # $0 - macro name

--- a/alpha-build-machinery/make/default.example.mk.help.log
+++ b/alpha-build-machinery/make/default.example.mk.help.log
@@ -4,7 +4,7 @@ build
 clean
 clean-binaries
 help
-image-ocp-cli
+image-ocp-openshift-apiserver
 images
 test
 test-unit


### PR DESCRIPTION
/assign @tnozicka 

add the option of building with a custom image registry/repo:tag, like so:
`make IMAGE_TAG=quay.io/sallyom/openshift-apiserver:test images` 