### PR TITLE
build: copy shared source-to-image helpers

### DIFF
--- a/pkg/build/OWNERS
+++ b/pkg/build/OWNERS
@@ -1,0 +1,14 @@
+reviewers:
+  - bparees
+  - smarterclayton
+  - mfojtik
+  - soltysh
+  - csrwng
+  - gabemontero
+  - adambkaplan
+approvers:
+  - bparees
+  - smarterclayton
+  - mfojtik
+  - soltysh
+  - adambkaplan

--- a/pkg/build/source-to-image/cmd/cmd.go
+++ b/pkg/build/source-to-image/cmd/cmd.go
@@ -1,0 +1,84 @@
+package cmd
+
+import (
+	"io"
+	"os"
+	"os/exec"
+)
+
+// CommandOpts contains options to attach Stdout/err to a command to run
+// or set its initial directory
+type CommandOpts struct {
+	Stdout    io.Writer
+	Stderr    io.Writer
+	Dir       string
+	EnvAppend []string
+}
+
+// CommandRunner executes OS commands with the given parameters and options
+type CommandRunner interface {
+	RunWithOptions(opts CommandOpts, name string, arg ...string) error
+	Run(name string, arg ...string) error
+	StartWithStdoutPipe(opts CommandOpts, name string, arg ...string) (io.ReadCloser, error)
+	Wait() error
+}
+
+// NewCommandRunner creates a new instance of the default implementation of
+// CommandRunner
+func NewCommandRunner() CommandRunner {
+	return &runner{}
+}
+
+type runner struct {
+	cmd *exec.Cmd
+}
+
+// RunWithOptions runs a command with the provided options
+func (c *runner) RunWithOptions(opts CommandOpts, name string, arg ...string) error {
+	cmd := exec.Command(name, arg...)
+	if opts.Stdout != nil {
+		cmd.Stdout = opts.Stdout
+	}
+	if opts.Stderr != nil {
+		cmd.Stderr = opts.Stderr
+	}
+	if opts.Dir != "" {
+		cmd.Dir = opts.Dir
+	}
+	if len(opts.EnvAppend) > 0 {
+		cmd.Env = os.Environ()
+		cmd.Env = append(cmd.Env, opts.EnvAppend...)
+	}
+	return cmd.Run()
+}
+
+// Run executes a command with default options
+func (c *runner) Run(name string, arg ...string) error {
+	return c.RunWithOptions(CommandOpts{}, name, arg...)
+}
+
+// StartWithStdoutPipe executes a command returning a ReadCloser connected to
+// the command's stdout.
+func (c *runner) StartWithStdoutPipe(opts CommandOpts, name string, arg ...string) (io.ReadCloser, error) {
+	c.cmd = exec.Command(name, arg...)
+	if opts.Stderr != nil {
+		c.cmd.Stderr = opts.Stderr
+	}
+	if opts.Dir != "" {
+		c.cmd.Dir = opts.Dir
+	}
+	if len(opts.EnvAppend) > 0 {
+		c.cmd.Env = os.Environ()
+		c.cmd.Env = append(c.cmd.Env, opts.EnvAppend...)
+	}
+	r, err := c.cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	return r, c.cmd.Start()
+}
+
+// Wait waits for the command to exit.
+func (c *runner) Wait() error {
+	return c.cmd.Wait()
+}

--- a/pkg/build/source-to-image/cmd/test/cmd.go
+++ b/pkg/build/source-to-image/cmd/test/cmd.go
@@ -1,0 +1,41 @@
+package test
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+
+	"github.com/openshift/library-go/pkg/build/source-to-image/cmd"
+)
+
+// FakeCmdRunner provider the fake command runner
+type FakeCmdRunner struct {
+	Name string
+	Args []string
+	Opts cmd.CommandOpts
+	Err  error
+}
+
+// RunWithOptions runs the command runner with extra options
+func (f *FakeCmdRunner) RunWithOptions(opts cmd.CommandOpts, name string, args ...string) error {
+	f.Name = name
+	f.Args = args
+	f.Opts = opts
+	return f.Err
+}
+
+// Run runs the fake command runner
+func (f *FakeCmdRunner) Run(name string, args ...string) error {
+	return f.RunWithOptions(cmd.CommandOpts{}, name, args...)
+}
+
+// StartWithStdoutPipe executes a command returning a ReadCloser connected to
+// the command's stdout.
+func (f *FakeCmdRunner) StartWithStdoutPipe(opts cmd.CommandOpts, name string, arg ...string) (io.ReadCloser, error) {
+	return ioutil.NopCloser(&bytes.Buffer{}), f.Err
+}
+
+// Wait waits for the command to exit.
+func (f *FakeCmdRunner) Wait() error {
+	return f.Err
+}

--- a/pkg/build/source-to-image/cygpath/cygpath.go
+++ b/pkg/build/source-to-image/cygpath/cygpath.go
@@ -1,0 +1,40 @@
+package cygpath
+
+import (
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// UsingCygwinGit indicates whether we believe the host's git utility is from
+// Cygwin (expects Windows paths as /cygdrive/c/dir/file) or not (expects paths
+// in host-native format).
+var UsingCygwinGit = isUsingCygwinGit()
+
+func isUsingCygwinGit() bool {
+	if runtime.GOOS == "windows" {
+		// If we find the cygpath utility (which translates between UNIX-style and
+		// Windows-style paths) in the same directory as git, assume we're using
+		// Cygwin.
+		cygpath, err := exec.LookPath("cygpath")
+		if err != nil {
+			return false
+		}
+		var git string
+		git, err = exec.LookPath("git")
+		if err == nil && filepath.Dir(cygpath) == filepath.Dir(git) {
+			return true
+		}
+	}
+	return false
+}
+
+// ToSlashCygwin converts a path to a format suitable for sending to a Cygwin
+// binary - `/dir/file` on UNIX-style systems; `c:\dir\file` on Windows without
+// Cygwin; `/cygdrive/c/dir/file` on Windows with Cygwin.
+func ToSlashCygwin(path string) (string, error) {
+	cmd := exec.Command("cygpath", path)
+	out, err := cmd.Output()
+	return strings.TrimRight(string(out), "\n"), err
+}

--- a/pkg/build/source-to-image/errors/doc.go
+++ b/pkg/build/source-to-image/errors/doc.go
@@ -1,0 +1,3 @@
+// Contains error definitions for errors thrown throughout the STI code
+
+package errors

--- a/pkg/build/source-to-image/errors/errors.go
+++ b/pkg/build/source-to-image/errors/errors.go
@@ -1,0 +1,304 @@
+package errors
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/openshift/source-to-image/pkg/api/constants"
+	utillog "github.com/openshift/source-to-image/pkg/util/log"
+)
+
+// Common S2I errors
+const (
+	InspectImageError int = 1 + iota
+	PullImageError
+	SaveArtifactsError
+	AssembleError
+	WorkdirError
+	BuildError
+	TarTimeoutError
+	DownloadError
+	ScriptsInsideImageError
+	InstallError
+	InstallErrorRequired
+	URLHandlerError
+	STIContainerError
+	SourcePathError
+	UserNotAllowedError
+	EmptyGitRepositoryError
+)
+
+// Error represents an error thrown during S2I execution
+type Error struct {
+	Message    string
+	Details    error
+	ErrorCode  int
+	Suggestion string
+}
+
+// ContainerError is an error returned when a container exits with a non-zero code.
+// ExitCode contains the exit code from the container
+type ContainerError struct {
+	Message    string
+	Output     string
+	ErrorCode  int
+	Suggestion string
+	ExitCode   int
+}
+
+// Error returns a string for a given error
+func (s Error) Error() string {
+	return s.Message
+}
+
+// Error returns a string for the given error
+func (s ContainerError) Error() string {
+	return s.Message
+}
+
+// NewInspectImageError returns a new error which indicates there was a problem
+// inspecting the image
+func NewInspectImageError(name string, err error) error {
+	return Error{
+		Message:    fmt.Sprintf("unable to get metadata for %s", name),
+		Details:    err,
+		ErrorCode:  InspectImageError,
+		Suggestion: "check image name",
+	}
+}
+
+// NewPullImageError returns a new error which indicates there was a problem
+// pulling the image
+func NewPullImageError(name string, err error) error {
+	return Error{
+		Message:    fmt.Sprintf("unable to get %s", name),
+		Details:    err,
+		ErrorCode:  PullImageError,
+		Suggestion: fmt.Sprintf("check image name, or if using a local image set the builder image pull policy to %q", "never"),
+	}
+}
+
+// NewSaveArtifactsError returns a new error which indicates there was a problem
+// calling save-artifacts script
+func NewSaveArtifactsError(name, output string, err error) error {
+	return Error{
+		Message:    fmt.Sprintf("saving artifacts for %s failed:\n%s", name, output),
+		Details:    err,
+		ErrorCode:  SaveArtifactsError,
+		Suggestion: "check the save-artifacts script for errors",
+	}
+}
+
+// NewAssembleError returns a new error which indicates there was a problem
+// running assemble script
+func NewAssembleError(name, output string, err error) error {
+	return Error{
+		Message:    fmt.Sprintf("assemble for %s failed:\n%s", name, output),
+		Details:    err,
+		ErrorCode:  AssembleError,
+		Suggestion: "check the assemble script output for errors",
+	}
+}
+
+// NewWorkDirError returns a new error which indicates there was a problem
+// when creating working directory
+func NewWorkDirError(dir string, err error) error {
+	return Error{
+		Message:    fmt.Sprintf("creating temporary directory %s failed", dir),
+		Details:    err,
+		ErrorCode:  WorkdirError,
+		Suggestion: "check if you have access to your system's temporary directory",
+	}
+}
+
+// NewBuildError returns a new error which indicates there was a problem
+// building the image
+func NewBuildError(name string, err error) error {
+	return Error{
+		Message:    fmt.Sprintf("building %s failed", name),
+		Details:    err,
+		ErrorCode:  BuildError,
+		Suggestion: "check the build output for errors",
+	}
+}
+
+// NewCommitError returns a new error which indicates there was a problem
+// committing the image
+func NewCommitError(name string, err error) error {
+	return Error{
+		Message:    fmt.Sprintf("building %s failed when committing the image due to error: %v", name, err),
+		Details:    err,
+		ErrorCode:  BuildError,
+		Suggestion: "check the build output for errors",
+	}
+}
+
+// NewTarTimeoutError returns a new error which indicates there was a problem
+// when sending or receiving tar stream
+func NewTarTimeoutError() error {
+	return Error{
+		Message:    fmt.Sprintf("timeout waiting for tar stream"),
+		Details:    nil,
+		ErrorCode:  TarTimeoutError,
+		Suggestion: "check the Source-To-Image scripts if it accepts tar stream for assemble and sends for save-artifacts",
+	}
+}
+
+// NewDownloadError returns a new error which indicates there was a problem
+// when downloading a file
+func NewDownloadError(url string, code int) error {
+	return Error{
+		Message:    fmt.Sprintf("failed to retrieve %s, response code %d", url, code),
+		Details:    nil,
+		ErrorCode:  DownloadError,
+		Suggestion: "check the availability of the address",
+	}
+}
+
+// NewScriptsInsideImageError returns a new error which informs of scripts
+// being placed inside the image
+func NewScriptsInsideImageError(url string) error {
+	return Error{
+		Message:    fmt.Sprintf("scripts inside the image: %s", url),
+		Details:    nil,
+		ErrorCode:  ScriptsInsideImageError,
+		Suggestion: "",
+	}
+}
+
+// NewInstallError returns a new error which indicates there was a problem
+// when downloading a script
+func NewInstallError(script string) error {
+	return Error{
+		Message:    fmt.Sprintf("failed to install %v", script),
+		Details:    nil,
+		ErrorCode:  InstallError,
+		Suggestion: fmt.Sprintf("set the scripts URL parameter with the location of the S2I scripts, or check if the image has the %q label set", constants.ScriptsURLLabel),
+	}
+}
+
+// NewInstallRequiredError returns a new error which indicates there was a problem
+// when downloading a required script
+func NewInstallRequiredError(scripts []string, label string) error {
+	return Error{
+		Message:    fmt.Sprintf("failed to install %v", scripts),
+		Details:    nil,
+		ErrorCode:  InstallErrorRequired,
+		Suggestion: fmt.Sprintf("set the scripts URL parameter with the location of the S2I scripts, or check if the image has the %q label set", constants.ScriptsURLLabel),
+	}
+}
+
+// NewURLHandlerError returns a new error which indicates there was a problem
+// when trying to read scripts URL
+func NewURLHandlerError(url string) error {
+	return Error{
+		Message:    fmt.Sprintf("no URL handler for %s", url),
+		Details:    nil,
+		ErrorCode:  URLHandlerError,
+		Suggestion: "check the URL",
+	}
+}
+
+// NewContainerError return a new error which indicates there was a problem
+// invoking command inside container
+func NewContainerError(name string, code int, output string) error {
+	return ContainerError{
+		Message:    fmt.Sprintf("non-zero (%d) exit code from %s", code, name),
+		Output:     output,
+		ErrorCode:  STIContainerError,
+		Suggestion: "check the container logs for more information on the failure",
+		ExitCode:   code,
+	}
+}
+
+// NewSourcePathError returns a new error which indicates there was a problem
+// when accessing the source code from the local filesystem
+func NewSourcePathError(path string) error {
+	return Error{
+		Message:    fmt.Sprintf("Local filesystem source path does not exist: %s", path),
+		Details:    nil,
+		ErrorCode:  SourcePathError,
+		Suggestion: "check the source code path on the local filesystem",
+	}
+}
+
+// NewUserNotAllowedError returns a new error that indicates that the build
+// could not run because the image uses a user outside of the range of allowed users
+func NewUserNotAllowedError(image string, onbuild bool) error {
+	var msg string
+	if onbuild {
+		msg = fmt.Sprintf("image %q includes at least one ONBUILD instruction that sets the user to a user that is not allowed", image)
+	} else {
+		msg = fmt.Sprintf("image %q must specify a user that is numeric and within the range of allowed users", image)
+	}
+	return Error{
+		Message:    msg,
+		ErrorCode:  UserNotAllowedError,
+		Suggestion: fmt.Sprintf("modify image %q to use a numeric user within the allowed range, or build without the allowed UIDs paremeter set", image),
+	}
+}
+
+// NewAssembleUserNotAllowedError returns a new error that indicates that the build
+// could not run because the build or image uses an assemble user outside of the range
+// of allowed users.
+func NewAssembleUserNotAllowedError(image string, usesConfig bool) error {
+	var msg, suggestion string
+	if usesConfig {
+		msg = "assemble user must be numeric and within the range of allowed users"
+		suggestion = "build without the allowed UIDs or assemble user configurations set"
+	} else {
+		msg = fmt.Sprintf("image %q includes the %q label whose value is not within the allowed range", image, constants.AssembleUserLabel)
+		suggestion = fmt.Sprintf("modify the %q label in image %q to use a numeric user within the allowed range, or build without the allowed UIDs configuration set", constants.AssembleUserLabel, image)
+	}
+	return Error{
+		Message:    msg,
+		ErrorCode:  UserNotAllowedError,
+		Suggestion: suggestion,
+	}
+}
+
+// NewEmptyGitRepositoryError returns a new error which indicates that a found
+// .git directory has no tracking information, e.g. if the user simply used
+// `git init` and forgot about the repository
+func NewEmptyGitRepositoryError(source string) error {
+	return Error{
+		Message:    fmt.Sprintf("The git repository \"%s\" has no tracking information or commits", source),
+		ErrorCode:  EmptyGitRepositoryError,
+		Suggestion: "Either commit files to the Git repository, remove the .git directory from the project, or force copy of source files to ignore the repository.",
+	}
+}
+
+// log is a placeholder until the builders pass an output stream down
+// client facing libraries should not be using log
+var log = utillog.StderrLog
+
+// CheckError checks input error.
+// 1. if the input error is nil, the function does nothing but return.
+// 2. if the input error is a kind of Error which is thrown during S2I execution,
+// the function handle it with Suggestion and Details.
+// 3. if the input error is a kind of system Error which is unknown, the function exit with 1.
+func CheckError(err error) {
+	if err == nil {
+		return
+	}
+
+	if e, ok := err.(Error); ok {
+		log.Errorf("An error occurred: %v", e)
+		log.Errorf("Suggested solution: %v", e.Suggestion)
+		if e.Details != nil {
+			log.V(1).Infof("Details: %v", e.Details)
+		}
+		log.Error("If the problem persists consult the docs at https://github.com/openshift/source-to-image/tree/master/docs. " +
+			"Eventually reach us on freenode #openshift or file an issue at https://github.com/openshift/source-to-image/issues " +
+			"providing us with a log from your build using log output level 3.")
+		os.Exit(e.ErrorCode)
+	} else {
+		log.Errorf("An error occurred: %v", err)
+		os.Exit(1)
+	}
+}
+
+// UsageError checks command usage error.
+func UsageError(msg string) error {
+	return fmt.Errorf("%s", msg)
+}

