### PR TITLE
pkg/operator/status/condition: Handle Unknown in internalUnionCondition

### DIFF
--- a/pkg/operator/status/condition.go
+++ b/pkg/operator/status/condition.go
@@ -38,12 +38,16 @@ func internalUnionCondition(conditionType string, defaultConditionStatus operato
 
 	interestingConditions := []operatorv1.OperatorCondition{}
 	badConditions := []operatorv1.OperatorCondition{}
+	badConditionStatus := operatorv1.ConditionUnknown
 	for _, condition := range allConditions {
 		if strings.HasSuffix(condition.Type, conditionType) {
 			interestingConditions = append(interestingConditions, condition)
 
-			if condition.Status == oppositeConditionStatus {
+			if condition.Status != defaultConditionStatus {
 				badConditions = append(badConditions, condition)
+				if condition.Status == oppositeConditionStatus {
+					badConditionStatus = oppositeConditionStatus
+				}
 			}
 		}
 	}
@@ -69,7 +73,7 @@ func internalUnionCondition(conditionType string, defaultConditionStatus operato
 	}
 
 	// at this point we have bad conditions
-	unionedCondition.Status = oppositeConditionStatus
+	unionedCondition.Status = badConditionStatus
 	unionedCondition.Message = unionMessage(badConditions)
 	unionedCondition.Reason = unionReason(badConditions)
 	unionedCondition.LastTransitionTime = latestTransitionTime(badConditions)

--- a/pkg/operator/status/status_controller_test.go
+++ b/pkg/operator/status/status_controller_test.go
@@ -204,6 +204,33 @@ func TestDegraded(t *testing.T) {
 				"TypeAAvailable: a message from type a",
 			},
 		},
+		{
+			name: "two present/one available/one unknown",
+			conditions: []operatorv1.OperatorCondition{
+				{Type: "TypeAAvailable", Status: operatorv1.ConditionTrue, LastTransitionTime: fiveSecondsAgo, Message: "a is great"},
+				{Type: "TypeBAvailable", Status: operatorv1.ConditionUnknown, LastTransitionTime: fiveSecondsAgo, Message: "b is confused"},
+			},
+			expectedType:   configv1.OperatorAvailable,
+			expectedStatus: configv1.ConditionUnknown,
+			expectedReason: "TypeBAvailable",
+			expectedMessages: []string{
+				"TypeBAvailable: b is confused",
+			},
+		},
+		{
+			name: "two present/one unavailable/one unknown",
+			conditions: []operatorv1.OperatorCondition{
+				{Type: "TypeAAvailable", Status: operatorv1.ConditionFalse, LastTransitionTime: fiveSecondsAgo, Message: "a is bad"},
+				{Type: "TypeBAvailable", Status: operatorv1.ConditionUnknown, LastTransitionTime: fiveSecondsAgo, Message: "b is confused"},
+			},
+			expectedType:   configv1.OperatorAvailable,
+			expectedStatus: configv1.ConditionFalse,
+			expectedReason: "MultipleConditionsMatching",
+			expectedMessages: []string{
+				"TypeAAvailable: a is bad",
+				"TypeBAvailable: b is confused",
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
The previous logic was built around a boolean assumption.  Running the old logic against my new unit tests from this commit gave:

```console
$ go test ./pkg/operator/status/
--- FAIL: TestDegraded (0.00s)
    --- FAIL: TestDegraded/two_present/one_available/one_unknown (0.00s)
    status_controller_test.go:293:   &v1.ClusterOperatorStatusCondition{
      Type:               "Available",
    - Status:             "Unknown",
    + Status:             "True",
      LastTransitionTime: v1.Time{},
    - Reason:             "TypeBAvailable",
    + Reason:             "AsExpected",
    - Message:            "TypeBAvailable: b is confused",
    + Message:            "TypeAAvailable: a is great\nTypeBAvailable: b is confused",
      }

    --- FAIL: TestDegraded/two_present/one_unavailable/one_unknown (0.00s)
    status_controller_test.go:293:   &v1.ClusterOperatorStatusCondition{
      Type:               "Available",
      Status:             "False",
      LastTransitionTime: v1.Time{},
    - Reason:             "MultipleConditionsMatching",
    + Reason:             "TypeAAvailable",
    - Message:            "TypeAAvailable: a is bad\nTypeBAvailable: b is confused",
    + Message:            "TypeAAvailable: a is bad",
      }

FAIL
FAIL  github.com/openshift/library-go/pkg/operator/status  0.013s
```

That was:

* Falsely claiming available in the first case, despite the presence of the unknown B.
* Not including the unknown B in the collated message, despite it also being not-good and therefore something that we should highlight for consumers.