### PR TITLE
WIP: pkg/operator/v1helpers/deployment: New package for reporting deployment status

### DIFF
--- a/pkg/operator/v1helpers/deployment/deployment.go
+++ b/pkg/operator/v1helpers/deployment/deployment.go
@@ -1,0 +1,65 @@
+// Package deployment contains helpers for operators which manage deployments.
+package deployment
+
+import (
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/klog"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+// SetOperatorConditions sets prefixed operator conditions based on the deployment's conditions.
+func SetOperatorConditions(conditions *[]operatorv1.OperatorCondition, prefix string, deployment *appsv1.Deployment) error {
+	available := operatorv1.ConditionUnknown
+	degraded := operatorv1.ConditionUnknown
+	for _, condition := range deployment.Status.Conditions {
+		operatorCondition := operatorv1.OperatorCondition{
+			Status:  v1helpers.ConvertCoreV1StatusToOperatorV1Status(condition.Status),
+			Reason:  condition.Reason,
+			Message: condition.Message,
+		}
+
+		switch condition.Type {
+		case appsv1.DeploymentAvailable:
+			operatorCondition.Type = prefix + "Available"
+			available = operatorCondition.Status
+		case appsv1.DeploymentProgressing:
+			operatorCondition.Type = prefix + "Progressing"
+			if operatorCondition.Status == operatorv1.ConditionFalse && deployment.Status.ObservedGeneration != deployment.ObjectMeta.Generation {
+				operatorCondition.Status = operatorv1.ConditionTrue
+				operatorCondition.Reason = "ObservedGeneration"
+				operatorCondition.Message = fmt.Sprintf("observed generation %d != expected generation %d", deployment.Status.ObservedGeneration, deployment.ObjectMeta.Generation)
+			}
+		case appsv1.DeploymentReplicaFailure:
+			operatorCondition.Type = prefix + "Degraded"
+			degraded = operatorCondition.Status
+		default:
+			klog.V(4).Infof("Unrecognized deployment condition type: %s (reason %s, message %s)", condition.Type, condition.Reason, condition.Message)
+			operatorCondition.Type = prefix + string(condition.Type)
+		}
+
+		v1helpers.SetOperatorCondition(conditions, operatorCondition)
+	}
+
+	if degraded == operatorv1.ConditionUnknown {
+		condition := operatorv1.OperatorCondition{
+			Type: prefix + "Degraded",
+		}
+
+		if available == operatorv1.ConditionTrue {
+			condition.Status = operatorv1.ConditionFalse
+			condition.Reason = "Available"
+			condition.Message = "Available with no replica failures."
+		} else {
+			condition.Status = operatorv1.ConditionUnknown
+			condition.Reason = "Unknown"
+			condition.Message = "Not available, but no replica failures either."
+		}
+		v1helpers.SetOperatorCondition(conditions, condition)
+	}
+
+	return nil
+}

--- a/pkg/operator/v1helpers/deployment/deployment_test.go
+++ b/pkg/operator/v1helpers/deployment/deployment_test.go
@@ -1,0 +1,147 @@
+package deployment
+
+import (
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/diff"
+
+	operatorsv1 "github.com/openshift/api/operator/v1"
+)
+
+func TestSetOperatorConditions(t *testing.T) {
+	tests := []struct {
+		name       string
+		deployment *appsv1.Deployment
+		expected   []operatorsv1.OperatorCondition
+	}{
+		{
+			name: "happy, but for some reason still progressing with NewReplicaSetAvailable",
+			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: 1,
+				},
+				Status: appsv1.DeploymentStatus{
+					ObservedGeneration: 1,
+					Replicas:           2,
+					AvailableReplicas:  2,
+					ReadyReplicas:      2,
+					UpdatedReplicas:    2,
+					Conditions: []appsv1.DeploymentCondition{
+						{
+							Type:    appsv1.DeploymentAvailable,
+							Status:  corev1.ConditionTrue,
+							Reason:  "MinimumReplicasAvailable",
+							Message: "Deployment has minimum availability.",
+						},
+						{
+							Type:    appsv1.DeploymentProgressing,
+							Status:  corev1.ConditionTrue,
+							Reason:  "NewReplicaSetAvailable",
+							Message: "ReplicaSet \"downloads-679d74f59d\" has successfully progressed.",
+						},
+					},
+				},
+			},
+			expected: []operatorsv1.OperatorCondition{
+				{
+					Type:    "PrefixAvailable",
+					Status:  operatorsv1.ConditionTrue,
+					Reason:  "MinimumReplicasAvailable",
+					Message: "Deployment has minimum availability.",
+				},
+				{
+					Type:    "PrefixProgressing",
+					Status:  operatorsv1.ConditionTrue,
+					Reason:  "NewReplicaSetAvailable",
+					Message: "ReplicaSet \"downloads-679d74f59d\" has successfully progressed.",
+				},
+				{
+					Type:    "PrefixDegraded",
+					Status:  operatorsv1.ConditionFalse,
+					Reason:  "Available",
+					Message: "Available with no replica failures.",
+				},
+			},
+		},
+		{
+			name: "ProgressDeadlineExceeded",
+			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: 2,
+				},
+				Status: appsv1.DeploymentStatus{
+					ObservedGeneration:  2,
+					Replicas:            3,
+					AvailableReplicas:   1,
+					ReadyReplicas:       1,
+					UnavailableReplicas: 2,
+					UpdatedReplicas:     2,
+					Conditions: []appsv1.DeploymentCondition{
+						{
+							Type:    appsv1.DeploymentAvailable,
+							Status:  corev1.ConditionFalse,
+							Reason:  "MinimumReplicasUnavailable",
+							Message: "Deployment does not have minimum availability.",
+						},
+						{
+							Type:    appsv1.DeploymentProgressing,
+							Status:  corev1.ConditionFalse,
+							Reason:  "ProgressDeadlineExceeded",
+							Message: "ReplicaSet \"console-6974765f97\" has timed out progressing.",
+						},
+					},
+				},
+			},
+			expected: []operatorsv1.OperatorCondition{
+				{
+					Type:    "PrefixAvailable",
+					Status:  operatorsv1.ConditionFalse,
+					Reason:  "MinimumReplicasUnavailable",
+					Message: "Deployment does not have minimum availability.",
+				},
+				{
+					Type:    "PrefixProgressing",
+					Status:  operatorsv1.ConditionFalse,
+					Reason:  "ProgressDeadlineExceeded",
+					Message: "ReplicaSet \"console-6974765f97\" has timed out progressing.",
+				},
+				{
+					Type:    "PrefixDegraded",
+					Status:  operatorsv1.ConditionUnknown,
+					Reason:  "Unknown",
+					Message: "Not available, but no replica failures either.",
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var actual []operatorsv1.OperatorCondition
+			err := SetOperatorConditions(&actual, "Prefix", test.deployment)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if len(actual) != len(test.expected) {
+				t.Fatal(spew.Sdump(actual))
+			}
+
+			for i := range test.expected {
+				expected := test.expected[i]
+				actualCondition := actual[i]
+				if expected.LastTransitionTime == (metav1.Time{}) {
+					actualCondition.LastTransitionTime = metav1.Time{}
+				}
+				if !equality.Semantic.DeepEqual(expected, actualCondition) {
+					t.Errorf(diff.ObjectDiff(expected, actualCondition))
+				}
+			}
+		})
+	}
+}

