### PR TITLE
config: default bind network to tcp instead of tcp4

### DIFF
--- a/pkg/config/configdefaults/config_default.go
+++ b/pkg/config/configdefaults/config_default.go
@@ -44,7 +44,7 @@ func SetRecommendedHTTPServingInfoDefaults(config *configv1.HTTPServingInfo) {
 
 func SetRecommendedServingInfoDefaults(config *configv1.ServingInfo) {
 	DefaultString(&config.BindAddress, "0.0.0.0:8443")
-	DefaultString(&config.BindNetwork, "tcp4")
+	DefaultString(&config.BindNetwork, "tcp")
 	DefaultString(&config.CertInfo.KeyFile, "/var/run/secrets/serving-cert/tls.key")
 	DefaultString(&config.CertInfo.CertFile, "/var/run/secrets/serving-cert/tls.crt")
 	DefaultString(&config.ClientCA, "/var/run/configmaps/client-ca/ca-bundle.crt")


### PR DESCRIPTION
Based on https://github.com/openshift/cluster-authentication-operator/pull/231 we should default to `tcp` instead of forcing `tcp4`