### PR TITLE
Bug 1780809: kube-apiserver stuck in Progressing/Degraded if target revision is deleted

### DIFF
--- a/pkg/operator/staticpod/controller/installer/installer_controller.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller.go
@@ -304,7 +304,10 @@ func (c *InstallerController) manageInstallationPods(operatorSpec *operatorv1.St
 			if err := c.ensureInstallerPod(currNodeState.NodeName, operatorSpec, currNodeState.TargetRevision); err != nil {
 				c.eventRecorder.Warningf("InstallerPodFailed", "Failed to create installer pod for revision %d on node %q: %v",
 					currNodeState.TargetRevision, currNodeState.NodeName, err)
-				return true, err
+				// if a newer revision is pending, continue, so we retry later with the latest available revision
+				if !(operatorStatus.LatestAvailableRevision > currNodeState.TargetRevision) {
+					return true, err
+				}
 			}
 
 			newCurrNodeState, installerPodFailed, reason, err := c.newNodeStateForInstallInProgress(currNodeState, operatorStatus.LatestAvailableRevision)


### PR DESCRIPTION
If the revision resources needed by a static pod installer are deleted, static pods are stuck, unable to be upgraded to use the latest revision of the resources. 
This PR detects this situation and moves the static pods to the latest available revision.