### PR TITLE
fileobserver: prometheus counter for observed actions

### DIFF
--- a/pkg/controller/fileobserver/observer.go
+++ b/pkg/controller/fileobserver/observer.go
@@ -28,6 +28,19 @@ const (
 	FileDeleted
 )
 
+func (t ActionType) name() string {
+	switch t {
+	case FileCreated:
+		return "create"
+	case FileDeleted:
+		return "delete"
+	case FileModified:
+		return "modified"
+	default:
+		return "unknown"
+	}
+}
+
 // String returns human readable form of action taken on a file.
 func (t ActionType) String(filename string) string {
 	switch t {


### PR DESCRIPTION
This add `fileobserver_action_count{name=ACTION, filename="file"}=N` prometheus metric that can be used to track changes on particular files over time and indicate problems when files are changed too often or not changed at all. 