### PR TITLE
encryption: fix freezing key controller

### DIFF
--- a/pkg/operator/encryption/controllers/key_controller.go
+++ b/pkg/operator/encryption/controllers/key_controller.go
@@ -309,9 +309,9 @@ func needsNewKey(grKeys state.GroupResourceState, currentMode state.Mode, extern
 		return latestKeyID, fmt.Sprintf("encryption-config-key-%d-not-backed-by-secret", latestKeyID), true
 	}
 
-	// if the length of read secrets is more than one (i.e. we have more than just the write key),
+	// if the length of read secrets is more than two (i.e. we have more than just the write key and a previous read key),
 	// then we haven't successfully migrated and removed old keys so you should wait before generating more keys.
-	if len(grKeys.ReadKeys) > 1 {
+	if len(grKeys.ReadKeys) > 2 {
 		return 0, "", false
 	}
 

--- a/pkg/operator/encryption/controllers/key_controller.go
+++ b/pkg/operator/encryption/controllers/key_controller.go
@@ -309,9 +309,14 @@ func needsNewKey(grKeys state.GroupResourceState, currentMode state.Mode, extern
 		return latestKeyID, fmt.Sprintf("encryption-config-key-%d-not-backed-by-secret", latestKeyID), true
 	}
 
-	// if the length of read secrets is more than two (i.e. we have more than just the write key and a previous read key),
-	// then we haven't successfully migrated and removed old keys so you should wait before generating more keys.
-	if len(grKeys.ReadKeys) > 2 {
+	// check that we have pruned read-keys: the write-keys, plus at most one more backed read-key (potentially some unbacked once before)
+	backedKeys := 0
+	for _, rk := range grKeys.ReadKeys {
+		if rk.Backed {
+			backedKeys++
+		}
+	}
+	if backedKeys > 2 {
 		return 0, "", false
 	}
 

--- a/pkg/operator/encryption/controllers/prune_controller_test.go
+++ b/pkg/operator/encryption/controllers/prune_controller_test.go
@@ -54,12 +54,12 @@ func TestPruneController(t *testing.T) {
 		},
 
 		{
-			name:            "14 keys were migrated, 1 of them is used, 10 are kept, the 3 most recent are pruned",
+			name:            "15 keys were migrated, 2 of them are used, 10 are kept, the 3 most oldest are pruned",
 			targetNamespace: "kms",
 			targetGRs: []schema.GroupResource{
 				{Group: "", Resource: "secrets"},
 			},
-			initialSecrets: createMigratedEncryptionKeySecretsWithRndKey(t, 14, "kms", "secrets"),
+			initialSecrets: createMigratedEncryptionKeySecretsWithRndKey(t, 15, "kms", "secrets"),
 			expectedActions: []string{
 				"list:pods:kms",
 				"get:secrets:kms",
@@ -144,7 +144,7 @@ func TestPruneController(t *testing.T) {
 			}
 
 			encryptionConfig := func() *corev1.Secret {
-				additionalReadKeys := state.KeysWithPotentiallyPersistedData(scenario.targetGRs, state.SortRecentFirst(initialKeys))
+				additionalReadKeys := state.KeysWithPotentiallyPersistedDataAndNextReadKey(scenario.targetGRs, state.SortRecentFirst(initialKeys))
 				var additionaConfigReadKeys []apiserverconfigv1.Key
 				for _, rk := range additionalReadKeys {
 					additionaConfigReadKeys = append(additionaConfigReadKeys, apiserverconfigv1.Key{

--- a/pkg/operator/encryption/state/helpers.go
+++ b/pkg/operator/encryption/state/helpers.go
@@ -34,11 +34,15 @@ func MigratedFor(grs []schema.GroupResource, km KeyState) (ok bool, missing []sc
 	return true, nil, ""
 }
 
-// KeysWithPotentiallyPersistedData returns the minimal, recent secrets which have migrated all given GRs.
-func KeysWithPotentiallyPersistedData(grs []schema.GroupResource, recentFirstSortedKeys []KeyState) []KeyState {
+// KeysWithPotentiallyPersistedDataAndNextReadKey returns the minimal, recent secrets which have migrated all given GRs.
+func KeysWithPotentiallyPersistedDataAndNextReadKey(grs []schema.GroupResource, recentFirstSortedKeys []KeyState) []KeyState {
 	for i, k := range recentFirstSortedKeys {
 		if allMigrated, missing, _ := MigratedFor(grs, k); allMigrated {
-			return recentFirstSortedKeys[:i+1]
+			if i+1 < len(recentFirstSortedKeys) {
+				return recentFirstSortedKeys[:i+2]
+			} else {
+				return recentFirstSortedKeys[:i+1]
+			}
 		} else {
 			// continue with keys we haven't found a migration key for yet
 			grs = missing

--- a/pkg/operator/encryption/statemachine/transition_test.go
+++ b/pkg/operator/encryption/statemachine/transition_test.go
@@ -356,6 +356,14 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 									Secret: base64.StdEncoding.EncodeToString([]byte("3cbfbe7d76876e076b076c659cd895ff")),
 								}},
 							},
+						}, {
+							// one more read key for backup/recovery
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "2",
+									Secret: base64.StdEncoding.EncodeToString([]byte("2b234b23cb23c4b2cb24cb24bcbffbca")),
+								}},
+							},
 						}},
 					},
 					{
@@ -381,6 +389,14 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 								Keys: []apiserverconfigv1.Key{{
 									Name:   "3",
 									Secret: base64.StdEncoding.EncodeToString([]byte("3cbfbe7d76876e076b076c659cd895ff")),
+								}},
+							},
+						}, {
+							// one more read key for backup/recovery
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "2",
+									Secret: base64.StdEncoding.EncodeToString([]byte("2b234b23cb23c4b2cb24cb24bcbffbca")),
 								}},
 							},
 						}},
