### PR TITLE
fileobserver: fix logging

### DIFF
--- a/pkg/controller/fileobserver/observer_polling.go
+++ b/pkg/controller/fileobserver/observer_polling.go
@@ -94,8 +94,6 @@ func (o *pollingObserver) processReactors(stopCh <-chan struct{}) {
 			lastKnownFileState := o.files[filename]
 			o.files[filename] = currentFileState
 
-			klog.Infof("Observed change: file:%s (current: %q, lastKnown: %q)", filename, currentFileState.hash, lastKnownFileState.hash)
-
 			for i := range reactors {
 				var action ActionType
 				switch {
@@ -104,13 +102,16 @@ func (o *pollingObserver) processReactors(stopCh <-chan struct{}) {
 					continue
 				case !lastKnownFileState.exists && currentFileState.exists && (len(currentFileState.hash) > 0 || currentFileState.isEmpty):
 					// if we see a new file created that has content or its empty, trigger FileCreate action
+					klog.Infof("Observed file %q has been created (hash=%q)", filename, currentFileState.hash)
 					action = FileCreated
 				case lastKnownFileState.exists && !currentFileState.exists:
+					klog.Infof("Observed file %q has been deleted", filename)
 					action = FileDeleted
 				case lastKnownFileState.hash == currentFileState.hash:
 					// skip if the hashes are the same
 					continue
 				case lastKnownFileState.hash != currentFileState.hash:
+					klog.Infof("Observed file %q has been modified (old=%q, new=%q)", filename, lastKnownFileState.hash, currentFileState.hash)
 					action = FileModified
 				}
 				if err := reactors[i](filename, action); err != nil {


### PR DESCRIPTION
Found that the recent changes to file observer also caused to spam log as we log the observed file on each resync.