### PR TITLE
build-machinery: respect -mod=vendor for go list

### DIFF
--- a/alpha-build-machinery/make/lib/golang.mk
+++ b/alpha-build-machinery/make/lib/golang.mk
@@ -30,7 +30,7 @@ GO_MOD_FLAGS ?=-mod=vendor
 endif
 
 GO_BUILD_PACKAGES ?=./cmd/...
-GO_BUILD_PACKAGES_EXPANDED ?=$(shell $(GO) list $(GO_BUILD_PACKAGES))
+GO_BUILD_PACKAGES_EXPANDED ?=$(shell $(GO) list $(GO_MOD_FLAGS) $(GO_BUILD_PACKAGES))
 go_build_binaries =$(notdir $(GO_BUILD_PACKAGES_EXPANDED))
 GO_BUILD_FLAGS ?=
 GO_BUILD_BINDIR ?=


### PR DESCRIPTION
`go list ./cmd/...` that is used in resolving `GO_BUILD_PACKAGES_EXPANDED` for some reason fetches the go modules although that's a local reference, respecting mod vendor there force the correct behaviour

/cc @soltysh 