### PR TITLE
Fix order in condition

### DIFF
--- a/alpha-build-machinery/make/lib/golang.mk
+++ b/alpha-build-machinery/make/lib/golang.mk
@@ -23,7 +23,7 @@ GO_TEST_PACKAGES ?=$(GO_PACKAGES)
 #
 # Conditional to avoid Go 1.13 bug on false double flag https://github.com/golang/go/issues/32471
 # TODO: Drop the contitional when golang is fixed so we can see the flag being explicitelly set in logs.
-ifeq "$(findstring -mod=vendor,$(GOFLAGS))" "-mod=vendor"
+ifeq "-mod=vendor" "$(findstring -mod=vendor,$(GOFLAGS))"
 GO_MOD_FLAGS ?=
 else
 GO_MOD_FLAGS ?=-mod=vendor


### PR DESCRIPTION
I'm not 100% sure why the order has to be reversed here, but w/o it, it won't work. Also https://www.gnu.org/software/make/manual/html_node/Testing-Flags.html#Testing-Flags used the reversed order as example, so I followed and proved this works fine in oc repository. From local tests where I've added prints right after that condition:
```
$ make
goflags is -mod=vendor
go_mod_flags is 
goflags is -mod=vendor
go_mod_flags is 
goflags is -mod=vendor
go_mod_flags is 
goflags is -mod=vendor
go_mod_flags is 
go build -tags 'include_gcs include_oss containers_image_openpgp gssapi' ...
```
vs
```
$ make
goflags is 
go_mod_flags is -mod=vendor
goflags is 
go_mod_flags is -mod=vendor
goflags is 
go_mod_flags is -mod=vendor
goflags is 
go_mod_flags is -mod=vendor
go build -mod=vendor -tags 'include_gcs include_oss containers_image_openpgp gssapi' ...
```
/assign @tnozicka