--- a/pkg/build/source-to-image/errors/errors.go
+++ b/pkg/build/source-to-image/errors/errors.go
@@ -4,8 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/openshift/source-to-image/pkg/api/constants"
-	utillog "github.com/openshift/source-to-image/pkg/util/log"
+	utillog "github.com/openshift/library-go/pkg/build/source-to-image/log"
 )
 
 // Common S2I errors
@@ -173,7 +172,7 @@ func NewInstallError(script string) error {
 		Message:    fmt.Sprintf("failed to install %v", script),
 		Details:    nil,
 		ErrorCode:  InstallError,
-		Suggestion: fmt.Sprintf("set the scripts URL parameter with the location of the S2I scripts, or check if the image has the %q label set", constants.ScriptsURLLabel),
+		Suggestion: fmt.Sprintf("set the scripts URL parameter with the location of the S2I scripts, or check if the image has the %q label set", "io.openshift.s2i.scripts-url"),
 	}
 }
 
@@ -184,7 +183,7 @@ func NewInstallRequiredError(scripts []string, label string) error {
 		Message:    fmt.Sprintf("failed to install %v", scripts),
 		Details:    nil,
 		ErrorCode:  InstallErrorRequired,
-		Suggestion: fmt.Sprintf("set the scripts URL parameter with the location of the S2I scripts, or check if the image has the %q label set", constants.ScriptsURLLabel),
+		Suggestion: fmt.Sprintf("set the scripts URL parameter with the location of the S2I scripts, or check if the image has the %q label set", "io.openshift.s2i.scripts-url"),
 	}
 }
 
@@ -247,8 +246,8 @@ func NewAssembleUserNotAllowedError(image string, usesConfig bool) error {
 		msg = "assemble user must be numeric and within the range of allowed users"
 		suggestion = "build without the allowed UIDs or assemble user configurations set"
 	} else {
-		msg = fmt.Sprintf("image %q includes the %q label whose value is not within the allowed range", image, constants.AssembleUserLabel)
-		suggestion = fmt.Sprintf("modify the %q label in image %q to use a numeric user within the allowed range, or build without the allowed UIDs configuration set", constants.AssembleUserLabel, image)
+		msg = fmt.Sprintf("image %q includes the %q label whose value is not within the allowed range", image, "io.openshift.s2i.assemble-user")
+		suggestion = fmt.Sprintf("modify the %q label in image %q to use a numeric user within the allowed range, or build without the allowed UIDs configuration set", "io.openshift.s2i.assemble-user", image)
 	}
 	return Error{
 		Message:    msg,

--- a/pkg/build/source-to-image/fs/fs.go
+++ b/pkg/build/source-to-image/fs/fs.go
@@ -1,0 +1,408 @@
+package fs
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"time"
+
+	s2ierr "github.com/openshift/library-go/pkg/build/source-to-image/errors"
+	utillog "github.com/openshift/library-go/pkg/build/source-to-image/log"
+)
+
+var log = utillog.StderrLog
+
+// FileSystem allows STI to work with the file system and
+// perform tasks such as creating and deleting directories
+type FileSystem interface {
+	Chmod(file string, mode os.FileMode) error
+	Rename(from, to string) error
+	MkdirAll(dirname string) error
+	MkdirAllWithPermissions(dirname string, perm os.FileMode) error
+	Mkdir(dirname string) error
+	Exists(file string) bool
+	Copy(sourcePath, targetPath string, filesToIgnore map[string]string) error
+	CopyContents(sourcePath, targetPath string, filesToIgnore map[string]string) error
+	RemoveDirectory(dir string) error
+	CreateWorkingDirectory() (string, error)
+	Open(file string) (io.ReadCloser, error)
+	Create(file string) (io.WriteCloser, error)
+	WriteFile(file string, data []byte) error
+	ReadDir(string) ([]os.FileInfo, error)
+	Stat(string) (os.FileInfo, error)
+	Lstat(string) (os.FileInfo, error)
+	Walk(string, filepath.WalkFunc) error
+	Readlink(string) (string, error)
+	Symlink(string, string) error
+	KeepSymlinks(bool)
+	ShouldKeepSymlinks() bool
+}
+
+// NewFileSystem creates a new instance of the default FileSystem
+// implementation
+func NewFileSystem() FileSystem {
+	return &fs{
+		fileModes:    make(map[string]os.FileMode),
+		keepSymlinks: false,
+	}
+}
+
+type fs struct {
+	// on Windows, fileModes is used to track the UNIX file mode of every file we
+	// work with; m is used to synchronize access to fileModes.
+	fileModes    map[string]os.FileMode
+	m            sync.Mutex
+	keepSymlinks bool
+}
+
+// FileInfo is a struct which implements os.FileInfo.  We use it (a) for test
+// purposes, and (b) because we enrich the FileMode on Windows systems
+type FileInfo struct {
+	FileName    string
+	FileSize    int64
+	FileMode    os.FileMode
+	FileModTime time.Time
+	FileIsDir   bool
+	FileSys     interface{}
+}
+
+// Name retuns the filename of fi
+func (fi *FileInfo) Name() string {
+	return fi.FileName
+}
+
+// Size returns the file size of fi
+func (fi *FileInfo) Size() int64 {
+	return fi.FileSize
+}
+
+// Mode returns the file mode of fi
+func (fi *FileInfo) Mode() os.FileMode {
+	return fi.FileMode
+}
+
+// ModTime returns the file modification time of fi
+func (fi *FileInfo) ModTime() time.Time {
+	return fi.FileModTime
+}
+
+// IsDir returns true if fi refers to a directory
+func (fi *FileInfo) IsDir() bool {
+	return fi.FileIsDir
+}
+
+// Sys returns the sys interface of fi
+func (fi *FileInfo) Sys() interface{} {
+	return fi.FileSys
+}
+
+func copyFileInfo(src os.FileInfo) *FileInfo {
+	return &FileInfo{
+		FileName:    src.Name(),
+		FileSize:    src.Size(),
+		FileMode:    src.Mode(),
+		FileModTime: src.ModTime(),
+		FileIsDir:   src.IsDir(),
+		FileSys:     src.Sys(),
+	}
+}
+
+// Stat returns a FileInfo describing the named file.
+func (h *fs) Stat(path string) (os.FileInfo, error) {
+	fi, err := os.Stat(path)
+	if runtime.GOOS == "windows" && err == nil {
+		fi = h.enrichFileInfo(path, fi)
+	}
+	return fi, err
+}
+
+// Lstat returns a FileInfo describing the named file (not following symlinks).
+func (h *fs) Lstat(path string) (os.FileInfo, error) {
+	fi, err := os.Lstat(path)
+	if runtime.GOOS == "windows" && err == nil {
+		fi = h.enrichFileInfo(path, fi)
+	}
+	return fi, err
+}
+
+// ReadDir reads the directory named by dirname and returns a list of directory
+// entries sorted by filename.
+func (h *fs) ReadDir(path string) ([]os.FileInfo, error) {
+	fis, err := ioutil.ReadDir(path)
+	if runtime.GOOS == "windows" && err == nil {
+		h.enrichFileInfos(path, fis)
+	}
+	return fis, err
+}
+
+// Chmod sets the file mode
+func (h *fs) Chmod(file string, mode os.FileMode) error {
+	err := os.Chmod(file, mode)
+	if runtime.GOOS == "windows" && err == nil {
+		h.m.Lock()
+		h.fileModes[file] = mode
+		h.m.Unlock()
+		return nil
+	}
+	return err
+}
+
+// Rename renames or moves a file
+func (h *fs) Rename(from, to string) error {
+	return os.Rename(from, to)
+}
+
+// MkdirAll creates the directory and all its parents
+func (h *fs) MkdirAll(dirname string) error {
+	return os.MkdirAll(dirname, 0700)
+}
+
+// MkdirAllWithPermissions creates the directory and all its parents with the provided permissions
+func (h *fs) MkdirAllWithPermissions(dirname string, perm os.FileMode) error {
+	return os.MkdirAll(dirname, perm)
+}
+
+// Mkdir creates the specified directory
+func (h *fs) Mkdir(dirname string) error {
+	return os.Mkdir(dirname, 0700)
+}
+
+// Exists determines whether the given file exists
+func (h *fs) Exists(file string) bool {
+	_, err := h.Stat(file)
+	return err == nil
+}
+
+// Copy copies the source to a destination.
+// If the source is a file, then the destination has to be a file as well,
+// otherwise you will get an error.
+// If the source is a directory, then the destination has to be a directory and
+// we copy the content of the source directory to destination directory
+// recursively.
+func (h *fs) Copy(source string, dest string, filesToIgnore map[string]string) (err error) {
+	return doCopy(h, source, dest, filesToIgnore)
+}
+
+// KeepSymlinks configures fs to copy symlinks from src as symlinks to dst.
+// Default behavior is to follow symlinks and copy files by content.
+func (h *fs) KeepSymlinks(k bool) {
+	h.keepSymlinks = k
+}
+
+// ShouldKeepSymlinks is exported only due to the design of fs util package
+// and how the tests are structured. It indicates whether the implementation
+// should copy symlinks as symlinks or follow symlinks and copy by content.
+func (h *fs) ShouldKeepSymlinks() bool {
+	return h.keepSymlinks
+}
+
+// If src is symlink and symlink copy has been enabled, copy as a symlink.
+// Otherwise ignore symlink and let rest of the code follow the symlink
+// and copy the content of the file
+func handleSymlink(h FileSystem, source, dest string) (bool, error) {
+	lstatinfo, lstaterr := h.Lstat(source)
+	_, staterr := h.Stat(source)
+	if lstaterr == nil &&
+		lstatinfo.Mode()&os.ModeSymlink != 0 {
+		if os.IsNotExist(staterr) {
+			log.V(5).Infof("(broken) L %q -> %q", source, dest)
+		} else if h.ShouldKeepSymlinks() {
+			log.V(5).Infof("L %q -> %q", source, dest)
+		} else {
+			// symlink not handled here, will copy the file content
+			return false, nil
+		}
+		linkdest, err := h.Readlink(source)
+		if err != nil {
+			return true, err
+		}
+		return true, h.Symlink(linkdest, dest)
+	}
+	// symlink not handled here, will copy the file content
+	return false, nil
+}
+
+func doCopy(h FileSystem, source, dest string, filesToIgnore map[string]string) error {
+	if handled, err := handleSymlink(h, source, dest); handled || err != nil {
+		return err
+	}
+	sourcefile, err := h.Open(source)
+	if err != nil {
+		return err
+	}
+	defer sourcefile.Close()
+	sourceinfo, err := h.Stat(source)
+	if err != nil {
+		return err
+	}
+
+	if sourceinfo.IsDir() {
+		_, ok := filesToIgnore[source]
+		if ok {
+			log.V(5).Infof("Directory %q ignored", source)
+			return nil
+		}
+		log.V(5).Infof("D %q -> %q", source, dest)
+		return h.CopyContents(source, dest, filesToIgnore)
+	}
+
+	destinfo, _ := h.Stat(dest)
+	if destinfo != nil && destinfo.IsDir() {
+		return fmt.Errorf("destination must be full path to a file, not directory")
+	}
+	destfile, err := h.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer destfile.Close()
+	_, ok := filesToIgnore[source]
+	if ok {
+		log.V(5).Infof("File %q ignored", source)
+		return nil
+	}
+	log.V(5).Infof("F %q -> %q", source, dest)
+	if _, err := io.Copy(destfile, sourcefile); err != nil {
+		return err
+	}
+
+	return h.Chmod(dest, sourceinfo.Mode())
+}
+
+// CopyContents copies the content of the source directory to a destination
+// directory.
+// If the destination directory does not exists, it will be created.
+// The source directory itself will not be copied, only its content. If you
+// want this behavior, the destination must include the source directory name.
+// It will skip any files provided in filesToIgnore from being copied
+func (h *fs) CopyContents(src string, dest string, filesToIgnore map[string]string) (err error) {
+	sourceinfo, err := h.Stat(src)
+	if err != nil {
+		return err
+	}
+	if err = os.MkdirAll(dest, sourceinfo.Mode()); err != nil {
+		return err
+	}
+	directory, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer directory.Close()
+	objects, err := directory.Readdir(-1)
+	if err != nil {
+		return err
+	}
+
+	for _, obj := range objects {
+		source := path.Join(src, obj.Name())
+		destination := path.Join(dest, obj.Name())
+		if err := h.Copy(source, destination, filesToIgnore); err != nil {
+			return err
+		}
+	}
+	return
+}
+
+// RemoveDirectory removes the specified directory and all its contents
+func (h *fs) RemoveDirectory(dir string) error {
+	log.V(2).Infof("Removing directory '%s'", dir)
+
+	// HACK: If deleting a directory in windows, call out to the system to do the deletion
+	// TODO: Remove this workaround when we switch to go 1.7 -- os.RemoveAll should
+	// be fixed for Windows in that release.  https://github.com/golang/go/issues/9606
+	if runtime.GOOS == "windows" {
+		command := exec.Command("cmd.exe", "/c", fmt.Sprintf("rd /s /q %s", dir))
+		output, err := command.Output()
+		if err != nil {
+			log.Errorf("Error removing directory %q: %v %s", dir, err, string(output))
+			return err
+		}
+		return nil
+	}
+
+	err := os.RemoveAll(dir)
+	if err != nil {
+		log.Errorf("Error removing directory '%s': %v", dir, err)
+	}
+	return err
+}
+
+// CreateWorkingDirectory creates a directory to be used for STI
+func (h *fs) CreateWorkingDirectory() (directory string, err error) {
+	directory, err = ioutil.TempDir("", "s2i")
+	if err != nil {
+		return "", s2ierr.NewWorkDirError(directory, err)
+	}
+
+	return directory, err
+}
+
+// Open opens a file and returns a ReadCloser interface to that file
+func (h *fs) Open(filename string) (io.ReadCloser, error) {
+	return os.Open(filename)
+}
+
+// Create creates a file and returns a WriteCloser interface to that file
+func (h *fs) Create(filename string) (io.WriteCloser, error) {
+	return os.Create(filename)
+}
+
+// WriteFile opens a file and writes data to it, returning error if such
+// occurred
+func (h *fs) WriteFile(filename string, data []byte) error {
+	return ioutil.WriteFile(filename, data, 0700)
+}
+
+// Walk walks the file tree rooted at root, calling walkFn for each file or
+// directory in the tree, including root.
+func (h *fs) Walk(root string, walkFn filepath.WalkFunc) error {
+	wrapper := func(path string, info os.FileInfo, err error) error {
+		if runtime.GOOS == "windows" && err == nil {
+			info = h.enrichFileInfo(path, info)
+		}
+		return walkFn(path, info, err)
+	}
+	return filepath.Walk(root, wrapper)
+}
+
+// enrichFileInfo is used on Windows.  It takes an os.FileInfo object, e.g. as
+// returned by os.Stat, and enriches the OS-returned file mode with the "real"
+// UNIX file mode, if we know what it is.
+func (h *fs) enrichFileInfo(path string, fi os.FileInfo) os.FileInfo {
+	h.m.Lock()
+	if mode, ok := h.fileModes[path]; ok {
+		fi = copyFileInfo(fi)
+		fi.(*FileInfo).FileMode = mode
+	}
+	h.m.Unlock()
+	return fi
+}
+
+// enrichFileInfos is used on Windows.  It takes an array of os.FileInfo
+// objects, e.g. as returned by os.ReadDir, and for each file enriches the OS-
+// returned file mode with the "real" UNIX file mode, if we know what it is.
+func (h *fs) enrichFileInfos(root string, fis []os.FileInfo) {
+	h.m.Lock()
+	for i := range fis {
+		if mode, ok := h.fileModes[filepath.Join(root, fis[i].Name())]; ok {
+			fis[i] = copyFileInfo(fis[i])
+			fis[i].(*FileInfo).FileMode = mode
+		}
+	}
+	h.m.Unlock()
+}
+
+// Readlink reads the destination of a symlink
+func (h *fs) Readlink(name string) (string, error) {
+	return os.Readlink(name)
+}
+
+// Symlink creates a symlink at newname, pointing to oldname
+func (h *fs) Symlink(oldname, newname string) error {
+	return os.Symlink(oldname, newname)
+}

