### PR TITLE
encryption: enrich current state with secret info to avoid spurious events

### DIFF
--- a/pkg/operator/encryption/controllers.go
+++ b/pkg/operator/encryption/controllers.go
@@ -74,6 +74,7 @@ func NewControllers(
 				encryptedGRs,
 			),
 			controllers.NewMigrationController(
+				component,
 				deployer,
 				migrator,
 				operatorClient,

--- a/pkg/operator/encryption/controllers/key_controller.go
+++ b/pkg/operator/encryption/controllers/key_controller.go
@@ -143,7 +143,7 @@ func (c *keyController) checkAndCreateKeys() error {
 		return err
 	}
 
-	currentConfig, desiredEncryptionState, secretsFound, isProgressingReason, err := statemachine.GetEncryptionConfigAndState(c.deployer, c.secretClient, c.encryptionSecretSelector, c.encryptedGRs)
+	currentConfig, desiredEncryptionState, secrets, isProgressingReason, err := statemachine.GetEncryptionConfigAndState(c.deployer, c.secretClient, c.encryptionSecretSelector, c.encryptedGRs)
 	if err != nil {
 		return err
 	}
@@ -153,7 +153,7 @@ func (c *keyController) checkAndCreateKeys() error {
 	}
 
 	// avoid intended start of encryption
-	hasBeenOnBefore := currentConfig != nil || secretsFound
+	hasBeenOnBefore := currentConfig != nil || len(secrets) > 0
 	if currentMode == state.Identity && !hasBeenOnBefore {
 		return nil
 	}

--- a/pkg/operator/encryption/controllers/key_controller_test.go
+++ b/pkg/operator/encryption/controllers/key_controller_test.go
@@ -19,6 +19,7 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	configv1clientfake "github.com/openshift/client-go/config/clientset/versioned/fake"
 	configv1informers "github.com/openshift/client-go/config/informers/externalversions"
+
 	encryptiondeployer "github.com/openshift/library-go/pkg/operator/encryption/deployer"
 	encryptiontesting "github.com/openshift/library-go/pkg/operator/encryption/testing"
 	"github.com/openshift/library-go/pkg/operator/events"

--- a/pkg/operator/encryption/controllers/migration_controller_test.go
+++ b/pkg/operator/encryption/controllers/migration_controller_test.go
@@ -147,7 +147,6 @@ func TestMigrationController(t *testing.T) {
 				"get:secrets:kms",
 				"list:secrets:openshift-config-managed",
 				"list:secrets:openshift-config-managed",
-				"list:secrets:openshift-config-managed",
 			},
 			expectedMigratorCalls: []string{
 				"ensure:configmaps:1",
@@ -245,7 +244,6 @@ func TestMigrationController(t *testing.T) {
 				"get:secrets:openshift-config-managed",
 				"update:secrets:openshift-config-managed",
 				"create:events:operator",
-				"list:secrets:openshift-config-managed",
 			},
 			expectedMigratorCalls: []string{
 				"ensure:configmaps:1",
@@ -343,7 +341,6 @@ func TestMigrationController(t *testing.T) {
 				"get:secrets:openshift-config-managed",
 				"update:secrets:openshift-config-managed",
 				"create:events:operator",
-				"list:secrets:openshift-config-managed",
 				"get:secrets:openshift-config-managed",
 				"get:secrets:openshift-config-managed",
 				"update:secrets:openshift-config-managed",
@@ -440,7 +437,6 @@ func TestMigrationController(t *testing.T) {
 				"get:secrets:kms",
 				"list:secrets:openshift-config-managed",
 				"list:secrets:openshift-config-managed",
-				"list:secrets:openshift-config-managed",
 			},
 			expectedMigratorCalls: []string{
 				"ensure:configmaps:1",
@@ -535,7 +531,6 @@ func TestMigrationController(t *testing.T) {
 			expectedActions: []string{
 				"list:pods:kms",
 				"get:secrets:kms",
-				"list:secrets:openshift-config-managed",
 				"list:secrets:openshift-config-managed",
 				"list:secrets:openshift-config-managed",
 			},
@@ -646,6 +641,7 @@ func TestMigrationController(t *testing.T) {
 
 			// act
 			target := NewMigrationController(
+				"kms",
 				deployer,
 				migrator,
 				fakeOperatorClient,

--- a/pkg/operator/encryption/controllers/state_controller_test.go
+++ b/pkg/operator/encryption/controllers/state_controller_test.go
@@ -119,7 +119,15 @@ func TestStateController(t *testing.T) {
 				ec := encryptiontesting.CreateEncryptionCfgWithWriteKey([]encryptiontesting.EncryptionKeysResourceTuple{keysRes})
 				return ec
 			}(),
-			expectedActions: []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config-managed", "create:secrets:openshift-config-managed", "create:events:kms", "create:events:kms"},
+			expectedActions: []string{
+				"list:pods:kms",
+				"get:secrets:kms",
+				"list:secrets:openshift-config-managed",
+				"get:secrets:openshift-config-managed",
+				"create:secrets:openshift-config-managed",
+				"create:events:kms",
+				"create:events:kms",
+			},
 			validateFunc: func(ts *testing.T, actions []clientgotesting.Action, destName string, expectedEncryptionCfg *apiserverconfigv1.EncryptionConfiguration) {
 				wasSecretValidated := false
 				for _, action := range actions {
@@ -249,7 +257,15 @@ func TestStateController(t *testing.T) {
 				ec := encryptiontesting.CreateEncryptionCfgWithWriteKey([]encryptiontesting.EncryptionKeysResourceTuple{keysRes})
 				return ec
 			}(),
-			expectedActions: []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config-managed", "update:secrets:openshift-config-managed", "create:events:kms", "create:events:kms"},
+			expectedActions: []string{
+				"list:pods:kms",
+				"get:secrets:kms",
+				"list:secrets:openshift-config-managed",
+				"get:secrets:openshift-config-managed",
+				"update:secrets:openshift-config-managed",
+				"create:events:kms",
+				"create:events:kms",
+			},
 			validateFunc: func(ts *testing.T, actions []clientgotesting.Action, destName string, expectedEncryptionCfg *apiserverconfigv1.EncryptionConfiguration) {
 				wasSecretValidated := false
 				for _, action := range actions {
@@ -443,8 +459,15 @@ func TestStateController(t *testing.T) {
 				ec := encryptiontesting.CreateEncryptionCfgWithWriteKey([]encryptiontesting.EncryptionKeysResourceTuple{keysRes})
 				return ec
 			}(),
-			expectedActions: []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config-managed", "update:secrets:openshift-config-managed",
-				"create:events:kms", "create:events:kms"},
+			expectedActions: []string{
+				"list:pods:kms",
+				"get:secrets:kms",
+				"list:secrets:openshift-config-managed",
+				"get:secrets:openshift-config-managed",
+				"update:secrets:openshift-config-managed",
+				"create:events:kms",
+				"create:events:kms",
+			},
 			validateFunc: func(ts *testing.T, actions []clientgotesting.Action, destName string, expectedEncryptionCfg *apiserverconfigv1.EncryptionConfiguration) {
 				wasSecretValidated := false
 				for _, action := range actions {

--- a/pkg/operator/encryption/encryptionconfig/config_test.go
+++ b/pkg/operator/encryption/encryptionconfig/config_test.go
@@ -331,7 +331,7 @@ func TestToEncryptionState(t *testing.T) {
 
 	for _, scenario := range scenarios {
 		t.Run(scenario.name, func(t *testing.T) {
-			actualOutput := ToEncryptionState(scenario.input)
+			actualOutput, _ := ToEncryptionState(scenario.input, nil)
 
 			if len(actualOutput) != len(scenario.output) {
 				t.Fatalf("expected to get %d GR, got %d", len(scenario.output), len(actualOutput))

--- a/pkg/operator/encryption/secrets/secrets.go
+++ b/pkg/operator/encryption/secrets/secrets.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/config/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 
 	"github.com/openshift/library-go/pkg/operator/encryption/state"
 )
@@ -121,4 +122,17 @@ func (m *MigratedGroupResources) HasResource(resource schema.GroupResource) bool
 		}
 	}
 	return false
+}
+
+// ListKeySecrets returns the current key secrets from openshift-config-managed.
+func ListKeySecrets(secretClient corev1client.SecretsGetter, encryptionSecretSelector metav1.ListOptions) ([]*corev1.Secret, error) {
+	encryptionSecretList, err := secretClient.Secrets("openshift-config-managed").List(encryptionSecretSelector)
+	if err != nil {
+		return nil, err
+	}
+	var encryptionSecrets []*corev1.Secret
+	for i := range encryptionSecretList.Items {
+		encryptionSecrets = append(encryptionSecrets, &encryptionSecretList.Items[i])
+	}
+	return encryptionSecrets, nil
 }

--- a/pkg/operator/encryption/statemachine/transition.go
+++ b/pkg/operator/encryption/statemachine/transition.go
@@ -32,35 +32,31 @@ func GetEncryptionConfigAndState(
 	secretClient corev1client.SecretsGetter,
 	encryptionSecretSelector metav1.ListOptions,
 	encryptedGRs []schema.GroupResource,
-) (current *apiserverconfigv1.EncryptionConfiguration, desired map[schema.GroupResource]state.GroupResourceState, secretsFound bool, transitioningReason string, err error) {
+) (current *apiserverconfigv1.EncryptionConfiguration, desired map[schema.GroupResource]state.GroupResourceState, encryptionSecrets []*corev1.Secret, transitioningReason string, err error) {
 	// get current config
 	encryptionConfigSecret, converged, err := deployer.DeployedEncryptionConfigSecret()
 	if err != nil {
-		return nil, nil, false, "", err
+		return nil, nil, nil, "", err
 	}
 	if !converged {
-		return nil, nil, false, "APIServerRevisionNotConverged", nil
+		return nil, nil, nil, "APIServerRevisionNotConverged", nil
 	}
 	var encryptionConfig *apiserverconfigv1.EncryptionConfiguration
 	if encryptionConfigSecret != nil {
 		encryptionConfig, err = encryptionconfig.FromSecret(encryptionConfigSecret)
 		if err != nil {
-			return nil, nil, false, "", fmt.Errorf("invalid encryption config %s/%s: %v", encryptionConfigSecret.Namespace, encryptionConfigSecret.Name, err)
+			return nil, nil, nil, "", fmt.Errorf("invalid encryption config %s/%s: %v", encryptionConfigSecret.Namespace, encryptionConfigSecret.Name, err)
 		}
 	}
 
 	// compute desired config
-	encryptionSecretList, err := secretClient.Secrets("openshift-config-managed").List(encryptionSecretSelector)
+	encryptionSecrets, err = secrets.ListKeySecrets(secretClient, encryptionSecretSelector)
 	if err != nil {
-		return nil, nil, false, "", err
-	}
-	var encryptionSecrets []*corev1.Secret
-	for i := range encryptionSecretList.Items {
-		encryptionSecrets = append(encryptionSecrets, &encryptionSecretList.Items[i])
+		return nil, nil, nil, "", err
 	}
 	desiredEncryptionState := getDesiredEncryptionState(encryptionConfig, encryptionSecrets, encryptedGRs)
 
-	return encryptionConfig, desiredEncryptionState, len(encryptionSecrets) > 0, "", nil
+	return encryptionConfig, desiredEncryptionState, encryptionSecrets, "", nil
 }
 
 // getDesiredEncryptionState returns the desired state of encryption for all resources.
@@ -76,21 +72,10 @@ func GetEncryptionConfigAndState(
 // 3. if (2) is the case, the write-key must be the most recent key.
 // 4. if (2) and (3) are the case, all non-write keys should be removed.
 func getDesiredEncryptionState(oldEncryptionConfig *apiserverconfigv1.EncryptionConfiguration, encryptionSecrets []*corev1.Secret, toBeEncryptedGRs []schema.GroupResource) map[schema.GroupResource]state.GroupResourceState {
-	backedKeys := make([]state.KeyState, 0, len(encryptionSecrets))
-	for _, s := range encryptionSecrets {
-		km, err := secrets.ToKeyState(s)
-		if err != nil {
-			klog.Warningf("skipping invalid secret: %v", err)
-			continue
-		}
-		backedKeys = append(backedKeys, km)
-	}
-	backedKeys = state.SortRecentFirst(backedKeys)
-
 	//
 	// STEP 0: start with old encryption config, and alter it towards the desired state in the following STEPs.
 	//
-	desiredEncryptionState := encryptionconfig.ToEncryptionState(oldEncryptionConfig)
+	desiredEncryptionState, backedKeys := encryptionconfig.ToEncryptionState(oldEncryptionConfig, encryptionSecrets)
 	if desiredEncryptionState == nil {
 		desiredEncryptionState = make(map[schema.GroupResource]state.GroupResourceState, len(toBeEncryptedGRs))
 	}
@@ -112,27 +97,6 @@ func getDesiredEncryptionState(oldEncryptionConfig *apiserverconfigv1.Encryption
 	if len(backedKeys) == 0 {
 		klog.V(4).Infof("no encryption secrets found")
 		return desiredEncryptionState
-	}
-
-	// enrich KeyState with values from secrets
-	for gr, grState := range desiredEncryptionState {
-		for i, rk := range grState.ReadKeys {
-			for _, k := range backedKeys {
-				if state.EqualKeyAndEqualID(&rk, &k) {
-					grState.ReadKeys[i] = k
-					break
-				}
-			}
-		}
-		if grState.HasWriteKey() {
-			for _, s := range backedKeys {
-				if state.EqualKeyAndEqualID(&grState.WriteKey, &s) {
-					grState.WriteKey = s
-					break
-				}
-			}
-		}
-		desiredEncryptionState[gr] = grState
 	}
 
 	//


### PR DESCRIPTION
The current config state was not enriched with the information we store in secret annotations (reasons, migration state). Hence, every comparison of that info between current and desired state was wrong, leading to more events and possibly other unwanted side-effects. This PR also updates the current state with the secrets, like we did with the desired state.