### PR TITLE
encryption: cleanup and fix static pod deployer nodeName logic

### DIFF
--- a/pkg/operator/encryption/controllers/key_controller_test.go
+++ b/pkg/operator/encryption/controllers/key_controller_test.go
@@ -80,7 +80,7 @@ func TestKeyController(t *testing.T) {
 				{Group: "", Resource: "secrets"},
 			},
 			targetNamespace:  "kms",
-			initialObjects:   []runtime.Object{encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms")},
+			initialObjects:   []runtime.Object{encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1")},
 			apiServerObjects: []runtime.Object{&configv1.APIServer{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}}},
 			validateFunc: func(ts *testing.T, actions []clientgotesting.Action, targetNamespace string, targetGRs []schema.GroupResource) {
 			},
@@ -97,7 +97,7 @@ func TestKeyController(t *testing.T) {
 			targetNamespace: "kms",
 			expectedActions: []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "create:secrets:openshift-config-managed"},
 			initialObjects: []runtime.Object{
-				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms"),
+				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
 			},
 			apiServerObjects: []runtime.Object{&configv1.APIServer{
 				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
@@ -136,7 +136,7 @@ func TestKeyController(t *testing.T) {
 				{Group: "", Resource: "secrets"},
 			},
 			initialObjects: []runtime.Object{
-				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms"),
+				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
 				encryptiontesting.CreateEncryptionKeySecretWithRawKey("kms", nil, 7, []byte("61def964fb967f5d7c44a2af8dab6865")),
 			},
 			apiServerObjects: apiServerAesCBC,
@@ -150,7 +150,7 @@ func TestKeyController(t *testing.T) {
 				{Group: "", Resource: "secrets"},
 			},
 			initialObjects: []runtime.Object{
-				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms"),
+				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
 				encryptiontesting.CreateMigratedEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 7, []byte("61def964fb967f5d7c44a2af8dab6865"), time.Now()),
 			},
 			apiServerObjects: apiServerAesCBC,
@@ -164,7 +164,7 @@ func TestKeyController(t *testing.T) {
 				{Group: "", Resource: "secrets"},
 			},
 			initialObjects: []runtime.Object{
-				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms"),
+				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
 				encryptiontesting.CreateEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 7, []byte("61def964fb967f5d7c44a2af8dab6865")),
 			},
 			apiServerObjects: apiServerAesCBC,
@@ -178,7 +178,7 @@ func TestKeyController(t *testing.T) {
 				{Group: "", Resource: "secrets"},
 			},
 			initialObjects: []runtime.Object{
-				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms"),
+				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
 				encryptiontesting.CreateExpiredMigratedEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 5, []byte("61def964fb967f5d7c44a2af8dab6865")),
 			},
 			apiServerObjects: apiServerAesCBC,
@@ -214,7 +214,7 @@ func TestKeyController(t *testing.T) {
 				{Group: "", Resource: "secrets"},
 			},
 			initialObjects: []runtime.Object{
-				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms"),
+				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
 				encryptiontesting.CreateExpiredMigratedEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 5, []byte("61def964fb967f5d7c44a2af8dab6865")),
 				encryptiontesting.CreateEncryptionKeySecretWithRawKey("kms", nil, 6, []byte("61def964fb967f5d7c44a2af8dab6865")),
 			},
@@ -229,7 +229,7 @@ func TestKeyController(t *testing.T) {
 				{Group: "", Resource: "secrets"},
 			},
 			initialObjects: []runtime.Object{
-				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms"),
+				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
 				encryptiontesting.CreateEncryptionKeySecretWithRawKey("kms", nil, 1, []byte("")),
 			},
 			apiServerObjects: apiServerAesCBC,
@@ -269,7 +269,7 @@ func TestKeyController(t *testing.T) {
 						},
 					},
 					NodeStatuses: []operatorv1.NodeStatus{
-						{NodeName: "kube-apiserver-1"},
+						{NodeName: "node-1"},
 					},
 				},
 				nil,