--- a/pkg/build/source-to-image/fs/fs_test.go
+++ b/pkg/build/source-to-image/fs/fs_test.go
@@ -1,0 +1,99 @@
+package fs
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	testfs "github.com/openshift/library-go/pkg/build/source-to-image/fs/test"
+)
+
+func helper(t *testing.T, keepSymlinks bool) {
+	sep := string(filepath.Separator)
+
+	// test plain file copy
+	fake := &testfs.FakeFileSystem{
+		Files: []os.FileInfo{
+			&FileInfo{FileName: "file", FileMode: 0600},
+		},
+		OpenContent: "test",
+	}
+	fake.KeepSymlinks(keepSymlinks)
+	err := doCopy(fake, sep+"file", sep+"dest", nil)
+	if err != nil {
+		t.Error(err)
+	}
+	if fake.CreateFile != sep+"dest" {
+		t.Error(fake.CreateFile)
+	}
+	if fake.CreateContent.String() != "test" {
+		t.Error(fake.CreateContent.String())
+	}
+	if !reflect.DeepEqual(fake.ChmodFile, []string{sep + "dest"}) {
+		t.Error(fake.ChmodFile)
+	}
+	if fake.ChmodMode != 0600 {
+		t.Error(fake.ChmodMode)
+	}
+
+	// test broken symlink copy
+	fake = &testfs.FakeFileSystem{
+		Files: []os.FileInfo{
+			&FileInfo{FileName: "link", FileMode: os.ModeSymlink},
+		},
+		ReadlinkName: sep + "linkdest",
+	}
+	fake.KeepSymlinks(keepSymlinks)
+	err = doCopy(fake, sep+"link", sep+"dest", nil)
+	if err != nil {
+		t.Error(err)
+	}
+	if fake.SymlinkNewname != sep+"dest" {
+		t.Error(fake.SymlinkNewname)
+	}
+	if fake.SymlinkOldname != sep+"linkdest" {
+		t.Error(fake.SymlinkOldname)
+	}
+
+	// test non-broken symlink copy
+	fake = &testfs.FakeFileSystem{
+		Files: []os.FileInfo{
+			&FileInfo{FileName: "file", FileMode: 0600},
+			&FileInfo{FileName: "link", FileMode: os.ModeSymlink},
+		},
+		OpenContent:  "test",
+		ReadlinkName: sep + "file",
+	}
+	fake.KeepSymlinks(keepSymlinks)
+	err = doCopy(fake, sep+"link", sep+"dest", nil)
+	if err != nil {
+		t.Error(err)
+	}
+	if keepSymlinks {
+		if fake.SymlinkNewname != sep+"dest" {
+			t.Error(fake.SymlinkNewname)
+		}
+	} else {
+		if fake.CreateFile != sep+"dest" {
+			t.Error(fake.CreateFile)
+		}
+		if fake.CreateContent.String() != "test" {
+			t.Error(fake.CreateContent.String())
+		}
+		if !reflect.DeepEqual(fake.ChmodFile, []string{sep + "dest"}) {
+			t.Error(fake.ChmodFile)
+		}
+		if fake.ChmodMode != 0600 {
+			t.Error(fake.ChmodMode)
+		}
+	}
+}
+
+func TestCopy(t *testing.T) {
+	helper(t, false)
+}
+
+func TestCopyKeepSymlinks(t *testing.T) {
+	helper(t, true)
+}

--- a/pkg/build/source-to-image/fs/test/fs.go
+++ b/pkg/build/source-to-image/fs/test/fs.go
@@ -1,0 +1,242 @@
+package test
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// FakeFileSystem provides a fake filesystem structure for testing
+type FakeFileSystem struct {
+	ChmodFile  []string
+	ChmodMode  os.FileMode
+	ChmodError map[string]error
+
+	RenameFrom  string
+	RenameTo    string
+	RenameError error
+
+	MkdirAllDir   []string
+	MkdirAllError error
+
+	MkdirDir   string
+	MkdirError error
+
+	ExistsFile   []string
+	ExistsResult map[string]bool
+
+	CopySource string
+	CopyDest   string
+	CopyError  error
+
+	FilesToIgnore map[string]string
+
+	RemoveDirName  string
+	RemoveDirError error
+
+	WorkingDirCalled bool
+	WorkingDirResult string
+	WorkingDirError  error
+
+	OpenFile       string
+	OpenFileResult *FakeReadCloser
+	OpenContent    string
+	OpenError      error
+	OpenCloseError error
+
+	CreateFile    string
+	CreateContent FakeWriteCloser
+	CreateError   error
+
+	WriteFileName    string
+	WriteFileError   error
+	WriteFileContent string
+
+	ReadlinkName  string
+	ReadlinkError error
+
+	SymlinkOldname string
+	SymlinkNewname string
+	SymlinkError   error
+
+	Files []os.FileInfo
+
+	mutex        sync.Mutex
+	keepSymlinks bool
+}
+
+// FakeReadCloser provider a fake ReadCloser
+type FakeReadCloser struct {
+	*bytes.Buffer
+	CloseCalled bool
+	CloseError  error
+}
+
+// Close closes the fake ReadCloser
+func (f *FakeReadCloser) Close() error {
+	f.CloseCalled = true
+	return f.CloseError
+}
+
+// FakeWriteCloser provider a fake ReadCloser
+type FakeWriteCloser struct {
+	bytes.Buffer
+}
+
+// Close closes the fake ReadCloser
+func (f *FakeWriteCloser) Close() error {
+	return nil
+}
+
+// ReadDir reads the files in specified directory
+func (f *FakeFileSystem) ReadDir(p string) ([]os.FileInfo, error) {
+	return f.Files, nil
+}
+
+// Lstat provides stats about a single file  (not following symlinks)
+func (f *FakeFileSystem) Lstat(p string) (os.FileInfo, error) {
+	for _, f := range f.Files {
+		if strings.HasSuffix(p, string(filepath.Separator)+f.Name()) {
+			return f, nil
+		}
+	}
+	return nil, &os.PathError{Path: p, Err: os.ErrNotExist}
+}
+
+// Stat returns a FileInfo describing the named file
+func (f *FakeFileSystem) Stat(p string) (os.FileInfo, error) {
+	fi, err := f.Lstat(p)
+	if err != nil || fi.Mode()&os.ModeSymlink == 0 {
+		return fi, err
+	}
+	p, err = f.Readlink(p)
+	if err != nil {
+		return nil, err
+	}
+	return f.Lstat(p)
+}
+
+// Chmod manipulates permissions on the fake filesystem
+func (f *FakeFileSystem) Chmod(file string, mode os.FileMode) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+	f.ChmodFile = append(f.ChmodFile, file)
+	f.ChmodMode = mode
+
+	return f.ChmodError[file]
+}
+
+// Rename renames files on the fake filesystem
+func (f *FakeFileSystem) Rename(from, to string) error {
+	f.RenameFrom = from
+	f.RenameTo = to
+	return f.RenameError
+}
+
+// MkdirAll creates a new directories on the fake filesystem
+func (f *FakeFileSystem) MkdirAll(dirname string) error {
+	f.MkdirAllDir = append(f.MkdirAllDir, dirname)
+	return f.MkdirAllError
+}
+
+// MkdirAllWithPermissions creates a new directories on the fake filesystem
+func (f *FakeFileSystem) MkdirAllWithPermissions(dirname string, perm os.FileMode) error {
+	f.MkdirAllDir = append(f.MkdirAllDir, dirname)
+	return f.MkdirAllError
+}
+
+// Mkdir creates a new directory on the fake filesystem
+func (f *FakeFileSystem) Mkdir(dirname string) error {
+	f.MkdirDir = dirname
+	return f.MkdirError
+}
+
+// Exists checks if the file exists in fake filesystem
+func (f *FakeFileSystem) Exists(file string) bool {
+	f.ExistsFile = append(f.ExistsFile, file)
+	return f.ExistsResult[file]
+}
+
+// Copy copies files on the fake filesystem
+func (f *FakeFileSystem) Copy(sourcePath, targetPath string, filesToIgnore map[string]string) error {
+	f.CopySource = sourcePath
+	f.CopyDest = targetPath
+	f.FilesToIgnore = filesToIgnore
+	return f.CopyError
+}
+
+// CopyContents copies directory contents on the fake filesystem
+func (f *FakeFileSystem) CopyContents(sourcePath, targetPath string, filesToIgnore map[string]string) error {
+	f.CopySource = sourcePath
+	f.CopyDest = targetPath
+	f.FilesToIgnore = filesToIgnore
+	return f.CopyError
+}
+
+// RemoveDirectory removes a directory in the fake filesystem
+func (f *FakeFileSystem) RemoveDirectory(dir string) error {
+	f.RemoveDirName = dir
+	return f.RemoveDirError
+}
+
+// CreateWorkingDirectory creates a fake working directory
+func (f *FakeFileSystem) CreateWorkingDirectory() (string, error) {
+	f.WorkingDirCalled = true
+	return f.WorkingDirResult, f.WorkingDirError
+}
+
+// Open opens a file
+func (f *FakeFileSystem) Open(file string) (io.ReadCloser, error) {
+	f.OpenFile = file
+	buf := bytes.NewBufferString(f.OpenContent)
+	f.OpenFileResult = &FakeReadCloser{
+		Buffer:     buf,
+		CloseError: f.OpenCloseError,
+	}
+	return f.OpenFileResult, f.OpenError
+}
+
+// Create creates a file
+func (f *FakeFileSystem) Create(file string) (io.WriteCloser, error) {
+	f.CreateFile = file
+	return &f.CreateContent, f.CreateError
+}
+
+// WriteFile writes a file
+func (f *FakeFileSystem) WriteFile(file string, data []byte) error {
+	f.WriteFileName = file
+	f.WriteFileContent = string(data)
+	return f.WriteFileError
+}
+
+// Walk walks the file tree rooted at root, calling walkFn for each file or
+// directory in the tree, including root.
+func (f *FakeFileSystem) Walk(root string, walkFn filepath.WalkFunc) error {
+	return filepath.Walk(root, walkFn)
+}
+
+// Readlink reads the destination of a symlink
+func (f *FakeFileSystem) Readlink(name string) (string, error) {
+	return f.ReadlinkName, f.ReadlinkError
+}
+
+// Symlink creates a symlink at newname, pointing to oldname
+func (f *FakeFileSystem) Symlink(oldname, newname string) error {
+	f.SymlinkOldname, f.SymlinkNewname = oldname, newname
+	return f.SymlinkError
+}
+
+// KeepSymlinks controls whether to handle symlinks as symlinks or follow
+// symlinks and copy files with content
+func (f *FakeFileSystem) KeepSymlinks(k bool) {
+	f.keepSymlinks = k
+}
+
+// ShouldKeepSymlinks informs whether to handle symlinks as symlinks or follow
+// symlinks and copy files by content
+func (f *FakeFileSystem) ShouldKeepSymlinks() bool {
+	return f.keepSymlinks
+}

