### PR TITLE
Add observer for APIServer.Spec.TLSSecurityProfile

### DIFF
--- a/pkg/crypto/crypto.go
+++ b/pkg/crypto/crypto.go
@@ -143,6 +143,39 @@ var ciphers = map[string]uint16{
 	"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305":  tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
 }
 
+// openSSLToIANACiphersMap maps OpenSSL cipher suite names to IANA names
+// ref: https://www.iana.org/assignments/tls-parameters/tls-parameters.xml
+var openSSLToIANACiphersMap = map[string]string{
+	// TLS 1.3 ciphers - not configurable in go 1.13, all of them are used in TLSv1.3 flows
+	//	"TLS_AES_128_GCM_SHA256":       "TLS_AES_128_GCM_SHA256",       // 0x13,0x01
+	//	"TLS_AES_256_GCM_SHA384":       "TLS_AES_256_GCM_SHA384",       // 0x13,0x02
+	//	"TLS_CHACHA20_POLY1305_SHA256": "TLS_CHACHA20_POLY1305_SHA256", // 0x13,0x03
+
+	// TLS 1.2
+	"ECDHE-ECDSA-AES128-GCM-SHA256": "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256", // 0xC0,0x2B
+	"ECDHE-RSA-AES128-GCM-SHA256":   "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",   // 0xC0,0x2F
+	"ECDHE-ECDSA-AES256-GCM-SHA384": "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384", // 0xC0,0x2C
+	"ECDHE-RSA-AES256-GCM-SHA384":   "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",   // 0xC0,0x30
+	"ECDHE-ECDSA-CHACHA20-POLY1305": "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",  // 0xCC,0xA9
+	"ECDHE-RSA-CHACHA20-POLY1305":   "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",    // 0xCC,0xA8
+	"ECDHE-ECDSA-AES128-SHA256":     "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256", // 0xC0,0x23
+	"ECDHE-RSA-AES128-SHA256":       "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",   // 0xC0,0x27
+	"AES128-GCM-SHA256":             "TLS_RSA_WITH_AES_128_GCM_SHA256",         // 0x00,0x9C
+	"AES256-GCM-SHA384":             "TLS_RSA_WITH_AES_256_GCM_SHA384",         // 0x00,0x9D
+	"AES128-SHA256":                 "TLS_RSA_WITH_AES_128_CBC_SHA256",         // 0x00,0x3C
+
+	// TLS 1
+	"ECDHE-ECDSA-AES128-SHA": "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA", // 0xC0,0x09
+	"ECDHE-RSA-AES128-SHA":   "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",   // 0xC0,0x13
+	"ECDHE-ECDSA-AES256-SHA": "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA", // 0xC0,0x0A
+	"ECDHE-RSA-AES256-SHA":   "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",   // 0xC0,0x14
+
+	// SSL 3
+	"AES128-SHA":   "TLS_RSA_WITH_AES_128_CBC_SHA",  // 0x00,0x2F
+	"AES256-SHA":   "TLS_RSA_WITH_AES_256_CBC_SHA",  // 0x00,0x35
+	"DES-CBC3-SHA": "TLS_RSA_WITH_3DES_EDE_CBC_SHA", // 0x00,0x0A
+}
+
 // CipherSuitesToNamesOrDie given a list of cipher suites as ints, return their readable names
 func CipherSuitesToNamesOrDie(intVals []uint16) []string {
 	ret := []string{}
@@ -248,6 +281,22 @@ func SecureTLSConfig(config *tls.Config) *tls.Config {
 		config.CipherSuites = DefaultCiphers()
 	}
 	return config
+}
+
+// OpenSSLToIANACipherSuites maps input OpenSSL Cipher Suite names to their
+// IANA counterparts.
+// Unknown ciphers are left out.
+func OpenSSLToIANACipherSuites(ciphers []string) []string {
+	ianaCiphers := make([]string, 0, len(ciphers))
+
+	for _, c := range ciphers {
+		ianaCipher, found := openSSLToIANACiphersMap[c]
+		if found {
+			ianaCiphers = append(ianaCiphers, ianaCipher)
+		}
+	}
+
+	return ianaCiphers
 }
 
 type TLSCertificateConfig struct {

--- a/pkg/crypto/crypto_test.go
+++ b/pkg/crypto/crypto_test.go
@@ -21,12 +21,16 @@ func TestConstantMaps(t *testing.T) {
 	}
 	discoveredVersions := map[string]bool{}
 	discoveredCiphers := map[string]bool{}
+	discoveredCiphersTLS13 := map[string]bool{}
 	for _, declName := range pkg.Scope().Names() {
 		if strings.HasPrefix(declName, "VersionTLS") {
 			discoveredVersions[declName] = true
 		}
 		if strings.HasPrefix(declName, "TLS_RSA_") || strings.HasPrefix(declName, "TLS_ECDHE_") {
 			discoveredCiphers[declName] = true
+		}
+		if strings.HasPrefix(declName, "TLS_AES_") || strings.HasPrefix(declName, "TLS_CHACHA20_") {
+			discoveredCiphersTLS13[declName] = true
 		}
 	}
 
@@ -38,6 +42,17 @@ func TestConstantMaps(t *testing.T) {
 	for k := range ciphers {
 		if _, ok := discoveredCiphers[k]; !ok {
 			t.Errorf("ciphers map has %s not in tls package", k)
+		}
+	}
+
+	for k := range discoveredCiphersTLS13 {
+		if _, ok := ciphersTLS13[k]; !ok {
+			t.Errorf("discovered cipher tls.%s not in ciphers map", k)
+		}
+	}
+	for k := range ciphersTLS13 {
+		if _, ok := discoveredCiphersTLS13[k]; !ok {
+			t.Errorf("ciphersTLS13 map has %s not in tls package", k)
 		}
 	}
 

--- a/pkg/operator/configobserver/apiserver/observe_tlssecurityprofile.go
+++ b/pkg/operator/configobserver/apiserver/observe_tlssecurityprofile.go
@@ -1,0 +1,104 @@
+package apiserver
+
+import (
+	"fmt"
+	"reflect"
+
+	"k8s.io/klog"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/tools/cache"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+
+	"github.com/openshift/library-go/pkg/crypto"
+	"github.com/openshift/library-go/pkg/operator/configobserver"
+	"github.com/openshift/library-go/pkg/operator/events"
+)
+
+// APIServerLister lists APIServer information and allows resources to be synced
+type APIServerLister interface {
+	APIServerLister() configlistersv1.APIServerLister
+	PreRunHasSynced() []cache.InformerSynced
+}
+
+// ObserveTLSSecurityProfile observes APIServer.Spec.TLSSecurityProfile field and sets
+// the ServingInfo.MinTLSVersion, ServingInfo.CipherSuites fields
+func ObserveTLSSecurityProfile(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (map[string]interface{}, []error) {
+	var (
+		minTlSVersionPath = []string{"servingInfo", "minTLSVersion"}
+		cipherSuitesPath  = []string{"servingInfo", "cipherSuites"}
+	)
+
+	listers := genericListers.(APIServerLister)
+	errs := []error{}
+
+	currentMinTLSVersion, _, versionErr := unstructured.NestedString(existingConfig, minTlSVersionPath...)
+	if versionErr != nil {
+		errs = append(errs, fmt.Errorf("failed to retrieve spec.servingInfo.minTLSVersion: %v", versionErr))
+	}
+
+	currentCipherSuites, _, suitesErr := unstructured.NestedStringSlice(existingConfig, cipherSuitesPath...)
+	if suitesErr != nil {
+		errs = append(errs, fmt.Errorf("failed to retrieve spec.servingInfo.cipherSuites: %v", suitesErr))
+	}
+
+	apiServer, err := listers.APIServerLister().Get("cluster")
+	if errors.IsNotFound(err) {
+		klog.Warningf("apiserver.config.openshift.io/cluster: not found")
+		apiServer = &configv1.APIServer{}
+	} else if err != nil {
+		return existingConfig, append(errs, err)
+	}
+
+	observedConfig := map[string]interface{}{
+		"servingInfo": map[string]interface{}{},
+	}
+	observedMinTLSVersion, observedCipherSuites := getSecurityProfileCiphers(apiServer.Spec.TLSSecurityProfile)
+	if err = unstructured.SetNestedField(observedConfig, observedMinTLSVersion, minTlSVersionPath...); err != nil {
+		errs = append(errs, err)
+	}
+	if err = unstructured.SetNestedStringSlice(observedConfig, observedCipherSuites, cipherSuitesPath...); err != nil {
+		errs = append(errs, err)
+	}
+
+	if observedMinTLSVersion != currentMinTLSVersion {
+		recorder.Eventf("ObserveTLSSecurityProfile", "minTLSVersion changed to %s", observedMinTLSVersion)
+	}
+	if !reflect.DeepEqual(observedCipherSuites, currentCipherSuites) {
+		recorder.Eventf("ObserveTLSSecurityProfile", "cipherSuites changed to %q", observedCipherSuites)
+	}
+
+	return observedConfig, errs
+}
+
+// Extracts the minimum TLS version and cipher suites from TLSSecurityProfile object,
+// Converts the ciphers to IANA names as supported by Kube ServingInfo config.
+// If profile is nil, returns config defined by the Intermediate TLS Profile
+func getSecurityProfileCiphers(profile *configv1.TLSSecurityProfile) (string, []string) {
+	var profileType configv1.TLSProfileType
+	if profile == nil {
+		profileType = configv1.TLSProfileIntermediateType
+	} else {
+		profileType = profile.Type
+	}
+
+	var profileSpec *configv1.TLSProfileSpec
+	if profileType == configv1.TLSProfileCustomType {
+		if profile.Custom != nil {
+			profileSpec = &profile.Custom.TLSProfileSpec
+		}
+	} else {
+		profileSpec = configv1.TLSProfiles[profileType]
+	}
+
+	// nothing found / custom type set but no actual custom spec
+	if profileSpec == nil {
+		profileSpec = configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+	}
+
+	// need to remap all Ciphers to their respective IANA names used by Go
+	return string(profileSpec.MinTLSVersion), crypto.OpenSSLToIANACipherSuites(profileSpec.Ciphers)
+}

--- a/pkg/operator/configobserver/apiserver/observe_tlssecurityprofile_test.go
+++ b/pkg/operator/configobserver/apiserver/observe_tlssecurityprofile_test.go
@@ -1,0 +1,117 @@
+package apiserver
+
+import (
+	"reflect"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/tools/cache"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+
+	"github.com/openshift/library-go/pkg/crypto"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
+)
+
+type testLister struct {
+	lister configlistersv1.APIServerLister
+}
+
+func (l testLister) APIServerLister() configlistersv1.APIServerLister {
+	return l.lister
+}
+
+func (l testLister) ResourceSyncer() resourcesynccontroller.ResourceSyncer {
+	return nil
+}
+
+func (l testLister) PreRunHasSynced() []cache.InformerSynced {
+	return nil
+}
+func TestObserveTLSSecurityProfile(t *testing.T) {
+	existingConfig := map[string]interface{}{
+		"minTLSVersion": "VersionTLS11",
+		"cipherSuites":  []string{"DES-CBC3-SHA"},
+	}
+
+	tests := []struct {
+		name                  string
+		config                *configv1.TLSSecurityProfile
+		existing              map[string]interface{}
+		expectedMinTLSVersion string
+		expectedSuites        []string
+	}{
+		{
+			name:                  "NoAPIServerConfig",
+			config:                nil,
+			existing:              existingConfig,
+			expectedMinTLSVersion: "VersionTLS12",
+			expectedSuites:        crypto.OpenSSLToIANACipherSuites(configv1.TLSProfiles[configv1.TLSProfileIntermediateType].Ciphers),
+		},
+		{
+			name: "ModernCrypto",
+			config: &configv1.TLSSecurityProfile{
+				Type:   configv1.TLSProfileModernType,
+				Modern: &configv1.ModernTLSProfile{},
+			},
+			existing:              existingConfig,
+			expectedMinTLSVersion: "VersionTLS13",
+			expectedSuites:        crypto.OpenSSLToIANACipherSuites(configv1.TLSProfiles[configv1.TLSProfileModernType].Ciphers),
+		},
+		{
+			name: "OldCrypto",
+			config: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileOldType,
+				Old:  &configv1.OldTLSProfile{},
+			},
+			existing:              existingConfig,
+			expectedMinTLSVersion: "VersionTLS10",
+			expectedSuites:        crypto.OpenSSLToIANACipherSuites(configv1.TLSProfiles[configv1.TLSProfileOldType].Ciphers),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			if tt.config != nil {
+				if err := indexer.Add(&configv1.APIServer{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster",
+					},
+					Spec: configv1.APIServerSpec{
+						TLSSecurityProfile: tt.config,
+					},
+				}); err != nil {
+					t.Fatal(err)
+				}
+			}
+			listers := testLister{
+				lister: configlistersv1.NewAPIServerLister(indexer),
+			}
+
+			result, errs := ObserveTLSSecurityProfile(listers, events.NewInMemoryRecorder(t.Name()), tt.existing)
+			if len(errs) > 0 {
+				t.Errorf("expected 0 errors, got %v", errs)
+			}
+
+			gotMinTLSVersion, _, err := unstructured.NestedString(result, "servingInfo", "minTLSVersion")
+			if err != nil {
+				t.Errorf("couldn't get minTLSVersion from the returned object: %v", err)
+			}
+
+			gotSuites, _, err := unstructured.NestedStringSlice(result, "servingInfo", "cipherSuites")
+			if err != nil {
+				t.Errorf("couldn't get cipherSuites from the returned object: %v", err)
+			}
+
+			if !reflect.DeepEqual(gotSuites, tt.expectedSuites) {
+				t.Errorf("ObserveTLSSecurityProfile() got cipherSuites = %v, expected %v", gotSuites, tt.expectedSuites)
+			}
+			if gotMinTLSVersion != tt.expectedMinTLSVersion {
+				t.Errorf("ObserveTLSSecurityProfile() got minTlSVersion = %v, expected %v", gotMinTLSVersion, tt.expectedMinTLSVersion)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add observer for `APIServer.Spec.TLSSecurityProfile` to be used in {kube,openshift}-apiserver-operator (and eventually by the authn operator).

Also adds OpenSSL -> IANA cipher names mapping which we need as the API for TLSSecurityProfile uses OpenSSL cipher names.

Requires https://github.com/openshift/library-go/pull/553 for TLS1.3 versions