### PR TITLE
encryption: adapt log output verbosity to default of 2

### DIFF
--- a/pkg/operator/encryption/controllers/migrators/inprocess.go
+++ b/pkg/operator/encryption/controllers/migrators/inprocess.go
@@ -62,7 +62,7 @@ func (m *InProcessMigrator) EnsureMigration(gr schema.GroupResource, writeKey st
 
 	// different key?
 	if migration != nil && migration.result == nil {
-		klog.V(4).Infof("interrupting running migration for resource %v and write key %q", gr, migration.writeKey)
+		klog.V(2).Infof("Interrupting running migration for resource %v and write key %q", gr, migration.writeKey)
 		close(migration.stopCh)
 
 		// give go routine time to update the result
@@ -135,8 +135,8 @@ func (m *InProcessMigrator) runMigration(gvr schema.GroupVersionResource, writeK
 				klog.Warningf("Update of %s/%s failed: %v", obj.GetNamespace(), obj.GetName(), updateErr)
 				return updateErr // not retryable or we don't know. Return error and controller will restart migration.
 			}
-			if seconds, delay := errors.SuggestsClientDelay(updateErr); delay {
-				klog.V(4).Infof("Sleeping %ds while updating %s/%s of type %v after retryable error: %v", seconds, obj.GetNamespace(), obj.GetName(), gvr, updateErr)
+			if seconds, delay := errors.SuggestsClientDelay(updateErr); delay && seconds > 0 {
+				klog.V(2).Infof("Sleeping %ds while updating %s/%s of type %v after retryable error: %v", seconds, obj.GetNamespace(), obj.GetName(), gvr, updateErr)
 				time.Sleep(time.Duration(seconds) * time.Second)
 			}
 		}

--- a/pkg/operator/encryption/controllers/migrators/inprocess_processor.go
+++ b/pkg/operator/encryption/controllers/migrators/inprocess_processor.go
@@ -59,7 +59,7 @@ func (p *listProcessor) Run(gvr schema.GroupVersionResource) error {
 						return nil, err
 					}
 					opts.Continue = token
-					klog.V(4).Infof("Relisting %v after handling expired token", gvr)
+					klog.V(2).Infof("Relisting %v after handling expired token", gvr)
 					continue
 				} else if retryable := canRetry(err); retryable == nil || *retryable == false {
 					return nil, err // not retryable or we don't know. Return error and controller will restart migration.
@@ -67,18 +67,18 @@ func (p *listProcessor) Run(gvr schema.GroupVersionResource) error {
 					if seconds, delay := errors.SuggestsClientDelay(err); delay {
 						time.Sleep(time.Duration(seconds) * time.Second)
 					}
-					klog.V(4).Infof("Relisting %v after retryable error: %v", gvr, err)
+					klog.V(2).Infof("Relisting %v after retryable error: %v", gvr, err)
 					continue
 				}
 			}
 
 			migrationStarted := time.Now()
-			klog.V(4).Infof("Migrating %d objects of %v", len(allResource.Items), gvr)
+			klog.V(2).Infof("Migrating %d objects of %v", len(allResource.Items), gvr)
 			if err = p.processList(allResource); err != nil {
 				klog.Warningf("Migration of %v failed after %v: %v", gvr, time.Now().Sub(migrationStarted), err)
 				return nil, err
 			}
-			klog.V(4).Infof("Migration of %d objects of %v finished in %v", len(allResource.Items), gvr, time.Now().Sub(migrationStarted))
+			klog.V(2).Infof("Migration of %d objects of %v finished in %v", len(allResource.Items), gvr, time.Now().Sub(migrationStarted))
 
 			allResource.Items = nil // do not accumulate items, this fakes the visitor pattern
 			return allResource, nil // leave the rest of the list intact to preserve continue token
@@ -90,7 +90,7 @@ func (p *listProcessor) Run(gvr schema.GroupVersionResource) error {
 	if _, err := listPager.List(p.ctx, metav1.ListOptions{}); err != nil {
 		return err
 	}
-	klog.V(4).Infof("Migration for %v finished in %v", gvr, time.Now().Sub(migrationStarted))
+	klog.V(2).Infof("Migration for %v finished in %v", gvr, time.Now().Sub(migrationStarted))
 	return nil
 }
 

--- a/pkg/operator/encryption/controllers/prune_controller.go
+++ b/pkg/operator/encryption/controllers/prune_controller.go
@@ -177,7 +177,7 @@ NextEncryptionSecret:
 			deleteErrs = append(deleteErrs, err)
 		} else {
 			deletedKeys++
-			klog.V(4).Infof("Successfully pruned secret %s/%s", secret.Namespace, secret.Name)
+			klog.V(2).Infof("Successfully pruned secret %s/%s", secret.Namespace, secret.Name)
 		}
 	}
 	if deletedKeys > 0 {


### PR DESCRIPTION
We assumed in the migration code that the default verbosity is 4, but it is 2. This PR fixes the `V(n)` call accordingly.