### PR TITLE
ApplySecret: Don't erase injected Data for ServiceAccounts

### DIFF
--- a/pkg/operator/resource/resourceapply/core.go
+++ b/pkg/operator/resource/resourceapply/core.go
@@ -222,23 +222,38 @@ func ApplySecret(client coreclientv1.SecretsGetter, recorder events.Recorder, re
 		return nil, false, err
 	}
 
-	modified := resourcemerge.BoolPtr(false)
 	existingCopy := existing.DeepCopy()
 
-	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
+	resourcemerge.EnsureObjectMeta(resourcemerge.BoolPtr(false), &existingCopy.ObjectMeta, required.ObjectMeta)
 
-	dataSame := equality.Semantic.DeepEqual(existingCopy.Data, required.Data)
-	if dataSame && !*modified {
-		return existingCopy, false, nil
+	switch required.Type {
+	case corev1.SecretTypeServiceAccountToken:
+		// Secrets for ServiceAccountTokens will have data injected by kube controller manager.
+		// We will apply only the explicitly set keys.
+		if existingCopy.Data == nil {
+			existingCopy.Data = map[string][]byte{}
+		}
+
+		for k, v := range required.Data {
+			existingCopy.Data[k] = v
+		}
+
+	default:
+		existingCopy.Data = required.Data
 	}
-	existingCopy.Data = required.Data
+
+	existingCopy.Type = required.Type
+
+	if equality.Semantic.DeepEqual(existingCopy, existing) {
+		return existing, false, nil
+	}
 
 	if klog.V(4) {
-		klog.Infof("Secret %s/%s changes: %v", required.Namespace, required.Name, JSONPatchSecretNoError(existing, required))
+		klog.Infof("Secret %s/%s changes: %v", required.Namespace, required.Name, JSONPatchSecretNoError(existing, existingCopy))
 	}
 	actual, err := client.Secrets(required.Namespace).Update(existingCopy)
 
-	reportUpdateEvent(recorder, required, err)
+	reportUpdateEvent(recorder, existingCopy, err)
 	return actual, true, err
 }
 


### PR DESCRIPTION
ApplySecret was fighting with kube controller manager - service account token controller when used for service accounts. It was constantly deleting the injected data. This PR prevents it.

/cc @deads2k 

needed for https://github.com/openshift/cluster-kube-apiserver-operator/pull/663