--- a/pkg/build/source-to-image/git/git.go
+++ b/pkg/build/source-to-image/git/git.go
@@ -1,0 +1,317 @@
+package git
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/openshift/library-go/pkg/build/source-to-image/cmd"
+	"github.com/openshift/library-go/pkg/build/source-to-image/cygpath"
+	"github.com/openshift/library-go/pkg/build/source-to-image/fs"
+
+	utillog "github.com/openshift/library-go/pkg/build/source-to-image/log"
+)
+
+var log = utillog.StderrLog
+var lsTreeRegexp = regexp.MustCompile("([0-7]{6}) [^ ]+ [0-9a-f]{40}\t(.*)")
+
+// Git is an interface used by main STI code to extract/checkout git repositories
+type Git interface {
+	Clone(source *URL, target string, opts CloneConfig) error
+	Checkout(repo, ref string) error
+	SubmoduleUpdate(repo string, init, recursive bool) error
+	LsTree(repo, ref string, recursive bool) ([]os.FileInfo, error)
+	GetInfo(string) *SourceInfo
+}
+
+// New returns a new instance of the default implementation of the Git interface
+func New(fs fs.FileSystem, runner cmd.CommandRunner) Git {
+	return &stiGit{
+		FileSystem:    fs,
+		CommandRunner: runner,
+	}
+}
+
+type stiGit struct {
+	fs.FileSystem
+	cmd.CommandRunner
+}
+
+func cloneConfigToArgs(opts CloneConfig) []string {
+	result := []string{}
+	if opts.Quiet {
+		result = append(result, "--quiet")
+	}
+	if opts.Recursive {
+		result = append(result, "--recursive")
+	}
+	return result
+}
+
+// followGitSubmodule looks at a .git /file/ and tries to retrieve from inside
+// it the gitdir value, which is supposed to indicate the location of the
+// corresponding .git /directory/.  Note: the gitdir value should point directly
+// to the corresponding .git directory even in the case of nested submodules.
+func followGitSubmodule(fs fs.FileSystem, gitPath string) (string, error) {
+	f, err := os.Open(gitPath)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	sc := bufio.NewScanner(f)
+	if sc.Scan() {
+		s := sc.Text()
+
+		if strings.HasPrefix(s, "gitdir: ") {
+			newGitPath := s[8:]
+
+			if !filepath.IsAbs(newGitPath) {
+				newGitPath = filepath.Join(filepath.Dir(gitPath), newGitPath)
+			}
+
+			fi, err := fs.Stat(newGitPath)
+			if err != nil && !os.IsNotExist(err) {
+				return "", err
+			}
+			if os.IsNotExist(err) || !fi.IsDir() {
+				return "", fmt.Errorf("gitdir link in .git file %q is invalid", gitPath)
+			}
+			return newGitPath, nil
+		}
+	}
+
+	return "", fmt.Errorf("unable to parse .git file %q", gitPath)
+}
+
+// IsLocalNonBareGitRepository returns true if dir hosts a non-bare git
+// repository, i.e. it contains a ".git" subdirectory or file (submodule case).
+func IsLocalNonBareGitRepository(fs fs.FileSystem, dir string) (bool, error) {
+	_, err := fs.Stat(filepath.Join(dir, ".git"))
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// LocalNonBareGitRepositoryIsEmpty returns true if the non-bare git repository
+// at dir has no refs or objects.  It also handles the case of dir being a
+// checked out git submodule.
+func LocalNonBareGitRepositoryIsEmpty(fs fs.FileSystem, dir string) (bool, error) {
+	gitPath := filepath.Join(dir, ".git")
+
+	fi, err := fs.Stat(gitPath)
+	if err != nil {
+		return false, err
+	}
+
+	if !fi.IsDir() {
+		gitPath, err = followGitSubmodule(fs, gitPath)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	// Search for any file in .git/{objects,refs}.  We don't just search the
+	// base .git directory because of the hook samples that are normally
+	// generated with `git init`
+	found := false
+	for _, dir := range []string{"objects", "refs"} {
+		err := fs.Walk(filepath.Join(gitPath, dir), func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+
+			if !info.IsDir() {
+				found = true
+			}
+
+			if found {
+				return filepath.SkipDir
+			}
+
+			return nil
+		})
+
+		if err != nil {
+			return false, err
+		}
+
+		if found {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+// HasGitBinary checks if the 'git' binary is available on the system
+func HasGitBinary() bool {
+	_, err := exec.LookPath("git")
+	return err == nil
+}
+
+// Clone clones a git repository to a specific target directory.
+func (h *stiGit) Clone(src *URL, target string, c CloneConfig) error {
+	var err error
+
+	source := *src
+
+	if cygpath.UsingCygwinGit {
+		if source.IsLocal() {
+			source.URL.Path, err = cygpath.ToSlashCygwin(source.LocalPath())
+			if err != nil {
+				return err
+			}
+		}
+
+		target, err = cygpath.ToSlashCygwin(target)
+		if err != nil {
+			return err
+		}
+	}
+
+	cloneArgs := append([]string{"clone"}, cloneConfigToArgs(c)...)
+	cloneArgs = append(cloneArgs, []string{source.StringNoFragment(), target}...)
+	stderr := &bytes.Buffer{}
+	opts := cmd.CommandOpts{Stderr: stderr}
+	err = h.RunWithOptions(opts, "git", cloneArgs...)
+	if err != nil {
+		log.Errorf("Clone failed: source %s, target %s, with output %q", source, target, stderr.String())
+		return err
+	}
+	return nil
+}
+
+// Checkout checks out a specific branch reference of a given git repository
+func (h *stiGit) Checkout(repo, ref string) error {
+	opts := cmd.CommandOpts{
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+		Dir:    repo,
+	}
+	if log.Is(1) {
+		return h.RunWithOptions(opts, "git", "checkout", "--quiet", ref)
+	}
+	return h.RunWithOptions(opts, "git", "checkout", ref)
+}
+
+// SubmoduleInit initializes/clones submodules
+func (h *stiGit) SubmoduleInit(repo string) error {
+	opts := cmd.CommandOpts{
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+		Dir:    repo,
+	}
+	return h.RunWithOptions(opts, "git", "submodule", "init")
+}
+
+// SubmoduleUpdate checks out submodules to their correct version.
+// Optionally also inits submodules, optionally operates recursively.
+func (h *stiGit) SubmoduleUpdate(repo string, init, recursive bool) error {
+	updateArgs := []string{"submodule", "update"}
+	if init {
+		updateArgs = append(updateArgs, "--init")
+	}
+	if recursive {
+		updateArgs = append(updateArgs, "--recursive")
+	}
+
+	opts := cmd.CommandOpts{
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+		Dir:    repo,
+	}
+	return h.RunWithOptions(opts, "git", updateArgs...)
+}
+
+// LsTree returns a slice of os.FileInfo objects populated with the paths and
+// file modes of files known to Git.  This is used on Windows systems where the
+// executable mode metadata is lost on git checkout.
+func (h *stiGit) LsTree(repo, ref string, recursive bool) ([]os.FileInfo, error) {
+	args := []string{"ls-tree", ref}
+	if recursive {
+		args = append(args, "-r")
+	}
+
+	opts := cmd.CommandOpts{
+		Dir: repo,
+	}
+
+	r, err := h.StartWithStdoutPipe(opts, "git", args...)
+	if err != nil {
+		return nil, err
+	}
+
+	submodules := []string{}
+	rv := []os.FileInfo{}
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		text := scanner.Text()
+		m := lsTreeRegexp.FindStringSubmatch(text)
+		if m == nil {
+			return nil, fmt.Errorf("unparsable response %q from git ls-files", text)
+		}
+		mode, _ := strconv.ParseInt(m[1], 8, 0)
+		path := m[2]
+		if recursive && mode == 0160000 { // S_IFGITLINK
+			submodules = append(submodules, filepath.Join(repo, path))
+			continue
+		}
+		rv = append(rv, &fs.FileInfo{FileMode: os.FileMode(mode), FileName: path})
+	}
+	err = scanner.Err()
+	if err != nil {
+		h.Wait()
+		return nil, err
+	}
+
+	err = h.Wait()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, submodule := range submodules {
+		rrv, err := h.LsTree(submodule, "HEAD", recursive)
+		if err != nil {
+			return nil, err
+		}
+		rv = append(rv, rrv...)
+	}
+
+	return rv, nil
+}
+
+// GetInfo retrieves the information about the source code and commit
+func (h *stiGit) GetInfo(repo string) *SourceInfo {
+	git := func(arg ...string) string {
+		command := exec.Command("git", arg...)
+		command.Dir = repo
+		out, err := command.CombinedOutput()
+		if err != nil {
+			log.V(1).Infof("Error executing 'git %#v': %s (%v)", arg, out, err)
+			return ""
+		}
+		return strings.TrimSpace(string(out))
+	}
+	return &SourceInfo{
+		Location:       git("config", "--get", "remote.origin.url"),
+		Ref:            git("rev-parse", "--abbrev-ref", "HEAD"),
+		CommitID:       git("rev-parse", "--verify", "HEAD"),
+		AuthorName:     git("--no-pager", "show", "-s", "--format=%an", "HEAD"),
+		AuthorEmail:    git("--no-pager", "show", "-s", "--format=%ae", "HEAD"),
+		CommitterName:  git("--no-pager", "show", "-s", "--format=%cn", "HEAD"),
+		CommitterEmail: git("--no-pager", "show", "-s", "--format=%ce", "HEAD"),
+		Date:           git("--no-pager", "show", "-s", "--format=%ad", "HEAD"),
+		Message:        git("--no-pager", "show", "-s", "--format=%<(80,trunc)%s", "HEAD"),
+	}
+}

--- a/pkg/build/source-to-image/git/git_test.go
+++ b/pkg/build/source-to-image/git/git_test.go
@@ -1,0 +1,131 @@
+package git
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	testcmd "github.com/openshift/library-go/pkg/build/source-to-image/cmd/test"
+	"github.com/openshift/library-go/pkg/build/source-to-image/fs"
+	testfs "github.com/openshift/library-go/pkg/build/source-to-image/fs/test"
+)
+
+func TestIsValidGitRepository(t *testing.T) {
+	fileSystem := fs.NewFileSystem()
+
+	// a local git repo with a commit
+	d, err := CreateLocalGitDirectory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(d)
+
+	ok, err := IsLocalNonBareGitRepository(fileSystem, d)
+	if !ok || err != nil {
+		t.Errorf("IsLocalNonBareGitRepository returned %v, %v", ok, err)
+	}
+	empty, err := LocalNonBareGitRepositoryIsEmpty(fileSystem, d)
+	if empty || err != nil {
+		t.Errorf("LocalNonBareGitRepositoryIsEmpty returned %v, %v", ok, err)
+	}
+
+	// a local git repo with no commit
+	d, err = CreateEmptyLocalGitDirectory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(d)
+
+	ok, err = IsLocalNonBareGitRepository(fileSystem, d)
+	if !ok || err != nil {
+		t.Errorf("IsLocalNonBareGitRepository returned %v, %v", ok, err)
+	}
+	empty, err = LocalNonBareGitRepositoryIsEmpty(fileSystem, d)
+	if !empty || err != nil {
+		t.Errorf("LocalNonBareGitRepositoryIsEmpty returned %v, %v", ok, err)
+	}
+
+	// a directory which is not a git repo
+	d = filepath.Join(d, ".git")
+
+	ok, err = IsLocalNonBareGitRepository(fileSystem, d)
+	if ok || err != nil {
+		t.Errorf("IsLocalNonBareGitRepository returned %v, %v", ok, err)
+	}
+
+	// a submodule git repo with a commit
+	d, err = CreateLocalGitDirectoryWithSubmodule()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(d)
+
+	ok, err = IsLocalNonBareGitRepository(fileSystem, filepath.Join(d, "submodule"))
+	if !ok || err != nil {
+		t.Errorf("IsLocalNonBareGitRepository returned %v, %v", ok, err)
+	}
+	empty, err = LocalNonBareGitRepositoryIsEmpty(fileSystem, filepath.Join(d, "submodule"))
+	if empty || err != nil {
+		t.Errorf("LocalNonBareGitRepositoryIsEmpty returned %v, %v", ok, err)
+	}
+}
+
+func getGit() (Git, *testcmd.FakeCmdRunner) {
+	cr := &testcmd.FakeCmdRunner{}
+	gh := New(&testfs.FakeFileSystem{}, cr)
+
+	return gh, cr
+}
+
+func TestGitClone(t *testing.T) {
+	gh, ch := getGit()
+	err := gh.Clone(MustParse("source1"), "target1", CloneConfig{Quiet: true, Recursive: true})
+	if err != nil {
+		t.Errorf("Unexpected error returned from clone: %v", err)
+	}
+	if ch.Name != "git" {
+		t.Errorf("Unexpected command name: %q", ch.Name)
+	}
+	if !reflect.DeepEqual(ch.Args, []string{"clone", "--quiet", "--recursive", "source1", "target1"}) {
+		t.Errorf("Unexpected command arguments: %#v", ch.Args)
+	}
+}
+
+func TestGitCloneError(t *testing.T) {
+	gh, ch := getGit()
+	runErr := fmt.Errorf("Run Error")
+	ch.Err = runErr
+	err := gh.Clone(MustParse("source1"), "target1", CloneConfig{})
+	if err != runErr {
+		t.Errorf("Unexpected error returned from clone: %v", err)
+	}
+}
+
+func TestGitCheckout(t *testing.T) {
+	gh, ch := getGit()
+	err := gh.Checkout("repo1", "ref1")
+	if err != nil {
+		t.Errorf("Unexpected error returned from checkout: %v", err)
+	}
+	if ch.Name != "git" {
+		t.Errorf("Unexpected command name: %q", ch.Name)
+	}
+	if !reflect.DeepEqual(ch.Args, []string{"checkout", "--quiet", "ref1"}) {
+		t.Errorf("Unexpected command arguments: %#v", ch.Args)
+	}
+	if ch.Opts.Dir != "repo1" {
+		t.Errorf("Unexpected value in exec directory: %q", ch.Opts.Dir)
+	}
+}
+
+func TestGitCheckoutError(t *testing.T) {
+	gh, ch := getGit()
+	runErr := fmt.Errorf("Run Error")
+	ch.Err = runErr
+	err := gh.Checkout("repo1", "ref1")
+	if err != runErr {
+		t.Errorf("Unexpected error returned from checkout: %v", err)
+	}
+}

--- a/pkg/build/source-to-image/git/testhelpers.go
+++ b/pkg/build/source-to-image/git/testhelpers.go
@@ -1,0 +1,86 @@
+package git
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/openshift/library-go/pkg/build/source-to-image/cmd"
+	"github.com/openshift/library-go/pkg/build/source-to-image/cygpath"
+)
+
+// CreateLocalGitDirectory creates a git directory with a commit
+func CreateLocalGitDirectory() (string, error) {
+	cr := cmd.NewCommandRunner()
+
+	dir, err := CreateEmptyLocalGitDirectory()
+	if err != nil {
+		return "", err
+	}
+
+	f, err := os.Create(filepath.Join(dir, "testfile"))
+	if err != nil {
+		return "", err
+	}
+	f.Close()
+
+	err = cr.RunWithOptions(cmd.CommandOpts{Dir: dir}, "git", "add", ".")
+	if err != nil {
+		return "", err
+	}
+
+	err = cr.RunWithOptions(cmd.CommandOpts{Dir: dir, EnvAppend: []string{"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test", "GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test"}}, "git", "commit", "-m", "testcommit")
+	if err != nil {
+		return "", err
+	}
+
+	return dir, nil
+}
+
+// CreateEmptyLocalGitDirectory creates a git directory with no checkin yet
+func CreateEmptyLocalGitDirectory() (string, error) {
+	cr := cmd.NewCommandRunner()
+
+	dir, err := ioutil.TempDir(os.TempDir(), "gitdir-s2i-test")
+	if err != nil {
+		return "", err
+	}
+
+	err = cr.RunWithOptions(cmd.CommandOpts{Dir: dir}, "git", "init")
+	if err != nil {
+		return "", err
+	}
+
+	return dir, nil
+}
+
+// CreateLocalGitDirectoryWithSubmodule creates a git directory with a submodule
+func CreateLocalGitDirectoryWithSubmodule() (string, error) {
+	cr := cmd.NewCommandRunner()
+
+	submodule, err := CreateLocalGitDirectory()
+	if err != nil {
+		return "", err
+	}
+	defer os.RemoveAll(submodule)
+
+	if cygpath.UsingCygwinGit {
+		var err error
+		submodule, err = cygpath.ToSlashCygwin(submodule)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	dir, err := CreateEmptyLocalGitDirectory()
+	if err != nil {
+		return "", err
+	}
+
+	err = cr.RunWithOptions(cmd.CommandOpts{Dir: dir}, "git", "submodule", "add", submodule, "submodule")
+	if err != nil {
+		return "", err
+	}
+
+	return dir, nil
+}

--- a/pkg/build/source-to-image/git/types.go
+++ b/pkg/build/source-to-image/git/types.go
@@ -1,0 +1,51 @@
+package git
+
+// CloneConfig specifies the options used when cloning the application source
+// code.
+type CloneConfig struct {
+	Recursive bool
+	Quiet     bool
+}
+
+// SourceInfo stores information about the source code
+type SourceInfo struct {
+	// Ref represents a commit SHA-1, valid Git branch name or a Git tag
+	// The output image will contain this information as 'io.openshift.build.commit.ref' label.
+	Ref string
+
+	// CommitID represents an arbitrary extended object reference in Git as SHA-1
+	// The output image will contain this information as 'io.openshift.build.commit.id' label.
+	CommitID string
+
+	// Date contains a date when the committer created the commit.
+	// The output image will contain this information as 'io.openshift.build.commit.date' label.
+	Date string
+
+	// AuthorName contains the name of the author
+	// The output image will contain this information (along with AuthorEmail) as 'io.openshift.build.commit.author' label.
+	AuthorName string
+
+	// AuthorEmail contains the e-mail of the author
+	// The output image will contain this information (along with AuthorName) as 'io.openshift.build.commit.author' lablel.
+	AuthorEmail string
+
+	// CommitterName contains the name of the committer
+	CommitterName string
+
+	// CommitterEmail contains the e-mail of the committer
+	CommitterEmail string
+
+	// Message represents the first 80 characters from the commit message.
+	// The output image will contain this information as 'io.openshift.build.commit.message' label.
+	Message string
+
+	// Location contains a valid URL to the original repository.
+	// The output image will contain this information as 'io.openshift.build.source-location' label.
+	Location string
+
+	// ContextDir contains path inside the Location directory that
+	// contains the application source code.
+	// The output image will contain this information as 'io.openshift.build.source-context-dir'
+	// label.
+	ContextDir string
+}

--- a/pkg/build/source-to-image/git/url.go
+++ b/pkg/build/source-to-image/git/url.go
@@ -1,0 +1,194 @@
+package git
+
+import (
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+)
+
+// According to git-clone(1), a "Git URL" can be in one of three broad types:
+// 1) A standards-compliant URL.
+//    a) The scheme may be followed by '://',
+//       e.g. https://github.com/openshift/origin, file:///foo/bar, etc.  In
+//       this case, note that among other things, a standards-compliant file URL
+//       must have an empty host part, an absolute path and no backslashes.  The
+//       Git for Windows URL parser accepts many non-compliant URLs, but we
+//       don't.
+//    b) Alternatively, the scheme may be followed by '::', in which case it is
+//       treated as an transport/opaque address pair, e.g.
+//       http::http://github.com/openshift/origin.git .
+// 2) The "alternative scp-like syntax", including a ':' with no preceding '/',
+//    but not of the form C:... on Windows, e.g.
+//    git@github.com:openshift/origin, etc.
+// 3) An OS-specific relative or absolute local file path, e.g. foo/bar,
+//    C:\foo\bar, etc.
+//
+// We extend all of the above URL types to additionally accept an optional
+// appended #fragment, which is given to specify a git reference.
+//
+// The git client allows Git URL rewriting rules to be defined.  The meaning of
+// a Git URL cannot be 100% guaranteed without consulting the rewriting rules.
+
+// URLType indicates the type of the URL (see above)
+type URLType int
+
+const (
+	// URLTypeURL is the URL type (see above)
+	URLTypeURL URLType = iota
+	// URLTypeSCP is the SCP type (see above)
+	URLTypeSCP
+	// URLTypeLocal is the local type (see above)
+	URLTypeLocal
+)
+
+// String returns a string representation of the URLType
+func (t URLType) String() string {
+	switch t {
+	case URLTypeURL:
+		return "URLTypeURL"
+	case URLTypeSCP:
+		return "URLTypeSCP"
+	case URLTypeLocal:
+		return "URLTypeLocal"
+	}
+	panic("unknown URLType")
+}
+
+// GoString returns a Go string representation of the URLType
+func (t URLType) GoString() string {
+	return t.String()
+}
+
+// URL represents a "Git URL"
+type URL struct {
+	URL  url.URL
+	Type URLType
+}
+
+var urlSchemeRegexp = regexp.MustCompile("(?i)^[a-z][-a-z0-9+.]*:") // matches scheme: according to RFC3986
+var dosDriveRegexp = regexp.MustCompile("(?i)^[a-z]:")
+var scpRegexp = regexp.MustCompile("^" +
+	"(?:([^@/]*)@)?" + // user@ (optional)
+	"([^/]*):" + //            host:
+	"(.*)" + //                     path
+	"$")
+
+func splitOnByte(s string, c byte) (string, string) {
+	if i := strings.IndexByte(s, c); i != -1 {
+		return s[:i], s[i+1:]
+	}
+	return s, ""
+}
+
+// Parse parses a "Git URL"
+func Parse(rawurl string) (*URL, error) {
+	if urlSchemeRegexp.MatchString(rawurl) &&
+		(runtime.GOOS != "windows" || !dosDriveRegexp.MatchString(rawurl)) {
+		u, err := url.Parse(rawurl)
+		if err != nil {
+			return nil, err
+		}
+		if u.Scheme == "file" && u.Opaque == "" {
+			if u.Host != "" {
+				return nil, fmt.Errorf("file url %q has non-empty host %q", rawurl, u.Host)
+			}
+			if runtime.GOOS == "windows" && (len(u.Path) == 0 || !filepath.IsAbs(u.Path[1:])) {
+				return nil, fmt.Errorf("file url %q has non-absolute path %q", rawurl, u.Path)
+			}
+		}
+
+		return &URL{
+			URL:  *u,
+			Type: URLTypeURL,
+		}, nil
+	}
+
+	s, fragment := splitOnByte(rawurl, '#')
+
+	if m := scpRegexp.FindStringSubmatch(s); m != nil &&
+		(runtime.GOOS != "windows" || !dosDriveRegexp.MatchString(s)) {
+		u := &url.URL{
+			Host:     m[2],
+			Path:     m[3],
+			Fragment: fragment,
+		}
+		if m[1] != "" {
+			u.User = url.User(m[1])
+		}
+
+		return &URL{
+			URL:  *u,
+			Type: URLTypeSCP,
+		}, nil
+	}
+
+	return &URL{
+		URL: url.URL{
+			Path:     s,
+			Fragment: fragment,
+		},
+		Type: URLTypeLocal,
+	}, nil
+}
+
+// MustParse parses a "Git URL" and panics on failure
+func MustParse(rawurl string) *URL {
+	u, err := Parse(rawurl)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}
+
+// String returns a string representation of the URL
+func (u URL) String() string {
+	var s string
+	switch u.Type {
+	case URLTypeURL:
+		return u.URL.String()
+	case URLTypeSCP:
+		if u.URL.User != nil {
+			s = u.URL.User.Username() + "@"
+		}
+		s += u.URL.Host + ":" + u.URL.Path
+	case URLTypeLocal:
+		s = u.URL.Path
+	}
+	if u.URL.RawQuery != "" {
+		s += "?" + u.URL.RawQuery
+	}
+	if u.URL.Fragment != "" {
+		s += "#" + u.URL.Fragment
+	}
+	return s
+}
+
+// StringNoFragment returns a string representation of the URL without its
+// fragment
+func (u URL) StringNoFragment() string {
+	u.URL.Fragment = ""
+	return u.String()
+}
+
+// IsLocal returns true if the Git URL refers to a local repository
+func (u URL) IsLocal() bool {
+	return u.Type == URLTypeLocal || (u.Type == URLTypeURL && u.URL.Scheme == "file" && u.URL.Opaque == "")
+}
+
+// LocalPath returns the path to a local repository in OS-native format.  It is
+// assumed that IsLocal() is true
+func (u URL) LocalPath() string {
+	switch {
+	case u.Type == URLTypeLocal:
+		return u.URL.Path
+	case u.Type == URLTypeURL && u.URL.Scheme == "file" && u.URL.Opaque == "":
+		if runtime.GOOS == "windows" && len(u.URL.Path) > 0 && u.URL.Path[0] == '/' {
+			return filepath.FromSlash(u.URL.Path[1:])
+		}
+		return filepath.FromSlash(u.URL.Path)
+	}
+	panic("LocalPath called on non-local URL")
+}

--- a/pkg/build/source-to-image/git/url_test.go
+++ b/pkg/build/source-to-image/git/url_test.go
@@ -1,0 +1,295 @@
+package git
+
+import (
+	"net/url"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+type parseTest struct {
+	rawurl         string
+	expectedGitURL *URL
+	expectedError  bool
+}
+
+func TestParse(t *testing.T) {
+	var tests []parseTest
+
+	switch runtime.GOOS {
+	case "windows":
+		tests = append(tests,
+			parseTest{
+				rawurl:        "file://relative/path",
+				expectedError: true,
+			},
+			parseTest{
+				rawurl:        "file:///relative/path",
+				expectedError: true,
+			},
+			parseTest{
+				rawurl: "file:///c:/absolute/path?query#fragment",
+				expectedGitURL: &URL{
+					URL: url.URL{
+						Scheme:   "file",
+						Path:     "/c:/absolute/path",
+						RawQuery: "query",
+						Fragment: "fragment",
+					},
+					Type: URLTypeURL,
+				},
+			},
+		)
+
+	default:
+		tests = append(tests,
+			parseTest{
+				rawurl:        "file://relative/path",
+				expectedError: true,
+			},
+			parseTest{
+				rawurl: "file:///absolute/path?query#fragment",
+				expectedGitURL: &URL{
+					URL: url.URL{
+						Scheme:   "file",
+						Path:     "/absolute/path",
+						RawQuery: "query",
+						Fragment: "fragment",
+					},
+					Type: URLTypeURL,
+				},
+			},
+		)
+	}
+
+	tests = append(tests,
+		// http://
+		parseTest{
+			rawurl: "http://user:pass@github.com:443/user/repo.git?query#fragment",
+			expectedGitURL: &URL{
+				URL: url.URL{
+					Scheme:   "http",
+					User:     url.UserPassword("user", "pass"),
+					Host:     "github.com:443",
+					Path:     "/user/repo.git",
+					RawQuery: "query",
+					Fragment: "fragment",
+				},
+				Type: URLTypeURL,
+			},
+		},
+		parseTest{
+			rawurl: "http://user@1.2.3.4:443/repo?query#fragment",
+			expectedGitURL: &URL{
+				URL: url.URL{
+					Scheme:   "http",
+					User:     url.User("user"),
+					Host:     "1.2.3.4:443",
+					Path:     "/repo",
+					RawQuery: "query",
+					Fragment: "fragment",
+				},
+				Type: URLTypeURL,
+			},
+		},
+		parseTest{
+			rawurl: "http://[::ffff:1.2.3.4]:443",
+			expectedGitURL: &URL{
+				URL: url.URL{
+					Scheme: "http",
+					Host:   "[::ffff:1.2.3.4]:443",
+				},
+				Type: URLTypeURL,
+			},
+		},
+		parseTest{
+			rawurl: "http://github.com/openshift/origin",
+			expectedGitURL: &URL{
+				URL: url.URL{
+					Scheme: "http",
+					Host:   "github.com",
+					Path:   "/openshift/origin",
+				},
+				Type: URLTypeURL,
+			},
+		},
+
+		// transport::opaque
+		parseTest{
+			rawurl: "http::http://github.com/openshift/origin",
+			expectedGitURL: &URL{
+				URL: url.URL{
+					Scheme: "http",
+					Opaque: ":http://github.com/openshift/origin",
+				},
+				Type: URLTypeURL,
+			},
+		},
+
+		// git@host ...
+		parseTest{
+			rawurl: "user@github.com:/user/repo.git#fragment",
+			expectedGitURL: &URL{
+				URL: url.URL{
+					User:     url.User("user"),
+					Host:     "github.com",
+					Path:     "/user/repo.git",
+					Fragment: "fragment",
+				},
+				Type: URLTypeSCP,
+			},
+		},
+		parseTest{
+			rawurl: "user@github.com:user/repo.git#fragment",
+			expectedGitURL: &URL{
+				URL: url.URL{
+					User:     url.User("user"),
+					Host:     "github.com",
+					Path:     "user/repo.git",
+					Fragment: "fragment",
+				},
+				Type: URLTypeSCP,
+			},
+		},
+		parseTest{
+			rawurl: "user@1.2.3.4:repo#fragment",
+			expectedGitURL: &URL{
+				URL: url.URL{
+					User:     url.User("user"),
+					Host:     "1.2.3.4",
+					Path:     "repo",
+					Fragment: "fragment",
+				},
+				Type: URLTypeSCP,
+			},
+		},
+		parseTest{
+			rawurl: "[::ffff:1.2.3.4]:",
+			expectedGitURL: &URL{
+				URL: url.URL{
+					Host: "[::ffff:1.2.3.4]",
+				},
+				Type: URLTypeSCP,
+			},
+		},
+		parseTest{
+			rawurl: "git@github.com:openshift/origin",
+			expectedGitURL: &URL{
+				URL: url.URL{
+					User: url.User("git"),
+					Host: "github.com",
+					Path: "openshift/origin",
+				},
+				Type: URLTypeSCP,
+			},
+		},
+
+		// path ...
+		parseTest{
+			rawurl: "/absolute#fragment",
+			expectedGitURL: &URL{
+				URL: url.URL{
+					Path:     "/absolute",
+					Fragment: "fragment",
+				},
+				Type: URLTypeLocal,
+			},
+		},
+		parseTest{
+			rawurl: "relative#fragment",
+			expectedGitURL: &URL{
+				URL: url.URL{
+					Path:     "relative",
+					Fragment: "fragment",
+				},
+				Type: URLTypeLocal,
+			},
+		},
+	)
+
+	for _, test := range tests {
+		parsedURL, err := Parse(test.rawurl)
+		if test.expectedError != (err != nil) {
+			t.Errorf("%s: Parse() returned err: %v", test.rawurl, err)
+		}
+		if err != nil {
+			continue
+		}
+
+		if !reflect.DeepEqual(parsedURL, test.expectedGitURL) {
+			t.Errorf("%s: Parse() returned\n\t%#v\nWanted\n\t%#v", test.rawurl, parsedURL, test.expectedGitURL)
+		}
+
+		if parsedURL.String() != test.rawurl {
+			t.Errorf("%s: String() returned %s", test.rawurl, parsedURL.String())
+		}
+
+		if parsedURL.StringNoFragment() != strings.SplitN(test.rawurl, "#", 2)[0] {
+			t.Errorf("%s: StringNoFragment() returned %s", test.rawurl, parsedURL.StringNoFragment())
+		}
+	}
+}
+
+func TestStringNoFragment(t *testing.T) {
+	u := MustParse("part#fragment")
+	if u.StringNoFragment() != "part" {
+		t.Errorf("StringNoFragment() returned %s", u.StringNoFragment())
+	}
+	if !reflect.DeepEqual(u, MustParse("part#fragment")) {
+		t.Errorf("StringNoFragment() modified its argument")
+	}
+}
+
+type localPathTest struct {
+	url      *URL
+	expected string
+}
+
+func TestLocalPath(t *testing.T) {
+	var tests []localPathTest
+
+	switch runtime.GOOS {
+	case "windows":
+		tests = append(tests,
+			localPathTest{
+				url:      MustParse("file:///c:/foo/bar"),
+				expected: `c:\foo\bar`,
+			},
+			localPathTest{
+				url:      MustParse(`c:\foo\bar`),
+				expected: `c:\foo\bar`,
+			},
+			localPathTest{
+				url:      MustParse(`\foo\bar`),
+				expected: `\foo\bar`,
+			},
+			localPathTest{
+				url:      MustParse(`foo\bar`),
+				expected: `foo\bar`,
+			},
+			localPathTest{
+				url:      MustParse(`foo`),
+				expected: `foo`,
+			},
+		)
+
+	default:
+		tests = append(tests,
+			localPathTest{
+				url:      MustParse("file:///foo/bar"),
+				expected: "/foo/bar",
+			},
+			localPathTest{
+				url:      MustParse("/foo/bar"),
+				expected: "/foo/bar",
+			},
+		)
+	}
+
+	for i, test := range tests {
+		if test.url.LocalPath() != test.expected {
+			t.Errorf("%d: LocalPath() returned %s", i, test.url.LocalPath())
+		}
+	}
+}

--- a/pkg/build/source-to-image/log/log.go
+++ b/pkg/build/source-to-image/log/log.go
@@ -1,0 +1,213 @@
+package log
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+
+	"k8s.io/klog"
+)
+
+// Logger is a simple interface that is roughly equivalent to klog.
+type Logger interface {
+	Is(level int32) bool
+	V(level int32) VerboseLogger
+	Infof(format string, args ...interface{})
+	Info(args ...interface{})
+	Warningf(format string, args ...interface{})
+	Warning(args ...interface{})
+	Errorf(format string, args ...interface{})
+	Error(args ...interface{})
+	Fatalf(format string, args ...interface{})
+	Fatal(args ...interface{})
+}
+
+// VerboseLogger is roughly equivalent to klog's Verbose.
+type VerboseLogger interface {
+	Infof(format string, args ...interface{})
+	Info(args ...interface{})
+}
+
+// ToFile creates a logger that will log any items at level or below to file, and defer
+// any other output to klog (no matter what the level is).
+func ToFile(x io.Writer, level int32) Logger {
+	return &FileLogger{
+		&sync.Mutex{},
+		bufio.NewWriter(x),
+		level,
+	}
+}
+
+var (
+	// None implements the Logger interface but does nothing with the log output.
+	None Logger = discard{}
+	// StderrLog implements the Logger interface for stderr.
+	StderrLog = ToFile(os.Stderr, 2)
+)
+
+// discard is a Logger that outputs nothing.
+type discard struct{}
+
+// Is returns whether the current logging level is greater than or equal to the parameter.
+func (discard) Is(level int32) bool {
+	return false
+}
+
+// V will returns a logger which will discard output if the specified level is greater than the current logging level.
+func (discarding discard) V(level int32) VerboseLogger {
+	return discarding
+}
+
+// Infof records an info log entry.
+func (discard) Infof(string, ...interface{}) {
+}
+
+// Info records an info log entry.
+func (discard) Info(...interface{}) {
+}
+
+// Errorf records an error log entry.
+func (discard) Errorf(string, ...interface{}) {
+}
+
+// Error records an error log entry.
+func (discard) Error(...interface{}) {
+}
+
+// Warningf records an warning log entry.
+func (discard) Warningf(string, ...interface{}) {
+}
+
+// Warning records an warning log entry.
+func (discard) Warning(...interface{}) {
+}
+
+// Fatalf records a fatal log entry.
+func (discard) Fatalf(string, ...interface{}) {
+}
+
+// Fatal records a fatal log entry.
+func (discard) Fatal(...interface{}) {
+}
+
+// FileLogger logs the provided messages at level or below to the writer, or delegates
+// to klog.
+type FileLogger struct {
+	mutex *sync.Mutex
+	w     *bufio.Writer
+	level int32
+}
+
+// Is returns whether the current logging level is greater than or equal to the parameter.
+func (f *FileLogger) Is(level int32) bool {
+	return level <= f.level
+}
+
+// V will returns a logger which will discard output if the specified level is greater than the current logging level.
+func (f *FileLogger) V(level int32) VerboseLogger {
+	// Is the loglevel set verbose enough to accept the forthcoming log statement
+	if klog.V(klog.Level(level)) {
+		return f
+	}
+	// Otherwise discard
+	return None
+}
+
+type severity int32
+
+const (
+	infoLog severity = iota
+	warningLog
+	errorLog
+	fatalLog
+)
+
+// Elevated logger methods output a detailed prefix for each logging statement.
+// At present, we delegate to klog to accomplish this.
+type elevated func(int, ...interface{})
+
+type severityDetail struct {
+	prefix     string
+	delegateFn elevated
+}
+
+var severities = []severityDetail{
+	infoLog:    {"", klog.InfoDepth},
+	warningLog: {"WARNING: ", klog.WarningDepth},
+	errorLog:   {"ERROR: ", klog.ErrorDepth},
+	fatalLog:   {"FATAL: ", klog.FatalDepth},
+}
+
+func (f *FileLogger) writeln(sev severity, line string) {
+	severity := severities[sev]
+
+	// If the loglevel has been elevated above this file logger's verbosity (generally set to 2)
+	// then delegate ALL messages to elevated logger in order to leverage its file/line/timestamp
+	// prefix information.
+	if klog.V(klog.Level(f.level + 1)) {
+		severity.delegateFn(3, line)
+	} else {
+		// buf.io is not threadsafe, so serialize access to the stream
+		f.mutex.Lock()
+		defer f.mutex.Unlock()
+		f.w.WriteString(severity.prefix)
+		f.w.WriteString(line)
+		if !strings.HasSuffix(line, "\n") {
+			f.w.WriteByte('\n')
+		}
+		f.w.Flush()
+	}
+}
+
+func (f *FileLogger) outputf(sev severity, format string, args ...interface{}) {
+	f.writeln(sev, fmt.Sprintf(format, args...))
+}
+
+func (f *FileLogger) output(sev severity, args ...interface{}) {
+	f.writeln(sev, fmt.Sprint(args...))
+}
+
+// Infof records an info log entry.
+func (f *FileLogger) Infof(format string, args ...interface{}) {
+	f.outputf(infoLog, format, args...)
+}
+
+// Info records an info log entry.
+func (f *FileLogger) Info(args ...interface{}) {
+	f.output(infoLog, args...)
+}
+
+// Warningf records an warning log entry.
+func (f *FileLogger) Warningf(format string, args ...interface{}) {
+	f.outputf(warningLog, format, args...)
+}
+
+// Warning records an warning log entry.
+func (f *FileLogger) Warning(args ...interface{}) {
+	f.output(warningLog, args...)
+}
+
+// Errorf records an error log entry.
+func (f *FileLogger) Errorf(format string, args ...interface{}) {
+	f.outputf(errorLog, format, args...)
+}
+
+// Error records an error log entry.
+func (f *FileLogger) Error(args ...interface{}) {
+	f.output(errorLog, args...)
+}
+
+// Fatalf records a fatal log entry and terminates the program.
+func (f *FileLogger) Fatalf(format string, args ...interface{}) {
+	defer os.Exit(1)
+	f.outputf(fatalLog, format, args...)
+}
+
+// Fatal records a fatal log entry and terminates the program.
+func (f *FileLogger) Fatal(args ...interface{}) {
+	defer os.Exit(1)
+	f.output(fatalLog, args...)
+}

--- a/pkg/build/source-to-image/tar/doc.go
+++ b/pkg/build/source-to-image/tar/doc.go
@@ -1,0 +1,3 @@
+// Provides a Tar interface with methods to create and extract tar archives
+
+package tar

--- a/pkg/build/source-to-image/tar/tar.go
+++ b/pkg/build/source-to-image/tar/tar.go
@@ -1,0 +1,494 @@
+package tar
+
+import (
+	"archive/tar"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	s2ierr "github.com/openshift/library-go/pkg/build/source-to-image/errors"
+	"github.com/openshift/library-go/pkg/build/source-to-image/fs"
+	utillog "github.com/openshift/library-go/pkg/build/source-to-image/log"
+	"github.com/openshift/library-go/pkg/build/source-to-image/timeout"
+)
+
+var log = utillog.StderrLog
+
+// defaultTimeout is the amount of time that the untar will wait for a tar
+// stream to extract a single file. A timeout is needed to guard against broken
+// connections in which it would wait for a long time to untar and nothing would happen
+const defaultTimeout = 300 * time.Second
+
+// DefaultExclusionPattern is the pattern of files that will not be included in a tar
+// file when creating one. By default it is any file inside a .git metadata directory
+var DefaultExclusionPattern = regexp.MustCompile(`(^|/)\.git(/|$)`)
+
+// Tar can create and extract tar files used in an STI build
+type Tar interface {
+	// SetExclusionPattern sets the exclusion pattern for tar
+	// creation
+	SetExclusionPattern(*regexp.Regexp)
+
+	// CreateTarFile creates a tar file in the base directory
+	// using the contents of dir directory
+	// The name of the new tar file is returned if successful
+	CreateTarFile(base, dir string) (string, error)
+
+	// CreateTarStreamToTarWriter creates a tar from the given directory
+	// and streams it to the given writer.
+	// An error is returned if an error occurs during streaming.
+	// Archived file names are written to the logger if provided
+	CreateTarStreamToTarWriter(dir string, includeDirInPath bool, writer Writer, logger io.Writer) error
+
+	// CreateTarStream creates a tar from the given directory
+	// and streams it to the given writer.
+	// An error is returned if an error occurs during streaming.
+	CreateTarStream(dir string, includeDirInPath bool, writer io.Writer) error
+
+	// CreateTarStreamReader returns an io.ReadCloser from which a tar stream can be
+	// read.  The tar stream is created using CreateTarStream.
+	CreateTarStreamReader(dir string, includeDirInPath bool) io.ReadCloser
+
+	// ExtractTarStream extracts files from a given tar stream.
+	// Times out if reading from the stream for any given file
+	// exceeds the value of timeout.
+	ExtractTarStream(dir string, reader io.Reader) error
+
+	// ExtractTarStreamWithLogging extracts files from a given tar stream.
+	// Times out if reading from the stream for any given file
+	// exceeds the value of timeout.
+	// Extracted file names are written to the logger if provided.
+	ExtractTarStreamWithLogging(dir string, reader io.Reader, logger io.Writer) error
+
+	// ExtractTarStreamFromTarReader extracts files from a given tar stream.
+	// Times out if reading from the stream for any given file
+	// exceeds the value of timeout.
+	// Extracted file names are written to the logger if provided.
+	ExtractTarStreamFromTarReader(dir string, tarReader Reader, logger io.Writer) error
+}
+
+// Reader is an interface which tar.Reader implements.
+type Reader interface {
+	io.Reader
+	Next() (*tar.Header, error)
+}
+
+// Writer is an interface which tar.Writer implements.
+type Writer interface {
+	io.WriteCloser
+	Flush() error
+	WriteHeader(hdr *tar.Header) error
+}
+
+// ChmodAdapter changes the mode of files and directories inline as a tarfile is
+// being written
+type ChmodAdapter struct {
+	Writer
+	NewFileMode     int64
+	NewExecFileMode int64
+	NewDirMode      int64
+}
+
+// WriteHeader changes the mode of files and directories inline as a tarfile is
+// being written
+func (a ChmodAdapter) WriteHeader(hdr *tar.Header) error {
+	if hdr.FileInfo().Mode()&os.ModeSymlink == 0 {
+		newMode := hdr.Mode &^ 0777
+		if hdr.FileInfo().IsDir() {
+			newMode |= a.NewDirMode
+		} else if hdr.FileInfo().Mode()&0010 != 0 { // S_IXUSR
+			newMode |= a.NewExecFileMode
+		} else {
+			newMode |= a.NewFileMode
+		}
+		hdr.Mode = newMode
+	}
+	return a.Writer.WriteHeader(hdr)
+}
+
+// RenameAdapter renames files and directories inline as a tarfile is being
+// written
+type RenameAdapter struct {
+	Writer
+	Old string
+	New string
+}
+
+// WriteHeader renames files and directories inline as a tarfile is being
+// written
+func (a RenameAdapter) WriteHeader(hdr *tar.Header) error {
+	if hdr.Name == a.Old {
+		hdr.Name = a.New
+	} else if strings.HasPrefix(hdr.Name, a.Old+"/") {
+		hdr.Name = a.New + hdr.Name[len(a.Old):]
+	}
+
+	return a.Writer.WriteHeader(hdr)
+}
+
+// New creates a new Tar
+func New(fs fs.FileSystem) Tar {
+	return &stiTar{
+		FileSystem: fs,
+		exclude:    DefaultExclusionPattern,
+		timeout:    defaultTimeout,
+	}
+}
+
+// NewWithTimeout creates a new Tar with the provided timeout extracting files.
+func NewWithTimeout(fs fs.FileSystem, timeout time.Duration) Tar {
+	return &stiTar{
+		FileSystem: fs,
+		exclude:    DefaultExclusionPattern,
+		timeout:    timeout,
+	}
+}
+
+// NewParanoid creates a new Tar that has restrictions
+// on what it can do while extracting files.
+func NewParanoid(fs fs.FileSystem) Tar {
+	return &stiTar{
+		FileSystem:           fs,
+		exclude:              DefaultExclusionPattern,
+		timeout:              defaultTimeout,
+		disallowOverwrite:    true,
+		disallowOutsidePaths: true,
+		disallowSpecialFiles: true,
+	}
+}
+
+// NewParanoidWithTimeout creates a new Tar with the provided timeout extracting files.
+// It has restrictions on what it can do while extracting files.
+func NewParanoidWithTimeout(fs fs.FileSystem, timeout time.Duration) Tar {
+	return &stiTar{
+		FileSystem:           fs,
+		exclude:              DefaultExclusionPattern,
+		timeout:              timeout,
+		disallowOverwrite:    true,
+		disallowOutsidePaths: true,
+		disallowSpecialFiles: true,
+	}
+}
+
+// stiTar is an implementation of the Tar interface
+type stiTar struct {
+	fs.FileSystem
+	timeout              time.Duration
+	exclude              *regexp.Regexp
+	includeDirInPath     bool
+	disallowOverwrite    bool
+	disallowOutsidePaths bool
+	disallowSpecialFiles bool
+}
+
+// SetExclusionPattern sets the exclusion pattern for tar creation.  The
+// exclusion pattern always uses UNIX-style (/) path separators, even on
+// Windows.
+func (t *stiTar) SetExclusionPattern(p *regexp.Regexp) {
+	t.exclude = p
+}
+
+// CreateTarFile creates a tar file from the given directory
+// while excluding files that match the given exclusion pattern
+// It returns the name of the created file
+func (t *stiTar) CreateTarFile(base, dir string) (string, error) {
+	tarFile, err := ioutil.TempFile(base, "tar")
+	defer tarFile.Close()
+	if err != nil {
+		return "", err
+	}
+	if err = t.CreateTarStream(dir, false, tarFile); err != nil {
+		return "", err
+	}
+	return tarFile.Name(), nil
+}
+
+func (t *stiTar) shouldExclude(path string) bool {
+	return t.exclude != nil && t.exclude.String() != "" && t.exclude.MatchString(filepath.ToSlash(path))
+}
+
+// CreateTarStream calls CreateTarStreamToTarWriter with a nil logger
+func (t *stiTar) CreateTarStream(dir string, includeDirInPath bool, writer io.Writer) error {
+	tarWriter := tar.NewWriter(writer)
+	defer tarWriter.Close()
+
+	return t.CreateTarStreamToTarWriter(dir, includeDirInPath, tarWriter, nil)
+}
+
+// CreateTarStreamReader returns an io.ReadCloser from which a tar stream can be
+// read.  The tar stream is created using CreateTarStream.
+func (t *stiTar) CreateTarStreamReader(dir string, includeDirInPath bool) io.ReadCloser {
+	r, w := io.Pipe()
+	go func() {
+		w.CloseWithError(t.CreateTarStream(dir, includeDirInPath, w))
+	}()
+	return r
+}
+
+// CreateTarStreamToTarWriter creates a tar stream on the given writer from
+// the given directory while excluding files that match the given
+// exclusion pattern.
+func (t *stiTar) CreateTarStreamToTarWriter(dir string, includeDirInPath bool, tarWriter Writer, logger io.Writer) error {
+	dir = filepath.Clean(dir) // remove relative paths and extraneous slashes
+	log.V(5).Infof("Adding %q to tar ...", dir)
+	err := t.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		// on Windows, directory symlinks report as a directory and as a symlink.
+		// They should be treated as symlinks.
+		if !t.shouldExclude(path) {
+			// if file is a link just writing header info is enough
+			if info.Mode()&os.ModeSymlink != 0 {
+				if dir == path {
+					return nil
+				}
+				if err = t.writeTarHeader(tarWriter, dir, path, info, includeDirInPath, logger); err != nil {
+					log.Errorf("Error writing header for %q: %v", info.Name(), err)
+				}
+				// on Windows, filepath.Walk recurses into directory symlinks when it
+				// shouldn't.  https://github.com/golang/go/issues/17540
+				if err == nil && info.Mode()&os.ModeDir != 0 {
+					return filepath.SkipDir
+				}
+				return err
+			}
+			if info.IsDir() {
+				if dir == path {
+					return nil
+				}
+				if err = t.writeTarHeader(tarWriter, dir, path, info, includeDirInPath, logger); err != nil {
+					log.Errorf("Error writing header for %q: %v", info.Name(), err)
+				}
+				return err
+			}
+
+			// regular files are copied into tar, if accessible
+			file, err := os.Open(path)
+			if err != nil {
+				log.Errorf("Ignoring file %s: %v", path, err)
+				return nil
+			}
+			defer file.Close()
+			if err = t.writeTarHeader(tarWriter, dir, path, info, includeDirInPath, logger); err != nil {
+				log.Errorf("Error writing header for %q: %v", info.Name(), err)
+				return err
+			}
+			if _, err = io.Copy(tarWriter, file); err != nil {
+				log.Errorf("Error copying file %q to tar: %v", path, err)
+				return err
+			}
+		}
+		return nil
+	})
+
+	if err != nil {
+		log.Errorf("Error writing tar: %v", err)
+		return err
+	}
+
+	return nil
+}
+
+// writeTarHeader writes tar header for given file, returns error if operation fails
+func (t *stiTar) writeTarHeader(tarWriter Writer, dir string, path string, info os.FileInfo, includeDirInPath bool, logger io.Writer) error {
+	var (
+		link string
+		err  error
+	)
+	if info.Mode()&os.ModeSymlink != 0 {
+		link, err = os.Readlink(path)
+		if err != nil {
+			return err
+		}
+	}
+	header, err := tar.FileInfoHeader(info, link)
+	if err != nil {
+		return err
+	}
+	// on Windows, tar.FileInfoHeader incorrectly interprets directory symlinks
+	// as directories.  https://github.com/golang/go/issues/17541
+	if info.Mode()&os.ModeSymlink != 0 && info.Mode()&os.ModeDir != 0 {
+		header.Typeflag = tar.TypeSymlink
+		header.Mode &^= 040000 // c_ISDIR
+		header.Mode |= 0120000 // c_ISLNK
+		header.Linkname = link
+	}
+	prefix := dir
+	if includeDirInPath {
+		prefix = filepath.Dir(prefix)
+	}
+	fileName := path
+	if prefix != "." {
+		fileName = path[1+len(prefix):]
+	}
+	header.Name = filepath.ToSlash(fileName)
+	header.Linkname = filepath.ToSlash(header.Linkname)
+	// Force the header format to PAX to support UTF-8 filenames
+	// and use the same format throughout the entire tar file.
+	header.Format = tar.FormatPAX
+	logFile(logger, header.Name)
+	log.V(5).Infof("Adding to tar: %s as %s", path, header.Name)
+	return tarWriter.WriteHeader(header)
+}
+
+// ExtractTarStream calls ExtractTarStreamFromTarReader with a default reader and nil logger
+func (t *stiTar) ExtractTarStream(dir string, reader io.Reader) error {
+	tarReader := tar.NewReader(reader)
+	return t.ExtractTarStreamFromTarReader(dir, tarReader, nil)
+}
+
+// ExtractTarStreamWithLogging calls ExtractTarStreamFromTarReader with a default reader
+func (t *stiTar) ExtractTarStreamWithLogging(dir string, reader io.Reader, logger io.Writer) error {
+	tarReader := tar.NewReader(reader)
+	return t.ExtractTarStreamFromTarReader(dir, tarReader, logger)
+}
+
+// ExtractTarStreamFromTarReader extracts files from a given tar stream.
+// Times out if reading from the stream for any given file
+// exceeds the value of timeout
+func (t *stiTar) ExtractTarStreamFromTarReader(dir string, tarReader Reader, logger io.Writer) error {
+	err := timeout.TimeoutAfter(t.timeout, "", func(timeoutTimer *time.Timer) error {
+		for {
+			header, err := tarReader.Next()
+			if !timeoutTimer.Stop() {
+				return &timeout.TimeoutError{}
+			}
+			timeoutTimer.Reset(t.timeout)
+			if err == io.EOF {
+				return nil
+			}
+			if err != nil {
+				log.Errorf("Error reading next tar header: %v", err)
+				return err
+			}
+
+			if t.disallowSpecialFiles {
+				switch header.Typeflag {
+				case tar.TypeReg, tar.TypeRegA, tar.TypeLink, tar.TypeSymlink, tar.TypeDir, tar.TypeGNUSparse:
+				default:
+					log.Warningf("Skipping special file %s, type: %v", header.Name, header.Typeflag)
+					continue
+				}
+			}
+
+			p := header.Name
+			if t.disallowOutsidePaths {
+				p = filepath.Clean(filepath.Join(dir, p))
+				if !strings.HasPrefix(p, dir) {
+					log.Warningf("Skipping relative path file in tar: %s", header.Name)
+					continue
+				}
+			}
+
+			if header.FileInfo().IsDir() {
+				dirPath := filepath.Join(dir, filepath.Clean(header.Name))
+				log.V(3).Infof("Creating directory %s", dirPath)
+				if err = os.MkdirAll(dirPath, 0700); err != nil {
+					log.Errorf("Error creating dir %q: %v", dirPath, err)
+					return err
+				}
+				t.Chmod(dirPath, header.FileInfo().Mode())
+			} else {
+				fileDir := filepath.Dir(header.Name)
+				dirPath := filepath.Join(dir, filepath.Clean(fileDir))
+				log.V(3).Infof("Creating directory %s", dirPath)
+				if err = os.MkdirAll(dirPath, 0700); err != nil {
+					log.Errorf("Error creating dir %q: %v", dirPath, err)
+					return err
+				}
+				if header.Typeflag == tar.TypeSymlink {
+					if err := t.extractLink(dir, header, tarReader); err != nil {
+						log.Errorf("Error extracting link %q: %v", header.Name, err)
+						return err
+					}
+					continue
+				}
+				logFile(logger, header.Name)
+				if err := t.extractFile(dir, header, tarReader); err != nil {
+					log.Errorf("Error extracting file %q: %v", header.Name, err)
+					return err
+				}
+			}
+		}
+	})
+
+	if err != nil {
+		log.Errorf("Error extracting tar stream: %v", err)
+	} else {
+		log.V(2).Info("Done extracting tar stream")
+	}
+
+	if timeout.IsTimeoutError(err) {
+		err = s2ierr.NewTarTimeoutError()
+	}
+
+	return err
+}
+
+func (t *stiTar) extractLink(dir string, header *tar.Header, tarReader io.Reader) error {
+	dest := filepath.Join(dir, header.Name)
+	source := header.Linkname
+
+	if t.disallowOutsidePaths {
+		target := filepath.Clean(filepath.Join(dest, "..", source))
+		if !strings.HasPrefix(target, dir) {
+			log.Warningf("Skipping symlink that points to relative path: %s", header.Linkname)
+			return nil
+		}
+	}
+
+	if t.disallowOverwrite {
+		if _, err := os.Stat(dest); !os.IsNotExist(err) {
+			log.Warningf("Refusing to overwrite existing file: %s", dest)
+			return nil
+		}
+	}
+
+	log.V(3).Infof("Creating symbolic link from %q to %q", dest, source)
+
+	// TODO: set mtime for symlink (unfortunately we can't use os.Chtimes() and probably should use syscall)
+	return os.Symlink(source, dest)
+}
+
+func (t *stiTar) extractFile(dir string, header *tar.Header, tarReader io.Reader) error {
+	path := filepath.Join(dir, header.Name)
+	if t.disallowOverwrite {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			log.Warningf("Refusing to overwrite existing file: %s", path)
+			return nil
+		}
+	}
+
+	log.V(3).Infof("Creating %s", path)
+
+	file, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	// The file times need to be modified after it's been closed thus this function
+	// is deferred after the file close (LIFO order for defer)
+	defer os.Chtimes(path, time.Now(), header.FileInfo().ModTime())
+	defer file.Close()
+	log.V(3).Infof("Extracting/writing %s", path)
+	written, err := io.Copy(file, tarReader)
+	if err != nil {
+		return err
+	}
+	if written != header.Size {
+		return fmt.Errorf("wrote %d bytes, expected to write %d", written, header.Size)
+	}
+	return t.Chmod(path, header.FileInfo().Mode())
+}
+
+func logFile(logger io.Writer, name string) {
+	if logger == nil {
+		return
+	}
+	fmt.Fprintf(logger, "%s\n", name)
+}