--- a/pkg/operator/encryption/controllers/migration_controller_test.go
+++ b/pkg/operator/encryption/controllers/migration_controller_test.go
@@ -66,7 +66,7 @@ func TestMigrationController(t *testing.T) {
 				},
 			},
 			initialResources: []runtime.Object{
-				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms"),
+				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
 				func() runtime.Object {
 					cm := createConfigMap("cm-1", "os")
 					cm.Kind = "ConfigMap"
@@ -110,7 +110,7 @@ func TestMigrationController(t *testing.T) {
 				},
 			},
 			initialResources: []runtime.Object{
-				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms"),
+				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
 				func() runtime.Object {
 					cm := createConfigMap("cm-1", "os")
 					cm.Kind = "ConfigMap"
@@ -229,7 +229,7 @@ func TestMigrationController(t *testing.T) {
 						},
 					},
 					NodeStatuses: []operatorv1.NodeStatus{
-						{NodeName: "kube-apiserver-1"},
+						{NodeName: "node-1"},
 					},
 				},
 				nil,

--- a/pkg/operator/encryption/controllers/prune_controller_test.go
+++ b/pkg/operator/encryption/controllers/prune_controller_test.go
@@ -115,7 +115,7 @@ func TestPruneController(t *testing.T) {
 						},
 					},
 					NodeStatuses: []operatorv1.NodeStatus{
-						{NodeName: "kube-apiserver-1"},
+						{NodeName: "node-1"},
 					},
 				},
 				nil,
@@ -127,7 +127,7 @@ func TestPruneController(t *testing.T) {
 				rawSecrets = append(rawSecrets, initialSecret)
 			}
 
-			fakePod := encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms")
+			fakePod := encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1")
 
 			writeKeyRaw := []byte("71ea7c91419a68fd1224f88d50316b4e") // NzFlYTdjOTE0MTlhNjhmZDEyMjRmODhkNTAzMTZiNGU=
 			writeKeyID := uint64(len(scenario.initialSecrets) + 1)

--- a/pkg/operator/encryption/controllers/state_controller_test.go
+++ b/pkg/operator/encryption/controllers/state_controller_test.go
@@ -49,7 +49,7 @@ func TestStateController(t *testing.T) {
 				{Group: "", Resource: "secrets"},
 			},
 			initialResources: []runtime.Object{
-				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms"),
+				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
 			},
 			expectedActions: []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed"},
 		},
@@ -64,7 +64,7 @@ func TestStateController(t *testing.T) {
 				{Group: "", Resource: "secrets"},
 			},
 			initialResources: []runtime.Object{
-				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms"),
+				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
 				encryptiontesting.CreateEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 1, []byte("61def964fb967f5d7c44a2af8dab6865")),
 			},
 			expectedActions:       []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config-managed", "create:secrets:openshift-config-managed", "create:events:kms"},
@@ -97,7 +97,7 @@ func TestStateController(t *testing.T) {
 				{Group: "", Resource: "secrets"},
 			},
 			initialResources: []runtime.Object{
-				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms"),
+				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
 				encryptiontesting.CreateEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 34, []byte("171582a0fcd6c5fdb65cbf5a3e9249d7")),
 				func() *corev1.Secret {
 					ec := encryptiontesting.CreateEncryptionCfgNoWriteKey("34", "MTcxNTgyYTBmY2Q2YzVmZGI2NWNiZjVhM2U5MjQ5ZDc=", "secrets")
@@ -147,7 +147,7 @@ func TestStateController(t *testing.T) {
 				{Group: "", Resource: "secrets"},
 			},
 			initialResources: []runtime.Object{
-				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms"),
+				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
 				encryptiontesting.CreateMigratedEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 34, []byte("171582a0fcd6c5fdb65cbf5a3e9249d7"), time.Now()),
 				func() *corev1.Secret {
 					keysRes := encryptiontesting.EncryptionKeysResourceTuple{
@@ -190,7 +190,7 @@ func TestStateController(t *testing.T) {
 				{Group: "", Resource: "secrets"},
 			},
 			initialResources: []runtime.Object{
-				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms"),
+				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
 				encryptiontesting.CreateExpiredMigratedEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 33, []byte("171582a0fcd6c5fdb65cbf5a3e9249d7")),
 				encryptiontesting.CreateEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 34, []byte("dda090c18770163d57d6aaca85f7b3a5")),
 				func() *corev1.Secret { // encryption config in kms namespace
@@ -277,7 +277,7 @@ func TestStateController(t *testing.T) {
 				{Group: "", Resource: "secrets"},
 			},
 			initialResources: []runtime.Object{
-				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms"),
+				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
 				encryptiontesting.CreateExpiredMigratedEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 31, []byte("a1f1b3e36c477d91ea85af0f32358f70")),
 				encryptiontesting.CreateExpiredMigratedEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 32, []byte("42b07b385a0edee268f1ac41cfc53857")),
 				encryptiontesting.CreateExpiredMigratedEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 33, []byte("b0af82240e10c032fd9bbbedd3b5955a")),
@@ -378,7 +378,7 @@ func TestStateController(t *testing.T) {
 				{Group: "", Resource: "secrets"},
 			},
 			initialResources: []runtime.Object{
-				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms"),
+				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
 				encryptiontesting.CreateExpiredMigratedEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 31, []byte("a1f1b3e36c477d91ea85af0f32358f70")),
 				encryptiontesting.CreateExpiredMigratedEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 32, []byte("42b07b385a0edee268f1ac41cfc53857")),
 				encryptiontesting.CreateExpiredMigratedEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 33, []byte("b0af82240e10c032fd9bbbedd3b5955a")),
