### PR TITLE
Bug 1775057: encryption: keep last read key after migration for easier backup/restore

### DIFF
--- a/pkg/operator/encryption/controllers/state_controller_test.go
+++ b/pkg/operator/encryption/controllers/state_controller_test.go
@@ -345,6 +345,10 @@ func TestStateController(t *testing.T) {
 							Name:   "34",
 							Secret: "MWMwNmU4NTE3ODkwYzhkYzQ0ZjYyNzkwNWVmYzg2Yjg=",
 						},
+						{
+							Name:   "33",
+							Secret: "YjBhZjgyMjQwZTEwYzAzMmZkOWJiYmVkZDNiNTk1NWE=",
+						},
 					},
 				}
 				ec := encryptiontesting.CreateEncryptionCfgWithWriteKey([]encryptiontesting.EncryptionKeysResourceTuple{keysRes})

--- a/pkg/operator/encryption/statemachine/transition_test.go
+++ b/pkg/operator/encryption/statemachine/transition_test.go
@@ -864,8 +864,15 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 						Providers: []apiserverconfigv1.ProviderConfiguration{{
 							AESCBC: &apiserverconfigv1.AESConfiguration{
 								Keys: []apiserverconfigv1.Key{{
+									Name:   "3",
+									Secret: base64.StdEncoding.EncodeToString([]byte("3bc2bdbc2bec2ebce7b27ce792639723")),
+								}},
+							},
+						}, {
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
 									Name:   "2",
-									Secret: base64.StdEncoding.EncodeToString([]byte("2bc2bdbc2bec2ebce7b27ce792639723")),
+									Secret: base64.StdEncoding.EncodeToString([]byte("21ea7c91419a68fd1224f88d50316b4e")),
 								}},
 							},
 						}, {
@@ -883,8 +890,15 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 						Providers: []apiserverconfigv1.ProviderConfiguration{{
 							AESCBC: &apiserverconfigv1.AESConfiguration{
 								Keys: []apiserverconfigv1.Key{{
+									Name:   "3",
+									Secret: base64.StdEncoding.EncodeToString([]byte("3bc2bdbc2bec2ebce7b27ce792639723")),
+								}},
+							},
+						}, {
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
 									Name:   "2",
-									Secret: base64.StdEncoding.EncodeToString([]byte("2bc2bdbc2bec2ebce7b27ce792639723")),
+									Secret: base64.StdEncoding.EncodeToString([]byte("21ea7c91419a68fd1224f88d50316b4e")),
 								}},
 							},
 						}, {
@@ -902,7 +916,8 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 				"kms",
 				[]*corev1.Secret{
 					encryptiontesting.CreateEncryptionKeySecretWithRawKey("kms", nil, 1, []byte("11ea7c91419a68fd1224f88d50316b4e")),
-					encryptiontesting.CreateMigratedEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "configmaps"}, {Group: "", Resource: "secrets"}}, 2, []byte("2bc2bdbc2bec2ebce7b27ce792639723"), time.Now()),
+					encryptiontesting.CreateEncryptionKeySecretWithRawKey("kms", nil, 2, []byte("21ea7c91419a68fd1224f88d50316b4e")),
+					encryptiontesting.CreateMigratedEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "configmaps"}, {Group: "", Resource: "secrets"}}, 3, []byte("3bc2bdbc2bec2ebce7b27ce792639723"), time.Now()),
 				},
 				[]schema.GroupResource{{Group: "", Resource: "configmaps"}, {Group: "", Resource: "secrets"}},
 			},
@@ -913,8 +928,15 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 						Providers: []apiserverconfigv1.ProviderConfiguration{{
 							AESCBC: &apiserverconfigv1.AESConfiguration{
 								Keys: []apiserverconfigv1.Key{{
+									Name:   "3",
+									Secret: base64.StdEncoding.EncodeToString([]byte("3bc2bdbc2bec2ebce7b27ce792639723")),
+								}},
+							},
+						}, {
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
 									Name:   "2",
-									Secret: base64.StdEncoding.EncodeToString([]byte("2bc2bdbc2bec2ebce7b27ce792639723")),
+									Secret: base64.StdEncoding.EncodeToString([]byte("21ea7c91419a68fd1224f88d50316b4e")),
 								}},
 							},
 						}, {
@@ -926,8 +948,15 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 						Providers: []apiserverconfigv1.ProviderConfiguration{{
 							AESCBC: &apiserverconfigv1.AESConfiguration{
 								Keys: []apiserverconfigv1.Key{{
+									Name:   "3",
+									Secret: base64.StdEncoding.EncodeToString([]byte("3bc2bdbc2bec2ebce7b27ce792639723")),
+								}},
+							},
+						}, {
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
 									Name:   "2",
-									Secret: base64.StdEncoding.EncodeToString([]byte("2bc2bdbc2bec2ebce7b27ce792639723")),
+									Secret: base64.StdEncoding.EncodeToString([]byte("21ea7c91419a68fd1224f88d50316b4e")),
 								}},
 							},
 						}, {


### PR DESCRIPTION
An etcd backup during migration might require the last read key to be used to decrypt. If the backup of the config might not include that last read key though when done too late. This PR makes the last read to stay in the encryption config such that decryption is always possible.