### PR TITLE
File observer fixes

### DIFF
--- a/pkg/controller/fileobserver/observer.go
+++ b/pkg/controller/fileobserver/observer.go
@@ -61,6 +61,6 @@ func NewObserver(interval time.Duration) (Observer, error) {
 	return &pollingObserver{
 		interval: interval,
 		reactors: map[string][]ReactorFn{},
-		files:    map[string]string{},
+		files:    map[string]fileHashAndState{},
 	}, nil
 }

--- a/pkg/controller/fileobserver/observer.go
+++ b/pkg/controller/fileobserver/observer.go
@@ -10,6 +10,7 @@ import (
 
 type Observer interface {
 	Run(stopChan <-chan struct{})
+	HasSynced() bool
 	AddReactor(reaction ReactorFn, startingFileContent map[string][]byte, files ...string) Observer
 }
 

--- a/pkg/controller/fileobserver/observer_polling.go
+++ b/pkg/controller/fileobserver/observer_polling.go
@@ -17,7 +17,7 @@ import (
 type pollingObserver struct {
 	interval time.Duration
 	reactors map[string][]ReactorFn
-	files    map[string]string
+	files    map[string]fileHashAndState
 
 	reactorsMutex sync.RWMutex
 
@@ -55,17 +55,19 @@ func (o *pollingObserver) AddReactor(reaction ReactorFn, startingFileContent map
 			// in case the file does not exists but empty string is specified as initial content, without this
 			// the content will be hashed and reaction will trigger as if the content changed.
 			if len(startingContent) == 0 {
-				o.files[f] = ""
+				o.files[f] = fileHashAndState{exists: true}
+				o.reactors[f] = append(o.reactors[f], reaction)
 				continue
 			}
-			o.files[f], err = calculateHash(bytes.NewBuffer(startingContent))
+			currentHash, emptyFile, err := calculateHash(bytes.NewBuffer(startingContent))
 			if err != nil {
 				panic(fmt.Sprintf("unexpected error while adding reactor for %#v: %v", files, err))
 			}
+			o.files[f] = fileHashAndState{exists: true, hash: currentHash, isEmpty: emptyFile}
 		} else {
 			klog.V(3).Infof("Adding reactor for file %q", f)
 			o.files[f], err = calculateFileHash(f)
-			if err != nil {
+			if err != nil && !os.IsNotExist(err) {
 				panic(fmt.Sprintf("unexpected error while adding reactor for %#v: %v", files, err))
 			}
 		}
@@ -84,31 +86,33 @@ func (o *pollingObserver) processReactors(stopCh <-chan struct{}) {
 		o.reactorsMutex.RLock()
 		defer o.reactorsMutex.RUnlock()
 		for filename, reactors := range o.reactors {
-			currentHash, err := calculateFileHash(filename)
-			if err != nil {
+			currentFileState, err := calculateFileHash(filename)
+			if err != nil && !os.IsNotExist(err) {
 				return false, err
 			}
-			lastKnownHash := o.files[filename]
 
-			// No file change detected
-			if lastKnownHash == currentHash {
-				continue
-			}
+			lastKnownFileState := o.files[filename]
+			o.files[filename] = currentFileState
 
-			klog.Infof("Observed change: file:%s (current: %q, lastKnown: %q)", filename, currentHash, lastKnownHash)
-			o.files[filename] = currentHash
+			klog.Infof("Observed change: file:%s (current: %q, lastKnown: %q)", filename, currentFileState.hash, lastKnownFileState.hash)
 
 			for i := range reactors {
-				action := FileModified
+				var action ActionType
 				switch {
-				case len(lastKnownHash) == 0:
+				case !lastKnownFileState.exists && !currentFileState.exists:
+					// skip non-existing file
+					continue
+				case !lastKnownFileState.exists && currentFileState.exists && (len(currentFileState.hash) > 0 || currentFileState.isEmpty):
+					// if we see a new file created that has content or its empty, trigger FileCreate action
 					action = FileCreated
-				case len(currentHash) == 0:
+				case lastKnownFileState.exists && !currentFileState.exists:
 					action = FileDeleted
-				case len(lastKnownHash) > 0:
+				case lastKnownFileState.hash == currentFileState.hash:
+					// skip if the hashes are the same
+					continue
+				case lastKnownFileState.hash != currentFileState.hash:
 					action = FileModified
 				}
-
 				if err := reactors[i](filename, action); err != nil {
 					klog.Errorf("Reactor for %q failed: %v", filename, err)
 				}
@@ -134,33 +138,53 @@ func (o *pollingObserver) Run(stopChan <-chan struct{}) {
 	o.processReactors(stopChan)
 }
 
-func calculateFileHash(path string) (string, error) {
-	stat, statErr := os.Stat(path)
-	if statErr != nil {
-		if os.IsNotExist(statErr) {
-			return "", nil
-		}
-		return "", statErr
+type fileHashAndState struct {
+	hash    string
+	exists  bool
+	isEmpty bool
+}
+
+func calculateFileHash(path string) (fileHashAndState, error) {
+	result := fileHashAndState{}
+	stat, err := os.Stat(path)
+	if err != nil {
+		return result, err
 	}
+
+	// this is fatal
 	if stat.IsDir() {
-		return "", fmt.Errorf("you can watch only files, %s is a directory", path)
+		return result, fmt.Errorf("you can watch only files, %s is a directory", path)
 	}
 
 	f, err := os.Open(path)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return "", nil
-		}
-		return "", err
+		return result, err
 	}
 	defer f.Close()
-	return calculateHash(f)
+
+	// at this point we know for sure the file exists and we can read its content even if that content is empty
+	result.exists = true
+
+	hash, empty, err := calculateHash(f)
+	if err != nil {
+		return result, err
+	}
+
+	result.hash = hash
+	result.isEmpty = empty
+
+	return result, nil
 }
 
-func calculateHash(content io.Reader) (string, error) {
+func calculateHash(content io.Reader) (string, bool, error) {
 	hasher := sha256.New()
-	if _, err := io.Copy(hasher, content); err != nil {
-		return "", err
+	written, err := io.Copy(hasher, content)
+	if err != nil {
+		return "", false, err
 	}
-	return hex.EncodeToString(hasher.Sum(nil)), nil
+	// written == 0 means the content is empty
+	if written == 0 {
+		return "", true, nil
+	}
+	return hex.EncodeToString(hasher.Sum(nil)), false, nil
 }

--- a/pkg/controller/fileobserver/observer_polling_test.go
+++ b/pkg/controller/fileobserver/observer_polling_test.go
@@ -4,13 +4,272 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/wait"
 )
+
+func TestObserverPolling(t *testing.T) {
+	type observedAction struct {
+		file   string
+		action ActionType
+	}
+
+	var (
+		nonEmptyContent = []byte("non-empty")
+		changedContent  = []byte("change")
+		emptyContent    = []byte("")
+
+		observedSingleFileCreated = func(actions []observedAction, t *testing.T) {
+			if len(actions) == 0 {
+				t.Errorf("no actions observed, but expected to observe created")
+				return
+			}
+			if actions[0].action != FileCreated {
+				t.Errorf("created action expected, but observed %q", actions[0].action.String(path.Base(actions[0].file)))
+			}
+		}
+
+		observedSingleFileModified = func(actions []observedAction, t *testing.T) {
+			if len(actions) == 0 {
+				t.Errorf("no actions observed, but expected to observe modified")
+				return
+			}
+			if actions[0].action != FileModified {
+				t.Errorf("modified action expected, but observed %q", actions[0].action.String(path.Base(actions[0].file)))
+			}
+		}
+
+		observedSingleFileDeleted = func(actions []observedAction, t *testing.T) {
+			if len(actions) == 0 {
+				t.Errorf("no actions observed, but expected to observe deleted")
+				return
+			}
+			if actions[0].action != FileDeleted {
+				t.Errorf("deleted action expected, but observed %q", actions[0].action.String(path.Base(actions[0].file)))
+			}
+		}
+
+		observedNoChanges = func(actions []observedAction, t *testing.T) {
+			if len(actions) != 0 {
+				var result []string
+				for _, a := range actions {
+					result = append(result, a.action.String(path.Base(a.file)))
+				}
+				t.Errorf("expected to not observe any actions, but observed: %s", strings.Join(result, ","))
+			}
+		}
+
+		defaultTimeout = 5 * time.Second
+	)
+
+	tests := []struct {
+		name              string
+		startFileContent  []byte            // the content the file is created with initially
+		changeFileContent []byte            // change the file content
+		deleteFile        bool              // change the file by deleting it
+		startWithNoFile   bool              // start test with no file
+		setInitialContent bool              // set the initial content
+		initialContent    map[string][]byte // initial content to pass to observer
+		timeout           time.Duration     // maximum test duration (default: 5s)
+		waitForObserver   time.Duration     // duration to wait for observer to sync changes (default: 300ms)
+
+		evaluateActions func([]observedAction, *testing.T) // func to evaluate observed actions
+	}{
+		{
+			name:              "start with existing non-empty file with no change and initial content set",
+			evaluateActions:   observedNoChanges,
+			setInitialContent: true,
+			startFileContent:  nonEmptyContent,
+			timeout:           1 * time.Second,
+		},
+		{
+			name:             "start with existing non-empty file with no change and no initial content set",
+			evaluateActions:  observedNoChanges,
+			startFileContent: nonEmptyContent,
+			timeout:          1 * time.Second,
+		},
+		{
+			name:              "start with existing non-empty file that change",
+			evaluateActions:   observedSingleFileModified,
+			setInitialContent: true,
+			startFileContent:  nonEmptyContent,
+			changeFileContent: changedContent,
+		},
+		{
+			name:              "start with existing non-empty file and no initial content that change",
+			evaluateActions:   observedSingleFileModified,
+			startFileContent:  nonEmptyContent,
+			changeFileContent: changedContent,
+		},
+		{
+			name:              "start with existing empty file with no change",
+			evaluateActions:   observedNoChanges,
+			setInitialContent: true,
+			startFileContent:  emptyContent,
+			changeFileContent: emptyContent,
+		},
+		{
+			name:              "start with existing empty file and no initial content with no change",
+			evaluateActions:   observedNoChanges,
+			startFileContent:  emptyContent,
+			changeFileContent: emptyContent,
+		},
+		{
+			name:              "start with existing empty file that change content",
+			evaluateActions:   observedSingleFileModified,
+			startFileContent:  emptyContent,
+			changeFileContent: changedContent,
+		},
+		{
+			name:              "start with existing empty file and empty initial content that change content",
+			evaluateActions:   observedSingleFileModified,
+			setInitialContent: true,
+			startFileContent:  emptyContent,
+			changeFileContent: changedContent,
+		},
+		{
+			name:            "start with non-existing file with no change",
+			evaluateActions: observedNoChanges,
+			startWithNoFile: true,
+		},
+		{
+			name:              "start with non-existing file that is created as empty file",
+			evaluateActions:   observedSingleFileCreated,
+			startWithNoFile:   true,
+			changeFileContent: emptyContent,
+		},
+		{
+			name:              "start with non-existing file that is created as non-empty file",
+			evaluateActions:   observedSingleFileCreated,
+			startWithNoFile:   true,
+			changeFileContent: nonEmptyContent,
+		},
+		{
+			name:              "start with existing file with content that is deleted",
+			evaluateActions:   observedSingleFileDeleted,
+			setInitialContent: true,
+			startFileContent:  nonEmptyContent,
+			deleteFile:        true,
+		},
+		{
+			name:             "start with existing file with content and not initial content set that is deleted",
+			evaluateActions:  observedSingleFileDeleted,
+			startFileContent: nonEmptyContent,
+			deleteFile:       true,
+		},
+	}
+
+	baseDir, err := ioutil.TempDir("", "observer-poll-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(baseDir)
+
+	for _, test := range tests {
+		if test.timeout == 0 {
+			test.timeout = defaultTimeout
+		}
+		t.Run(test.name, func(t *testing.T) {
+			observer, err := NewObserver(200 * time.Millisecond)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			testDir := filepath.Join(baseDir, t.Name())
+			if err := os.MkdirAll(filepath.Join(baseDir, t.Name()), 0777); err != nil {
+				t.Fatal(err)
+			}
+
+			testFile := filepath.Join(testDir, "testfile")
+
+			if test.setInitialContent {
+				test.initialContent = map[string][]byte{
+					testFile: test.startFileContent,
+				}
+			}
+
+			if !test.startWithNoFile {
+				if err := ioutil.WriteFile(testFile, test.startFileContent, os.ModePerm); err != nil {
+					t.Fatal(err)
+				}
+				t.Logf("created file %q with content: %q", testFile, string(test.startFileContent))
+			}
+
+			observedChan := make(chan observedAction)
+			observer.AddReactor(func(file string, action ActionType) error {
+				t.Logf("observed %q", action.String(path.Base(file)))
+				observedChan <- observedAction{
+					file:   file,
+					action: action,
+				}
+				return nil
+			}, test.initialContent, testFile)
+
+			stopChan := make(chan struct{})
+
+			// start observing actions
+			observedActions := []observedAction{}
+			var observedActionsMutex sync.Mutex
+			stopObservingChan := make(chan struct{})
+			go func() {
+				for {
+					select {
+					case action := <-observedChan:
+						observedActionsMutex.Lock()
+						observedActions = append(observedActions, action)
+						observedActionsMutex.Unlock()
+					case <-stopObservingChan:
+						return
+					}
+				}
+			}()
+
+			// start file observer
+			go observer.Run(stopChan)
+
+			// wait until file observer see the files at least once
+			if err := wait.PollImmediate(10*time.Millisecond, test.timeout, func() (done bool, err error) {
+				return observer.HasSynced(), nil
+			}); err != nil {
+				t.Errorf("failed to wait for observer to sync: %v", err)
+			}
+			t.Logf("starting observing changes ...")
+
+			if test.changeFileContent != nil {
+				t.Logf("writing %q ...", string(test.changeFileContent))
+				if err := ioutil.WriteFile(testFile, test.changeFileContent, os.ModePerm); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			if test.deleteFile {
+				if err := os.RemoveAll(testDir); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			// give observer time to observe latest events
+			if test.waitForObserver == 0 {
+				time.Sleep(400 * time.Millisecond)
+			} else {
+				time.Sleep(test.waitForObserver)
+			}
+
+			close(stopObservingChan)
+			close(stopChan)
+
+			observedActionsMutex.Lock()
+			defer observedActionsMutex.Unlock()
+			test.evaluateActions(observedActions, t) // evaluate observed actions
+		})
+	}
+}
 
 type reactionRecorder struct {
 	reactions map[string][]ActionType


### PR DESCRIPTION
* First commit is adding mechanism for callers to ensure the initial sync passed and the fileobserver see and observing changes on files successfully
* Second commit is critical as when the initial content of file is empty, the reactor for the file is never added
* Third commit is adding much more unit test coverage to ensure all corner cases are handled

There is one TODO in unit test when the initial content is empty and the file content is empty (but exists), the observer will trigger "Created" action, even when the file existed. This should be handled as follow up issue.