--- a/pkg/build/source-to-image/tar/tar_test.go
+++ b/pkg/build/source-to-image/tar/tar_test.go
@@ -1,0 +1,654 @@
+package tar
+
+import (
+	"archive/tar"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"testing"
+	"time"
+
+	s2ierr "github.com/openshift/library-go/pkg/build/source-to-image/errors"
+	"github.com/openshift/library-go/pkg/build/source-to-image/fs"
+)
+
+type dirDesc struct {
+	name         string
+	modifiedDate time.Time
+	mode         os.FileMode
+}
+
+type fileDesc struct {
+	name         string
+	modifiedDate time.Time
+	mode         os.FileMode
+	content      string
+	shouldSkip   bool
+	target       string
+}
+
+type linkDesc struct {
+	linkName string
+	fileName string
+}
+
+func createTestFiles(baseDir string, dirs []dirDesc, files []fileDesc, links []linkDesc) error {
+	for _, dd := range dirs {
+		fileName := filepath.Join(baseDir, dd.name)
+		err := os.Mkdir(fileName, dd.mode)
+		if err != nil {
+			return err
+		}
+		os.Chmod(fileName, dd.mode) // umask
+	}
+	for _, fd := range files {
+		fileName := filepath.Join(baseDir, fd.name)
+		err := ioutil.WriteFile(fileName, []byte(fd.content), fd.mode)
+		if err != nil {
+			return err
+		}
+		os.Chmod(fileName, fd.mode)
+		os.Chtimes(fileName, fd.modifiedDate, fd.modifiedDate)
+	}
+	for _, ld := range links {
+		linkName := filepath.Join(baseDir, ld.linkName)
+		if err := os.MkdirAll(filepath.Dir(linkName), 0700); err != nil {
+			return err
+		}
+		if err := os.Symlink(ld.fileName, linkName); err != nil {
+			return err
+		}
+	}
+	for _, dd := range dirs {
+		fileName := filepath.Join(baseDir, dd.name)
+		os.Chtimes(fileName, dd.modifiedDate, dd.modifiedDate)
+	}
+	return nil
+}
+
+func verifyTarFile(t *testing.T, filename string, dirs []dirDesc, files []fileDesc, links []linkDesc) {
+	if runtime.GOOS == "windows" {
+		for i := range files {
+			if files[i].mode&0700 == 0400 {
+				files[i].mode = 0444
+			} else {
+				files[i].mode = 0666
+			}
+		}
+		for i := range dirs {
+			if dirs[i].mode&0700 == 0500 {
+				dirs[i].mode = 0555
+			} else {
+				dirs[i].mode = 0777
+			}
+		}
+	}
+	dirsToVerify := make(map[string]dirDesc)
+	for _, dd := range dirs {
+		dirsToVerify[dd.name] = dd
+	}
+	filesToVerify := make(map[string]fileDesc)
+	for _, fd := range files {
+		if !fd.shouldSkip {
+			filesToVerify[fd.name] = fd
+		}
+	}
+	linksToVerify := make(map[string]linkDesc)
+	for _, ld := range links {
+		linksToVerify[ld.linkName] = ld
+	}
+
+	file, err := os.Open(filename)
+	defer file.Close()
+	if err != nil {
+		t.Fatalf("Cannot open tar file %q: %v", filename, err)
+	}
+	tr := tar.NewReader(file)
+	for {
+		hdr, err := tr.Next()
+		if hdr == nil {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Error reading tar %q: %v", filename, err)
+		}
+		finfo := hdr.FileInfo()
+		if dd, ok := dirsToVerify[hdr.Name]; ok {
+			delete(dirsToVerify, hdr.Name)
+			if finfo.Mode()&os.ModeDir == 0 {
+				t.Errorf("Incorrect dir %q", finfo.Name())
+			}
+			if finfo.Mode().Perm() != dd.mode {
+				t.Errorf("Dir %q from tar %q does not match expected mode. Expected: %v, actual: %v",
+					hdr.Name, filename, dd.mode, finfo.Mode().Perm())
+			}
+			if !dd.modifiedDate.IsZero() && finfo.ModTime().UTC() != dd.modifiedDate {
+				t.Errorf("Dir %q from tar %q does not match expected modified date. Expected: %v, actual: %v",
+					hdr.Name, filename, dd.modifiedDate, finfo.ModTime().UTC())
+			}
+		} else if fd, ok := filesToVerify[hdr.Name]; ok {
+			delete(filesToVerify, hdr.Name)
+			if finfo.Mode().Perm() != fd.mode {
+				t.Errorf("File %q from tar %q does not match expected mode. Expected: %v, actual: %v",
+					hdr.Name, filename, fd.mode, finfo.Mode().Perm())
+			}
+			if !fd.modifiedDate.IsZero() && finfo.ModTime().UTC() != fd.modifiedDate {
+				t.Errorf("File %q from tar %q does not match expected modified date. Expected: %v, actual: %v",
+					hdr.Name, filename, fd.modifiedDate, finfo.ModTime().UTC())
+			}
+			fileBytes, err := ioutil.ReadAll(tr)
+			if err != nil {
+				t.Fatalf("Error reading tar %q: %v", filename, err)
+			}
+			fileContent := string(fileBytes)
+			if fileContent != fd.content {
+				t.Errorf("Content for file %q in tar %q doesn't match expected value. Expected: %q, Actual: %q",
+					finfo.Name(), filename, fd.content, fileContent)
+			}
+		} else if ld, ok := linksToVerify[hdr.Name]; ok {
+			delete(linksToVerify, hdr.Name)
+			if finfo.Mode()&os.ModeSymlink == 0 {
+				t.Errorf("Incorrect link %q", finfo.Name())
+			}
+			if hdr.Linkname != ld.fileName {
+				t.Errorf("Incorrect link location. Expected: %q, Actual %q", ld.fileName, hdr.Linkname)
+			}
+		} else {
+			t.Errorf("Cannot find file %q from tar in files to verify.", hdr.Name)
+		}
+	}
+
+	if len(filesToVerify) > 0 || len(linksToVerify) > 0 {
+		t.Errorf("Did not find all expected files in tar: fileToVerify %v, linksToVerify %v", filesToVerify, linksToVerify)
+	}
+}
+
+func TestCreateTarStreamIncludeParentDir(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "testtar")
+	defer os.RemoveAll(tempDir)
+	if err != nil {
+		t.Fatalf("Cannot create temp directory for test: %v", err)
+	}
+	modificationDate := time.Date(2011, time.March, 5, 23, 30, 1, 0, time.UTC)
+	testDirs := []dirDesc{
+		{"dir01", modificationDate, 0700},
+		{"dir01/.git", modificationDate, 0755},
+		{"dir01/dir02", modificationDate, 0755},
+		{"dir01/dir03", modificationDate, 0775},
+	}
+	testFiles := []fileDesc{
+		{"dir01/dir02/test1.txt", modificationDate, 0700, "Test1 file content", false, ""},
+		{"dir01/test2.git", modificationDate, 0660, "Test2 file content", false, ""},
+		{"dir01/dir03/test3.txt", modificationDate, 0444, "Test3 file content", false, ""},
+		{"dir01/.git/hello.txt", modificationDate, 0600, "Ignore file content", true, ""},
+	}
+	if err = createTestFiles(tempDir, testDirs, testFiles, []linkDesc{}); err != nil {
+		t.Fatalf("Cannot create test files: %v", err)
+	}
+	th := New(fs.NewFileSystem())
+	tarFile, err := ioutil.TempFile("", "testtarout")
+	if err != nil {
+		t.Fatalf("Unable to create temporary file %v", err)
+	}
+	defer os.Remove(tarFile.Name())
+	err = th.CreateTarStream(tempDir, true, tarFile)
+	if err != nil {
+		t.Fatalf("Unable to create tar file %v", err)
+	}
+	tarFile.Close()
+	for i := range testDirs {
+		testDirs[i].name = filepath.ToSlash(filepath.Join(filepath.Base(tempDir), testDirs[i].name))
+	}
+	for i := range testFiles {
+		testFiles[i].name = filepath.ToSlash(filepath.Join(filepath.Base(tempDir), testFiles[i].name))
+	}
+	verifyTarFile(t, tarFile.Name(), testDirs, testFiles, []linkDesc{})
+}
+
+func TestCreateTar(t *testing.T) {
+	th := New(fs.NewFileSystem())
+	tempDir, err := ioutil.TempDir("", "testtar")
+	defer os.RemoveAll(tempDir)
+	if err != nil {
+		t.Fatalf("Cannot create temp directory for test: %v", err)
+	}
+	modificationDate := time.Date(2011, time.March, 5, 23, 30, 1, 0, time.UTC)
+	testDirs := []dirDesc{
+		{"dir01", modificationDate, 0700},
+		{"dir01/.git", modificationDate, 0755},
+		{"dir01/dir02", modificationDate, 0755},
+		{"dir01/dir03", modificationDate, 0775},
+		{"link", modificationDate, 0775},
+	}
+	testFiles := []fileDesc{
+		{"dir01/dir02/test1.txt", modificationDate, 0700, "Test1 file content", false, ""},
+		{"dir01/test2.git", modificationDate, 0660, "Test2 file content", false, ""},
+		{"dir01/dir03/test3.txt", modificationDate, 0444, "Test3 file content", false, ""},
+		{"dir01/.git/hello.txt", modificationDate, 0600, "Ignore file content", true, ""},
+		{"dir01/dir03/tëst3.txt", modificationDate, 0444, "Test utf-8 file header content", false, ""},
+	}
+	testLinks := []linkDesc{
+		{"link/okfilelink", "../dir01/dir02/test1.txt"},
+		{"link/errfilelink", "../dir01/missing.target"},
+		{"link/okdirlink", "../dir01/dir02"},
+		{"link/errdirlink", "../dir01/.git"},
+	}
+	if err = createTestFiles(tempDir, testDirs, testFiles, testLinks); err != nil {
+		t.Fatalf("Cannot create test files: %v", err)
+	}
+
+	tarFile, err := th.CreateTarFile("", tempDir)
+	defer os.Remove(tarFile)
+	if err != nil {
+		t.Fatalf("Unable to create new tar upload file: %v", err)
+	}
+	verifyTarFile(t, tarFile, testDirs, testFiles, testLinks)
+}
+
+func TestCreateTarIncludeDotGit(t *testing.T) {
+	th := New(fs.NewFileSystem())
+	th.SetExclusionPattern(regexp.MustCompile("test3.txt"))
+	tempDir, err := ioutil.TempDir("", "testtar")
+	defer os.RemoveAll(tempDir)
+	if err != nil {
+		t.Fatalf("Cannot create temp directory for test: %v", err)
+	}
+	modificationDate := time.Date(2011, time.March, 5, 23, 30, 1, 0, time.UTC)
+	testDirs := []dirDesc{
+		{"dir01", modificationDate, 0700},
+		{"dir01/.git", modificationDate, 0755},
+		{"dir01/dir02", modificationDate, 0755},
+		{"dir01/dir03", modificationDate, 0775},
+		{"link", modificationDate, 0775},
+	}
+	testFiles := []fileDesc{
+		{"dir01/dir02/test1.txt", modificationDate, 0700, "Test1 file content", false, ""},
+		{"dir01/test2.git", modificationDate, 0660, "Test2 file content", false, ""},
+		{"dir01/dir03/test3.txt", modificationDate, 0444, "Test3 file content", true, ""},
+		{"dir01/.git/hello.txt", modificationDate, 0600, "Allow .git content", false, ""},
+	}
+	testLinks := []linkDesc{
+		{"link/okfilelink", "../dir01/dir02/test1.txt"},
+		{"link/errfilelink", "../dir01/missing.target"},
+		{"link/okdirlink", "../dir01/dir02"},
+		{"link/okdirlink2", "../dir01/.git"},
+	}
+	if err = createTestFiles(tempDir, testDirs, testFiles, testLinks); err != nil {
+		t.Fatalf("Cannot create test files: %v", err)
+	}
+
+	tarFile, err := th.CreateTarFile("", tempDir)
+	defer os.Remove(tarFile)
+	if err != nil {
+		t.Fatalf("Unable to create new tar upload file: %v", err)
+	}
+	verifyTarFile(t, tarFile, testDirs, testFiles, testLinks)
+}
+
+func TestCreateTarEmptyRegexp(t *testing.T) {
+	th := New(fs.NewFileSystem())
+	th.SetExclusionPattern(regexp.MustCompile(""))
+	tempDir, err := ioutil.TempDir("", "testtar")
+	defer os.RemoveAll(tempDir)
+	if err != nil {
+		t.Fatalf("Cannot create temp directory for test: %v", err)
+	}
+	modificationDate := time.Date(2011, time.March, 5, 23, 30, 1, 0, time.UTC)
+	testDirs := []dirDesc{
+		{"dir01", modificationDate, 0700},
+		{"dir01/.git", modificationDate, 0755},
+		{"dir01/dir02", modificationDate, 0755},
+		{"dir01/dir03", modificationDate, 0775},
+		{"link", modificationDate, 0775},
+	}
+	testFiles := []fileDesc{
+		{"dir01/dir02/test1.txt", modificationDate, 0700, "Test1 file content", false, ""},
+		{"dir01/test2.git", modificationDate, 0660, "Test2 file content", false, ""},
+		{"dir01/dir03/test3.txt", modificationDate, 0444, "Test3 file content", false, ""},
+		{"dir01/.git/hello.txt", modificationDate, 0600, "Allow .git content", false, ""},
+	}
+	testLinks := []linkDesc{
+		{"link/okfilelink", "../dir01/dir02/test1.txt"},
+		{"link/errfilelink", "../dir01/missing.target"},
+		{"link/okdirlink", "../dir01/dir02"},
+		{"link/okdirlink2", "../dir01/.git"},
+	}
+	if err = createTestFiles(tempDir, testDirs, testFiles, testLinks); err != nil {
+		t.Fatalf("Cannot create test files: %v", err)
+	}
+
+	tarFile, err := th.CreateTarFile("", tempDir)
+	defer os.Remove(tarFile)
+	if err != nil {
+		t.Fatalf("Unable to create new tar upload file: %v", err)
+	}
+	verifyTarFile(t, tarFile, testDirs, testFiles, testLinks)
+}
+
+func createTestTar(files []fileDesc, writer io.Writer) error {
+	tw := tar.NewWriter(writer)
+	defer tw.Close()
+	for _, fd := range files {
+		if isSymLink(fd.mode) {
+			if err := addSymLink(tw, &fd); err != nil {
+				msg := "unable to add symbolic link %q (points to %q) to archive: %v"
+				return fmt.Errorf(msg, fd.name, fd.target, err)
+			}
+			continue
+		}
+		if fd.mode.IsDir() {
+			if err := addDir(tw, &fd); err != nil {
+				msg := "unable to add dir %q to archive: %v"
+				return fmt.Errorf(msg, fd.name, err)
+			}
+			continue
+		}
+		if err := addRegularFile(tw, &fd); err != nil {
+			return fmt.Errorf("unable to add file %q to archive: %v", fd.name, err)
+		}
+	}
+	return nil
+}
+
+func addRegularFile(tw *tar.Writer, fd *fileDesc) error {
+	contentBytes := []byte(fd.content)
+	hdr := &tar.Header{
+		Name:       fd.name,
+		Mode:       int64(fd.mode),
+		Size:       int64(len(contentBytes)),
+		Typeflag:   tar.TypeReg,
+		AccessTime: time.Now(),
+		ModTime:    fd.modifiedDate,
+		ChangeTime: fd.modifiedDate,
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		return err
+	}
+	_, err := tw.Write(contentBytes)
+	return err
+}
+
+func addDir(tw *tar.Writer, fd *fileDesc) error {
+	hdr := &tar.Header{
+		Name:       fd.name,
+		Mode:       int64(fd.mode & 0777),
+		Typeflag:   tar.TypeDir,
+		AccessTime: time.Now(),
+		ModTime:    fd.modifiedDate,
+		ChangeTime: fd.modifiedDate,
+	}
+	return tw.WriteHeader(hdr)
+}
+
+func addSymLink(tw *tar.Writer, fd *fileDesc) error {
+	if len(fd.target) == 0 {
+		return fmt.Errorf("link %q must point to somewhere, but target wasn't defined", fd.name)
+	}
+
+	hdr := &tar.Header{
+		Name:     fd.name,
+		Linkname: fd.target,
+		Mode:     int64(fd.mode & os.ModePerm),
+		Typeflag: tar.TypeSymlink,
+		ModTime:  fd.modifiedDate,
+	}
+
+	return tw.WriteHeader(hdr)
+}
+
+func isSymLink(mode os.FileMode) bool {
+	return mode&os.ModeSymlink == os.ModeSymlink
+}
+
+func verifyDirectory(t *testing.T, dir string, dirs []dirDesc, files []fileDesc, links []linkDesc) {
+	if dirs == nil {
+		dirs = []dirDesc{}
+	}
+	if files == nil {
+		files = []fileDesc{}
+	}
+	if links == nil {
+		links = []linkDesc{}
+	}
+	if runtime.GOOS == "windows" {
+		for i := range files {
+			files[i].name = filepath.FromSlash(files[i].name)
+			if files[i].mode&0200 == 0200 {
+				// if the file is user writable make it writable for everyone
+				files[i].mode |= 0666
+			} else {
+				// if the file is only readable, make it readable for everyone
+				// first clear the r/w permission bits
+				files[i].mode &^= 0666
+				// then set r permission for all
+				files[i].mode |= 0444
+			}
+			if files[i].mode.IsDir() {
+				// if the file is a directory, make it executable for everyone
+				files[i].mode |= 0111
+			} else {
+				// if it's not a directory, clear the executable bits as they are
+				// irrelevant on windows.
+				files[i].mode &^= 0111
+			}
+			files[i].target = filepath.FromSlash(files[i].target)
+		}
+		for j := range dirs {
+			dirs[j].name = filepath.FromSlash(dirs[j].name)
+			if dirs[j].mode&0200 == 0200 {
+				// if the file is user writable make it writable for everyone
+				dirs[j].mode |= 0666
+			} else {
+				// if the file is only readable, make it readable for everyone
+				// first clear the r/w permission bits
+				dirs[j].mode &^= 0666
+				// then set r permission for all
+				dirs[j].mode |= 0444
+			}
+			if dirs[j].mode.IsDir() {
+				// if the file is a directory, make it executable for everyone
+				dirs[j].mode |= 0111
+			} else {
+				// if it's not a directory, clear the executable bits as they are
+				// irrelevant on windows.
+				dirs[j].mode &^= 0111
+			}
+
+		}
+		for k := range links {
+			links[k].fileName = filepath.FromSlash(links[k].fileName)
+			links[k].linkName = filepath.FromSlash(links[k].linkName)
+		}
+	}
+	dirsToVerify := make(map[string]dirDesc)
+	for _, dd := range dirs {
+		dirsToVerify[dd.name] = dd
+	}
+	pathsToVerify := make(map[string]fileDesc)
+	for _, fd := range files {
+		pathsToVerify[fd.name] = fd
+	}
+	linksToVerify := make(map[string]linkDesc)
+	for _, ld := range links {
+		linksToVerify[ld.linkName] = ld
+	}
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if path == dir {
+			return nil
+		}
+		relpath := path[len(dir)+1:]
+		if dd, ok := dirsToVerify[relpath]; ok {
+			if !info.IsDir() {
+				t.Errorf("Incorrect dir %q", info.Name())
+			}
+			if info.Mode().Perm() != dd.mode {
+				t.Errorf("Dir %q does not match expected mode. Expected: %v, actual: %v",
+					info.Name(), dd.mode, info.Mode().Perm())
+			}
+			// Do not test directories - mod time will be time directory was created on filesystem
+		} else if fd, ok := pathsToVerify[relpath]; ok {
+			if info.Mode() != fd.mode {
+				t.Errorf("File mode is not equal for %q. Expected: %v, Actual: %v",
+					relpath, fd.mode, info.Mode())
+			}
+			// TODO: check modification time for symlinks when extractLink() will support it
+			if info.ModTime().UTC() != fd.modifiedDate && !isSymLink(fd.mode) && !fd.mode.IsDir() {
+				t.Errorf("File modified date is not equal for %q. Expected: %v, Actual: %v",
+					relpath, fd.modifiedDate, info.ModTime())
+			}
+			if !info.IsDir() {
+				contentBytes, err := ioutil.ReadFile(path)
+				if err != nil {
+					t.Errorf("Error reading file %q: %v", path, err)
+					return err
+				}
+				content := string(contentBytes)
+				if content != fd.content {
+					t.Errorf("File content is not equal for %q. Expected: %q, Actual: %q",
+						relpath, fd.content, content)
+				}
+			}
+			if isSymLink(fd.mode) {
+				target, err := os.Readlink(path)
+				if err != nil {
+					t.Errorf("Error reading symlink %q: %v", path, err)
+					return err
+				}
+				if target != fd.target {
+					msg := "Symbolic link %q points to wrong path. Expected: %q, Actual: %q"
+					t.Errorf(msg, fd.name, fd.target, target)
+				}
+			}
+		} else if ld, ok := linksToVerify[relpath]; ok {
+			if isSymLink(info.Mode()) {
+				target, err := os.Readlink(path)
+				if err != nil {
+					t.Errorf("Error reading symlink %q: %v", path, err)
+					return err
+				}
+				if target != ld.fileName {
+					t.Errorf("Incorrect link location. Expected: %q, Actual %q", ld.fileName, target)
+				}
+			} else {
+				t.Errorf("Expected file %q to be a symlink", path)
+			}
+		} else {
+			t.Errorf("Unexpected file found: %q", relpath)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Error walking directory %q: %v", dir, err)
+	}
+}
+
+func TestExtractTarStream(t *testing.T) {
+	modificationDate := time.Date(2011, time.March, 5, 23, 30, 1, 0, time.UTC)
+	var symLinkMode os.FileMode = 0777
+	if runtime.GOOS == "darwin" {
+		// Symlinks show up as Lrwxr-xr-x on macOS
+		symLinkMode = 0755
+	}
+	testFiles := []fileDesc{
+		{"dir01", modificationDate, 0700 | os.ModeDir, "", false, ""},
+		{"dir01/.git", modificationDate, 0755 | os.ModeDir, "", false, ""},
+		{"dir01/dir02", modificationDate, 0755 | os.ModeDir, "", false, ""},
+		{"dir01/dir03", modificationDate, 0775 | os.ModeDir, "", false, ""},
+		{"dir01/dir02/test1.txt", modificationDate, 0700, "Test1 file content", false, ""},
+		{"dir01/test2.git", modificationDate, 0660, "Test2 file content", false, ""},
+		{"dir01/dir03/test3.txt", modificationDate, 0444, "Test3 file content", false, ""},
+		{"dir01/symlink", modificationDate, os.ModeSymlink | symLinkMode, "Test3 file content", false, "../dir01/dir03/test3.txt"},
+		{"dir01/dir03/tëst3.txt", modificationDate, 0444, "utf-8 header file content", false, ""},
+	}
+	reader, writer := io.Pipe()
+	destDir, err := ioutil.TempDir("", "testExtract")
+	if err != nil {
+		t.Fatalf("Cannot create temp directory: %v", err)
+	}
+	defer os.RemoveAll(destDir)
+	th := New(fs.NewFileSystem())
+
+	go func() {
+		err := createTestTar(testFiles, writer)
+		if err != nil {
+			t.Fatalf("Error creating tar stream: %v", err)
+		}
+		writer.CloseWithError(err)
+	}()
+	th.ExtractTarStream(destDir, reader)
+	verifyDirectory(t, destDir, nil, testFiles, nil)
+}
+
+func TestExtractTarStreamTimeout(t *testing.T) {
+	reader, writer := io.Pipe()
+	destDir, err := ioutil.TempDir("", "testExtract")
+	if err != nil {
+		t.Fatalf("Cannot create temp directory: %v", err)
+	}
+	defer os.RemoveAll(destDir)
+	th := New(fs.NewFileSystem())
+	th.(*stiTar).timeout = 5 * time.Millisecond
+	time.AfterFunc(30*time.Millisecond, func() { writer.Close() })
+	err = th.ExtractTarStream(destDir, reader)
+	if e, ok := err.(s2ierr.Error); err == nil || (ok && e.ErrorCode != s2ierr.TarTimeoutError) {
+		t.Errorf("Did not get the expected timeout error. err = %v", err)
+	}
+}
+
+func TestRoundTripTar(t *testing.T) {
+	tarWriter := New(fs.NewFileSystem())
+	tarReader := New(fs.NewFileSystem())
+	tempDir, err := ioutil.TempDir("", "testtar")
+	defer os.RemoveAll(tempDir)
+	if err != nil {
+		t.Fatalf("Cannot create temp input directory for test: %v", err)
+	}
+	destDir, err := ioutil.TempDir("", "testExtract")
+	defer os.RemoveAll(destDir)
+	if err != nil {
+		t.Fatalf("Cannot create temp extract directory for test: %v", err)
+	}
+	modificationDate := time.Date(2011, time.March, 5, 23, 30, 1, 0, time.UTC)
+	testDirs := []dirDesc{
+		{"dir01", modificationDate, 0700},
+		{"dir01/.git", modificationDate, 0755},
+		{"dir01/dir02", modificationDate, 0755},
+		{"dir01/dir03", modificationDate, 0775},
+		{"link", modificationDate, 0775},
+	}
+	testFiles := []fileDesc{
+		{"dir01/dir02/test1.txt", modificationDate, 0700, "Test1 file content", false, ""},
+		{"dir01/test2.git", modificationDate, 0660, "Test2 file content", false, ""},
+		{"dir01/dir03/test3.txt", modificationDate, 0444, "Test3 file content", false, ""},
+		{"dir01/.git/hello.txt", modificationDate, 0600, "Ignore file content", true, ""},
+		{"dir01/dir03/tëst3.txt", modificationDate, 0444, "Test utf-8 file header content", false, ""},
+	}
+	testLinks := []linkDesc{
+		{"link/okfilelink", "../dir01/dir02/test1.txt"},
+		{"link/errfilelink", "../dir01/missing.target"},
+		{"link/okdirlink", "../dir01/dir02"},
+		{"link/okdirlink2", "../dir01/.git"},
+	}
+	if err = createTestFiles(tempDir, testDirs, testFiles, testLinks); err != nil {
+		t.Fatalf("Cannot create test files: %v", err)
+	}
+
+	r, w := io.Pipe()
+	go func() {
+		writeErr := tarWriter.CreateTarStream(tempDir, false, w)
+		if writeErr != nil {
+			t.Errorf("Unable to create tar stream: %v", err)
+		}
+		w.CloseWithError(writeErr)
+	}()
+
+	err = tarReader.ExtractTarStream(destDir, r)
+	if err != nil {
+		t.Errorf("error extracting tar stream: %v", err)
+	}
+	verifyDirectory(t, destDir, testDirs, testFiles, testLinks)
+}

