### PR TITLE
adds context to ControllerContext for signal and cancellation propagation

### DIFF
--- a/pkg/controller/controllercmd/builder.go
+++ b/pkg/controller/controllercmd/builder.go
@@ -47,12 +47,7 @@ type ControllerContext struct {
 	// Server is the GenericAPIServer serving healthz checks and debug info
 	Server *genericapiserver.GenericAPIServer
 
-	stopChan <-chan struct{}
-}
-
-// Done returns a channel which will close on termination.
-func (c ControllerContext) Done() <-chan struct{} {
-	return c.stopChan
+	Ctx context.Context
 }
 
 // defaultObserverInterval specifies the default interval that file observer will do rehash the files it watches and react to any changes
@@ -227,7 +222,7 @@ func (b *ControllerBuilder) Run(config *unstructured.Unstructured, ctx context.C
 		ProtoKubeConfig: protoConfig,
 		EventRecorder:   eventRecorder,
 		Server:          server,
-		stopChan:        ctx.Done(),
+		Ctx:             ctx,
 	}
 
 	if b.leaderElection == nil {
@@ -243,7 +238,7 @@ func (b *ControllerBuilder) Run(config *unstructured.Unstructured, ctx context.C
 	}
 
 	leaderElection.Callbacks.OnStartedLeading = func(ctx context.Context) {
-		controllerContext.stopChan = ctx.Done()
+		controllerContext.Ctx = ctx
 		if err := b.startFunc(controllerContext); err != nil {
 			klog.Fatal(err)
 		}


### PR DESCRIPTION
since `ControllerBuilder` is used as a building block for other controllers and due to the recent changes in the controller interface which now accepts a context keeping `ctx` as part of `ControllerBuilder` seems to be reasonable.