@@ -484,6 +500,14 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 								}},
 							},
 						}, {
+							// one more read key for backup/recovery
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "2",
+									Secret: base64.StdEncoding.EncodeToString([]byte("2b234b23cb23c4b2cb24cb24bcbffbca")),
+								}},
+							},
+						}, {
 							Identity: &apiserverconfigv1.IdentityConfiguration{},
 						}},
 					},
@@ -508,6 +532,14 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 								Keys: []apiserverconfigv1.Key{{
 									Name:   "3",
 									Secret: base64.StdEncoding.EncodeToString([]byte("3cbfbe7d76876e076b076c659cd895ff")),
+								}},
+							},
+						}, {
+							// one more read key for backup/recovery
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "2",
+									Secret: base64.StdEncoding.EncodeToString([]byte("2b234b23cb23c4b2cb24cb24bcbffbca")),
 								}},
 							},
 						}, {

--- a/test/e2e-encryption/encryption_test.go
+++ b/test/e2e-encryption/encryption_test.go
@@ -220,7 +220,7 @@ func TestEncryptionIntegration(tt *testing.T) {
 	waitForKeys(3)
 	waitForConfigs(
 		"kubeapiservers.operator.openshift.io=identity,aescbc:3,aescbc:1,aesgcm:2;kubeschedulers.operator.openshift.io=identity,aescbc:3,aescbc:1,aesgcm:2",
-		"kubeapiservers.operator.openshift.io=aescbc:3,identity,aescbc:1,aesgcm:2;kubeschedulers.operator.openshift.io=aescbc:3,identity,aescbc:1,aesgcm:2",
+		"kubeapiservers.operator.openshift.io=aescbc:3,aescbc:1,identity,aesgcm:2;kubeschedulers.operator.openshift.io=aescbc:3,aescbc:1,identity,aesgcm:2",
 		"kubeapiservers.operator.openshift.io=aescbc:3,identity,aesgcm:2;kubeschedulers.operator.openshift.io=aescbc:3,identity,aesgcm:2",
 	)
 
@@ -282,12 +282,14 @@ func TestEncryptionIntegration(tt *testing.T) {
 	//   kubeapiservers.operator.openshift.io=aescbc:6,aescbc:5,identity;kubeschedulers.operator.openshift.io=aescbc:6,aescbc:5,identity
 	// but eventually we get the following:
 	waitForConfigEventually(
-		// 6 as preserved config key, 7 as newly created key, and 5 as fully migrated key
-		"kubeapiservers.operator.openshift.io=aescbc:6,aescbc:7,aescbc:5,identity;kubeschedulers.operator.openshift.io=aescbc:6,aescbc:7,aescbc:5,identity",
+		// 6 as preserved, unbacked config key, 7 as newly created key, and 5 as fully migrated key
+		"kubeapiservers.operator.openshift.io=aescbc:6,aescbc:7,aescbc:5,aescbc:4,identity;kubeschedulers.operator.openshift.io=aescbc:6,aescbc:7,aescbc:5,aescbc:4,identity",
 	)
 	waitForConfigs(
+		// 7 is promoted
+		"kubeapiservers.operator.openshift.io=aescbc:7,aescbc:6,aescbc:5,aescbc:4,identity;kubeschedulers.operator.openshift.io=aescbc:7,aescbc:6,aescbc:5,aescbc:4,identity",
+		// 7 is migrated, plus one more backed key, which is 5 (6 is deleted)
 		"kubeapiservers.operator.openshift.io=aescbc:7,aescbc:6,aescbc:5,identity;kubeschedulers.operator.openshift.io=aescbc:7,aescbc:6,aescbc:5,identity",
-		"kubeapiservers.operator.openshift.io=aescbc:7,aescbc:6,identity;kubeschedulers.operator.openshift.io=aescbc:7,aescbc:6,identity",
 	)
 
 	t.Logf("Delete the openshift-config-managed config")
@@ -296,7 +298,8 @@ func TestEncryptionIntegration(tt *testing.T) {
 	err = kubeClient.CoreV1().Secrets("openshift-config-managed").Delete(fmt.Sprintf("encryption-config-%s", component), nil)
 	require.NoError(t, err)
 	waitForConfigs(
-		"kubeapiservers.operator.openshift.io=aescbc:7,identity;kubeschedulers.operator.openshift.io=aescbc:7,identity",
+		// one migrated read-key (7) and one more backed key (5), and everything in between (6)
+		"kubeapiservers.operator.openshift.io=aescbc:7,aescbc:6,aescbc:5,identity;kubeschedulers.operator.openshift.io=aescbc:7,aescbc:6,aescbc:5,identity",
 	)
 
 	t.Logf("Delete the openshift-config-managed config")
@@ -304,7 +307,8 @@ func TestEncryptionIntegration(tt *testing.T) {
 	waitForConfigs(
 		// 7 is migrated and hence only one needed, but we rotate through identity
 		"kubeapiservers.operator.openshift.io=identity,aescbc:7;kubeschedulers.operator.openshift.io=identity,aescbc:7",
-		"kubeapiservers.operator.openshift.io=aescbc:7,identity;kubeschedulers.operator.openshift.io=aescbc:7,identity",
+		// 7 is migrated, plus one backed key (5). 6 is deleted, and therefore is not preserved (would be if the operand config was not deleted)
+		"kubeapiservers.operator.openshift.io=aescbc:7,aescbc:5,identity;kubeschedulers.operator.openshift.io=aescbc:7,aescbc:5,identity",
 	)
 }
 

--- a/test/e2e-encryption/encryption_test.go
+++ b/test/e2e-encryption/encryption_test.go
@@ -206,7 +206,6 @@ func TestEncryptionIntegration(tt *testing.T) {
 	waitForConfigs(
 		"kubeapiservers.operator.openshift.io=aescbc:1,identity,aesgcm:2;kubeschedulers.operator.openshift.io=aescbc:1,identity,aesgcm:2",
 		"kubeapiservers.operator.openshift.io=identity,aescbc:1,aesgcm:2;kubeschedulers.operator.openshift.io=identity,aescbc:1,aesgcm:2",
-		"kubeapiservers.operator.openshift.io=identity,aesgcm:2;kubeschedulers.operator.openshift.io=identity,aesgcm:2",
 	)
 
 	t.Logf("Switch to empty mode")
@@ -220,9 +219,9 @@ func TestEncryptionIntegration(tt *testing.T) {
 	require.NoError(t, err)
 	waitForKeys(3)
 	waitForConfigs(
-		"kubeapiservers.operator.openshift.io=identity,aescbc:3,aesgcm:2;kubeschedulers.operator.openshift.io=identity,aescbc:3,aesgcm:2",
+		"kubeapiservers.operator.openshift.io=identity,aescbc:3,aescbc:1,aesgcm:2;kubeschedulers.operator.openshift.io=identity,aescbc:3,aescbc:1,aesgcm:2",
+		"kubeapiservers.operator.openshift.io=aescbc:3,identity,aescbc:1,aesgcm:2;kubeschedulers.operator.openshift.io=aescbc:3,identity,aescbc:1,aesgcm:2",
 		"kubeapiservers.operator.openshift.io=aescbc:3,identity,aesgcm:2;kubeschedulers.operator.openshift.io=aescbc:3,identity,aesgcm:2",
-		"kubeapiservers.operator.openshift.io=aescbc:3,identity;kubeschedulers.operator.openshift.io=aescbc:3,identity",
 	)
 
 	t.Logf("Setting external reason")
@@ -242,18 +241,18 @@ func TestEncryptionIntegration(tt *testing.T) {
 	setExternalReason("a")
 	waitForKeys(4)
 	waitForConfigs(
-		"kubeapiservers.operator.openshift.io=aescbc:3,aescbc:4,identity;kubeschedulers.operator.openshift.io=aescbc:3,aescbc:4,identity",
+		"kubeapiservers.operator.openshift.io=aescbc:3,aescbc:4,identity,aesgcm:2;kubeschedulers.operator.openshift.io=aescbc:3,aescbc:4,identity,aesgcm:2",
+		"kubeapiservers.operator.openshift.io=aescbc:4,aescbc:3,identity,aesgcm:2;kubeschedulers.operator.openshift.io=aescbc:4,aescbc:3,identity,aesgcm:2",
 		"kubeapiservers.operator.openshift.io=aescbc:4,aescbc:3,identity;kubeschedulers.operator.openshift.io=aescbc:4,aescbc:3,identity",
-		"kubeapiservers.operator.openshift.io=aescbc:4,identity;kubeschedulers.operator.openshift.io=aescbc:4,identity",
 	)
 
 	t.Logf("Setting another external reason")
 	setExternalReason("b")
 	waitForKeys(5)
 	waitForConfigs(
-		"kubeapiservers.operator.openshift.io=aescbc:4,aescbc:5,identity;kubeschedulers.operator.openshift.io=aescbc:4,aescbc:5,identity",
+		"kubeapiservers.operator.openshift.io=aescbc:4,aescbc:5,aescbc:3,identity;kubeschedulers.operator.openshift.io=aescbc:4,aescbc:5,aescbc:3,identity",
+		"kubeapiservers.operator.openshift.io=aescbc:5,aescbc:4,aescbc:3,identity;kubeschedulers.operator.openshift.io=aescbc:5,aescbc:4,aescbc:3,identity",
 		"kubeapiservers.operator.openshift.io=aescbc:5,aescbc:4,identity;kubeschedulers.operator.openshift.io=aescbc:5,aescbc:4,identity",
-		"kubeapiservers.operator.openshift.io=aescbc:5,identity;kubeschedulers.operator.openshift.io=aescbc:5,identity",
 	)
 
 	t.Logf("Expire the last key")
@@ -261,9 +260,9 @@ func TestEncryptionIntegration(tt *testing.T) {
 	require.NoError(t, err)
 	waitForKeys(6)
 	waitForConfigs(
-		"kubeapiservers.operator.openshift.io=aescbc:5,aescbc:6,identity;kubeschedulers.operator.openshift.io=aescbc:5,aescbc:6,identity",
+		"kubeapiservers.operator.openshift.io=aescbc:5,aescbc:6,aescbc:4,identity;kubeschedulers.operator.openshift.io=aescbc:5,aescbc:6,aescbc:4,identity",
+		"kubeapiservers.operator.openshift.io=aescbc:6,aescbc:5,aescbc:4,identity;kubeschedulers.operator.openshift.io=aescbc:6,aescbc:5,aescbc:4,identity",
 		"kubeapiservers.operator.openshift.io=aescbc:6,aescbc:5,identity;kubeschedulers.operator.openshift.io=aescbc:6,aescbc:5,identity",
-		"kubeapiservers.operator.openshift.io=aescbc:6,identity;kubeschedulers.operator.openshift.io=aescbc:6,identity",
 	)
 
 	t.Logf("Delete the last key")
@@ -288,7 +287,7 @@ func TestEncryptionIntegration(tt *testing.T) {
 	)
 	waitForConfigs(
 		"kubeapiservers.operator.openshift.io=aescbc:7,aescbc:6,aescbc:5,identity;kubeschedulers.operator.openshift.io=aescbc:7,aescbc:6,aescbc:5,identity",
-		"kubeapiservers.operator.openshift.io=aescbc:7,identity;kubeschedulers.operator.openshift.io=aescbc:7,identity",
+		"kubeapiservers.operator.openshift.io=aescbc:7,aescbc:6,identity;kubeschedulers.operator.openshift.io=aescbc:7,aescbc:6,identity",
 	)
 
 	t.Logf("Delete the openshift-config-managed config")


### PR DESCRIPTION
The key controller was still just expecting one read-key, while with the recent change for backup/restore we always preserve one more key. This made the key controller freeze after the first two read-keys were in the config.

While fixing the upper, we also run into the case that during pruning this one more read-key is preserved, but this read-key must be backed. Hence, we have to preserve also all other unbacked read-keys in between.