### PR TITLE
encryption: missing node pods => progressing

### DIFF
--- a/pkg/operator/encryption/deployer/revisionedpod.go
+++ b/pkg/operator/encryption/deployer/revisionedpod.go
@@ -175,7 +175,7 @@ func getAPIServerRevisionOfAllInstances(revisionLabel string, nodes []string, po
 		}
 	}
 	if len(missingNodes) > 0 {
-		return "", fmt.Errorf("api server pods missing for nodes %v", missingNodes)
+		return "", nil // we are still progressing
 	}
 
 	revisionNum, err := strconv.Atoi(revision)


### PR DESCRIPTION
Missing good pods for a master node is not an error, but a sign of progress rolling out a new revision.