### PR TITLE
Bug 1779796: controllercmd: set TCP timeout on leader election client

### DIFF
--- a/pkg/controller/controllercmd/builder.go
+++ b/pkg/controller/controllercmd/builder.go
@@ -232,7 +232,11 @@ func (b *ControllerBuilder) Run(config *unstructured.Unstructured, ctx context.C
 		return fmt.Errorf("exited")
 	}
 
-	leaderElection, err := leaderelectionconverter.ToConfigMapLeaderElection(clientConfig, *b.leaderElection, b.componentName, b.instanceIdentity)
+	// ensure blocking TCP connections don't block the leader election
+	leaderConfig := rest.CopyConfig(clientConfig)
+	leaderConfig.Timeout = b.leaderElection.RenewDeadline.Duration
+
+	leaderElection, err := leaderelectionconverter.ToConfigMapLeaderElection(leaderConfig, *b.leaderElection, b.componentName, b.instanceIdentity)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Leader election client can freeze due to a TCP connection timeout not being set. Then the other timeouts set in the election config have no effect.