@@ -470,7 +470,7 @@ func TestStateController(t *testing.T) {
 				{Group: "", Resource: "secrets"},
 			},
 			initialResources: []runtime.Object{
-				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms"),
+				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
 				encryptiontesting.CreateMigratedEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 34, []byte("171582a0fcd6c5fdb65cbf5a3e9249d7"), time.Now()),
 				func() *corev1.Secret {
 					keysRes := encryptiontesting.EncryptionKeysResourceTuple{
@@ -535,7 +535,7 @@ func TestStateController(t *testing.T) {
 				{Group: "", Resource: "secrets"},
 			},
 			initialResources: []runtime.Object{
-				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms"),
+				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
 				encryptiontesting.CreateMigratedEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}, {Group: "", Resource: "configmaps"}}, 34, []byte("171582a0fcd6c5fdb65cbf5a3e9249d7"), time.Now()),
 				func() *corev1.Secret { // encryption config in kms namespace
 					keysRes := []encryptiontesting.EncryptionKeysResourceTuple{
@@ -600,7 +600,7 @@ func TestStateController(t *testing.T) {
 				{Group: "", Resource: "secrets"},
 			},
 			initialResources: []runtime.Object{
-				encryptiontesting.CreateDummyKubeAPIPodInUnknownPhase("kube-apiserver-1", "kms"),
+				encryptiontesting.CreateDummyKubeAPIPodInUnknownPhase("kube-apiserver-1", "kms", "node-1"),
 			},
 			expectedActions: []string{"list:pods:kms"},
 			expectedError:   errors.New("failed to get converged static pod revision: api server pod kube-apiserver-1 in unknown phase"),
@@ -623,7 +623,7 @@ func TestStateController(t *testing.T) {
 				{Group: "", Resource: "secrets"},
 			},
 			initialResources: []runtime.Object{
-				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms"),
+				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
 				func() *corev1.Secret { // encryption config in kms namespace
 					ecs := createEncryptionCfgSecret(t, "kms", "1", &apiserverconfigv1.EncryptionConfiguration{})
 					ecs.Data[encryptionconfig.EncryptionConfSecretName] = []byte{1, 2, 3} // invalid
@@ -665,7 +665,7 @@ func TestStateController(t *testing.T) {
 						},
 					},
 					NodeStatuses: []operatorv1.NodeStatus{
-						{NodeName: "kube-apiserver-1"},
+						{NodeName: "node-1"},
 					},
 				},
 				nil,

--- a/pkg/operator/encryption/deployer/staticpod.go
+++ b/pkg/operator/encryption/deployer/staticpod.go
@@ -72,7 +72,7 @@ func (d *StaticPodDeployer) DeployedEncryptionConfigSecret() (secret *corev1.Sec
 		return nil, false, nil
 	}
 
-	revision, err := getAPIServerRevisionOfAllInstances(status.NodeStatuses, d.podClient)
+	revision, err := getAPIServerRevisionOfAllInstances("revision", status.NodeStatuses, d.podClient)
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to get converged static pod revision: %v", err)
 	}
@@ -109,9 +109,6 @@ func (d *StaticPodDeployer) AddEventHandler(handler cache.ResourceEventHandler) 
 	}
 }
 
