### PR TITLE
encryption: improve EncryptionWriteKeyTriggeredInternal reasons

### DIFF
--- a/pkg/operator/encryption/controllers/key_controller_test.go
+++ b/pkg/operator/encryption/controllers/key_controller_test.go
@@ -114,7 +114,7 @@ func TestKeyController(t *testing.T) {
 						createAction := action.(clientgotesting.CreateAction)
 						actualSecret := createAction.GetObject().(*corev1.Secret)
 						expectedSecret := encryptiontesting.CreateEncryptionKeySecretWithKeyFromExistingSecret(targetNamespace, []schema.GroupResource{}, 1, actualSecret)
-						expectedSecret.Annotations["encryption.apiserver.operator.openshift.io/internal-reason"] = "no-secrets" // TODO: Fix this
+						expectedSecret.Annotations["encryption.apiserver.operator.openshift.io/internal-reason"] = "secrets-key-does-not-exist" // TODO: Fix this
 						if !equality.Semantic.DeepEqual(actualSecret, expectedSecret) {
 							ts.Errorf(diff.ObjectDiff(expectedSecret, actualSecret))
 						}
@@ -192,7 +192,7 @@ func TestKeyController(t *testing.T) {
 						createAction := action.(clientgotesting.CreateAction)
 						actualSecret := createAction.GetObject().(*corev1.Secret)
 						expectedSecret := encryptiontesting.CreateEncryptionKeySecretWithKeyFromExistingSecret(targetNamespace, []schema.GroupResource{}, 6, actualSecret)
-						expectedSecret.Annotations["encryption.apiserver.operator.openshift.io/internal-reason"] = "timestamp-too-old"
+						expectedSecret.Annotations["encryption.apiserver.operator.openshift.io/internal-reason"] = "secrets-rotation-interval-has-passed"
 						if !equality.Semantic.DeepEqual(actualSecret, expectedSecret) {
 							ts.Errorf(diff.ObjectDiff(expectedSecret, actualSecret))
 						}


### PR DESCRIPTION
The old

```
I1127 10:41:49.608448       1 event.go:255] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-apiserver-operator", Name:"kube-apiserver-operator", UID:"e7160562-1117-4844-a859-1c5a94e5729c", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'EncryptionWriteKeyTriggeredInternal' Triggered key "1" for resource "configmaps" because no-secrets, no-secrets
```

could not be understood by users, nor us developers.