### PR TITLE
cert-syncer: Fix events for not-found resources

### DIFF
--- a/pkg/operator/staticpod/certsyncpod/certsync_controller.go
+++ b/pkg/operator/staticpod/certsyncpod/certsync_controller.go
@@ -102,14 +102,14 @@ func (c *CertSyncController) sync() error {
 
 			// remove missing content
 			if err := os.RemoveAll(getConfigMapDir(c.destinationDir, cm.Name)); err != nil {
-				c.eventRecorder.Warningf("CertificateUpdateFailed", "Failed removing file for configmap: %s/%s: %v", configMap.Namespace, configMap.Name, err)
+				c.eventRecorder.Warningf("CertificateUpdateFailed", "Failed removing file for configmap: %s/%s: %v", c.namespace, cm.Name, err)
 				errors = append(errors, err)
 			}
-			c.eventRecorder.Eventf("CertificateRemoved", "Removed file for configmap: %s/%s", configMap.Namespace, configMap.Name)
+			c.eventRecorder.Eventf("CertificateRemoved", "Removed file for configmap: %s/%s", c.namespace, cm.Name)
 			continue
 
 		case err != nil:
-			c.eventRecorder.Warningf("CertificateUpdateFailed", "Failed getting configmap: %s/%s: %v", configMap.Namespace, configMap.Name, err)
+			c.eventRecorder.Warningf("CertificateUpdateFailed", "Failed getting configmap: %s/%s: %v", c.namespace, cm.Name, err)
 			errors = append(errors, err)
 			continue
 		}
@@ -142,7 +142,7 @@ func (c *CertSyncController) sync() error {
 		configMap, err = c.configmapGetter.Get(configMap.Name, metav1.GetOptions{})
 		if err != nil {
 			// Even if the error is not exists we will act on it when caches catch up
-			c.eventRecorder.Warningf("CertificateUpdateFailed", "Failed getting configmap: %s/%s: %v", configMap.Namespace, configMap.Name, err)
+			c.eventRecorder.Warningf("CertificateUpdateFailed", "Failed getting configmap: %s/%s: %v", c.namespace, cm.Name, err)
 			errors = append(errors, err)
 			continue
 		}
@@ -205,15 +205,15 @@ func (c *CertSyncController) sync() error {
 
 			// remove missing content
 			if err := os.RemoveAll(secretFile); err != nil {
-				c.eventRecorder.Warningf("CertificateUpdateFailed", "Failed removing file for missing secret: %s/%s: %v", secret.Namespace, secret.Name, err)
+				c.eventRecorder.Warningf("CertificateUpdateFailed", "Failed removing file for missing secret: %s/%s: %v", c.namespace, s.Name, err)
 				errors = append(errors, err)
 				continue
 			}
-			c.eventRecorder.Warningf("CertificateRemoved", "Removed file for missing secret: %s/%s", secret.Namespace, secret.Name)
+			c.eventRecorder.Warningf("CertificateRemoved", "Removed file for missing secret: %s/%s", c.namespace, s.Name)
 			continue
 
 		case err != nil:
-			c.eventRecorder.Warningf("CertificateUpdateFailed", "Failed getting secret: %s/%s: %v", secret.Namespace, secret.Name, err)
+			c.eventRecorder.Warningf("CertificateUpdateFailed", "Failed getting secret: %s/%s: %v", c.namespace, s.Name, err)
 			errors = append(errors, err)
 			continue
 		}
@@ -246,7 +246,7 @@ func (c *CertSyncController) sync() error {
 		secret, err = c.secretGetter.Get(secret.Name, metav1.GetOptions{})
 		if err != nil {
 			// Even if the error is not exists we will act on it when caches catch up
-			c.eventRecorder.Warningf("CertificateUpdateFailed", "Failed getting secret: %s/%s: %v", secret.Namespace, secret.Name, err)
+			c.eventRecorder.Warningf("CertificateUpdateFailed", "Failed getting secret: %s/%s: %v", c.namespace, s.Name, err)
 			errors = append(errors, err)
 			continue
 		}


### PR DESCRIPTION
When emitting an event concerning the absence of a resource, use the namespace and name that were used to try to get the resource, rather than the namespace and name from the result of trying to get the resource (which will both be blank since the resource did not exist).

Remove a superfluous `err` argument in the `Warningf` call made when removing the file for a non-existent secret.  The `err` argument has no corresponding placeholder in the format string; the extra argument, combined with using the empty result's namespace and name, resulted in messages like the following:

    Removed file for secret: /%!(EXTRA *errors.StatusError=secrets "user-serving-cert" not found)

As the error is always a "not found" error, it can be omitted.

Follow-up to #546.

* `pkg/operator/staticpod/certsyncpod/certsync_controller.go` (`sync`): Omit `err` from "Removed file for secret" event.  Use the correct namespace and name for events concerning not-found resources.