--- a/pkg/operator/v1helpers/helpers.go
+++ b/pkg/operator/v1helpers/helpers.go
@@ -4,16 +4,33 @@ import (
 	"strings"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/klog"
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 )
+
+// ConvertCoreV1StatusToOperatorV1Status converts a core/v1 condition status to an operator condition status.
+func ConvertCoreV1StatusToOperatorV1Status(status corev1.ConditionStatus) operatorv1.ConditionStatus {
+	switch status {
+	case corev1.ConditionTrue:
+		return operatorv1.ConditionTrue
+	case corev1.ConditionFalse:
+		return operatorv1.ConditionFalse
+	case corev1.ConditionUnknown:
+		return operatorv1.ConditionUnknown
+	default:
+		klog.V(4).Infof("Unrecognized core/v1 status: %s", status)
+		return operatorv1.ConditionStatus(status)
+	}
+}
 
 // SetOperandVersion sets the new version and returns the previous value.
 func SetOperandVersion(versions *[]configv1.OperandVersion, operandVersion configv1.OperandVersion) string {


### PR DESCRIPTION
Many operators manage a deployment as one of their operands (e.g. the console operator manages a console deployment).  Make it easier for those operators to report the status of the managed deployment by providing a centralized helper that mostly leans on [deployment conditions][1] [set][2] by [the Kubernetes controller][3].

Test examples are picked from [the console namespace][5] in [this CI job][4].

Things I don't like about the current status output:

* Why is `Progressing=True` for the `downloads` deployment?  Seems like `ReplicaSet ... has successfully progressed.` would be a cause to say `Progressing=False, we're all good`.

* Why is there no `ReplicaFailure` condition on the console deployment?  Seems like `Available=False` and `Progressing=False` would be grounds for some kind of degraded condition on the deployment.

* The messages are pretty terse, I'd expect `1 available replica is less than the minimum 2` or similar instead of a blanket `does not have minimum availability`.  Bonus points for including things like the `CrashLoopBackOff` and OAuth `connection refused` from [the unavailabled pods][6].

But however we sort out those things, I think some sort of centralized helper here will make it easier to get consistent, high-quality reporting out of all the operators that manage deployments.  Thoughts?

[1]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#deployment-status
[2]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#progress-deadline-seconds
[3]: https://github.com/kubernetes/kubernetes/tree/b7bc5dc9db16731b6e64053bc5b9e8cdca872e14/pkg/controller/deployment
[4]: https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/logs/release-openshift-origin-installer-e2e-gcp-4.3/507
[5]: https://storage.googleapis.com/origin-ci-test/logs/release-openshift-origin-installer-e2e-gcp-4.3/507/artifacts/e2e-gcp/must-gather/registry-svc-ci-openshift-org-ci-op-xcjcp0gb-stable-sha256-dae1257b516a5c177237cfef5a6a3e241962b0d20cf54bcb2b66dc1671c5035e/namespaces/openshift-console/apps/deployments.yaml
[6]: https://storage.googleapis.com/origin-ci-test/logs/release-openshift-origin-installer-e2e-gcp-4.3/507/artifacts/e2e-gcp/must-gather/registry-svc-ci-openshift-org-ci-op-xcjcp0gb-stable-sha256-dae1257b516a5c177237cfef5a6a3e241962b0d20cf54bcb2b66dc1671c5035e/namespaces/openshift-console/pods/console-7974bb6477-xqrmt/console-7974bb6477-xqrmt.yaml