### PR TITLE
image/reference: A ref with tag and ID should prefer ID

### DIFF
--- a/pkg/image/reference/reference.go
+++ b/pkg/image/reference/reference.go
@@ -174,8 +174,6 @@ func (r DockerImageReference) NameString() string {
 	switch {
 	case len(r.Name) == 0:
 		return ""
-	case len(r.Tag) > 0:
-		return r.Name + ":" + r.Tag
 	case len(r.ID) > 0:
 		var ref string
 		if _, err := digest.ParseDigest(r.ID); err == nil {
@@ -186,6 +184,8 @@ func (r DockerImageReference) NameString() string {
 			ref = ":" + r.ID
 		}
 		return r.Name + ref
+	case len(r.Tag) > 0:
+		return r.Name + ":" + r.Tag
 	default:
 		return r.Name
 	}


### PR DESCRIPTION
When we convert a ref like `foo/bar:baz@sha256:...` to Exact(), we
should prefer the digest.