-// revisionLabel is used to find the current revision for a given API server.
-const revisionLabel = "revision"
-
 // getAPIServerRevisionOfAllInstances attempts to find the current revision that
 // the API servers are running at.  If all API servers have not converged onto a
 // a single revision, it returns the empty string and possibly an error.
@@ -123,57 +120,43 @@ const revisionLabel = "revision"
 // Once a converged revision has been determined, it can be used to determine
 // what encryption config state has been successfully observed by the API servers.
 // It assumes that podClient is doing live lookups against the cluster state.
-func getAPIServerRevisionOfAllInstances(nodes []operatorv1.NodeStatus, podClient corev1client.PodInterface) (string, error) {
+func getAPIServerRevisionOfAllInstances(revisionLabel string, nodes []operatorv1.NodeStatus, podClient corev1client.PodInterface) (string, error) {
 	// do a live list so we never get confused about what revision we are on
 	apiServerPods, err := podClient.List(metav1.ListOptions{LabelSelector: "apiserver=true"})
 	if err != nil {
 		return "", err
 	}
 
-	revisions := sets.NewString()
-	failed := sets.NewString()
-	running := sets.NewString()
-
-	for _, apiServerPod := range apiServerPods.Items {
-		switch phase := apiServerPod.Status.Phase; phase {
-		case corev1.PodRunning: // TODO check that total running == number of masters?
-			if !podReady(apiServerPod) {
-				return "", nil // pods are not fully ready
-			}
-			revisions.Insert(apiServerPod.Labels[revisionLabel])
-			running.Insert(apiServerPod.Name)
-		case corev1.PodPending:
-			return "", nil // pods are not fully ready
-		case corev1.PodUnknown:
-			return "", fmt.Errorf("api server pod %s in unknown phase", apiServerPod.Name)
-		case corev1.PodSucceeded, corev1.PodFailed:
-			// handle failed pods carefully to make sure things are healthy
-			// since the API server should never exit, a succeeded pod is considered as failed
-			failed.Insert(apiServerPod.Labels[revisionLabel])
-		default:
-			// error in case new unexpected phases get added
-			return "", fmt.Errorf("api server pod %s has unexpected phase %v", apiServerPod.Name, phase)
-		}
+	good, bad, progressing, err := categorizePods(apiServerPods.Items)
+	if err != nil {
+		return "", err
+	}
+	if progressing {
+		return "", nil
 	}
 
-	if len(revisions) != 1 {
+	goodRevisions := revisions(revisionLabel, good)
+	goodNodes := nodeNames(good)
+	failingRevisions := revisions(revisionLabel, bad)
+
+	if len(goodRevisions) != 1 {
 		return "", nil // api servers have not converged onto a single revision
 	}
-	revision, _ := revisions.PopAny()
+	revision, _ := goodRevisions.PopAny()
 
-	if failed.Has(revision) {
+	if failingRevisions.Has(revision) {
 		return "", fmt.Errorf("api server revision %s has both running and failed pods", revision)
 	}
 
 	// make sure all expected nodes are there
-	missing := []string{}
+	missingNodes := []string{}
 	for _, n := range nodes {
-		if !running.Has(n.NodeName) {
-			missing = append(missing, n.NodeName)
+		if !goodNodes.Has(n.NodeName) {
+			missingNodes = append(missingNodes, n.NodeName)
 		}
 	}
-	if len(missing) > 0 {
-		return "", fmt.Errorf("api server pods missing for nodes %v", missing)
+	if len(missingNodes) > 0 {
+		return "", fmt.Errorf("api server pods missing for nodes %v", missingNodes)
 	}
 
 	revisionNum, err := strconv.Atoi(revision)
@@ -181,7 +164,7 @@ func getAPIServerRevisionOfAllInstances(nodes []operatorv1.NodeStatus, podClient
 		return "", fmt.Errorf("api server has invalid revision: %v", err)
 	}
 
-	for _, failedRevision := range failed.List() { // iterate in defined order
+	for _, failedRevision := range failingRevisions.List() { // iterate in defined order
 		failedRevisionNum, err := strconv.Atoi(failedRevision)
 		if err != nil {
 			return "", fmt.Errorf("api server has invalid failed revision: %v", err)
@@ -192,6 +175,46 @@ func getAPIServerRevisionOfAllInstances(nodes []operatorv1.NodeStatus, podClient
 	}
 
 	return revision, nil
+}
+
+func revisions(revisionLabel string, pods []*corev1.Pod) sets.String {
+	ret := sets.NewString()
+	for _, p := range pods {
+		ret.Insert(p.Labels[revisionLabel])
+	}
+	return ret
+}
+
+func nodeNames(pods []*corev1.Pod) sets.String {
+	ret := sets.NewString()
+	for _, p := range pods {
+		ret.Insert(p.Spec.NodeName)
+	}
+	return ret
+}
+
+func categorizePods(pods []corev1.Pod) (good []*corev1.Pod, bad []*corev1.Pod, progressing bool, err error) {
+	for _, apiServerPod := range pods {
+		switch phase := apiServerPod.Status.Phase; phase {
+		case corev1.PodRunning: // TODO check that total running == number of masters?
+			if !podReady(apiServerPod) {
+				return nil, nil, true, nil // pods are not fully ready
+			}
+			good = append(good, &apiServerPod)
+		case corev1.PodPending:
+			return nil, nil, true, nil // pods are not fully ready
+		case corev1.PodUnknown:
+			return nil, nil, false, fmt.Errorf("api server pod %s in unknown phase", apiServerPod.Name)
+		case corev1.PodSucceeded, corev1.PodFailed:
+			// handle failed pods carefully to make sure things are healthy
+			// since the API server should never exit, a succeeded pod is considered as failed
+			bad = append(bad, &apiServerPod)
+		default:
+			// error in case new unexpected phases get added
+			return nil, nil, false, fmt.Errorf("api server pod %s has unexpected phase %v", apiServerPod.Name, phase)
+		}
+	}
+	return good, bad, false, nil
 }
 
 func podReady(pod corev1.Pod) bool {

--- a/pkg/operator/encryption/deployer/staticpod.go
+++ b/pkg/operator/encryption/deployer/staticpod.go
@@ -196,7 +196,7 @@ func nodeNames(pods []*corev1.Pod) sets.String {
 func categorizePods(pods []corev1.Pod) (good []*corev1.Pod, bad []*corev1.Pod, progressing bool, err error) {
 	for _, apiServerPod := range pods {
 		switch phase := apiServerPod.Status.Phase; phase {
-		case corev1.PodRunning: // TODO check that total running == number of masters?
+		case corev1.PodRunning:
 			if !podReady(apiServerPod) {
 				return nil, nil, true, nil // pods are not fully ready
 			}

--- a/pkg/operator/encryption/testing/helpers.go
+++ b/pkg/operator/encryption/testing/helpers.go
@@ -89,7 +89,7 @@ func CreateExpiredMigratedEncryptionKeySecretWithRawKey(targetNS string, grs []s
 	return CreateMigratedEncryptionKeySecretWithRawKey(targetNS, grs, keyID, rawKey, time.Now().Add(-(time.Hour*24*7 + time.Hour)))
 }
 
-func CreateDummyKubeAPIPod(name, namespace string) *corev1.Pod {
+func CreateDummyKubeAPIPod(name, namespace string, nodeName string) *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -98,6 +98,9 @@ func CreateDummyKubeAPIPod(name, namespace string) *corev1.Pod {
 				"apiserver": "true",
 				"revision":  "1",
 			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: nodeName,
 		},
 		Status: corev1.PodStatus{
 			Phase: corev1.PodRunning,
@@ -111,8 +114,8 @@ func CreateDummyKubeAPIPod(name, namespace string) *corev1.Pod {
 	}
 }
 
-func CreateDummyKubeAPIPodInUnknownPhase(name, namespace string) *corev1.Pod {
-	p := CreateDummyKubeAPIPod(name, namespace)
+func CreateDummyKubeAPIPodInUnknownPhase(name, namespace string, nodeName string) *corev1.Pod {
+	p := CreateDummyKubeAPIPod(name, namespace, nodeName)
 	p.Status.Phase = corev1.PodUnknown
 	return p
 }


### PR DESCRIPTION
We compared the pod names, not the node name they were scheduled to.