--- a/pkg/build/source-to-image/timeout/timeout.go
+++ b/pkg/build/source-to-image/timeout/timeout.go
@@ -1,0 +1,52 @@
+package timeout
+
+import (
+	"fmt"
+	"time"
+)
+
+// TimeoutError is error returned after timeout occurred.
+type TimeoutError struct {
+	after   time.Duration
+	message string
+}
+
+// Error implements the Go error interface.
+func (t *TimeoutError) Error() string {
+	if len(t.message) > 0 {
+		return fmt.Sprintf("%s timed out after %v", t.message, t.after)
+	}
+	return fmt.Sprintf("function timed out after %v", t.after)
+}
+
+// TimeoutAfter executes the provided function and returns TimeoutError in the
+// case that the execution time of the function exceeded the provided duration.
+// The provided function is passed the timer in case it wishes to reset it.  If
+// so, the following pattern must be used:
+// if !timer.Stop() {
+//   return &TimeoutError{}
+// }
+// timer.Reset(timeout)
+func TimeoutAfter(t time.Duration, errorMsg string, f func(*time.Timer) error) error {
+	c := make(chan error, 1)
+	timer := time.NewTimer(t)
+	go func() {
+		err := f(timer)
+		if !IsTimeoutError(err) {
+			c <- err
+		}
+	}()
+	select {
+	case err := <-c:
+		timer.Stop()
+		return err
+	case <-timer.C:
+		return &TimeoutError{after: t, message: errorMsg}
+	}
+}
+
+// IsTimeoutError checks if the provided error is a TimeoutError.
+func IsTimeoutError(e error) bool {
+	_, ok := e.(*TimeoutError)
+	return ok
+}

