### PR TITLE
leaderelection: set release on cancel to true

### DIFF
--- a/pkg/config/leaderelection/leaderelection.go
+++ b/pkg/config/leaderelection/leaderelection.go
@@ -57,10 +57,11 @@ func ToConfigMapLeaderElection(clientConfig *rest.Config, config configv1.Leader
 	}
 
 	return leaderelection.LeaderElectionConfig{
-		Lock:          rl,
-		LeaseDuration: config.LeaseDuration.Duration,
-		RenewDeadline: config.RenewDeadline.Duration,
-		RetryPeriod:   config.RetryPeriod.Duration,
+		Lock:            rl,
+		ReleaseOnCancel: true,
+		LeaseDuration:   config.LeaseDuration.Duration,
+		RenewDeadline:   config.RenewDeadline.Duration,
+		RetryPeriod:     config.RetryPeriod.Duration,
 		Callbacks: leaderelection.LeaderCallbacks{
 			OnStoppedLeading: func() {
 				klog.Fatalf("leaderelection lost")


### PR DESCRIPTION
This will cause faster operator upgrades as we release the leader when the context that we pass to all control loops in operators is cancelled (typically on graceful shutdown).