### PR TITLE
pkg/operator/status: Add configurable inertia

### DIFF
--- a/pkg/operator/status/condition.go
+++ b/pkg/operator/status/condition.go
@@ -12,23 +12,12 @@ import (
 )
 
 // unionCondition returns a single cluster operator condition that is the union of multiple operator conditions.
-func unionCondition(conditionType string, defaultConditionStatus operatorv1.ConditionStatus, allConditions ...operatorv1.OperatorCondition) configv1.ClusterOperatorStatusCondition {
-	return internalUnionCondition(conditionType, defaultConditionStatus, false, allConditions...)
-}
-
-// unionInertialCondition returns a single cluster operator condition that is the union of multiple operator conditions,
-// but resists returning a condition with a status opposite the defaultConditionStatus.
-func unionInertialCondition(conditionType string, defaultConditionStatus operatorv1.ConditionStatus, allConditions ...operatorv1.OperatorCondition) configv1.ClusterOperatorStatusCondition {
-	return internalUnionCondition(conditionType, defaultConditionStatus, true, allConditions...)
-}
-
-// internalUnionCondition returns a single cluster operator condition that is the union of multiple operator conditions.
 //
 // defaultConditionStatus indicates whether you want to merge all Falses or merge all Trues.  For instance, Failures merge
 // on true, but Available merges on false.  Thing of it like an anti-default.
 //