--- a/pkg/build/source-to-image/timeout/timeout_test.go
+++ b/pkg/build/source-to-image/timeout/timeout_test.go
@@ -1,0 +1,61 @@
+package timeout
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestTimeoutAfter(t *testing.T) {
+	type testCase struct {
+		fn      func(*time.Timer) error
+		msg     string
+		timeout time.Duration
+		expect  interface{}
+	}
+	table := []testCase{
+		{
+			fn:      func(timer *time.Timer) error { time.Sleep(1 * time.Second); return nil },
+			timeout: 50 * time.Millisecond,
+			expect:  &TimeoutError{after: 50 * time.Millisecond},
+		},
+		{
+			fn:      func(timer *time.Timer) error { return fmt.Errorf("foo") },
+			timeout: 50 * time.Millisecond,
+			expect:  fmt.Errorf("foo"),
+		},
+		{
+			fn:      func(timer *time.Timer) error { time.Sleep(1 * time.Second); return fmt.Errorf("foo") },
+			msg:     "bar",
+			timeout: 50 * time.Millisecond,
+			expect:  fmt.Errorf("bar timed out after 50ms"),
+		},
+		{
+			fn:      func(timer *time.Timer) error { return nil },
+			timeout: 50 * time.Millisecond,
+			expect:  nil,
+		},
+	}
+	for _, item := range table {
+		got := TimeoutAfter(item.timeout, item.msg, item.fn)
+		if len(item.msg) > 0 {
+			expect, ok := item.expect.(error)
+			if !ok {
+				t.Errorf("expect must be an error, got %+v", item.expect)
+			}
+			if expect.Error() != got.Error() {
+				t.Errorf("expected message %q, got %q", item.msg, got.Error())
+			}
+			continue
+		}
+		if !reflect.DeepEqual(item.expect, got) {
+			t.Errorf("expected %+v, got %+v", item.expect, got)
+		}
+		if _, ok := item.expect.(*TimeoutError); ok {
+			if !IsTimeoutError(got) {
+				t.Errorf("expected %+v to be timeout error", got)
+			}
+		}
+	}
+}


### PR DESCRIPTION
This is a clean move from source-to-image for packages that are shared between OpenShift build controllers, CLI (oc new-app) and source-to-image.

Since vendoring source-to-image already causing trouble for `oc` and we don't want to vendor source-to-image docker and other transitive (buildkit, etc.) this establish minimal common ground and set `oc` repo free from source-to-image.

`oc` import list: https://gist.github.com/mfojtik/2df592fe3e3abd61af54e458a3fffd9a