### PR TITLE
Bug 1776797: encryption: speed-up, Encrypted condition, allow backup/restore

### DIFF
--- a/pkg/operator/encryption/controllers.go
+++ b/pkg/operator/encryption/controllers.go
@@ -84,6 +84,15 @@ func NewControllers(
 				eventRecorder,
 				encryptedGRs,
 			),
+			controllers.NewConditionController(
+				deployer,
+				operatorClient,
+				kubeInformersForNamespaces,
+				secretsClient,
+				encryptionSecretSelector,
+				eventRecorder,
+				encryptedGRs,
+			),
 		},
 	}, nil
 }

--- a/pkg/operator/encryption/controllers.go
+++ b/pkg/operator/encryption/controllers.go
@@ -74,6 +74,7 @@ func NewControllers(
 				encryptedGRs,
 			),
 			controllers.NewMigrationController(
+				component,
 				deployer,
 				migrator,
 				operatorClient,

--- a/pkg/operator/encryption/controllers/condition_controller.go
+++ b/pkg/operator/encryption/controllers/condition_controller.go
@@ -1,0 +1,236 @@
+package controllers
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	"github.com/openshift/library-go/pkg/operator/encryption/encryptionconfig"
+	"github.com/openshift/library-go/pkg/operator/encryption/state"
+	"github.com/openshift/library-go/pkg/operator/encryption/statemachine"
+	"github.com/openshift/library-go/pkg/operator/events"
+	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+const (
+	conditionWorkKey = "key"
+)
+
+// conditionController maintains the Encrypted condition. It sets it to true iff there is a
+// fully migrated read-key in the current config, and no later key is of identity type.
+type conditionController struct {
+	operatorClient operatorv1helpers.OperatorClient
+
+	queue         workqueue.RateLimitingInterface
+	eventRecorder events.Recorder
+
+	preRunCachesSynced []cache.InformerSynced
+
+	encryptedGRs []schema.GroupResource
+
+	encryptionSecretSelector metav1.ListOptions
+
+	deployer     statemachine.Deployer
+	secretClient corev1client.SecretsGetter
+}
+
+func NewConditionController(
+	deployer statemachine.Deployer,
+	operatorClient operatorv1helpers.OperatorClient,
+	kubeInformersForNamespaces operatorv1helpers.KubeInformersForNamespaces,
+	secretClient corev1client.SecretsGetter,
+	encryptionSecretSelector metav1.ListOptions,
+	eventRecorder events.Recorder,
+	encryptedGRs []schema.GroupResource,
+) *conditionController {
+	c := &conditionController{
+		operatorClient: operatorClient,
+
+		queue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "EncryptionConditionController"),
+		eventRecorder: eventRecorder.WithComponentSuffix("encryption-condition-controller"),
+
+		encryptedGRs: encryptedGRs,
+
+		encryptionSecretSelector: encryptionSecretSelector,
+		deployer:                 deployer,
+		secretClient:             secretClient,
+	}
+
+	c.preRunCachesSynced = setUpInformers(deployer, operatorClient, kubeInformersForNamespaces, c.eventHandler())
+
+	return c
+}
+
+func (c *conditionController) sync() error {
+	if ready, err := shouldRunEncryptionController(c.operatorClient); err != nil || !ready {
+		return err // we will get re-kicked when the operator status updates
+	}
+
+	currentConfig, desiredState, _, transitioningReason, err := statemachine.GetEncryptionConfigAndState(c.deployer, c.secretClient, c.encryptionSecretSelector, c.encryptedGRs)
+	if err != nil || len(transitioningReason) > 0 {
+		return err
+	}
+
+	cond := operatorv1.OperatorCondition{
+		Type:    "Encrypted",
+		Status:  operatorv1.ConditionTrue,
+		Reason:  "EncryptionComplete",
+		Message: fmt.Sprintf("Resources all encrypted: %s", grString(c.encryptedGRs)),
+	}
+	currentState := encryptionconfig.ToEncryptionState(currentConfig)
+
+	// check for identity key in desired state first. This will make us catch upcoming decryption early before
+	// it settles into the current config.
+	for _, s := range desiredState {
+		if s.WriteKey.Mode != state.Identity {
+			continue
+		}
+
+		if allMigrated(c.encryptedGRs, s.WriteKey.Migrated.Resources) {
+			cond.Status = operatorv1.ConditionFalse
+			cond.Reason = "EverythingDecrypted"
+			cond.Message = "Encryption mode set to identity and everything is decrypted"
+		} else {
+			cond.Status = operatorv1.ConditionFalse
+			cond.Reason = "EncryptionBeingDisabled"
+			cond.Message = "Encryption mode set to identity and decryption is not finished"
+		}
+		break
+	}
+	if cond.Status == operatorv1.ConditionTrue {
+		// now that the desired state look like it won't lead to identity as write-key, test the current state
+	NextResource:
+		for _, gr := range c.encryptedGRs {
+			s, ok := currentState[gr]
+			if !ok {
+				cond.Status = operatorv1.ConditionFalse
+				cond.Reason = "EncryptionIncomplete"
+				cond.Message = fmt.Sprintf("Resource %s is not encrypted", gr.String())
+				break NextResource
+			}
+
+			if s.WriteKey.Mode == state.Identity {
+				if allMigrated(c.encryptedGRs, s.WriteKey.Migrated.Resources) {
+					cond.Status = operatorv1.ConditionFalse
+					cond.Reason = "EverythingDecrypted"
+					cond.Message = "Encryption mode set to identity and everything is decrypted"
+				} else {
+					cond.Status = operatorv1.ConditionFalse
+					cond.Reason = "EncryptionBeingDisabled"
+					cond.Message = "Encryption mode set to identity and decryption is not finished"
+				}
+				break
+			}
+
+			// go through read keys until we find a completely migrated one. Finding an identity mode before
+			// means migration is ongoing. :
+			for _, rk := range s.ReadKeys {
+				if rk.Mode == state.Identity {
+					cond.Status = operatorv1.ConditionFalse
+					cond.Reason = "EncryptionBeingEnabled"
+					cond.Message = "Encryption is ongoing"
+					break NextResource
+				}
+				if migratedSet(rk.Migrated.Resources).Has(gr.String()) {
+					continue NextResource
+				}
+			}
+
+			cond.Status = operatorv1.ConditionFalse
+			cond.Reason = "EncryptionUnfinished"
+			cond.Message = fmt.Sprintf("Resource %s is being encrypted", gr.String())
+			break
+		}
+	}
+
+	// update Encrypted condition
+	_, _, updateError := operatorv1helpers.UpdateStatus(c.operatorClient, operatorv1helpers.UpdateConditionFn(cond))
+	return updateError
+}
+
+func allMigrated(toBeEncrypted, migrated []schema.GroupResource) bool {
+	s := migratedSet(migrated)
+	for _, gr := range toBeEncrypted {
+		if !s.Has(gr.String()) {
+			return false
+		}
+	}
+	return true
+}
+
+func migratedSet(grs []schema.GroupResource) sets.String {
+	migrated := sets.NewString()
+	for _, gr := range grs {
+		migrated.Insert(gr.String())
+	}
+	return migrated
+}
+
+func (c *conditionController) Run(stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	klog.Infof("Starting EncryptionConditionController")
+	defer klog.Infof("Shutting down EncryptionConditionController")
+	if !cache.WaitForCacheSync(stopCh, c.preRunCachesSynced...) {
+		utilruntime.HandleError(fmt.Errorf("caches did not sync"))
+		return
+	}
+
+	// only start one worker
+	go wait.Until(c.runWorker, time.Second, stopCh)
+
+	<-stopCh
+}
+
+func (c *conditionController) runWorker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+func (c *conditionController) processNextWorkItem() bool {
+	dsKey, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(dsKey)
+
+	err := c.sync()
+	if err == nil {
+		c.queue.Forget(dsKey)
+		return true
+	}
+
+	utilruntime.HandleError(fmt.Errorf("%v failed with: %v", dsKey, err))
+	c.queue.AddRateLimited(dsKey)
+
+	return true
+}
+
+func (c *conditionController) eventHandler() cache.ResourceEventHandler {
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { c.queue.Add(conditionWorkKey) },
+		UpdateFunc: func(old, new interface{}) { c.queue.Add(conditionWorkKey) },
+		DeleteFunc: func(obj interface{}) { c.queue.Add(conditionWorkKey) },
+	}
+}
+
+func grString(grs []schema.GroupResource) string {
+	ss := make([]string, 0, len(grs))
+	for _, gr := range grs {
+		ss = append(ss, gr.String())
+	}
+	return strings.Join(ss, ", ")
+}

--- a/pkg/operator/encryption/controllers/key_controller.go
+++ b/pkg/operator/encryption/controllers/key_controller.go
@@ -143,7 +143,7 @@ func (c *keyController) checkAndCreateKeys() error {
 		return err
 	}
 
-	currentConfig, desiredEncryptionState, secretsFound, isProgressingReason, err := statemachine.GetEncryptionConfigAndState(c.deployer, c.secretClient, c.encryptionSecretSelector, c.encryptedGRs)
+	currentConfig, desiredEncryptionState, secrets, isProgressingReason, err := statemachine.GetEncryptionConfigAndState(c.deployer, c.secretClient, c.encryptionSecretSelector, c.encryptedGRs)
 	if err != nil {
 		return err
 	}
@@ -153,7 +153,7 @@ func (c *keyController) checkAndCreateKeys() error {
 	}
 
 	// avoid intended start of encryption
-	hasBeenOnBefore := currentConfig != nil || secretsFound
+	hasBeenOnBefore := currentConfig != nil || len(secrets) > 0
 	if currentMode == state.Identity && !hasBeenOnBefore {
 		return nil
 	}

--- a/pkg/operator/encryption/controllers/key_controller.go
+++ b/pkg/operator/encryption/controllers/key_controller.go
@@ -309,9 +309,9 @@ func needsNewKey(grKeys state.GroupResourceState, currentMode state.Mode, extern
 		return latestKeyID, fmt.Sprintf("encryption-config-key-%d-not-backed-by-secret", latestKeyID), true
 	}
 
-	// if the length of read secrets is more than one (i.e. we have more than just the write key),
+	// if the length of read secrets is more than two (i.e. we have more than just the write key and a previous read key),
 	// then we haven't successfully migrated and removed old keys so you should wait before generating more keys.