-// If hasInertia, then resist returning a condition with a status opposite the defaultConditionStatus.
-func internalUnionCondition(conditionType string, defaultConditionStatus operatorv1.ConditionStatus, hasInertia bool, allConditions ...operatorv1.OperatorCondition) configv1.ClusterOperatorStatusCondition {
+// If interia is non-nil, then resist returning a condition with a status opposite the defaultConditionStatus.
+func unionCondition(conditionType string, defaultConditionStatus operatorv1.ConditionStatus, inertia Inertia, allConditions ...operatorv1.OperatorCondition) configv1.ClusterOperatorStatusCondition {
 	var oppositeConditionStatus operatorv1.ConditionStatus
 	if defaultConditionStatus == operatorv1.ConditionTrue {
 		oppositeConditionStatus = operatorv1.ConditionFalse
@@ -59,11 +48,19 @@ func internalUnionCondition(conditionType string, defaultConditionStatus operato
 		return OperatorConditionToClusterOperatorCondition(unionedCondition)
 	}
 
-	// This timeout needs to be longer than the delay in kube-apiserver after setting not ready and before we stop serving.
-	// That delay use to be 30 seconds, but we switched it to 70 seconds to reflect the reality on AWS.
-	twoMinutesAgo := time.Now().Add(-2 * time.Minute)
-	earliestBadConditionNotOldEnough := earliestTransitionTime(badConditions).Time.After(twoMinutesAgo)
-	if len(badConditions) == 0 || (hasInertia && earliestBadConditionNotOldEnough) {
+	var elderBadConditions []operatorv1.OperatorCondition
+	if inertia == nil {
+		elderBadConditions = badConditions
+	} else {
+		now := time.Now()
+		for _, condition := range badConditions {
+			if condition.LastTransitionTime.Time.Before(now.Add(-inertia(condition))) {
+				elderBadConditions = append(elderBadConditions, condition)
+			}
+		}
+	}
+
+	if len(elderBadConditions) == 0 {
 		unionedCondition.Status = defaultConditionStatus
 		unionedCondition.Message = unionMessage(interestingConditions)
 		unionedCondition.Reason = "AsExpected"
@@ -89,16 +86,6 @@ func latestTransitionTime(conditions []operatorv1.OperatorCondition) metav1.Time
 		}
 	}
 	return latestTransitionTime
-}
-
-func earliestTransitionTime(conditions []operatorv1.OperatorCondition) metav1.Time {
-	earliestTransitionTime := metav1.Now()
-	for _, condition := range conditions {
-		if !earliestTransitionTime.Before(&condition.LastTransitionTime) {
-			earliestTransitionTime = condition.LastTransitionTime
-		}
-	}
-	return earliestTransitionTime
 }
 
 func uniq(s []string) []string {

--- a/pkg/operator/status/inertia.go
+++ b/pkg/operator/status/inertia.go
@@ -1,0 +1,66 @@
+package status
+
+import (
+	"fmt"
+	"regexp"
+	"time"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+)
+
+// Inertia returns the inertial duration for the given condition.
+type Inertia func(condition operatorv1.OperatorCondition) time.Duration
+
+// InertiaCondition configures an inertia duration for a given set of
+// condition types.
+type InertiaCondition struct {
+	// ConditionTypeMatcher is a regular expression selecting condition types
+	// with which this InertiaCondition is associated.
+	ConditionTypeMatcher *regexp.Regexp
+
+	// Duration is the inertial duration for associated conditions.
+	Duration time.Duration
+}
+
+// InertiaConfig holds configuration for an Inertia implementation.
+type InertiaConfig struct {
+	defaultDuration time.Duration
+	conditions      []InertiaCondition
+}
+
+// NewInertia creates a new InertiaConfig object.  Conditions are
+// applied in the given order, so a condition type matching multiple
+// regular expressions will have the duration associated with the first
+// matching entry.
+func NewInertia(defaultDuration time.Duration, conditions ...InertiaCondition) (*InertiaConfig, error) {
+	for i, condition := range conditions {
+		if condition.ConditionTypeMatcher == nil {
+			return nil, fmt.Errorf("condition %d has a nil ConditionTypeMatcher", i)
+		}
+	}
+
+	return &InertiaConfig{
+		defaultDuration: defaultDuration,
+		conditions:      conditions,
+	}, nil
+}
+
+// MustNewInertia is like NewInertia but panics on error.
+func MustNewInertia(defaultDuration time.Duration, conditions ...InertiaCondition) *InertiaConfig {
+	inertia, err := NewInertia(defaultDuration, conditions...)
+	if err != nil {
+		panic(err)
+	}
+
+	return inertia
+}
+
+// Inertia returns the configured inertia for the given condition type.
+func (c *InertiaConfig) Inertia(condition operatorv1.OperatorCondition) time.Duration {
+	for _, matcher := range c.conditions {
+		if matcher.ConditionTypeMatcher.MatchString(condition.Type) {
+			return matcher.Duration
+		}
+	}
+	return c.defaultDuration
+}

--- a/pkg/operator/status/status_controller.go
+++ b/pkg/operator/status/status_controller.go
@@ -49,9 +49,10 @@ type StatusSyncer struct {
 	clusterOperatorClient configv1client.ClusterOperatorsGetter
 	clusterOperatorLister configv1listers.ClusterOperatorLister
 
-	cachesToSync  []cache.InformerSynced
-	queue         workqueue.RateLimitingInterface
-	eventRecorder events.Recorder
+	cachesToSync    []cache.InformerSynced
+	queue           workqueue.RateLimitingInterface
+	eventRecorder   events.Recorder
+	degradedInertia Inertia
 }
 
 func NewClusterOperatorStatusController(
@@ -71,6 +72,7 @@ func NewClusterOperatorStatusController(
 		clusterOperatorLister: clusterOperatorInformer.Lister(),
 		operatorClient:        operatorClient,
 		eventRecorder:         recorder.WithComponentSuffix("status-controller"),
+		degradedInertia:       MustNewInertia(2 * time.Minute).Inertia,
 
 		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "StatusSyncer_"+strings.Replace(name, "-", "_", -1)),
 	}
@@ -82,6 +84,14 @@ func NewClusterOperatorStatusController(
 	c.cachesToSync = append(c.cachesToSync, clusterOperatorInformer.Informer().HasSynced)
 
 	return c
+}
+
+// WithDegradedInertia returns a copy of the StatusSyncer with the
+// requested inertia function for degraded conditions.
+func (c *StatusSyncer) WithDegradedInertia(inertia Inertia) *StatusSyncer {
+	output := *c
+	output.degradedInertia = inertia
+	return &output
 }
 
 // sync reacts to a change in prereqs by finding information that is required to match another value in the cluster. This
@@ -144,10 +154,10 @@ func (c StatusSyncer) sync() error {
 	}
 
 	clusterOperatorObj.Status.RelatedObjects = c.relatedObjects
-	configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, unionInertialCondition("Degraded", operatorv1.ConditionFalse, currentDetailedStatus.Conditions...))
-	configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, unionCondition("Progressing", operatorv1.ConditionFalse, currentDetailedStatus.Conditions...))
-	configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, unionCondition("Available", operatorv1.ConditionTrue, currentDetailedStatus.Conditions...))
-	configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, unionCondition("Upgradeable", operatorv1.ConditionTrue, currentDetailedStatus.Conditions...))
+	configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, unionCondition("Degraded", operatorv1.ConditionFalse, c.degradedInertia, currentDetailedStatus.Conditions...))
+	configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, unionCondition("Progressing", operatorv1.ConditionFalse, nil, currentDetailedStatus.Conditions...))
+	configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, unionCondition("Available", operatorv1.ConditionTrue, nil, currentDetailedStatus.Conditions...))
+	configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, unionCondition("Upgradeable", operatorv1.ConditionTrue, nil, currentDetailedStatus.Conditions...))
 
 	// TODO work out removal.  We don't always know the existing value, so removing early seems like a bad idea.  Perhaps a remove flag.
 	versions := c.versionGetter.GetVersions()


### PR DESCRIPTION
Instead of hard-coding a two-minute inertia, allow the controller-creator to set a custom inertia function.  The previous value was chosen to work fairly well for most cases, but there was contention between important conditions where 2m was pushing too long and less severe conditions where 2m was short enough to catch slow launch-time initialization that triggered distracting Degraded flaps (e.g. the 2m10s missing ConfigMaps in [rhbz#1775922][1], where the bulk of that 2m was taken by other kube-apiserver initialization actions).  With this commit, the kube-apiserver can say:

> 3m of missing ConfigMaps is ok, but only accept 1m of SomeOtherThing before going `Degraded=True`.

or whatever.

/assign @deads2k

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1775922