### PR TITLE
Bug 1779263: encryption: cope with missing revisions on upgrade

### DIFF
--- a/pkg/operator/encryption/deployer/revisionedpod_test.go
+++ b/pkg/operator/encryption/deployer/revisionedpod_test.go
@@ -10,76 +10,116 @@ import (
 
 func TestCategorizePods(t *testing.T) {
 	tests := []struct {
-		name            string
-		pods            []corev1.Pod
-		wantGood        []*corev1.Pod
-		wantBad         []*corev1.Pod
-		wantProgressing bool
-		wantErr         bool
+		name                      string
+		pods                      []corev1.Pod
+		nodes                     []string
+		wantGood                  []*corev1.Pod
+		wantBad                   []*corev1.Pod
+		wantCategorizeProgressing bool
+		wantCategorizeErr         bool
+
+		wantCommonRevision                          string
+		wantGetAPIServerRevisionOfAllInstancesError bool
 	}{
-		{"no pod", nil, nil, nil, true, false},
+		{"no pod", nil, nil, nil, nil, true, false, "", false},
 		{
 			"good pods, same revision", []corev1.Pod{
-				*newPod(corev1.PodRunning, corev1.ConditionTrue, "3"),
-				*newPod(corev1.PodRunning, corev1.ConditionTrue, "3"),
-			}, []*corev1.Pod{
-				newPod(corev1.PodRunning, corev1.ConditionTrue, "3"),
-				newPod(corev1.PodRunning, corev1.ConditionTrue, "3"),
-			}, nil, false, false,
+				*newPod(corev1.PodRunning, corev1.ConditionTrue, "3", "node1"),
+				*newPod(corev1.PodRunning, corev1.ConditionTrue, "3", "node2"),
+			}, []string{"node1", "node2"}, []*corev1.Pod{
+				newPod(corev1.PodRunning, corev1.ConditionTrue, "3", "node1"),
+				newPod(corev1.PodRunning, corev1.ConditionTrue, "3", "node2"),
+			}, nil, false, false, "3", false,
 		},
 		{
 			"good pods, different revision", []corev1.Pod{
-				*newPod(corev1.PodRunning, corev1.ConditionTrue, "3"),
-				*newPod(corev1.PodRunning, corev1.ConditionTrue, "5"),
-			}, []*corev1.Pod{
-				newPod(corev1.PodRunning, corev1.ConditionTrue, "3"),
-				newPod(corev1.PodRunning, corev1.ConditionTrue, "5"),
-			}, nil, false, false,
+				*newPod(corev1.PodRunning, corev1.ConditionTrue, "3", "node1"),
+				*newPod(corev1.PodRunning, corev1.ConditionTrue, "5", "node2"),
+			}, []string{"node1", "node2"}, []*corev1.Pod{
+				newPod(corev1.PodRunning, corev1.ConditionTrue, "3", "node1"),
+				newPod(corev1.PodRunning, corev1.ConditionTrue, "5", "node2"),
+			}, nil, false, false, "", false,
 		},
 		{
 			"ready and unready pods", []corev1.Pod{
-				*newPod(corev1.PodRunning, corev1.ConditionTrue, "3"),
-				*newPod(corev1.PodRunning, corev1.ConditionFalse, "3"),
-			}, nil, nil, true, false,
+				*newPod(corev1.PodRunning, corev1.ConditionTrue, "3", "node1"),
+				*newPod(corev1.PodRunning, corev1.ConditionFalse, "3", "node2"),
+			}, []string{"node1", "node2"}, nil, nil, true, false, "3", false,
 		},
 		{
 			"good pods and pending pods", []corev1.Pod{
-				*newPod(corev1.PodRunning, corev1.ConditionTrue, "3"),
-				*newPod(corev1.PodPending, corev1.ConditionFalse, "3"),
-			}, nil, nil, true, false,
+				*newPod(corev1.PodRunning, corev1.ConditionTrue, "3", "node1"),
+				*newPod(corev1.PodPending, corev1.ConditionFalse, "3", "node2"),
+			}, []string{"node1", "node2"}, nil, nil, true, false, "3", false,
 		},
 		{
 			"good pods and failed pods", []corev1.Pod{
-				*newPod(corev1.PodRunning, corev1.ConditionTrue, "3"),
-				*newPod(corev1.PodFailed, corev1.ConditionFalse, "3"),
+				*newPod(corev1.PodRunning, corev1.ConditionTrue, "3", "node1"),
+				*newPod(corev1.PodFailed, corev1.ConditionFalse, "3", "node2"),
+			}, []string{"node1", "node2"}, []*corev1.Pod{
+				newPod(corev1.PodRunning, corev1.ConditionTrue, "3", "node1"),
 			}, []*corev1.Pod{
-				newPod(corev1.PodRunning, corev1.ConditionTrue, "3"),
-			}, []*corev1.Pod{
-				newPod(corev1.PodFailed, corev1.ConditionFalse, "3"),
-			}, false, false,
+				newPod(corev1.PodFailed, corev1.ConditionFalse, "3", "node2"),
+			}, false, false, "3", false,
 		},
 		{
 			"good pods and succeeded pods", []corev1.Pod{
-				*newPod(corev1.PodRunning, corev1.ConditionTrue, "3"),
-				*newPod(corev1.PodSucceeded, corev1.ConditionFalse, "3"),
+				*newPod(corev1.PodRunning, corev1.ConditionTrue, "3", "node1"),
+				*newPod(corev1.PodSucceeded, corev1.ConditionFalse, "3", "node2"),
+			}, []string{"node1", "node2"}, []*corev1.Pod{
+				newPod(corev1.PodRunning, corev1.ConditionTrue, "3", "node1"),
 			}, []*corev1.Pod{
-				newPod(corev1.PodRunning, corev1.ConditionTrue, "3"),
-			}, []*corev1.Pod{
-				newPod(corev1.PodSucceeded, corev1.ConditionFalse, "3"),
-			}, false, false,
+				newPod(corev1.PodSucceeded, corev1.ConditionFalse, "3", "node2"),
+			}, false, false, "3", false,
 		},
 		{
 			"good pods and unknown phase pods", []corev1.Pod{
-				*newPod(corev1.PodRunning, corev1.ConditionTrue, "3"),
-				*newPod(corev1.PodUnknown, corev1.ConditionFalse, "3"),
-			}, nil, nil, false, true,
+				*newPod(corev1.PodRunning, corev1.ConditionTrue, "3", "node1"),
+				*newPod(corev1.PodUnknown, corev1.ConditionFalse, "3", "node2"),
+			}, []string{"node1", "node2"}, nil, nil, false, true, "", false,
+		},
+		{
+			"all empty revision", []corev1.Pod{
+				*newPod(corev1.PodRunning, corev1.ConditionTrue, "", "node1"),
+				*newPod(corev1.PodRunning, corev1.ConditionTrue, "", "node2"),
+			}, []string{"node1", "node2"}, []*corev1.Pod{
+				newPod(corev1.PodRunning, corev1.ConditionTrue, "", "node1"),
+				newPod(corev1.PodRunning, corev1.ConditionTrue, "", "node2"),
+			}, nil, false, false, "0", false,
+		},
+		{
+			"one empty revision", []corev1.Pod{
+				*newPod(corev1.PodRunning, corev1.ConditionTrue, "", "node1"),
+				*newPod(corev1.PodRunning, corev1.ConditionTrue, "1", "node2"),
+			}, []string{"node1", "node2"}, []*corev1.Pod{
+				newPod(corev1.PodRunning, corev1.ConditionTrue, "", "node1"),
+				newPod(corev1.PodRunning, corev1.ConditionTrue, "1", "node2"),
+			}, nil, false, false, "1", false,
+		},
+		{
+			"one empty revision, one zero", []corev1.Pod{
+				*newPod(corev1.PodRunning, corev1.ConditionTrue, "", "node1"),
+				*newPod(corev1.PodRunning, corev1.ConditionTrue, "0", "node2"),
+			}, []string{"node1", "node2"}, []*corev1.Pod{
+				newPod(corev1.PodRunning, corev1.ConditionTrue, "", "node1"),
+				newPod(corev1.PodRunning, corev1.ConditionTrue, "0", "node2"),
+			}, nil, false, false, "0", false,
+		},
+		{
+			"one invalid revision", []corev1.Pod{
+				*newPod(corev1.PodRunning, corev1.ConditionTrue, "", "node1"),
+				*newPod(corev1.PodRunning, corev1.ConditionTrue, "abc", "node2"),
+			}, []string{"node1", "node2"}, []*corev1.Pod{
+				newPod(corev1.PodRunning, corev1.ConditionTrue, "", "node1"),
+				newPod(corev1.PodRunning, corev1.ConditionTrue, "abc", "node2"),
+			}, nil, false, false, "", true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gotGood, gotBad, gotProgressing, err := categorizePods(tt.pods)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("categorizePods() error = %v, wantErr %v", err, tt.wantErr)
+			if (err != nil) != tt.wantCategorizeErr {
+				t.Errorf("categorizePods() error = %v, wantErr %v", err, tt.wantCategorizeErr)
 				return
 			}
 			if !reflect.DeepEqual(gotGood, tt.wantGood) {
@@ -88,21 +128,34 @@ func TestCategorizePods(t *testing.T) {
 			if !reflect.DeepEqual(gotBad, tt.wantBad) {
 				t.Errorf("categorizePods() gotBad = %v, want %v", gotBad, tt.wantBad)
 			}
-			if gotProgressing != tt.wantProgressing {
-				t.Errorf("categorizePods() gotProgressing = %v, want %v", gotProgressing, tt.wantProgressing)
+			if gotProgressing != tt.wantCategorizeProgressing {
+				t.Errorf("categorizePods() gotProgressing = %v, want %v", gotProgressing, tt.wantCategorizeProgressing)
+			}
+
+			if err != nil {
+				rev, err := getAPIServerRevisionOfAllInstances("revision", tt.nodes, tt.pods)
+				if (err != nil) != tt.wantCategorizeErr {
+					t.Errorf("getAPIServerRevisionOfAllInstances() error = %v, wantErr %v", err, tt.wantGetAPIServerRevisionOfAllInstancesError)
+					return
+				}
+				if rev != tt.wantCommonRevision {
+					t.Errorf("getAPIServerRevisionOfAllInstances() rev = %q, want %q", rev, tt.wantCommonRevision)
+				}
 			}
 		})
 	}
 }
 
-func newPod(phase corev1.PodPhase, ready corev1.ConditionStatus, revision string) *corev1.Pod {
+func newPod(phase corev1.PodPhase, ready corev1.ConditionStatus, revision, nodeName string) *corev1.Pod {
 	pod := corev1.Pod{
 		TypeMeta: v1.TypeMeta{Kind: "Pod"},
 		ObjectMeta: v1.ObjectMeta{
 			Labels: map[string]string{
 				"revision": revision,
 			}},
-		Spec: corev1.PodSpec{},
+		Spec: corev1.PodSpec{
+			NodeName: nodeName,
+		},
 		Status: corev1.PodStatus{
 			Phase: phase,
 			Conditions: []corev1.PodCondition{{


### PR DESCRIPTION
On upgrade the openshift-apiserver pods have no revision making the encryption controller fall over.