-	if len(grKeys.ReadKeys) > 1 {
+	if len(grKeys.ReadKeys) > 2 {
 		return 0, "", false
 	}
 

--- a/pkg/operator/encryption/controllers/key_controller.go
+++ b/pkg/operator/encryption/controllers/key_controller.go
@@ -309,9 +309,14 @@ func needsNewKey(grKeys state.GroupResourceState, currentMode state.Mode, extern
 		return latestKeyID, fmt.Sprintf("encryption-config-key-%d-not-backed-by-secret", latestKeyID), true
 	}
 
-	// if the length of read secrets is more than two (i.e. we have more than just the write key and a previous read key),
-	// then we haven't successfully migrated and removed old keys so you should wait before generating more keys.
-	if len(grKeys.ReadKeys) > 2 {
+	// check that we have pruned read-keys: the write-keys, plus at most one more backed read-key (potentially some unbacked once before)
+	backedKeys := 0
+	for _, rk := range grKeys.ReadKeys {
+		if rk.Backed {
+			backedKeys++
+		}
+	}
+	if backedKeys > 2 {
 		return 0, "", false
 	}
 

--- a/pkg/operator/encryption/controllers/key_controller_test.go
+++ b/pkg/operator/encryption/controllers/key_controller_test.go
@@ -114,7 +114,7 @@ func TestKeyController(t *testing.T) {
 						createAction := action.(clientgotesting.CreateAction)
 						actualSecret := createAction.GetObject().(*corev1.Secret)
 						expectedSecret := encryptiontesting.CreateEncryptionKeySecretWithKeyFromExistingSecret(targetNamespace, []schema.GroupResource{}, 1, actualSecret)
-						expectedSecret.Annotations["encryption.apiserver.operator.openshift.io/internal-reason"] = "no-secrets" // TODO: Fix this
+						expectedSecret.Annotations["encryption.apiserver.operator.openshift.io/internal-reason"] = "secrets-key-does-not-exist" // TODO: Fix this
 						if !equality.Semantic.DeepEqual(actualSecret, expectedSecret) {
 							ts.Errorf(diff.ObjectDiff(expectedSecret, actualSecret))
 						}
@@ -192,7 +192,7 @@ func TestKeyController(t *testing.T) {
 						createAction := action.(clientgotesting.CreateAction)
 						actualSecret := createAction.GetObject().(*corev1.Secret)
 						expectedSecret := encryptiontesting.CreateEncryptionKeySecretWithKeyFromExistingSecret(targetNamespace, []schema.GroupResource{}, 6, actualSecret)
-						expectedSecret.Annotations["encryption.apiserver.operator.openshift.io/internal-reason"] = "timestamp-too-old"
+						expectedSecret.Annotations["encryption.apiserver.operator.openshift.io/internal-reason"] = "secrets-rotation-interval-has-passed"
 						if !equality.Semantic.DeepEqual(actualSecret, expectedSecret) {
 							ts.Errorf(diff.ObjectDiff(expectedSecret, actualSecret))
 						}

--- a/pkg/operator/encryption/controllers/key_controller_test.go
+++ b/pkg/operator/encryption/controllers/key_controller_test.go
@@ -19,6 +19,7 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	configv1clientfake "github.com/openshift/client-go/config/clientset/versioned/fake"
 	configv1informers "github.com/openshift/client-go/config/informers/externalversions"
+
 	encryptiondeployer "github.com/openshift/library-go/pkg/operator/encryption/deployer"
 	encryptiontesting "github.com/openshift/library-go/pkg/operator/encryption/testing"
 	"github.com/openshift/library-go/pkg/operator/events"

--- a/pkg/operator/encryption/controllers/migration_controller_test.go
+++ b/pkg/operator/encryption/controllers/migration_controller_test.go
@@ -147,7 +147,6 @@ func TestMigrationController(t *testing.T) {
 				"get:secrets:kms",
 				"list:secrets:openshift-config-managed",
 				"list:secrets:openshift-config-managed",
-				"list:secrets:openshift-config-managed",
 			},
 			expectedMigratorCalls: []string{
 				"ensure:configmaps:1",
@@ -245,7 +244,6 @@ func TestMigrationController(t *testing.T) {
 				"get:secrets:openshift-config-managed",
 				"update:secrets:openshift-config-managed",
 				"create:events:operator",
-				"list:secrets:openshift-config-managed",
 			},
 			expectedMigratorCalls: []string{
 				"ensure:configmaps:1",
@@ -343,7 +341,6 @@ func TestMigrationController(t *testing.T) {
 				"get:secrets:openshift-config-managed",
 				"update:secrets:openshift-config-managed",
 				"create:events:operator",
-				"list:secrets:openshift-config-managed",
 				"get:secrets:openshift-config-managed",
 				"get:secrets:openshift-config-managed",
 				"update:secrets:openshift-config-managed",
@@ -440,7 +437,6 @@ func TestMigrationController(t *testing.T) {
 				"get:secrets:kms",
 				"list:secrets:openshift-config-managed",
 				"list:secrets:openshift-config-managed",
-				"list:secrets:openshift-config-managed",
 			},
 			expectedMigratorCalls: []string{
 				"ensure:configmaps:1",
@@ -535,7 +531,6 @@ func TestMigrationController(t *testing.T) {
 			expectedActions: []string{
 				"list:pods:kms",
 				"get:secrets:kms",
-				"list:secrets:openshift-config-managed",
 				"list:secrets:openshift-config-managed",
 				"list:secrets:openshift-config-managed",
 			},
@@ -646,6 +641,7 @@ func TestMigrationController(t *testing.T) {
 
 			// act
 			target := NewMigrationController(
+				"kms",
 				deployer,
 				migrator,
 				fakeOperatorClient,

--- a/pkg/operator/encryption/controllers/migrators/inprocess.go
+++ b/pkg/operator/encryption/controllers/migrators/inprocess.go
@@ -62,7 +62,7 @@ func (m *InProcessMigrator) EnsureMigration(gr schema.GroupResource, writeKey st
 
 	// different key?
 	if migration != nil && migration.result == nil {
-		klog.V(4).Infof("interrupting running migration for resource %v and write key %q", gr, migration.writeKey)
+		klog.V(2).Infof("Interrupting running migration for resource %v and write key %q", gr, migration.writeKey)
 		close(migration.stopCh)
 
 		// give go routine time to update the result
@@ -135,8 +135,8 @@ func (m *InProcessMigrator) runMigration(gvr schema.GroupVersionResource, writeK
 				klog.Warningf("Update of %s/%s failed: %v", obj.GetNamespace(), obj.GetName(), updateErr)
 				return updateErr // not retryable or we don't know. Return error and controller will restart migration.
 			}
-			if seconds, delay := errors.SuggestsClientDelay(updateErr); delay {
-				klog.V(4).Infof("Sleeping %ds while updating %s/%s of type %v after retryable error: %v", seconds, obj.GetNamespace(), obj.GetName(), gvr, updateErr)
+			if seconds, delay := errors.SuggestsClientDelay(updateErr); delay && seconds > 0 {
+				klog.V(2).Infof("Sleeping %ds while updating %s/%s of type %v after retryable error: %v", seconds, obj.GetNamespace(), obj.GetName(), gvr, updateErr)
 				time.Sleep(time.Duration(seconds) * time.Second)
 			}
 		}

--- a/pkg/operator/encryption/controllers/migrators/inprocess.go
+++ b/pkg/operator/encryption/controllers/migrators/inprocess.go
@@ -141,7 +141,7 @@ func (m *InProcessMigrator) runMigration(gvr schema.GroupVersionResource, writeK
 			}
 		}
 	})
-	result = listProcessor.Run(gvr)
+	result = listProcessor.run(gvr)
 }
 
 func (m *InProcessMigrator) PruneMigration(gr schema.GroupResource) error {

--- a/pkg/operator/encryption/controllers/migrators/inprocess.go
+++ b/pkg/operator/encryption/controllers/migrators/inprocess.go
@@ -9,13 +9,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/pager"
 	"k8s.io/klog"
 )
 
@@ -126,57 +124,24 @@ func (m *InProcessMigrator) runMigration(gvr schema.GroupVersionResource, writeK
 	}()
 
 	d := m.dynamicClient.Resource(gvr)
-	var errs []error
-	listPager := pager.New(pager.SimplePageFunc(func(opts metav1.ListOptions) (runtime.Object, error) {
+
+	listProcessor := newListProcessor(ctx, m.dynamicClient, func(obj *unstructured.Unstructured) error {
 		for {
-			allResource, err := d.List(opts)
-			if err != nil {
-				klog.Warningf("List of %v failed: %v", gvr, err)
-				if errors.IsResourceExpired(err) {
-					return nil, err // the pager will handle that
-				} else if retryable := canRetry(err); retryable == nil || *retryable == false {
-					return nil, err // not retryable or we don't know. Return error and controller will restart migration.
-				} else {
-					if seconds, delay := errors.SuggestsClientDelay(err); delay {
-						time.Sleep(time.Duration(seconds) * time.Second)
-					}
-					klog.V(4).Infof("Relisting %v after retryable error: %v", gvr, err)
-					continue
-				}
+			_, updateErr := d.Namespace(obj.GetNamespace()).Update(obj, metav1.UpdateOptions{})
+			if updateErr == nil || errors.IsNotFound(updateErr) || errors.IsConflict(updateErr) {
+				return nil
 			}
-
-			klog.V(4).Infof("Migrating %d objects of %v", len(allResource.Items), gvr)
-
-		nextItem:
-			for _, obj := range allResource.Items { // TODO parallelize for-loop
-				for {
-					_, updateErr := d.Namespace(obj.GetNamespace()).Update(&obj, metav1.UpdateOptions{})
-					if updateErr == nil || errors.IsNotFound(updateErr) || errors.IsConflict(updateErr) {
-						continue nextItem
-					}
-					if retryable := canRetry(updateErr); retryable == nil || *retryable == false {
-						klog.Warningf("Update of %s/%s failed: %v", obj.GetNamespace(), obj.GetName(), updateErr)
-						errs = append(errs, updateErr) // not retryable or we don't know. Return error and controller will restart migration.
-						break
-					}
-					if seconds, delay := errors.SuggestsClientDelay(updateErr); delay {
-						klog.V(4).Infof("Sleeping %ds while updating %s/%s of type %v after retryable error: %v", seconds, obj.GetNamespace(), obj.GetName(), gvr, updateErr)
-						time.Sleep(time.Duration(seconds) * time.Second)
-					}
-				}
+			if retryable := canRetry(updateErr); retryable == nil || *retryable == false {
+				klog.Warningf("Update of %s/%s failed: %v", obj.GetNamespace(), obj.GetName(), updateErr)
+				return updateErr // not retryable or we don't know. Return error and controller will restart migration.
 			}
-
-			klog.V(4).Infof("Migration of %d objects of %v finished", len(allResource.Items), gvr)
-
-			allResource.Items = nil // do not accumulate items, this fakes the visitor pattern
-			return allResource, nil // leave the rest of the list intact to preserve continue token
+			if seconds, delay := errors.SuggestsClientDelay(updateErr); delay {
+				klog.V(4).Infof("Sleeping %ds while updating %s/%s of type %v after retryable error: %v", seconds, obj.GetNamespace(), obj.GetName(), gvr, updateErr)
+				time.Sleep(time.Duration(seconds) * time.Second)
+			}
 		}
-	}))
-
-	listPager.FullListIfExpired = false // prevent memory explosion from full list
-	_, listErr := listPager.List(ctx, metav1.ListOptions{})
-	errs = append(errs, listErr)
-	result = utilerrors.NewAggregate(errs)
+	})
+	result = listProcessor.Run(gvr)
 }
 
 func (m *InProcessMigrator) PruneMigration(gr schema.GroupResource) error {

--- a/pkg/operator/encryption/controllers/migrators/inprocess_processor.go
+++ b/pkg/operator/encryption/controllers/migrators/inprocess_processor.go
@@ -59,7 +59,7 @@ func (p *listProcessor) Run(gvr schema.GroupVersionResource) error {
 						return nil, err
 					}
 					opts.Continue = token
-					klog.V(4).Infof("Relisting %v after handling expired token", gvr)
+					klog.V(2).Infof("Relisting %v after handling expired token", gvr)
 					continue
 				} else if retryable := canRetry(err); retryable == nil || *retryable == false {
 					return nil, err // not retryable or we don't know. Return error and controller will restart migration.
@@ -67,18 +67,18 @@ func (p *listProcessor) Run(gvr schema.GroupVersionResource) error {
 					if seconds, delay := errors.SuggestsClientDelay(err); delay {
 						time.Sleep(time.Duration(seconds) * time.Second)
 					}
-					klog.V(4).Infof("Relisting %v after retryable error: %v", gvr, err)
+					klog.V(2).Infof("Relisting %v after retryable error: %v", gvr, err)
 					continue
 				}
 			}
 
 			migrationStarted := time.Now()
-			klog.V(4).Infof("Migrating %d objects of %v", len(allResource.Items), gvr)
+			klog.V(2).Infof("Migrating %d objects of %v", len(allResource.Items), gvr)
 			if err = p.processList(allResource); err != nil {
 				klog.Warningf("Migration of %v failed after %v: %v", gvr, time.Now().Sub(migrationStarted), err)
 				return nil, err
 			}
-			klog.V(4).Infof("Migration of %d objects of %v finished in %v", len(allResource.Items), gvr, time.Now().Sub(migrationStarted))
+			klog.V(2).Infof("Migration of %d objects of %v finished in %v", len(allResource.Items), gvr, time.Now().Sub(migrationStarted))
 
 			allResource.Items = nil // do not accumulate items, this fakes the visitor pattern
 			return allResource, nil // leave the rest of the list intact to preserve continue token
@@ -90,7 +90,7 @@ func (p *listProcessor) Run(gvr schema.GroupVersionResource) error {
 	if _, err := listPager.List(p.ctx, metav1.ListOptions{}); err != nil {
 		return err
 	}
-	klog.V(4).Infof("Migration for %v finished in %v", gvr, time.Now().Sub(migrationStarted))
+	klog.V(2).Infof("Migration for %v finished in %v", gvr, time.Now().Sub(migrationStarted))
 	return nil
 }
 

--- a/pkg/operator/encryption/controllers/migrators/inprocess_processor.go
+++ b/pkg/operator/encryption/controllers/migrators/inprocess_processor.go
@@ -1,0 +1,179 @@
+package migrators
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/pager"
+	"k8s.io/klog"
+)
+
+const (
+	defaultConcurrency = 10
+)
+
+// workerFunc function that is executed by workers to process a single item
+type workerFunc func(*unstructured.Unstructured) error
+
+// listProcessor represents a type that processes resources in parallel.
+// It retrieves resources from the server in batches and distributes among set of workers.
+type listProcessor struct {
+	concurrency   int
+	workerFn      workerFunc
+	dynamicClient dynamic.Interface
+	ctx           context.Context
+}
+
+// newListProcessor creates a new instance of listProcessor
+func newListProcessor(ctx context.Context, dynamicClient dynamic.Interface, workerFn workerFunc) *listProcessor {
+	return &listProcessor{
+		concurrency:   defaultConcurrency,
+		workerFn:      workerFn,
+		dynamicClient: dynamicClient,
+		ctx:           ctx,
+	}
+}
+
+// Run starts processing all the instance of the given GVR in batches.
+// Note that this operation block until all resources have been process, we can't get the next page or the context has been cancelled
+func (p *listProcessor) Run(gvr schema.GroupVersionResource) error {
+	listPager := pager.New(pager.SimplePageFunc(func(opts metav1.ListOptions) (runtime.Object, error) {
+		for {
+			allResource, err := p.dynamicClient.Resource(gvr).List(opts)
+			if err != nil {
+				klog.Warningf("List of %v failed: %v", gvr, err)
+				if errors.IsResourceExpired(err) {
+					token, err := inconsistentContinueToken(err)
+					if err != nil {
+						return nil, err
+					}
+					opts.Continue = token
+					klog.V(4).Infof("Relisting %v after handling expired token", gvr)
+					continue
+				} else if retryable := canRetry(err); retryable == nil || *retryable == false {
+					return nil, err // not retryable or we don't know. Return error and controller will restart migration.
+				} else {
+					if seconds, delay := errors.SuggestsClientDelay(err); delay {
+						time.Sleep(time.Duration(seconds) * time.Second)
+					}
+					klog.V(4).Infof("Relisting %v after retryable error: %v", gvr, err)
+					continue
+				}
+			}
+
+			migrationStarted := time.Now()
+			klog.V(4).Infof("Migrating %d objects of %v", len(allResource.Items), gvr)
+			if err = p.processList(allResource); err != nil {
+				klog.Warningf("Migration of %v failed after %v: %v", gvr, time.Now().Sub(migrationStarted), err)
+				return nil, err
+			}
+			klog.V(4).Infof("Migration of %d objects of %v finished in %v", len(allResource.Items), gvr, time.Now().Sub(migrationStarted))
+
+			allResource.Items = nil // do not accumulate items, this fakes the visitor pattern
+			return allResource, nil // leave the rest of the list intact to preserve continue token
+		}
+	}))
+	listPager.FullListIfExpired = false // prevent memory explosion from full list
+
+	migrationStarted := time.Now()
+	if _, err := listPager.List(p.ctx, metav1.ListOptions{}); err != nil {
+		return err
+	}
+	klog.V(4).Infof("Migration for %v finished in %v", gvr, time.Now().Sub(migrationStarted))
+	return nil
+}
+
+func (p *listProcessor) processList(l *unstructured.UnstructuredList) error {
+	workCh := make(chan *unstructured.Unstructured, p.concurrency)
+	ctx, cancel := context.WithCancel(p.ctx)
+	defer cancel()
+
+	processed := 0
+	go func() {
+		defer utilruntime.HandleCrash()
+		defer close(workCh)
+		for i := range l.Items {
+			select {
+			case workCh <- &l.Items[i]:
+				processed++
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, p.concurrency)
+	for i := 0; i < p.concurrency; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := p.worker(workCh); err != nil {
+				errCh <- err
+				cancel() // stop everything when the first worker errors
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+
+	var errs []error
+	for err := range errCh {
+		errs = append(errs, err)
+	}
+	if len(errs) > 0 {
+		return utilerrors.NewAggregate(errs)
+	}
+	if processed < len(l.Items) {
+		return fmt.Errorf("context cancelled")
+	}
+	return nil
+}
+
+func (p *listProcessor) worker(workCh <-chan *unstructured.Unstructured) (result error) {
+	defer func() {
+		if r := recover(); r != nil {
+			if err, ok := r.(error); ok {
+				result = err
+			} else {
+				result = fmt.Errorf("panic: %v", r)
+			}
+		}
+	}()
+
+	for item := range workCh {
+		if err := p.workerFn(item); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// inconsistentContinueToken extracts the continue token from the response which might be used to retrieve the remainder of the results
+//
+// Note:
+// continuing with the provided token might result in an inconsistent list. Objects that were created,
+// modified, or deleted between the time the first chunk was returned and now may show up in the list.
+func inconsistentContinueToken(err error) (string, error) {
+	status, ok := err.(errors.APIStatus)
+	if !ok {
+		return "", fmt.Errorf("expected error to implement the APIStatus interface, got %v", reflect.TypeOf(err))
+	}
+	token := status.Status().ListMeta.Continue
+	if len(token) == 0 {
+		return "", fmt.Errorf("expected non empty continue token")
+	}
+	return token, nil
+}

--- a/pkg/operator/encryption/controllers/migrators/inprocess_processor_test.go
+++ b/pkg/operator/encryption/controllers/migrators/inprocess_processor_test.go
@@ -1,0 +1,301 @@
+package migrators
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	clientgotesting "k8s.io/client-go/testing"
+)
+
+func TestInprocessProcessor(t *testing.T) {
+	scenarios := []struct {
+		name         string
+		workerFunc   func(*unstructured.Unstructured) error
+		validateFunc func(ts *testing.T, actions []clientgotesting.Action, count int, err error)
+		resources    []runtime.Object
+		gvr          schema.GroupVersionResource
+	}{
+		// scenario 1:
+		{
+			name: "worker function is executed",
+			workerFunc: func(obj *unstructured.Unstructured) error {
+				if obj.GetKind() != "Secret" {
+					return fmt.Errorf("incorrect kind %v", obj.GetKind())
+				}
+				return nil
+			},
+			validateFunc: func(ts *testing.T, actions []clientgotesting.Action, count int, err error) {
+				if err != nil {
+					t.Error(err)
+				}
+				if err := validateActionsVerbs(actions, []string{"list:secrets"}); err != nil {
+					t.Error(err)
+				}
+				if count != 100 {
+					t.Errorf("workerFunc haven't seen 100 only %d", count)
+				}
+			},
+			resources: func() []runtime.Object {
+				ret := []runtime.Object{}
+				ret = append(ret, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm1", Namespace: "ns1"}})
+				ret = append(ret, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm2", Namespace: "ns1"}})
+				ret = append(ret, createSecrets(100)...)
+				return ret
+			}(),
+			gvr: schema.GroupResource{Resource: "secrets"}.WithVersion("v1"),
+		},
+
+		// scenario 2:
+		{
+			name: "handles panic",
+			workerFunc: func(obj *unstructured.Unstructured) error {
+				panic("nasty panic")
+			},
+			validateFunc: func(ts *testing.T, actions []clientgotesting.Action, count int, err error) {
+				if err == nil {
+					t.Error("expected to receive an error")
+				}
+				if err := validateActionsVerbs(actions, []string{"list:secrets"}); err != nil {
+					t.Error(err)
+				}
+			},
+			resources: func() []runtime.Object {
+				ret := []runtime.Object{}
+				ret = append(ret, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm1", Namespace: "ns1"}})
+				ret = append(ret, createSecrets(100)...)
+				return ret
+			}(),
+			gvr: schema.GroupResource{Resource: "secrets"}.WithVersion("v1"),
+		},
+
+		// scenario 3:
+		{
+			name: "handles more than one page (default is 500 items)",
+			workerFunc: func(obj *unstructured.Unstructured) error {
+				if obj.GetKind() != "Secret" {
+					return fmt.Errorf("incorrect kind %v", obj.GetKind())
+				}
+				return nil
+			},
+			validateFunc: func(ts *testing.T, actions []clientgotesting.Action, count int, err error) {
+				if err != nil {
+					t.Error(err)
+				}
+				if err := validateActionsVerbs(actions, []string{"list:secrets"}); err != nil {
+					t.Error(err)
+				}
+				if count != 500*4 {
+					t.Errorf("workerFunc haven't seen all 500 * 4 only %d", count)
+				}
+			},
+			resources: func() []runtime.Object {
+				ret := []runtime.Object{}
+				ret = append(ret, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm1", Namespace: "ns1"}})
+				ret = append(ret, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm2", Namespace: "ns1"}})
+				ret = append(ret, createSecrets(500*4)...)
+				return ret
+			}(),
+			gvr: schema.GroupResource{Resource: "secrets"}.WithVersion("v1"),
+		},
+
+		// scenario 4:
+		{
+			name: "handles an empty list",
+			workerFunc: func(obj *unstructured.Unstructured) error {
+				return fmt.Errorf("an empty list passed but received %v", obj)
+			},
+			validateFunc: func(ts *testing.T, actions []clientgotesting.Action, count int, err error) {
+				if err != nil {
+					t.Error(err)
+				}
+				if err := validateActionsVerbs(actions, []string{"list:secrets"}); err != nil {
+					t.Error(err)
+				}
+				if count != 0 {
+					t.Errorf("workerFunc seen %d object", count)
+				}
+			},
+			resources: func() []runtime.Object {
+				ret := []runtime.Object{}
+				ret = append(ret, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm1", Namespace: "ns1"}})
+				ret = append(ret, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm2", Namespace: "ns1"}})
+				return ret
+			}(),
+			gvr: schema.GroupResource{Resource: "secrets"}.WithVersion("v1"),
+		},
+
+		// scenario 5:
+		{
+			name: "stops further processing on worker error",
+			workerFunc: func(obj *unstructured.Unstructured) error {
+				if obj.GetKind() != "Secret" {
+					return fmt.Errorf("incorrect kind %v", obj.GetKind())
+				}
+				return fmt.Errorf("fake error for %v", obj.GetName())
+			},
+			validateFunc: func(ts *testing.T, actions []clientgotesting.Action, count int, err error) {
+				if err == nil {
+					t.Error("expected to receive an error but none was returned")
+				}
+				if err := validateActionsVerbs(actions, []string{"list:secrets"}); err != nil {
+					t.Error(err)
+				}
+				// it is hard to give an exact number because we don't know how many workers are progressing
+				// mainly due to propagation time (closing `onWorkerErrorCtx` which propagates the stop signal to `workCh`)
+				if count >= 30 {
+					t.Errorf("workerFunc shouldn't have processed >= %d items, expected < 30 ", count)
+				}
+			},
+			resources: func() []runtime.Object {
+				ret := []runtime.Object{}
+				ret = append(ret, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm1", Namespace: "ns1"}})
+				ret = append(ret, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm2", Namespace: "ns1"}})
+				ret = append(ret, createSecrets(500*4)...)
+				return ret
+			}(),
+			gvr: schema.GroupResource{Resource: "secrets"}.WithVersion("v1"),
+		},
+	}
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			// prepare
+			scheme := runtime.NewScheme()
+			unstructuredObjs := []runtime.Object{}
+			for _, rawObject := range scenario.resources {
+				rawUnstructured, err := runtime.DefaultUnstructuredConverter.ToUnstructured(rawObject.DeepCopyObject())
+				if err != nil {
+					t.Fatal(err)
+				}
+				unstructured.SetNestedField(rawUnstructured, "v1", "apiVersion")
+				unstructured.SetNestedField(rawUnstructured, reflect.TypeOf(rawObject).Elem().Name(), "kind")
+				unstructuredObjs = append(unstructuredObjs, &unstructured.Unstructured{Object: rawUnstructured})
+			}
+			dynamicClient := dynamicfake.NewSimpleDynamicClient(scheme, unstructuredObjs...)
+
+			// act
+			totalCountCh := make(chan int)
+			listProcessor := newListProcessor(context.TODO(), dynamicClient, func(obj *unstructured.Unstructured) error {
+				totalCountCh <- 1
+				return scenario.workerFunc(obj)
+			})
+
+			// validate
+			totalCount := 0
+			wg := sync.WaitGroup{}
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for i := range totalCountCh {
+					totalCount += i
+				}
+			}()
+
+			err := listProcessor.Run(scenario.gvr)
+			close(totalCountCh)
+			wg.Wait()
+			scenario.validateFunc(t, dynamicClient.Actions(), totalCount, err)
+		})
+	}
+}
+
+func TestInprocessProcessorContextCancellation(t *testing.T) {
+	// prepare
+	ctx, cancelCtxFn := context.WithCancel(context.TODO())
+	lock := sync.Mutex{}
+
+	workerFunc := func(obj *unstructured.Unstructured) error {
+		lock.Lock()
+		defer lock.Unlock()
+		time.Sleep(100 * time.Millisecond)
+		cancelCtxFn()
+		return nil
+	}
+
+	resources := func() []runtime.Object {
+		ret := []runtime.Object{}
+		ret = append(ret, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm1", Namespace: "ns1"}})
+		ret = append(ret, createSecrets(500*4)...)
+		return ret
+	}()
+	gvr := schema.GroupResource{Resource: "secrets"}.WithVersion("v1")
+
+	scheme := runtime.NewScheme()
+	unstructuredObjs := []runtime.Object{}
+	for _, rawObject := range resources {
+		rawUnstructured, err := runtime.DefaultUnstructuredConverter.ToUnstructured(rawObject.DeepCopyObject())
+		if err != nil {
+			t.Fatal(err)
+		}
+		unstructured.SetNestedField(rawUnstructured, "v1", "apiVersion")
+		unstructured.SetNestedField(rawUnstructured, reflect.TypeOf(rawObject).Elem().Name(), "kind")
+		unstructuredObjs = append(unstructuredObjs, &unstructured.Unstructured{Object: rawUnstructured})
+	}
+	dynamicClient := dynamicfake.NewSimpleDynamicClient(scheme, unstructuredObjs...)
+
+	// act
+	listProcessor := newListProcessor(ctx, dynamicClient, func(obj *unstructured.Unstructured) error {
+		return workerFunc(obj)
+	})
+
+	// validate
+	testTimeoutCh := time.After(6 * time.Second)
+	testCompletedCh := make(chan bool)
+	defer close(testCompletedCh)
+	go func() {
+		err := listProcessor.Run(gvr)
+		if err == nil {
+			t.Error("expected to receive an error")
+		}
+		if err := validateActionsVerbs(dynamicClient.Actions(), []string{"list:secrets"}); err != nil {
+			t.Error(err)
+		}
+		testCompletedCh <- true
+	}()
+
+	select {
+	case <-testTimeoutCh:
+		t.Fatal("timeout waiting for context propagation")
+	case <-testCompletedCh:
+	}
+}
+
+func validateActionsVerbs(actualActions []clientgotesting.Action, expectedActions []string) error {
+	actionString := func(a clientgotesting.Action) string {
+		return a.GetVerb() + ":" + a.GetResource().Resource
+	}
+	actionStrings := func(actions []clientgotesting.Action) []string {
+		res := make([]string, 0, len(actions))
+		for _, a := range actions {
+			res = append(res, actionString(a))
+		}
+		return res
+	}
+
+	if len(actualActions) != len(expectedActions) {
+		return fmt.Errorf("expected to get %d actions but got %d\nexpected=%v \n got=%v", len(expectedActions), len(actualActions), expectedActions, actionStrings(actualActions))
+	}
+	for i, a := range actualActions {
+		if got, expected := actionString(a), expectedActions[i]; got != expected {
+			return fmt.Errorf("at %d got %s, expected %s", i, got, expected)
+		}
+	}
+	return nil
+}
+
+func createSecrets(count int) []runtime.Object {
+	ret := make([]runtime.Object, count)
+	for i := 0; i < count; i++ {
+		ret[i] = &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("secret%d", i), Namespace: "ns2"}}
+	}
+	return ret
+}

--- a/pkg/operator/encryption/controllers/migrators/inprocess_processor_test.go
+++ b/pkg/operator/encryption/controllers/migrators/inprocess_processor_test.go
@@ -200,7 +200,7 @@ func TestInprocessProcessor(t *testing.T) {
 				}
 			}()
 
-			err := listProcessor.Run(scenario.gvr)
+			err := listProcessor.run(scenario.gvr)
 			close(totalCountCh)
 			wg.Wait()
 			scenario.validateFunc(t, dynamicClient.Actions(), totalCount, err)
@@ -252,7 +252,7 @@ func TestInprocessProcessorContextCancellation(t *testing.T) {
 	testCompletedCh := make(chan bool)
 	defer close(testCompletedCh)
 	go func() {
-		err := listProcessor.Run(gvr)
+		err := listProcessor.run(gvr)
 		if err == nil {
 			t.Error("expected to receive an error")
 		}

--- a/pkg/operator/encryption/controllers/migrators/metrics.go
+++ b/pkg/operator/encryption/controllers/migrators/metrics.go
@@ -1,0 +1,93 @@
+package migrators
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	k8smetrics "k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+const (
+	namespace = "storage_migrator"
+	subsystem = "core_migrator"
+)
+
+// metrics provides access to all core migrator metrics.
+var metrics *migratorMetrics
+
+func init() {
+	metrics = newMigratorMetrics(legacyregistry.Register)
+}
+
+// migratorMetrics instruments core migrator with prometheus metrics.
+type migratorMetrics struct {
+	objectsMigrated   *k8smetrics.CounterVec
+	migration         *k8smetrics.CounterVec
+	migrationDuration *k8smetrics.HistogramVec
+}
+
+// newMigratorMetrics create a new MigratorMetrics, configured with default metric names.
+func newMigratorMetrics(registerFunc func(k8smetrics.Registerable) error) *migratorMetrics {
+	// objectMigrates is defined in kube-storave-version-migrator
+	objectsMigrated := k8smetrics.NewCounterVec(
+		&k8smetrics.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "migrated_objects",
+			Help:      "The total number of objects that have been migrated, labeled with the full resource name",
+		}, []string{"resource"})
+	registerFunc(objectsMigrated)
+
+	// migration is defined in kube-storave-version-migrator
+	migration := k8smetrics.NewCounterVec(
+		&k8smetrics.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "migrations",
+			Help:      "The total number of completed migration, labeled with the full resource name, and the status of the migration (failed or succeeded)",
+		}, []string{"resource", "status"})
+	registerFunc(migration)
+
+	// migrationDuration is not defined upstream but uses the same Namespace and Subsystem
+	// as the other metrics that are defined in kube-storave-version-migrator
+	migrationDuration := k8smetrics.NewHistogramVec(
+		&k8smetrics.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "migration_duration_seconds",
+			Help:      "How long a successful migration takes in seconds, labeled with the full resource name",
+			Buckets:   prometheus.ExponentialBuckets(120, 2, 7),
+		}, []string{"resource"})
+	registerFunc(migrationDuration)
+
+	return &migratorMetrics{
+		objectsMigrated:   objectsMigrated,
+		migration:         migration,
+		migrationDuration: migrationDuration,
+	}
+}
+
+func (m *migratorMetrics) Reset() {
+	m.objectsMigrated.Reset()
+	m.migration.Reset()
+}
+
+// ObserveObjectsMigrated adds the number of migrated objects for a resource type
+func (m *migratorMetrics) ObserveObjectsMigrated(added int, resource string) {
+	m.objectsMigrated.WithLabelValues(resource).Add(float64(added))
+}
+
+// ObserveSucceededMigration increments the number of successful migrations for a resource type
+func (m *migratorMetrics) ObserveSucceededMigration(resource string) {
+	m.migration.WithLabelValues(resource, "Succeeded").Add(float64(1))
+}
+
+// ObserveFailedMigration increments the number of failed migrations for a resource type
+func (m *migratorMetrics) ObserveFailedMigration(resource string) {
+	m.migration.WithLabelValues(resource, "Failed").Add(float64(1))
+}
+
+// ObserveMigrationDuration records migration duration in seconds for a resource type
+func (m *migratorMetrics) ObserveSucceededMigrationDuration(seconds float64, resource string) {
+	m.migrationDuration.WithLabelValues(resource).Observe(seconds)
+}

--- a/pkg/operator/encryption/controllers/prune_controller.go
+++ b/pkg/operator/encryption/controllers/prune_controller.go
@@ -177,7 +177,7 @@ NextEncryptionSecret:
 			deleteErrs = append(deleteErrs, err)
 		} else {
 			deletedKeys++
-			klog.V(4).Infof("Successfully pruned secret %s/%s", secret.Namespace, secret.Name)
+			klog.V(2).Infof("Successfully pruned secret %s/%s", secret.Namespace, secret.Name)
 		}
 	}
 	if deletedKeys > 0 {

--- a/pkg/operator/encryption/controllers/prune_controller_test.go
+++ b/pkg/operator/encryption/controllers/prune_controller_test.go
@@ -54,12 +54,12 @@ func TestPruneController(t *testing.T) {
 		},
 
 		{
-			name:            "14 keys were migrated, 1 of them is used, 10 are kept, the 3 most recent are pruned",
+			name:            "15 keys were migrated, 2 of them are used, 10 are kept, the 3 most oldest are pruned",
 			targetNamespace: "kms",
 			targetGRs: []schema.GroupResource{
 				{Group: "", Resource: "secrets"},
 			},
-			initialSecrets: createMigratedEncryptionKeySecretsWithRndKey(t, 14, "kms", "secrets"),
+			initialSecrets: createMigratedEncryptionKeySecretsWithRndKey(t, 15, "kms", "secrets"),
 			expectedActions: []string{
 				"list:pods:kms",
 				"get:secrets:kms",
@@ -144,7 +144,7 @@ func TestPruneController(t *testing.T) {
 			}
 
 			encryptionConfig := func() *corev1.Secret {
-				additionalReadKeys := state.KeysWithPotentiallyPersistedData(scenario.targetGRs, state.SortRecentFirst(initialKeys))
+				additionalReadKeys := state.KeysWithPotentiallyPersistedDataAndNextReadKey(scenario.targetGRs, state.SortRecentFirst(initialKeys))
 				var additionaConfigReadKeys []apiserverconfigv1.Key
 				for _, rk := range additionalReadKeys {
 					additionaConfigReadKeys = append(additionaConfigReadKeys, apiserverconfigv1.Key{

--- a/pkg/operator/encryption/controllers/state_controller_test.go
+++ b/pkg/operator/encryption/controllers/state_controller_test.go
@@ -119,7 +119,15 @@ func TestStateController(t *testing.T) {
 				ec := encryptiontesting.CreateEncryptionCfgWithWriteKey([]encryptiontesting.EncryptionKeysResourceTuple{keysRes})
 				return ec
 			}(),
-			expectedActions: []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config-managed", "create:secrets:openshift-config-managed", "create:events:kms", "create:events:kms"},
+			expectedActions: []string{
+				"list:pods:kms",
+				"get:secrets:kms",
+				"list:secrets:openshift-config-managed",
+				"get:secrets:openshift-config-managed",
+				"create:secrets:openshift-config-managed",
+				"create:events:kms",
+				"create:events:kms",
+			},
 			validateFunc: func(ts *testing.T, actions []clientgotesting.Action, destName string, expectedEncryptionCfg *apiserverconfigv1.EncryptionConfiguration) {
 				wasSecretValidated := false
 				for _, action := range actions {
@@ -249,7 +257,15 @@ func TestStateController(t *testing.T) {
 				ec := encryptiontesting.CreateEncryptionCfgWithWriteKey([]encryptiontesting.EncryptionKeysResourceTuple{keysRes})
 				return ec
 			}(),
-			expectedActions: []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config-managed", "update:secrets:openshift-config-managed", "create:events:kms", "create:events:kms"},
+			expectedActions: []string{
+				"list:pods:kms",
+				"get:secrets:kms",
+				"list:secrets:openshift-config-managed",
+				"get:secrets:openshift-config-managed",
+				"update:secrets:openshift-config-managed",
+				"create:events:kms",
+				"create:events:kms",
+			},
 			validateFunc: func(ts *testing.T, actions []clientgotesting.Action, destName string, expectedEncryptionCfg *apiserverconfigv1.EncryptionConfiguration) {
 				wasSecretValidated := false
 				for _, action := range actions {
@@ -443,8 +459,15 @@ func TestStateController(t *testing.T) {
 				ec := encryptiontesting.CreateEncryptionCfgWithWriteKey([]encryptiontesting.EncryptionKeysResourceTuple{keysRes})
 				return ec
 			}(),
-			expectedActions: []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config-managed", "update:secrets:openshift-config-managed",
-				"create:events:kms", "create:events:kms"},
+			expectedActions: []string{
+				"list:pods:kms",
+				"get:secrets:kms",
+				"list:secrets:openshift-config-managed",
+				"get:secrets:openshift-config-managed",
+				"update:secrets:openshift-config-managed",
+				"create:events:kms",
+				"create:events:kms",
+			},
 			validateFunc: func(ts *testing.T, actions []clientgotesting.Action, destName string, expectedEncryptionCfg *apiserverconfigv1.EncryptionConfiguration) {
 				wasSecretValidated := false
 				for _, action := range actions {

--- a/pkg/operator/encryption/encryptionconfig/config_test.go
+++ b/pkg/operator/encryption/encryptionconfig/config_test.go
@@ -331,7 +331,7 @@ func TestToEncryptionState(t *testing.T) {
 
 	for _, scenario := range scenarios {
 		t.Run(scenario.name, func(t *testing.T) {
-			actualOutput := ToEncryptionState(scenario.input)
+			actualOutput, _ := ToEncryptionState(scenario.input, nil)
 
 			if len(actualOutput) != len(scenario.output) {
 				t.Fatalf("expected to get %d GR, got %d", len(scenario.output), len(actualOutput))

--- a/pkg/operator/encryption/secrets/secrets.go
+++ b/pkg/operator/encryption/secrets/secrets.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/config/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 
 	"github.com/openshift/library-go/pkg/operator/encryption/state"
 )
@@ -121,4 +122,17 @@ func (m *MigratedGroupResources) HasResource(resource schema.GroupResource) bool
 		}
 	}
 	return false
+}
+
+// ListKeySecrets returns the current key secrets from openshift-config-managed.
+func ListKeySecrets(secretClient corev1client.SecretsGetter, encryptionSecretSelector metav1.ListOptions) ([]*corev1.Secret, error) {
+	encryptionSecretList, err := secretClient.Secrets("openshift-config-managed").List(encryptionSecretSelector)
+	if err != nil {
+		return nil, err
+	}
+	var encryptionSecrets []*corev1.Secret
+	for i := range encryptionSecretList.Items {
+		encryptionSecrets = append(encryptionSecrets, &encryptionSecretList.Items[i])
+	}
+	return encryptionSecrets, nil
 }

--- a/pkg/operator/encryption/state/helpers.go
+++ b/pkg/operator/encryption/state/helpers.go
@@ -34,11 +34,15 @@ func MigratedFor(grs []schema.GroupResource, km KeyState) (ok bool, missing []sc
 	return true, nil, ""
 }
 
-// KeysWithPotentiallyPersistedData returns the minimal, recent secrets which have migrated all given GRs.
-func KeysWithPotentiallyPersistedData(grs []schema.GroupResource, recentFirstSortedKeys []KeyState) []KeyState {
+// KeysWithPotentiallyPersistedDataAndNextReadKey returns the minimal, recent secrets which have migrated all given GRs.
+func KeysWithPotentiallyPersistedDataAndNextReadKey(grs []schema.GroupResource, recentFirstSortedKeys []KeyState) []KeyState {
 	for i, k := range recentFirstSortedKeys {
 		if allMigrated, missing, _ := MigratedFor(grs, k); allMigrated {
-			return recentFirstSortedKeys[:i+1]
+			if i+1 < len(recentFirstSortedKeys) {
+				return recentFirstSortedKeys[:i+2]
+			} else {
+				return recentFirstSortedKeys[:i+1]
+			}
 		} else {
 			// continue with keys we haven't found a migration key for yet
 			grs = missing

--- a/pkg/operator/encryption/statemachine/transition.go
+++ b/pkg/operator/encryption/statemachine/transition.go
@@ -32,35 +32,31 @@ func GetEncryptionConfigAndState(
 	secretClient corev1client.SecretsGetter,
 	encryptionSecretSelector metav1.ListOptions,
 	encryptedGRs []schema.GroupResource,
-) (current *apiserverconfigv1.EncryptionConfiguration, desired map[schema.GroupResource]state.GroupResourceState, secretsFound bool, transitioningReason string, err error) {
+) (current *apiserverconfigv1.EncryptionConfiguration, desired map[schema.GroupResource]state.GroupResourceState, encryptionSecrets []*corev1.Secret, transitioningReason string, err error) {
 	// get current config
 	encryptionConfigSecret, converged, err := deployer.DeployedEncryptionConfigSecret()
 	if err != nil {
-		return nil, nil, false, "", err
+		return nil, nil, nil, "", err
 	}
 	if !converged {
-		return nil, nil, false, "APIServerRevisionNotConverged", nil
+		return nil, nil, nil, "APIServerRevisionNotConverged", nil
 	}
 	var encryptionConfig *apiserverconfigv1.EncryptionConfiguration
 	if encryptionConfigSecret != nil {
 		encryptionConfig, err = encryptionconfig.FromSecret(encryptionConfigSecret)
 		if err != nil {
-			return nil, nil, false, "", fmt.Errorf("invalid encryption config %s/%s: %v", encryptionConfigSecret.Namespace, encryptionConfigSecret.Name, err)
+			return nil, nil, nil, "", fmt.Errorf("invalid encryption config %s/%s: %v", encryptionConfigSecret.Namespace, encryptionConfigSecret.Name, err)
 		}
 	}
 
 	// compute desired config
-	encryptionSecretList, err := secretClient.Secrets("openshift-config-managed").List(encryptionSecretSelector)
+	encryptionSecrets, err = secrets.ListKeySecrets(secretClient, encryptionSecretSelector)
 	if err != nil {
-		return nil, nil, false, "", err
-	}
-	var encryptionSecrets []*corev1.Secret
-	for i := range encryptionSecretList.Items {
-		encryptionSecrets = append(encryptionSecrets, &encryptionSecretList.Items[i])
+		return nil, nil, nil, "", err
 	}
 	desiredEncryptionState := getDesiredEncryptionState(encryptionConfig, encryptionSecrets, encryptedGRs)
 
-	return encryptionConfig, desiredEncryptionState, len(encryptionSecrets) > 0, "", nil
+	return encryptionConfig, desiredEncryptionState, encryptionSecrets, "", nil
 }
 
 // getDesiredEncryptionState returns the desired state of encryption for all resources.
@@ -76,21 +72,10 @@ func GetEncryptionConfigAndState(
 // 3. if (2) is the case, the write-key must be the most recent key.
 // 4. if (2) and (3) are the case, all non-write keys should be removed.
 func getDesiredEncryptionState(oldEncryptionConfig *apiserverconfigv1.EncryptionConfiguration, encryptionSecrets []*corev1.Secret, toBeEncryptedGRs []schema.GroupResource) map[schema.GroupResource]state.GroupResourceState {
-	backedKeys := make([]state.KeyState, 0, len(encryptionSecrets))
-	for _, s := range encryptionSecrets {
-		km, err := secrets.ToKeyState(s)
-		if err != nil {
-			klog.Warningf("skipping invalid secret: %v", err)
-			continue
-		}
-		backedKeys = append(backedKeys, km)
-	}
-	backedKeys = state.SortRecentFirst(backedKeys)
-
 	//
 	// STEP 0: start with old encryption config, and alter it towards the desired state in the following STEPs.
 	//
-	desiredEncryptionState := encryptionconfig.ToEncryptionState(oldEncryptionConfig)
+	desiredEncryptionState, backedKeys := encryptionconfig.ToEncryptionState(oldEncryptionConfig, encryptionSecrets)
 	if desiredEncryptionState == nil {
 		desiredEncryptionState = make(map[schema.GroupResource]state.GroupResourceState, len(toBeEncryptedGRs))
 	}
@@ -112,27 +97,6 @@ func getDesiredEncryptionState(oldEncryptionConfig *apiserverconfigv1.Encryption
 	if len(backedKeys) == 0 {
 		klog.V(4).Infof("no encryption secrets found")
 		return desiredEncryptionState
-	}
-
-	// enrich KeyState with values from secrets
-	for gr, grState := range desiredEncryptionState {
-		for i, rk := range grState.ReadKeys {
-			for _, k := range backedKeys {
-				if state.EqualKeyAndEqualID(&rk, &k) {
-					grState.ReadKeys[i] = k
-					break
-				}
-			}
-		}
-		if grState.HasWriteKey() {
-			for _, s := range backedKeys {
-				if state.EqualKeyAndEqualID(&grState.WriteKey, &s) {
-					grState.WriteKey = s
-					break
-				}
-			}
-		}
-		desiredEncryptionState[gr] = grState
 	}
 
 	//

--- a/pkg/operator/encryption/statemachine/transition_test.go
+++ b/pkg/operator/encryption/statemachine/transition_test.go
@@ -356,6 +356,14 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 									Secret: base64.StdEncoding.EncodeToString([]byte("3cbfbe7d76876e076b076c659cd895ff")),
 								}},
 							},
+						}, {
+							// one more read key for backup/recovery
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "2",
+									Secret: base64.StdEncoding.EncodeToString([]byte("2b234b23cb23c4b2cb24cb24bcbffbca")),
+								}},
+							},
 						}},
 					},
 					{
@@ -381,6 +389,14 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 								Keys: []apiserverconfigv1.Key{{
 									Name:   "3",
 									Secret: base64.StdEncoding.EncodeToString([]byte("3cbfbe7d76876e076b076c659cd895ff")),
+								}},
+							},
+						}, {
+							// one more read key for backup/recovery
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "2",
+									Secret: base64.StdEncoding.EncodeToString([]byte("2b234b23cb23c4b2cb24cb24bcbffbca")),
 								}},
 							},
 						}},
@@ -484,6 +500,14 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 								}},
 							},
 						}, {
+							// one more read key for backup/recovery
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "2",
+									Secret: base64.StdEncoding.EncodeToString([]byte("2b234b23cb23c4b2cb24cb24bcbffbca")),
+								}},
+							},
+						}, {
 							Identity: &apiserverconfigv1.IdentityConfiguration{},
 						}},
 					},
@@ -508,6 +532,14 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 								Keys: []apiserverconfigv1.Key{{
 									Name:   "3",
 									Secret: base64.StdEncoding.EncodeToString([]byte("3cbfbe7d76876e076b076c659cd895ff")),
+								}},
+							},
+						}, {
+							// one more read key for backup/recovery
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "2",
+									Secret: base64.StdEncoding.EncodeToString([]byte("2b234b23cb23c4b2cb24cb24bcbffbca")),
 								}},
 							},
 						}, {

--- a/test/e2e-encryption/encryption_test.go
+++ b/test/e2e-encryption/encryption_test.go
@@ -220,7 +220,7 @@ func TestEncryptionIntegration(tt *testing.T) {
 	waitForKeys(3)
 	waitForConfigs(
 		"kubeapiservers.operator.openshift.io=identity,aescbc:3,aescbc:1,aesgcm:2;kubeschedulers.operator.openshift.io=identity,aescbc:3,aescbc:1,aesgcm:2",
-		"kubeapiservers.operator.openshift.io=aescbc:3,identity,aescbc:1,aesgcm:2;kubeschedulers.operator.openshift.io=aescbc:3,identity,aescbc:1,aesgcm:2",
+		"kubeapiservers.operator.openshift.io=aescbc:3,aescbc:1,identity,aesgcm:2;kubeschedulers.operator.openshift.io=aescbc:3,aescbc:1,identity,aesgcm:2",
 		"kubeapiservers.operator.openshift.io=aescbc:3,identity,aesgcm:2;kubeschedulers.operator.openshift.io=aescbc:3,identity,aesgcm:2",
 	)
 
@@ -282,12 +282,14 @@ func TestEncryptionIntegration(tt *testing.T) {
 	//   kubeapiservers.operator.openshift.io=aescbc:6,aescbc:5,identity;kubeschedulers.operator.openshift.io=aescbc:6,aescbc:5,identity
 	// but eventually we get the following:
 	waitForConfigEventually(
-		// 6 as preserved config key, 7 as newly created key, and 5 as fully migrated key
-		"kubeapiservers.operator.openshift.io=aescbc:6,aescbc:7,aescbc:5,identity;kubeschedulers.operator.openshift.io=aescbc:6,aescbc:7,aescbc:5,identity",
+		// 6 as preserved, unbacked config key, 7 as newly created key, and 5 as fully migrated key
+		"kubeapiservers.operator.openshift.io=aescbc:6,aescbc:7,aescbc:5,aescbc:4,identity;kubeschedulers.operator.openshift.io=aescbc:6,aescbc:7,aescbc:5,aescbc:4,identity",
 	)
 	waitForConfigs(
+		// 7 is promoted
+		"kubeapiservers.operator.openshift.io=aescbc:7,aescbc:6,aescbc:5,aescbc:4,identity;kubeschedulers.operator.openshift.io=aescbc:7,aescbc:6,aescbc:5,aescbc:4,identity",
+		// 7 is migrated, plus one more backed key, which is 5 (6 is deleted)
 		"kubeapiservers.operator.openshift.io=aescbc:7,aescbc:6,aescbc:5,identity;kubeschedulers.operator.openshift.io=aescbc:7,aescbc:6,aescbc:5,identity",
-		"kubeapiservers.operator.openshift.io=aescbc:7,aescbc:6,identity;kubeschedulers.operator.openshift.io=aescbc:7,aescbc:6,identity",
 	)
 
 	t.Logf("Delete the openshift-config-managed config")
@@ -296,7 +298,8 @@ func TestEncryptionIntegration(tt *testing.T) {
 	err = kubeClient.CoreV1().Secrets("openshift-config-managed").Delete(fmt.Sprintf("encryption-config-%s", component), nil)
 	require.NoError(t, err)
 	waitForConfigs(
-		"kubeapiservers.operator.openshift.io=aescbc:7,identity;kubeschedulers.operator.openshift.io=aescbc:7,identity",
+		// one migrated read-key (7) and one more backed key (5), and everything in between (6)
+		"kubeapiservers.operator.openshift.io=aescbc:7,aescbc:6,aescbc:5,identity;kubeschedulers.operator.openshift.io=aescbc:7,aescbc:6,aescbc:5,identity",
 	)
 
 	t.Logf("Delete the openshift-config-managed config")
@@ -304,7 +307,8 @@ func TestEncryptionIntegration(tt *testing.T) {
 	waitForConfigs(
 		// 7 is migrated and hence only one needed, but we rotate through identity
 		"kubeapiservers.operator.openshift.io=identity,aescbc:7;kubeschedulers.operator.openshift.io=identity,aescbc:7",
-		"kubeapiservers.operator.openshift.io=aescbc:7,identity;kubeschedulers.operator.openshift.io=aescbc:7,identity",
+		// 7 is migrated, plus one backed key (5). 6 is deleted, and therefore is not preserved (would be if the operand config was not deleted)
+		"kubeapiservers.operator.openshift.io=aescbc:7,aescbc:5,identity;kubeschedulers.operator.openshift.io=aescbc:7,aescbc:5,identity",
 	)
 }
 

--- a/test/e2e-encryption/encryption_test.go
+++ b/test/e2e-encryption/encryption_test.go
@@ -171,6 +171,46 @@ func TestEncryptionIntegration(tt *testing.T) {
 			require.NoError(t, err)
 		}
 	}
+	conditionStatus := func(condType string) operatorv1.ConditionStatus {
+		_, status, _, err := operatorClient.GetOperatorState()
+		require.NoError(t, err)
+
+		for _, c := range status.Conditions {
+			if c.Type != condType {
+				continue
+			}
+			return c.Status
+		}
+		return operatorv1.ConditionUnknown
+	}
+	requireConditionStatus := func(condType string, expected operatorv1.ConditionStatus) {
+		t.Helper()
+		if status := conditionStatus(condType); status != expected {
+			t.Errorf("expected condition %s of status %s, found: %q", condType, expected, status)
+		}
+	}
+	waitForConditionStatus := func(condType string, expected operatorv1.ConditionStatus) {
+		t.Helper()
+		err := wait.PollImmediate(time.Millisecond*100, wait.ForeverTestTimeout, func() (bool, error) {
+			return conditionStatus(condType) == expected, nil
+		})
+		require.NoError(t, err)
+	}
+	waitForMigration := func(key string) {
+		t.Helper()
+		err := wait.PollImmediate(time.Millisecond*100, wait.ForeverTestTimeout, func() (bool, error) {
+			s, err := kubeClient.CoreV1().Secrets("openshift-config-managed").Get(fmt.Sprintf("encryption-key-%s-%s", component, key), metav1.GetOptions{})
+			require.NoError(t, err)
+
+			ks, err := secrets.ToKeyState(s)
+			require.NoError(t, err)
+			return len(ks.Migrated.Resources) == 2, nil
+		})
+		require.NoError(t, err)
+	}
+
+	t.Logf("Wait for initial Encrypted condition")
+	waitForConditionStatus("Encrypted", operatorv1.ConditionFalse)
 
 	t.Logf("Enable encryption, mode aescbc")
 	_, err = fakeApiServerClient.Patch("cluster", types.MergePatchType, []byte(`{"spec":{"encryption":{"type":"aescbc"}}}`))
@@ -198,6 +238,8 @@ func TestEncryptionIntegration(tt *testing.T) {
 		"kubeapiservers.operator.openshift.io=identity,aescbc:1;kubeschedulers.operator.openshift.io=identity,aescbc:1",
 		"kubeapiservers.operator.openshift.io=aescbc:1,identity;kubeschedulers.operator.openshift.io=aescbc:1,identity",
 	)
+	waitForMigration("1")
+	requireConditionStatus("Encrypted", operatorv1.ConditionTrue)
 
 	t.Logf("Switch to identity")
 	_, err = fakeApiServerClient.Patch("cluster", types.MergePatchType, []byte(`{"spec":{"encryption":{"type":"identity"}}}`))
@@ -207,12 +249,14 @@ func TestEncryptionIntegration(tt *testing.T) {
 		"kubeapiservers.operator.openshift.io=aescbc:1,identity,aesgcm:2;kubeschedulers.operator.openshift.io=aescbc:1,identity,aesgcm:2",
 		"kubeapiservers.operator.openshift.io=identity,aescbc:1,aesgcm:2;kubeschedulers.operator.openshift.io=identity,aescbc:1,aesgcm:2",
 	)
+	requireConditionStatus("Encrypted", operatorv1.ConditionFalse)
 
 	t.Logf("Switch to empty mode")
 	_, err = fakeApiServerClient.Patch("cluster", types.MergePatchType, []byte(`{"spec":{"encryption":{"type":""}}}`))
 	require.NoError(t, err)
-	time.Sleep(5 * time.Second)
+	time.Sleep(5 * time.Second) // give controller time to create keys (it shouldn't)
 	waitForKeys(2)
+	requireConditionStatus("Encrypted", operatorv1.ConditionFalse)
 
 	t.Logf("Switch to aescbc again")
 	_, err = fakeApiServerClient.Patch("cluster", types.MergePatchType, []byte(`{"spec":{"encryption":{"type":"aescbc"}}}`))
@@ -223,6 +267,7 @@ func TestEncryptionIntegration(tt *testing.T) {
 		"kubeapiservers.operator.openshift.io=aescbc:3,aescbc:1,identity,aesgcm:2;kubeschedulers.operator.openshift.io=aescbc:3,aescbc:1,identity,aesgcm:2",
 		"kubeapiservers.operator.openshift.io=aescbc:3,identity,aesgcm:2;kubeschedulers.operator.openshift.io=aescbc:3,identity,aesgcm:2",
 	)
+	waitForConditionStatus("Encrypted", operatorv1.ConditionTrue)
 
 	t.Logf("Setting external reason")
 	setExternalReason := func(reason string) {
@@ -264,6 +309,7 @@ func TestEncryptionIntegration(tt *testing.T) {
 		"kubeapiservers.operator.openshift.io=aescbc:6,aescbc:5,aescbc:4,identity;kubeschedulers.operator.openshift.io=aescbc:6,aescbc:5,aescbc:4,identity",
 		"kubeapiservers.operator.openshift.io=aescbc:6,aescbc:5,identity;kubeschedulers.operator.openshift.io=aescbc:6,aescbc:5,identity",
 	)
+	waitForConditionStatus("Encrypted", operatorv1.ConditionTrue)
 
 	t.Logf("Delete the last key")
 	_, err = kubeClient.CoreV1().Secrets("openshift-config-managed").Patch(fmt.Sprintf("encryption-key-%s-6", component), types.JSONPatchType, []byte(`[{"op":"remove","path":"/metadata/finalizers"}]`))
@@ -291,6 +337,7 @@ func TestEncryptionIntegration(tt *testing.T) {
 		// 7 is migrated, plus one more backed key, which is 5 (6 is deleted)
 		"kubeapiservers.operator.openshift.io=aescbc:7,aescbc:6,aescbc:5,identity;kubeschedulers.operator.openshift.io=aescbc:7,aescbc:6,aescbc:5,identity",
 	)
+	waitForConditionStatus("Encrypted", operatorv1.ConditionTrue)
 
 	t.Logf("Delete the openshift-config-managed config")
 	_, err = kubeClient.CoreV1().Secrets("openshift-config-managed").Patch(fmt.Sprintf("encryption-config-%s", component), types.JSONPatchType, []byte(`[{"op":"remove","path":"/metadata/finalizers"}]`))
@@ -301,6 +348,7 @@ func TestEncryptionIntegration(tt *testing.T) {
 		// one migrated read-key (7) and one more backed key (5), and everything in between (6)
 		"kubeapiservers.operator.openshift.io=aescbc:7,aescbc:6,aescbc:5,identity;kubeschedulers.operator.openshift.io=aescbc:7,aescbc:6,aescbc:5,identity",
 	)
+	waitForConditionStatus("Encrypted", operatorv1.ConditionTrue)
 
 	t.Logf("Delete the openshift-config-managed config")
 	deployer.DeleteOperandConfig()
@@ -310,6 +358,7 @@ func TestEncryptionIntegration(tt *testing.T) {
 		// 7 is migrated, plus one backed key (5). 6 is deleted, and therefore is not preserved (would be if the operand config was not deleted)
 		"kubeapiservers.operator.openshift.io=aescbc:7,aescbc:5,identity;kubeschedulers.operator.openshift.io=aescbc:7,aescbc:5,identity",
 	)
+	waitForConditionStatus("Encrypted", operatorv1.ConditionTrue)
 }
 
 const encryptionTestOperatorCRD = `

--- a/test/e2e-encryption/encryption_test.go
+++ b/test/e2e-encryption/encryption_test.go
@@ -206,7 +206,6 @@ func TestEncryptionIntegration(tt *testing.T) {
 	waitForConfigs(
 		"kubeapiservers.operator.openshift.io=aescbc:1,identity,aesgcm:2;kubeschedulers.operator.openshift.io=aescbc:1,identity,aesgcm:2",
 		"kubeapiservers.operator.openshift.io=identity,aescbc:1,aesgcm:2;kubeschedulers.operator.openshift.io=identity,aescbc:1,aesgcm:2",
-		"kubeapiservers.operator.openshift.io=identity,aesgcm:2;kubeschedulers.operator.openshift.io=identity,aesgcm:2",
 	)
 
 	t.Logf("Switch to empty mode")
@@ -220,9 +219,9 @@ func TestEncryptionIntegration(tt *testing.T) {
 	require.NoError(t, err)
 	waitForKeys(3)
 	waitForConfigs(
-		"kubeapiservers.operator.openshift.io=identity,aescbc:3,aesgcm:2;kubeschedulers.operator.openshift.io=identity,aescbc:3,aesgcm:2",
+		"kubeapiservers.operator.openshift.io=identity,aescbc:3,aescbc:1,aesgcm:2;kubeschedulers.operator.openshift.io=identity,aescbc:3,aescbc:1,aesgcm:2",
+		"kubeapiservers.operator.openshift.io=aescbc:3,identity,aescbc:1,aesgcm:2;kubeschedulers.operator.openshift.io=aescbc:3,identity,aescbc:1,aesgcm:2",
 		"kubeapiservers.operator.openshift.io=aescbc:3,identity,aesgcm:2;kubeschedulers.operator.openshift.io=aescbc:3,identity,aesgcm:2",
-		"kubeapiservers.operator.openshift.io=aescbc:3,identity;kubeschedulers.operator.openshift.io=aescbc:3,identity",
 	)
 
 	t.Logf("Setting external reason")
@@ -242,18 +241,18 @@ func TestEncryptionIntegration(tt *testing.T) {
 	setExternalReason("a")
 	waitForKeys(4)
 	waitForConfigs(
-		"kubeapiservers.operator.openshift.io=aescbc:3,aescbc:4,identity;kubeschedulers.operator.openshift.io=aescbc:3,aescbc:4,identity",
+		"kubeapiservers.operator.openshift.io=aescbc:3,aescbc:4,identity,aesgcm:2;kubeschedulers.operator.openshift.io=aescbc:3,aescbc:4,identity,aesgcm:2",
+		"kubeapiservers.operator.openshift.io=aescbc:4,aescbc:3,identity,aesgcm:2;kubeschedulers.operator.openshift.io=aescbc:4,aescbc:3,identity,aesgcm:2",
 		"kubeapiservers.operator.openshift.io=aescbc:4,aescbc:3,identity;kubeschedulers.operator.openshift.io=aescbc:4,aescbc:3,identity",
-		"kubeapiservers.operator.openshift.io=aescbc:4,identity;kubeschedulers.operator.openshift.io=aescbc:4,identity",
 	)
 
 	t.Logf("Setting another external reason")
 	setExternalReason("b")
 	waitForKeys(5)
 	waitForConfigs(
-		"kubeapiservers.operator.openshift.io=aescbc:4,aescbc:5,identity;kubeschedulers.operator.openshift.io=aescbc:4,aescbc:5,identity",
+		"kubeapiservers.operator.openshift.io=aescbc:4,aescbc:5,aescbc:3,identity;kubeschedulers.operator.openshift.io=aescbc:4,aescbc:5,aescbc:3,identity",
+		"kubeapiservers.operator.openshift.io=aescbc:5,aescbc:4,aescbc:3,identity;kubeschedulers.operator.openshift.io=aescbc:5,aescbc:4,aescbc:3,identity",
 		"kubeapiservers.operator.openshift.io=aescbc:5,aescbc:4,identity;kubeschedulers.operator.openshift.io=aescbc:5,aescbc:4,identity",
-		"kubeapiservers.operator.openshift.io=aescbc:5,identity;kubeschedulers.operator.openshift.io=aescbc:5,identity",
 	)
 
 	t.Logf("Expire the last key")
@@ -261,9 +260,9 @@ func TestEncryptionIntegration(tt *testing.T) {
 	require.NoError(t, err)
 	waitForKeys(6)
 	waitForConfigs(
-		"kubeapiservers.operator.openshift.io=aescbc:5,aescbc:6,identity;kubeschedulers.operator.openshift.io=aescbc:5,aescbc:6,identity",
+		"kubeapiservers.operator.openshift.io=aescbc:5,aescbc:6,aescbc:4,identity;kubeschedulers.operator.openshift.io=aescbc:5,aescbc:6,aescbc:4,identity",
+		"kubeapiservers.operator.openshift.io=aescbc:6,aescbc:5,aescbc:4,identity;kubeschedulers.operator.openshift.io=aescbc:6,aescbc:5,aescbc:4,identity",
 		"kubeapiservers.operator.openshift.io=aescbc:6,aescbc:5,identity;kubeschedulers.operator.openshift.io=aescbc:6,aescbc:5,identity",
-		"kubeapiservers.operator.openshift.io=aescbc:6,identity;kubeschedulers.operator.openshift.io=aescbc:6,identity",
 	)
 
 	t.Logf("Delete the last key")
@@ -288,7 +287,7 @@ func TestEncryptionIntegration(tt *testing.T) {
 	)
 	waitForConfigs(
 		"kubeapiservers.operator.openshift.io=aescbc:7,aescbc:6,aescbc:5,identity;kubeschedulers.operator.openshift.io=aescbc:7,aescbc:6,aescbc:5,identity",
-		"kubeapiservers.operator.openshift.io=aescbc:7,identity;kubeschedulers.operator.openshift.io=aescbc:7,identity",
+		"kubeapiservers.operator.openshift.io=aescbc:7,aescbc:6,identity;kubeschedulers.operator.openshift.io=aescbc:7,aescbc:6,identity",
 	)
 
 	t.Logf("Delete the openshift-config-managed config")

--- a/test/library/encryption/errors.go
+++ b/test/library/encryption/errors.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package encryption
+
+import (
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// isConnectionRefusedError checks if the error string include "connection refused"
+// TODO: find a "go-way" to detect this error, probably using *os.SyscallError
+func isConnectionRefusedError(err error) bool {
+	return strings.Contains(err.Error(), "connection refused")
+}
+
+// transientAPIError returns true if the provided error indicates that a retry
+// against an HA server has a good chance to succeed.
+func transientAPIError(err error) bool {
+	switch {
+	case err == nil:
+		return false
+	case errors.IsServerTimeout(err), errors.IsTooManyRequests(err), net.IsProbableEOF(err), net.IsConnectionReset(err), net.IsNoRoutesError(err), isConnectionRefusedError(err):
+		return true
+	default:
+		return false
+	}
+}
+
+func orError(a, b func(error) bool) func(error) bool {
+	return func(err error) bool {
+		return a(err) || b(err)
+	}
+}
+
+func onErrorWithTimeout(timeout time.Duration, backoff wait.Backoff, errorFunc func(error) bool, fn func() error) error {
+	var lastMatchingError error
+	stopCh := time.After(timeout)
+	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		select {
+		case <-stopCh:
+			return false, wait.ErrWaitTimeout
+		default:
+		}
+		err := fn()
+		switch {
+		case err == nil:
+			return true, nil
+		case errorFunc(err):
+			lastMatchingError = err
+			return false, nil
+		default:
+			return false, err
+		}
+	})
+	if err == wait.ErrWaitTimeout && lastMatchingError != nil {
+		err = lastMatchingError
+	}
+	return err
+}

--- a/test/library/encryption/perf_helpers.go
+++ b/test/library/encryption/perf_helpers.go
@@ -152,7 +152,7 @@ func DBLoaderRepeatParallel(times int, workers int, genNamespaceName bool, workT
 		wg := sync.WaitGroup{}
 		workPerWorker := times / workers
 		for w := 0; w < workers; w++ {
-			work := func(wg sync.WaitGroup) {
+			work := func() {
 				defer wg.Done()
 				for i := 0; i < workPerWorker; i++ {
 					if genNamespaceName {
@@ -164,7 +164,7 @@ func DBLoaderRepeatParallel(times int, workers int, genNamespaceName bool, workT
 				}
 			}
 			wg.Add(1)
-			go work(wg)
+			go work()
 		}
 		wg.Wait()
 		return nil

--- a/test/library/encryption/perf_helpers.go
+++ b/test/library/encryption/perf_helpers.go
@@ -1,0 +1,192 @@
+package encryption
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	test "github.com/openshift/library-go/test/library"
+)
+
+func watchForMigrationControllerProgressingConditionAsync(t testing.TB, getOperatorCondFn GetOperatorConditionsFuncType, migrationStartedCh chan time.Time) {
+	t.Helper()
+	go watchForMigrationControllerProgressingCondition(t, getOperatorCondFn, migrationStartedCh)
+}
+
+func watchForMigrationControllerProgressingCondition(t testing.TB, getOperatorConditionsFn GetOperatorConditionsFuncType, migrationStartedCh chan time.Time) {
+	t.Helper()
+
+	t.Logf("Waiting up to %s for the condition %q with the reason %q to be set to true", waitPollTimeout.String(), "EncryptionMigrationControllerProgressing", "Migrating")
+	err := wait.Poll(waitPollInterval, waitPollTimeout, func() (bool, error) {
+		conditions, err := getOperatorConditionsFn(t)
+		if err != nil {
+			return false, err
+		}
+		for _, cond := range conditions {
+			if cond.Type == "EncryptionMigrationControllerProgressing" && cond.Status == operatorv1.ConditionTrue {
+				t.Logf("EncryptionMigrationControllerProgressing condition observed at %v", cond.LastTransitionTime)
+				migrationStartedCh <- cond.LastTransitionTime.Time
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Logf("failed waiting for the condition %q with the reason %q to be set to true", "EncryptionMigrationControllerProgressing", "Migrating")
+	}
+}
+
+func populateDatabase(t testing.TB, workers int, dbLoaderFun DBLoaderFuncType, assertDBPopulatedFunc func(t testing.TB, errorStore map[string]int, statStore map[string]int)) {
+	t.Helper()
+	start := time.Now()
+	defer func() {
+		end := time.Now()
+		t.Logf("Populating etcd took %v", end.Sub(start))
+	}()
+
+	r := newRunner()
+
+	// run executes loaderFunc for each worker
+	r.run(t, workers, dbLoaderFun)
+
+	assertDBPopulatedFunc(t, r.errorStore, r.statsStore)
+}
+
+type DBLoaderFuncType func(kubernetes.Interface, string, func(error) /*error collector*/, func(string) /*stats collector*/) error
+
+type runner struct {
+	errorStore map[string]int
+	lock       *sync.Mutex
+
+	statsStore map[string]int
+	lockStats  *sync.Mutex
+	wg         *sync.WaitGroup
+}
+
+func newRunner() *runner {
+	r := &runner{}
+
+	r.errorStore = map[string]int{}
+	r.lock = &sync.Mutex{}
+	r.statsStore = map[string]int{}
+	r.lockStats = &sync.Mutex{}
+
+	r.wg = &sync.WaitGroup{}
+
+	return r
+}
+
+func (r *runner) run(t testing.TB, workers int, workFunc ...DBLoaderFuncType) {
+	t.Logf("Executing provided load function for %d workers", workers)
+	for i := 0; i < workers; i++ {
+		wrapper := func(wg *sync.WaitGroup) {
+			defer wg.Done()
+			kubeClient, err := newKubeClient(300, 600)
+			if err != nil {
+				t.Errorf("Unable to create a kube client for a worker due to %v", err)
+				r.collectError(err)
+				return
+			}
+			_ = runWorkFunctions(kubeClient, "", r.collectError, r.collectStat, workFunc...)
+		}
+		r.wg.Add(1)
+		go wrapper(r.wg)
+	}
+	r.wg.Wait()
+	t.Log("All workers completed successfully")
+}
+
+func (r *runner) collectError(err error) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	errCount, ok := r.errorStore[err.Error()]
+	if !ok {
+		r.errorStore[err.Error()] = 1
+		return
+	}
+	errCount += 1
+	r.errorStore[err.Error()] = errCount
+}
+
+func (r *runner) collectStat(stat string) {
+	r.lockStats.Lock()
+	defer r.lockStats.Unlock()
+	statCount, ok := r.statsStore[stat]
+	if !ok {
+		r.statsStore[stat] = 1
+		return
+	}
+	statCount += 1
+	r.statsStore[stat] = statCount
+}
+
+func runWorkFunctions(kubeClient kubernetes.Interface, namespace string, errorCollector func(error), statsCollector func(string), workFunc ...DBLoaderFuncType) error {
+	if len(namespace) == 0 {
+		namespace = createNamespaceName()
+	}
+	for _, work := range workFunc {
+		err := work(kubeClient, namespace, errorCollector, statsCollector)
+		if err != nil {
+			errorCollector(err)
+			return err
+		}
+	}
+	return nil
+}
+
+func DBLoaderRepeat(times int, genNamespaceName bool, workToRepeatFunc ...DBLoaderFuncType) DBLoaderFuncType {
+	return DBLoaderRepeatParallel(times, 1, genNamespaceName, workToRepeatFunc...)
+}
+
+func DBLoaderRepeatParallel(times int, workers int, genNamespaceName bool, workToRepeatFunc ...DBLoaderFuncType) DBLoaderFuncType {
+	return func(kubeClient kubernetes.Interface, namespace string, errorCollector func(error), statsCollector func(string)) error {
+		if times < workers {
+			panic("DBLoaderRepeat cannot be < workers")
+		}
+		wg := sync.WaitGroup{}
+		workPerWorker := times / workers
+		for w := 0; w < workers; w++ {
+			work := func(wg sync.WaitGroup) {
+				defer wg.Done()
+				for i := 0; i < workPerWorker; i++ {
+					if genNamespaceName {
+						namespace = createNamespaceName()
+					}
+					if err := runWorkFunctions(kubeClient, namespace, errorCollector, statsCollector, workToRepeatFunc...); err != nil {
+						errorCollector(err)
+					}
+				}
+			}
+			wg.Add(1)
+			go work(wg)
+		}
+		wg.Wait()
+		return nil
+	}
+}
+
+func createNamespaceName() string {
+	return fmt.Sprintf("encryption-%s", rand.String(10))
+}
+
+func newKubeClient(qps float32, burst int) (kubernetes.Interface, error) {
+	kubeConfig, err := test.NewClientConfigForTest()
+	if err != nil {
+		return nil, err
+	}
+
+	kubeConfig.QPS = qps
+	kubeConfig.Burst = burst
+
+	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+	if err != nil {
+		return nil, err
+	}
+	return kubeClient, nil
+}

--- a/test/library/encryption/perf_scenarios.go
+++ b/test/library/encryption/perf_scenarios.go
@@ -1,0 +1,57 @@
+package encryption
+
+import (
+	"testing"
+	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+	v1 "github.com/openshift/api/operator/v1"
+)
+
+type GetOperatorConditionsFuncType func(t testing.TB) ([]v1.OperatorCondition, error)
+
+type PerfScenario struct {
+	BasicScenario
+	GetOperatorConditionsFunc GetOperatorConditionsFuncType
+
+	DBLoaderFunc          DBLoaderFuncType
+	AssertDBPopulatedFunc func(t testing.TB, errorStore map[string]int, statStore map[string]int)
+	AssertMigrationTime   func(t testing.TB, migrationTime time.Duration)
+	// DBLoaderWorker is the number of workers that will execute DBLoaderFunc
+	DBLoaderWorkers int
+}
+
+func TestPerfEncryptionTypeAESCBC(t *testing.T, scenario PerfScenario) {
+	e := NewE(t, PrintEventsOnFailure(scenario.OperatorNamespace))
+	migrationStartedCh := make(chan time.Time, 1)
+
+	populateDatabase(e, scenario.DBLoaderWorkers, scenario.DBLoaderFunc, scenario.AssertDBPopulatedFunc)
+	watchForMigrationControllerProgressingConditionAsync(e, scenario.GetOperatorConditionsFunc, migrationStartedCh)
+	endTimeStamp := runTestEncryptionTypeAESCBCScenario(t, scenario.BasicScenario)
+
+	select {
+	case migrationStarted := <-migrationStartedCh:
+		scenario.AssertMigrationTime(e, endTimeStamp.Sub(migrationStarted))
+	default:
+		e.Error("unable to calculate the migration time, failed to observe when the migration has started")
+	}
+}
+
+func runTestEncryptionTypeAESCBCScenario(tt *testing.T, scenario BasicScenario) time.Time {
+	var ts time.Time
+	TestEncryptionTypeAESCBC(tt, BasicScenario{
+		Namespace:                       scenario.Namespace,
+		LabelSelector:                   scenario.LabelSelector,
+		EncryptionConfigSecretName:      scenario.EncryptionConfigSecretName,
+		EncryptionConfigSecretNamespace: scenario.EncryptionConfigSecretNamespace,
+		OperatorNamespace:               scenario.OperatorNamespace,
+		TargetGRs:                       scenario.TargetGRs,
+		AssertFunc: func(t testing.TB, clientSet ClientSet, expectedMode configv1.EncryptionType, namespace, labelSelector string) {
+			// Note that AssertFunc is executed after an encryption secret has been annotated
+			ts = time.Now()
+			scenario.AssertFunc(t, clientSet, expectedMode, scenario.Namespace, scenario.LabelSelector)
+			t.Logf("AssertFunc for TestEncryptionTypeAESCBC scenario took %v", time.Now().Sub(ts))
+		},
+	})
+	return ts
+}


### PR DESCRIPTION
This PR syncs 4.4 work with 4.3 mainly doing:

- speeding up migration by a factor: 50k objects in half an hour (before around 1k in 5m)
- added Encrypted condition for the user to see the encryption status
- leave last read-key in encryption config in order to allow backup/restore when encryption-config backup is done after backup, without losing data (compare https://github.com/openshift/enhancements/pull/131).