### PR TITLE
Controller factory

### DIFF
--- a/pkg/controller/factory/base_controller.go
+++ b/pkg/controller/factory/base_controller.go
@@ -1,0 +1,123 @@
+package factory
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+)
+
+// baseController represents generic Kubernetes controller boiler-plate
+type baseController struct {
+	name         string
+	cachesToSync []cache.InformerSynced
+	sync         func(ctx context.Context, controllerContext SyncContext) error
+	resyncEvery  time.Duration
+	syncContext  SyncContext
+}
+
+var _ Controller = &baseController{}
+
+func (c *baseController) Run(ctx context.Context, workers int) {
+	// HandleCrash recovers panics
+	defer utilruntime.HandleCrash()
+	if !cache.WaitForNamedCacheSync(c.name, ctx.Done(), c.cachesToSync...) {
+		panic("timeout waiting for informer cache") // this will be recovered using HandleCrash()
+	}
+
+	var workerWaitGroup sync.WaitGroup
+	defer func() {
+		defer klog.Infof("All %s workers have been terminated", c.name)
+		workerWaitGroup.Wait()
+	}()
+
+	// queueContext is used to track and initiate queue shutdown
+	queueContext, queueContextCancel := context.WithCancel(context.TODO())
+
+	for i := 1; i <= workers; i++ {
+		klog.Infof("Starting #%d worker of %s controller ...", i, c.name)
+		workerWaitGroup.Add(1)
+		go func() {
+			defer func() {
+				klog.Infof("Shutting down worker of %s controller ...", c.name)
+				workerWaitGroup.Done()
+			}()
+			c.runWorker(queueContext)
+		}()
+	}
+
+	// runPeriodicalResync is independent from queue
+	if c.resyncEvery > 0 {
+		workerWaitGroup.Add(1)
+		go func() {
+			defer workerWaitGroup.Done()
+			c.runPeriodicalResync(ctx, c.resyncEvery)
+		}()
+	}
+
+	// Handle controller shutdown
+
+	<-ctx.Done()                     // wait for controller context to be cancelled
+	c.syncContext.Queue().ShutDown() // shutdown the controller queue first
+	queueContextCancel()             // cancel the queue context, which tell workers to initiate shutdown
+
+	// Wait for all workers to finish their job.
+	// at this point the Run() can hang and caller have to implement the logic that will kill
+	// this controller (SIGKILL).
+	klog.Infof("Shutting down %s ...", c.name)
+}
+
+func (c *baseController) Sync(ctx context.Context, syncCtx SyncContext) error {
+	return c.sync(ctx, syncCtx)
+}
+
+func (c *baseController) runPeriodicalResync(ctx context.Context, interval time.Duration) {
+	go wait.UntilWithContext(ctx, func(ctx context.Context) {
+		if err := c.sync(ctx, c.syncContext); err != nil {
+			utilruntime.HandleError(fmt.Errorf("periodical resync of controller %s failed: %v", c.name, err))
+		}
+	}, interval)
+}
+
+// runWorker runs a single worker
+// The worker is asked to terminate when the passed context is cancelled and is given terminationGraceDuration time
+// to complete its shutdown.
+func (c *baseController) runWorker(queueCtx context.Context) {
+	var workerWaitGroup sync.WaitGroup
+	workerWaitGroup.Add(1)
+	go func() {
+		defer workerWaitGroup.Done()
+		for {
+			select {
+			case <-queueCtx.Done():
+				return
+			default:
+				c.processNextWorkItem(queueCtx)
+			}
+		}
+	}()
+	workerWaitGroup.Wait()
+}
+
+func (c *baseController) processNextWorkItem(queueCtx context.Context) {
+	syncObject, quit := c.syncContext.Queue().Get()
+	if quit {
+		return
+	}
+	defer c.syncContext.Queue().Done(syncObject)
+
+	runtimeObject, _ := syncObject.(runtime.Object)
+	if err := c.sync(queueCtx, c.syncContext.(syncContext).withRuntimeObject(runtimeObject)); err != nil {
+		utilruntime.HandleError(fmt.Errorf("%s controller failed to sync %+v with: %w", c.name, syncObject, err))
+		c.syncContext.Queue().AddRateLimited(syncObject)
+		return
+	}
+
+	c.syncContext.Queue().Forget(syncObject)
+}

--- a/pkg/controller/factory/controller_context.go
+++ b/pkg/controller/factory/controller_context.go
@@ -1,0 +1,154 @@
+package factory
+
+import (
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/openshift/library-go/pkg/operator/events"
+)
+
+// syncContext implements SyncContext and provide user access to queue and object that caused
+// the sync to be triggered.
+type syncContext struct {
+	queue         workqueue.RateLimitingInterface
+	eventRecorder events.Recorder
+
+	// queueRuntimeObject holds the object we got from informer
+	// There is no direct access to this object to prevent cache mutation.
+	queueRuntimeObject runtime.Object
+}
+
+var _ SyncContext = syncContext{}
+
+// NewSyncContext gives new sync context.
+func NewSyncContext(name string, recorder events.Recorder) SyncContext {
+	return syncContext{
+		queue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), name),
+		eventRecorder: recorder.WithComponentSuffix(strings.ToLower(name)),
+	}
+}
+
+// GetObject gives the object from the queue.
+// For controllers generated without WithRuntimeObject() this always return nil.
+func (c syncContext) GetObject() runtime.Object {
+	if c.queueRuntimeObject == nil {
+		return nil
+	}
+	return c.queueRuntimeObject.DeepCopyObject()
+}
+
+func (c syncContext) Queue() workqueue.RateLimitingInterface {
+	return c.queue
+}
+
+func (c syncContext) Recorder() events.Recorder {
+	return c.eventRecorder
+}
+
+// withRuntimeObject make a copy of existing sync context and set the queueRuntimeObject.
+func (c syncContext) withRuntimeObject(obj runtime.Object) SyncContext {
+	return syncContext{
+		eventRecorder:      c.Recorder(),
+		queue:              c.Queue(),
+		queueRuntimeObject: obj,
+	}
+}
+
+func (c syncContext) isInterestingNamespace(obj interface{}, interestingNamespaces sets.String) (bool, bool) {
+	ns, ok := obj.(*corev1.Namespace)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if ok {
+			if ns, ok := tombstone.Obj.(*corev1.Namespace); ok {
+				return true, interestingNamespaces.Has(ns.Name)
+			}
+		}
+		return false, false
+	}
+	return true, interestingNamespaces.Has(ns.Name)
+}
+
+// eventHandler provides default event handler that is added to an informers passed to controller factory.
+func (c syncContext) eventHandler(keyName string, objectQueue bool, interestingNamespaces sets.String) cache.ResourceEventHandler {
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			isNamespace, isInteresting := c.isInterestingNamespace(obj, interestingNamespaces)
+			if !objectQueue {
+				if !isNamespace {
+					c.Queue().Add(keyName)
+				} else if isInteresting {
+					c.Queue().Add(keyName)
+				}
+				return
+			}
+			runtimeObj, ok := obj.(runtime.Object)
+			if !ok {
+				utilruntime.HandleError(fmt.Errorf("added object %+v is not runtime Object", obj))
+				return
+			}
+			if !isNamespace {
+				c.Queue().Add(runtimeObj)
+			} else if isInteresting {
+				c.Queue().Add(runtimeObj)
+			}
+		},
+		UpdateFunc: func(old, new interface{}) {
+			isNamespace, isInteresting := c.isInterestingNamespace(new, interestingNamespaces)
+			if !objectQueue {
+				if !isNamespace {
+					c.Queue().Add(keyName)
+				} else if isInteresting {
+					c.Queue().Add(keyName)
+				}
+				return
+			}
+			runtimeObj, ok := new.(runtime.Object)
+			if !ok {
+				utilruntime.HandleError(fmt.Errorf("updated object %+v is not runtime Object", runtimeObj))
+				return
+			}
+			if !isNamespace {
+				c.Queue().Add(runtimeObj)
+			} else if isInteresting {
+				c.Queue().Add(runtimeObj)
+			}
+		},
+		DeleteFunc: func(obj interface{}) {
+			isNamespace, isInteresting := c.isInterestingNamespace(obj, interestingNamespaces)
+			if !objectQueue {
+				if !isNamespace {
+					c.Queue().Add(keyName)
+				} else if isInteresting {
+					c.Queue().Add(keyName)
+				}
+				return
+			}
+			runtimeObj, ok := obj.(runtime.Object)
+			if !ok {
+				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+				if ok {
+					if !isNamespace {
+						c.Queue().Add(tombstone.Obj.(runtime.Object))
+					} else if isInteresting {
+						c.Queue().Add(tombstone.Obj.(runtime.Object))
+					}
+					return
+				}
+				utilruntime.HandleError(fmt.Errorf("updated object %+v is not runtime Object", runtimeObj))
+				return
+			}
+			if !isNamespace {
+				c.Queue().Add(runtimeObj)
+			} else if isInteresting {
+				c.Queue().Add(runtimeObj)
+			}
+		},
+	}
+}

--- a/pkg/controller/factory/controller_test.go
+++ b/pkg/controller/factory/controller_test.go
@@ -1,0 +1,193 @@
+package factory
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	coreinformersv1 "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/openshift/library-go/pkg/operator/events"
+)
+
+func makeFakeSecret() *v1.Secret {
+	return &v1.Secret{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "test-secret",
+			Namespace: "test",
+		},
+		Data: map[string][]byte{
+			"test": {},
+		},
+	}
+}
+
+type FakeController struct {
+	synced chan struct{}
+	t      *testing.T
+}
+
+func NewFakeController(t *testing.T, synced chan struct{}, secretsInformer coreinformersv1.SecretInformer) Controller {
+	factory := New().WithInformers(secretsInformer.Informer())
+	controller := &FakeController{synced: synced, t: t}
+	return factory.WithSync(controller.Sync).WithRuntimeObject().ToController("FakeController", events.NewInMemoryRecorder("fake-controller"))
+}
+
+func (f *FakeController) Sync(ctx context.Context, controllerContext SyncContext) error {
+	defer close(f.synced)
+	if ctx.Err() != nil {
+		f.t.Logf("syncContext %v", ctx.Err())
+		return ctx.Err()
+	}
+	if name := controllerContext.GetObject().(*v1.Secret).GetName(); name != "test-secret" {
+		f.t.Errorf("expected controller context to give secret name 'test-secret', got %q", name)
+	}
+	if _, ok := controllerContext.GetObject().(*v1.Secret); !ok {
+		f.t.Errorf("expected Secret object, got %+v", controllerContext.GetObject())
+	}
+	f.t.Logf("controller sync called")
+	return nil
+}
+
+func TestEmbeddedController(t *testing.T) {
+	kubeClient := fake.NewSimpleClientset()
+	kubeInformers := informers.NewSharedInformerFactoryWithOptions(kubeClient, 3*time.Second, informers.WithNamespace("test"))
+	ctx, cancel := context.WithCancel(context.TODO())
+
+	go kubeInformers.Start(ctx.Done())
+
+	controllerSynced := make(chan struct{})
+	controller := NewFakeController(t, controllerSynced, kubeInformers.Core().V1().Secrets())
+	go controller.Run(ctx, 1)
+
+	time.Sleep(1 * time.Second) // Give controller time to start
+	if _, err := kubeClient.CoreV1().Secrets("test").Create(makeFakeSecret()); err != nil {
+		t.Fatalf("failed to create fake secret: %v", err)
+	}
+
+	select {
+	case <-controllerSynced:
+		cancel()
+	case <-time.After(30 * time.Second):
+		t.Fatal("test timeout")
+	}
+}
+
+func TestResyncController(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.TODO())
+	factory := New().ResyncEvery(100 * time.Millisecond)
+
+	controllerSynced := make(chan struct{})
+	syncCallCount := 0
+	controller := factory.WithSync(func(ctx context.Context, controllerContext SyncContext) error {
+		syncCallCount++
+		if syncCallCount == 3 {
+			defer close(controllerSynced)
+		}
+		t.Logf("controller sync called (%d)", syncCallCount)
+		return nil
+	}).ToController("PeriodicController", events.NewInMemoryRecorder("periodic-controller"))
+
+	go controller.Run(ctx, 1)
+	time.Sleep(1 * time.Second) // Give controller time to start
+
+	select {
+	case <-controllerSynced:
+		cancel()
+	case <-time.After(10 * time.Second):
+		t.Fatal("failed to resync at least three times")
+	}
+}
+
+func TestMultiWorkerControllerShutdown(t *testing.T) {
+	controllerCtx, shutdown := context.WithCancel(context.TODO())
+	factory := New().ResyncEvery(5 * time.Minute) // make sure we only call 1 sync manually
+	var workersShutdownMutex sync.Mutex
+	workersShutdownCount := 0
+	syncCallCount := 0
+	var syncCallCountMutex sync.Mutex
+	recorder := events.NewInMemoryRecorder("shutdown-controller")
+
+	// simulate a long running sync logic that is signalled to shutdown
+	controller := factory.WithSync(func(ctx context.Context, syncContext SyncContext) error {
+		defer t.Logf("shutting down sync()")
+		syncCallCountMutex.Lock()
+		t.Logf("starting %d sync()", syncCallCount)
+		syncCallCount++
+		// First sync() enqueue 5 items which will result to all 5 workers having a job
+		if syncCallCount == 1 {
+			syncContext.Queue().Add("TestKey1")
+			syncContext.Queue().Add("TestKey2")
+			syncContext.Queue().Add("TestKey3")
+			syncContext.Queue().Add("TestKey4")
+			syncContext.Queue().Add("TestKey5")
+		}
+		syncCallCountMutex.Unlock()
+		// This will make the worker stucked until shutdown is called
+		<-ctx.Done()
+		time.Sleep(1 * time.Second) // simulate worker being busy finishing
+		workersShutdownMutex.Lock()
+		workersShutdownCount++
+		workersShutdownMutex.Unlock()
+		return nil
+	}).ToController("ShutdownController", recorder)
+
+	runComplete := make(chan struct{})
+	go func() {
+		defer close(runComplete)
+		controller.Run(controllerCtx, 5)
+	}() // start controller with 5 workers
+
+	time.Sleep(3 * time.Second) // give it time to periodically resync and call the sync() function
+
+	shutdown() // initiate controller shutdown
+	<-runComplete
+
+	workersShutdownMutex.Lock()
+	if workersShutdownCount != 6 {
+		t.Fatalf("expected all 6 workers to gracefully shutdown, got %d", workersShutdownCount)
+	}
+	workersShutdownMutex.Unlock()
+}
+
+func TestSimpleController(t *testing.T) {
+	kubeClient := fake.NewSimpleClientset()
+
+	kubeInformers := informers.NewSharedInformerFactoryWithOptions(kubeClient, 1*time.Minute, informers.WithNamespace("test"))
+	ctx, cancel := context.WithCancel(context.TODO())
+
+	go kubeInformers.Start(ctx.Done())
+	factory := New().WithInformers(kubeInformers.Core().V1().Secrets().Informer())
+
+	controllerSynced := make(chan struct{})
+	controller := factory.WithSync(func(ctx context.Context, syncContext SyncContext) error {
+		defer close(controllerSynced)
+		t.Logf("controller sync called")
+		if syncContext.GetObject() != nil {
+			t.Errorf("expected queue object to be nil, it is %+v", syncContext.GetObject())
+		}
+		if syncContext.Queue() == nil {
+			t.Errorf("expected queue to be initialized, it is not")
+		}
+		return nil
+	}).ToController("FakeController", events.NewInMemoryRecorder("fake-controller"))
+
+	go controller.Run(ctx, 1)
+	time.Sleep(1 * time.Second) // Give controller time to start
+
+	if _, err := kubeClient.CoreV1().Secrets("test").Create(makeFakeSecret()); err != nil {
+		t.Fatalf("failed to create fake secret: %v", err)
+	}
+
+	select {
+	case <-controllerSynced:
+		cancel()
+	case <-time.After(30 * time.Second):
+		t.Fatal("test timeout")
+	}
+}

--- a/pkg/controller/factory/factory.go
+++ b/pkg/controller/factory/factory.go
@@ -1,0 +1,104 @@
+package factory
+
+import (
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/openshift/library-go/pkg/operator/events"
+)
+
+// Factory is generator that generate standard Kubernetes controllers.
+// Factory is really generic and should be only used for simple controllers that does not require special stuff..
+type Factory struct {
+	sync                  SyncFunc
+	resyncInterval        time.Duration
+	objectQueue           bool
+	informers             []cache.SharedInformer
+	namespaceInformers    []*namespaceInformer
+	cachesToSync          []cache.InformerSynced
+	interestingNamespaces sets.String
+}
+
+type namespaceInformer struct {
+	informer   cache.SharedInformer
+	namespaces sets.String
+}
+
+// New return new factory instance.
+func New() *Factory {
+	return &Factory{}
+}
+
+// Sync is used to set the controller synchronization function. This function is the core of the controller and is
+// usually hold the main controller logic.
+func (f *Factory) WithSync(syncFn SyncFunc) *Factory {
+	f.sync = syncFn
+	return f
+}
+
+// WithInformers is used to register event handlers and get the caches synchronized functions.
+// Pass informers you want to use to react to changes on resources. If informer event is observed, then the Sync() function
+// is called.
+func (f *Factory) WithInformers(informers ...cache.SharedInformer) *Factory {
+	f.informers = append(f.informers, informers...)
+	return f
+}
+
+// WithNamespaceInformer is used to register event handlers and get the caches synchronized functions.
+// The sync function will only trigger when the object observed by this informer is a namespace and its name matches the interestingNamespaces.
+// Do not use this to register non-namespace informers.
+func (f *Factory) WithNamespaceInformer(informer cache.SharedInformer, interestingNamespaces ...string) *Factory {
+	f.namespaceInformers = append(f.namespaceInformers, &namespaceInformer{
+		informer:   informer,
+		namespaces: sets.NewString(interestingNamespaces...),
+	})
+	return f
+}
+
+// ResyncEvery will cause the Sync() function to be called periodically, regardless of informers.
+// This is useful when you want to refresh every N minutes or you fear that your informers can be stucked.
+// If this is not called, no periodical resync will happen.
+// Note: The controller context passed to Sync() function in this case does not contain the object metadata or object itself.
+//       This can be used to detect periodical resyncs, but normal Sync() have to be cautious about `nil` objects.
+func (f *Factory) ResyncEvery(interval time.Duration) *Factory {
+	f.resyncInterval = interval
+	return f
+}
+
+// WithRuntimeObject cause the factory to produce controller that pass the runtime.Object from event handler that was
+// triggered to queue (instead of requeue using simple string key). This allow to access this object, however storing
+// object in queue might increase memory usage (?).
+func (f *Factory) WithRuntimeObject() *Factory {
+	f.objectQueue = true
+	return f
+}
+
+// Controller produce a runnable controller.
+func (f *Factory) ToController(name string, eventRecorder events.Recorder) Controller {
+	if f.sync == nil {
+		panic("Sync() function must be called before making controller")
+	}
+
+	ctx := NewSyncContext(name, eventRecorder)
+	c := &baseController{
+		name:        name,
+		sync:        f.sync,
+		resyncEvery: f.resyncInterval,
+		syncContext: ctx,
+	}
+
+	for i := range f.informers {
+		f.informers[i].AddEventHandler(c.syncContext.(syncContext).eventHandler(strings.ToLower(name)+"Key", f.objectQueue, sets.NewString()))
+		c.cachesToSync = append(f.cachesToSync, f.informers[i].HasSynced)
+	}
+
+	for i := range f.namespaceInformers {
+		f.namespaceInformers[i].informer.AddEventHandler(c.syncContext.(syncContext).eventHandler(strings.ToLower(name)+"Key", f.objectQueue, f.namespaceInformers[i].namespaces))
+		c.cachesToSync = append(f.cachesToSync, f.informers[i].HasSynced)
+	}
+
+	return c
+}

--- a/pkg/controller/factory/interfaces.go
+++ b/pkg/controller/factory/interfaces.go
@@ -1,0 +1,46 @@
+package factory
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/openshift/library-go/pkg/operator/events"
+)
+
+// Controller interface represents a runnable Kubernetes controller.
+// Cancelling the syncContext passed will cause the controller to shutdown.
+// Number of workers determine how much parallel the job processing should be.
+type Controller interface {
+	// Run runs the controller and blocks until the controller is finished.
+	// Number of workers can be specified via workers parameter.
+	// This function will return when all internal loops are finished.
+	// Note that having more than one worker usually means handing parallelization of Sync().
+	Run(ctx context.Context, workers int)
+
+	// Sync contain the main controller logic.
+	// This should not be called directly, but can be used in unit tests to exercise the sync.
+	Sync(ctx context.Context, controllerContext SyncContext) error
+}
+
+// SyncContext interface represents a context given to the Sync() function where the main controller logic happen.
+// SyncContext exposes controller name and give user access to the queue (for manual requeue).
+// SyncContext also provides metadata about object that informers observed as changed.
+type SyncContext interface {
+	// Queue gives access to controller queue. This can be used for manual requeue, although if a Sync() function return
+	// an error, the object is automatically re-queued. Use with caution.
+	Queue() workqueue.RateLimitingInterface
+
+	// GetObject provides access to current synced object deep copy.
+	// It is safe to mutate this object inside Sync().
+	GetObject() runtime.Object
+
+	// Recorder provide access to event recorder.
+	Recorder() events.Recorder
+}
+
+// SyncFunc is a function that contain main controller logic.
+// The syncContext.syncContext passed is the main controller syncContext, when cancelled it means the controller is being shut down.
+// The syncContext provides access to controller name, queue and event recorder.
+type SyncFunc func(ctx context.Context, controllerContext SyncContext) error

--- a/pkg/controller/manager/controller_manager.go
+++ b/pkg/controller/manager/controller_manager.go
@@ -1,0 +1,25 @@
+package manager
+
+import (
+	"context"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
+)
+
+type ControllerManager interface {
+	Run(ctx context.Context)
+}
+
+type controllerManager struct {
+	controllers []factory.Controller
+}
+
+func (c *controllerManager) Run(ctx context.Context) {
+	for i := range c.controllers {
+		go func(index int) {
+			// TODO: Usually
+			c.controllers[index].Run(ctx, 1)
+		}(i)
+	}
+	panic("implement me")
+}

--- a/pkg/operator/loglevel/logging_controller.go
+++ b/pkg/operator/loglevel/logging_controller.go
@@ -2,53 +2,27 @@ package loglevel
 
 import (
 	"context"
-	"fmt"
-	"time"
-
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
-	"k8s.io/klog"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 
+	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
 	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
 )
 
-var workQueueKey = "instance"
-
 type LogLevelController struct {
 	operatorClient operatorv1helpers.OperatorClient
-
-	cachesToSync  []cache.InformerSynced
-	queue         workqueue.RateLimitingInterface
-	eventRecorder events.Recorder
 }
 
 // sets the klog level based on desired state
-func NewClusterOperatorLoggingController(
-	operatorClient operatorv1helpers.OperatorClient,
-	recorder events.Recorder,
-) *LogLevelController {
-	c := &LogLevelController{
-		operatorClient: operatorClient,
-		eventRecorder:  recorder.WithComponentSuffix("loglevel-controller"),
-
-		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "LoggingSyncer"),
-	}
-
-	operatorClient.Informer().AddEventHandler(c.eventHandler())
-
-	c.cachesToSync = append(c.cachesToSync, operatorClient.Informer().HasSynced)
-
-	return c
+func NewClusterOperatorLoggingController(operatorClient operatorv1helpers.OperatorClient, recorder events.Recorder) factory.Controller {
+	c := &LogLevelController{operatorClient: operatorClient}
+	return factory.New().WithInformers(operatorClient.Informer()).WithSync(c.sync).ToController("LoggingSyncer", recorder)
 }
 
 // sync reacts to a change in prereqs by finding information that is required to match another value in the cluster. This
 // must be information that is logically "owned" by another component.
-func (c LogLevelController) sync() error {
+func (c LogLevelController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
 	detailedSpec, _, _, err := c.operatorClient.GetOperatorState()
 	if err != nil {
 		return err
@@ -68,59 +42,10 @@ func (c LogLevelController) sync() error {
 
 	// Set the new loglevel if the operator spec changed
 	if err := SetVerbosityValue(desiredLogLevel); err != nil {
-		c.eventRecorder.Warningf("OperatorLoglevelChangeFailed", "Unable to change operator log level from %q to %q: %v", currentLogLevel, desiredLogLevel, err)
+		syncCtx.Recorder().Warningf("OperatorLoglevelChangeFailed", "Unable to change operator log level from %q to %q: %v", currentLogLevel, desiredLogLevel, err)
 		return err
 	}
 
-	c.eventRecorder.Eventf("OperatorLoglevelChange", "Operator log level changed from %q to %q", currentLogLevel, desiredLogLevel)
+	syncCtx.Recorder().Eventf("OperatorLoglevelChange", "Operator log level changed from %q to %q", currentLogLevel, desiredLogLevel)
 	return nil
-}
-
-func (c *LogLevelController) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
-	defer c.queue.ShutDown()
-
-	klog.Infof("Starting LogLevelController")
-	defer klog.Infof("Shutting down LogLevelController")
-	if !cache.WaitForCacheSync(ctx.Done(), c.cachesToSync...) {
-		return
-	}
-
-	// doesn't matter what workers say, only start one.
-	go wait.UntilWithContext(ctx, c.runWorker, time.Second)
-
-	<-ctx.Done()
-}
-
-func (c *LogLevelController) runWorker(ctx context.Context) {
-	for c.processNextWorkItem() {
-	}
-}
-
-func (c *LogLevelController) processNextWorkItem() bool {
-	dsKey, quit := c.queue.Get()
-	if quit {
-		return false
-	}
-	defer c.queue.Done(dsKey)
-
-	err := c.sync()
-	if err == nil {
-		c.queue.Forget(dsKey)
-		return true
-	}
-
-	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", dsKey, err))
-	c.queue.AddRateLimited(dsKey)
-
-	return true
-}
-
-// eventHandler queues the operator to check spec and loglevel
-func (c *LogLevelController) eventHandler() cache.ResourceEventHandler {
-	return cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) { c.queue.Add(workQueueKey) },
-		UpdateFunc: func(old, new interface{}) { c.queue.Add(workQueueKey) },
-		DeleteFunc: func(obj interface{}) { c.queue.Add(workQueueKey) },
-	}
 }

--- a/pkg/operator/loglevel/logging_controller_test.go
+++ b/pkg/operator/loglevel/logging_controller_test.go
@@ -1,10 +1,12 @@
 package loglevel
 
 import (
+	"context"
 	"testing"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 
+	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
@@ -30,7 +32,7 @@ func TestClusterOperatorLoggingController(t *testing.T) {
 
 	// no-op, desired == current
 	// When OperatorLogLevel is "" we assume the loglevel is Normal.
-	if err := controller.sync(); err != nil {
+	if err := controller.Sync(context.TODO(), factory.NewSyncContext("LoggingController", recorder)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -40,7 +42,7 @@ func TestClusterOperatorLoggingController(t *testing.T) {
 
 	// change the log level to trace should 1 emit event
 	operatorSpec.OperatorLogLevel = operatorv1.Trace
-	if err := controller.sync(); err != nil {
+	if err := controller.Sync(context.TODO(), factory.NewSyncContext("LoggingController", recorder)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -54,7 +56,7 @@ func TestClusterOperatorLoggingController(t *testing.T) {
 	}
 
 	// next sync should not produce any extra event
-	if err := controller.sync(); err != nil {
+	if err := controller.Sync(context.TODO(), factory.NewSyncContext("LoggingController", recorder)); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/operator/revisioncontroller/revision_controller_test.go
+++ b/pkg/operator/revisioncontroller/revision_controller_test.go
@@ -1,10 +1,12 @@
 package revisioncontroller
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 
 	v1 "k8s.io/api/core/v1"
@@ -448,7 +450,7 @@ func TestRevisionController(t *testing.T) {
 				kubeClient.CoreV1(),
 				eventRecorder,
 			)
-			syncErr := c.sync()
+			syncErr := c.Sync(context.TODO(), factory.NewSyncContext("RevisionController", eventRecorder))
 			if tc.validateStatus != nil {
 				_, status, _, _ := tc.staticPodOperatorClient.GetStaticPodOperatorState()
 				tc.validateStatus(t, status)

--- a/pkg/operator/staticpod/controller/backingresource/backing_resource_controller_test.go
+++ b/pkg/operator/staticpod/controller/backingresource/backing_resource_controller_test.go
@@ -1,11 +1,13 @@
 package backingresource
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/condition"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
@@ -184,7 +186,7 @@ func TestBackingResourceController(t *testing.T) {
 				tc.operatorClient,
 				eventRecorder,
 			)
-			syncErr := c.Sync()
+			syncErr := c.Sync(context.TODO(), factory.NewSyncContext("BackingResourceController", eventRecorder))
 			if tc.validateStatus != nil {
 				_, status, _, _ := tc.operatorClient.GetOperatorState()
 				tc.validateStatus(t, status)

--- a/pkg/operator/staticpod/controller/installer/installer_controller.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/davecgh/go-spew/spew"
 
@@ -17,17 +16,14 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 
+	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/condition"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/loglevel"
@@ -40,9 +36,8 @@ import (
 )
 
 const (
-	installerControllerWorkQueueKey = "key"
-	manifestDir                     = "pkg/operator/staticpod/controller/installer"
-	manifestInstallerPodPath        = "manifests/installer-pod.yaml"
+	manifestDir              = "pkg/operator/staticpod/controller/installer"
+	manifestInstallerPodPath = "manifests/installer-pod.yaml"
 
 	hostResourceDirDir = "/etc/kubernetes/static-pod-resources"
 	hostPodManifestDir = "/etc/kubernetes/manifests"
@@ -73,10 +68,7 @@ type InstallerController struct {
 	configMapsGetter corev1client.ConfigMapsGetter
 	secretsGetter    corev1client.SecretsGetter
 	podsGetter       corev1client.PodsGetter
-
-	cachesToSync  []cache.InformerSynced
-	queue         workqueue.RateLimitingInterface
-	eventRecorder events.Recorder
+	eventRecorder    events.Recorder
 
 	// installerPodImageFn returns the image name for the installer pod
 	installerPodImageFn func() string
@@ -84,6 +76,8 @@ type InstallerController struct {
 	ownerRefsFn func(revision int32) ([]metav1.OwnerReference, error)
 
 	installerPodMutationFns []InstallerPodMutationFunc
+
+	factory *factory.Factory
 }
 
 // InstallerPodMutationFunc is a function that has a chance at changing the installer pod before it is created
@@ -113,6 +107,8 @@ const (
 	staticPodStateFailed
 )
 
+var _ factory.Controller = &InstallerController{}
+
 // NewInstallerController creates a new installer controller.
 func NewInstallerController(
 	targetNamespace, staticPodName string,
@@ -139,20 +135,17 @@ func NewInstallerController(
 		podsGetter:       podsGetter,
 		eventRecorder:    eventRecorder.WithComponentSuffix("installer-controller"),
 
-		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "InstallerController"),
-
 		installerPodImageFn: getInstallerPodImageFromEnv,
 	}
 
 	c.ownerRefsFn = c.setOwnerRefs
-
-	operatorClient.Informer().AddEventHandler(c.eventHandler())
-	kubeInformersForTargetNamespace.Core().V1().Pods().Informer().AddEventHandler(c.eventHandler())
-
-	c.cachesToSync = append(c.cachesToSync, operatorClient.Informer().HasSynced)
-	c.cachesToSync = append(c.cachesToSync, kubeInformersForTargetNamespace.Core().V1().Pods().Informer().HasSynced)
+	c.factory = factory.New().WithInformers(operatorClient.Informer(), kubeInformersForTargetNamespace.Core().V1().Pods().Informer())
 
 	return c
+}
+
+func (c *InstallerController) Run(ctx context.Context, workers int) {
+	c.factory.WithSync(c.Sync).ToController("InstallerController", c.eventRecorder).Run(ctx, workers)
 }
 
 func (c *InstallerController) getStaticPodState(nodeName string) (state staticPodState, revision, reason string, errors []string, err error) {
@@ -803,7 +796,7 @@ func (c InstallerController) ensureRequiredResourcesExist(revisionNumber int32) 
 	return fmt.Errorf("missing required resources: %v", aggregatedErr)
 }
 
-func (c InstallerController) sync() error {
+func (c InstallerController) Sync(ctx context.Context, syncCtx factory.SyncContext) error {
 	operatorSpec, originalOperatorStatus, resourceVersion, err := c.operatorClient.GetStaticPodOperatorState()
 	if err != nil {
 		return err
@@ -843,56 +836,6 @@ func (c InstallerController) sync() error {
 	}
 
 	return err
-}
-
-// Run starts the kube-apiserver and blocks until stopCh is closed.
-func (c *InstallerController) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
-	defer c.queue.ShutDown()
-
-	klog.Infof("Starting InstallerController")
-	defer klog.Infof("Shutting down InstallerController")
-	if !cache.WaitForCacheSync(ctx.Done(), c.cachesToSync...) {
-		return
-	}
-
-	// doesn't matter what workers say, only start one.
-	go wait.UntilWithContext(ctx, c.runWorker, time.Second)
-
-	<-ctx.Done()
-}
-
-func (c *InstallerController) runWorker(ctx context.Context) {
-	for c.processNextWorkItem() {
-	}
-}
-
-func (c *InstallerController) processNextWorkItem() bool {
-	dsKey, quit := c.queue.Get()
-	if quit {
-		return false
-	}
-	defer c.queue.Done(dsKey)
-
-	err := c.sync()
-	if err == nil {
-		c.queue.Forget(dsKey)
-		return true
-	}
-
-	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", dsKey, err))
-	c.queue.AddRateLimited(dsKey)
-
-	return true
-}
-
-// eventHandler queues the operator to check spec and status
-func (c *InstallerController) eventHandler() cache.ResourceEventHandler {
-	return cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) { c.queue.Add(installerControllerWorkQueueKey) },
-		UpdateFunc: func(old, new interface{}) { c.queue.Add(installerControllerWorkQueueKey) },
-		DeleteFunc: func(obj interface{}) { c.queue.Add(installerControllerWorkQueueKey) },
-	}
 }
 
 func mirrorPodNameForNode(staticPodName, nodeName string) string {

--- a/pkg/operator/staticpod/controller/installer/installer_controller_test.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller_test.go
@@ -1,6 +1,7 @@
 package installer
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -17,10 +18,10 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	ktesting "k8s.io/client-go/testing"
-	"k8s.io/client-go/util/workqueue"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 
+	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/condition"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/events/eventstesting"
@@ -90,7 +91,7 @@ func TestNewNodeStateForInstallInProgress(t *testing.T) {
 	c.installerPodImageFn = func() string { return "docker.io/foo/bar" }
 
 	t.Log("setting target revision")
-	if err := c.sync(); err != nil {
+	if err := c.Sync(context.TODO(), factory.NewSyncContext("InstallerController", eventRecorder)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -105,7 +106,7 @@ func TestNewNodeStateForInstallInProgress(t *testing.T) {
 
 	t.Log("starting installer pod")
 
-	if err := c.sync(); err != nil {
+	if err := c.Sync(context.TODO(), factory.NewSyncContext("InstallerController", eventRecorder)); err != nil {
 		t.Fatal(err)
 	}
 	if installerPod == nil {
@@ -136,7 +137,7 @@ func TestNewNodeStateForInstallInProgress(t *testing.T) {
 	})
 
 	t.Log("synching again, nothing happens")
-	if err := c.sync(); err != nil {
+	if err := c.Sync(context.TODO(), factory.NewSyncContext("InstallerController", eventRecorder)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -150,7 +151,7 @@ func TestNewNodeStateForInstallInProgress(t *testing.T) {
 	t.Log("installer succeeded")
 	installerPod.Status.Phase = corev1.PodSucceeded
 
-	if err := c.sync(); err != nil {
+	if err := c.Sync(context.TODO(), factory.NewSyncContext("InstallerController", eventRecorder)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -179,7 +180,7 @@ func TestNewNodeStateForInstallInProgress(t *testing.T) {
 	}
 	kubeClient.PrependReactor("get", "pods", getPodsReactor(staticPod))
 
-	if err := c.sync(); err != nil {
+	if err := c.Sync(context.TODO(), factory.NewSyncContext("InstallerController", eventRecorder)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -191,7 +192,7 @@ func TestNewNodeStateForInstallInProgress(t *testing.T) {
 	t.Log("static pod is ready")
 	staticPod.Status.Conditions[0].Status = corev1.ConditionTrue
 
-	if err := c.sync(); err != nil {
+	if err := c.Sync(context.TODO(), factory.NewSyncContext("InstallerController", eventRecorder)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -216,7 +217,7 @@ func TestNewNodeStateForInstallInProgress(t *testing.T) {
 			},
 		},
 	}
-	if err := c.sync(); err != nil {
+	if err := c.Sync(context.TODO(), factory.NewSyncContext("InstallerController", eventRecorder)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -302,7 +303,7 @@ func TestCreateInstallerPod(t *testing.T) {
 		return []metav1.OwnerReference{}, nil
 	}
 	c.installerPodImageFn = func() string { return "docker.io/foo/bar" }
-	if err := c.sync(); err != nil {
+	if err := c.Sync(context.TODO(), factory.NewSyncContext("InstallerController", eventRecorder)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -310,7 +311,7 @@ func TestCreateInstallerPod(t *testing.T) {
 		t.Fatalf("expected first sync not to create installer pod")
 	}
 
-	if err := c.sync(); err != nil {
+	if err := c.Sync(context.TODO(), factory.NewSyncContext("InstallerController", eventRecorder)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1056,7 +1057,7 @@ func TestCreateInstallerPodMultiNode(t *testing.T) {
 
 			// Each node needs at least 2 syncs to first create the pod and then acknowledge its existence.
 			for i := 1; i <= len(test.nodeStatuses)*2+1; i++ {
-				err := c.sync()
+				err := c.Sync(context.TODO(), factory.NewSyncContext("InstallerController", eventRecorder))
 				expectedErr := false
 				if i-1 < len(test.expectedSyncError) && test.expectedSyncError[i-1] {
 					expectedErr = true
@@ -1096,7 +1097,6 @@ func TestInstallerController_manageInstallationPods(t *testing.T) {
 		operatorConfigClient v1helpers.StaticPodOperatorClient
 		kubeClient           kubernetes.Interface
 		eventRecorder        events.Recorder
-		queue                workqueue.RateLimitingInterface
 		installerPodImageFn  func() string
 	}
 	type args struct {
@@ -1125,7 +1125,6 @@ func TestInstallerController_manageInstallationPods(t *testing.T) {
 				configMapsGetter:    tt.fields.kubeClient.CoreV1(),
 				podsGetter:          tt.fields.kubeClient.CoreV1(),
 				eventRecorder:       tt.fields.eventRecorder,
-				queue:               tt.fields.queue,
 				installerPodImageFn: tt.fields.installerPodImageFn,
 			}
 			got, err := c.manageInstallationPods(tt.args.operatorSpec, tt.args.originalOperatorStatus, tt.args.resourceVersion)

--- a/pkg/operator/staticpod/controller/installerstate/installer_state_controller_test.go
+++ b/pkg/operator/staticpod/controller/installerstate/installer_state_controller_test.go
@@ -1,6 +1,7 @@
 package installerstate
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -13,6 +14,7 @@ import (
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 
+	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events/eventstesting"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
@@ -158,7 +160,7 @@ func TestInstallerStateController(t *testing.T) {
 			fakeStaticPodOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(&operatorv1.StaticPodOperatorSpec{}, &operatorv1.StaticPodOperatorStatus{}, nil, nil)
 			eventRecorder := eventstesting.NewTestingEventRecorder(t)
 			controller := NewInstallerStateController(kubeInformers, kubeClient.CoreV1(), kubeClient.CoreV1(), fakeStaticPodOperatorClient, "test", eventRecorder)
-			if err := controller.sync(); err != nil {
+			if err := controller.Sync(context.TODO(), factory.NewSyncContext("InstallerStateController", eventRecorder)); err != nil {
 				t.Error(err)
 				return
 			}

--- a/pkg/operator/staticpod/controller/monitoring/monitoring_resource_controller.go
+++ b/pkg/operator/staticpod/controller/monitoring/monitoring_resource_controller.go
@@ -4,47 +4,39 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
-	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	rbaclisterv1 "k8s.io/client-go/listers/rbac/v1"
+	"k8s.io/klog"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
+
 	"github.com/openshift/library-go/pkg/assets"
+	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/condition"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/management"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/openshift/library-go/pkg/operator/staticpod/controller/monitoring/bindata"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
-	"k8s.io/apimachinery/pkg/api/errors"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/informers"
-	"k8s.io/client-go/kubernetes"
-	rbaclisterv1 "k8s.io/client-go/listers/rbac/v1"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
-	"k8s.io/klog"
 )
 
 const (
-	controllerWorkQueueKey = "key"
-	manifestDir            = "pkg/operator/staticpod/controller/monitoring"
+	manifestDir = "pkg/operator/staticpod/controller/monitoring"
 )
 
 var syntheticRequeueError = fmt.Errorf("synthetic requeue request")
 
 type MonitoringResourceController struct {
-	targetNamespace    string
-	serviceMonitorName string
-
+	targetNamespace          string
+	serviceMonitorName       string
 	clusterRoleBindingLister rbaclisterv1.ClusterRoleBindingLister
 	kubeClient               kubernetes.Interface
 	dynamicClient            dynamic.Interface
 	operatorClient           v1helpers.StaticPodOperatorClient
-
-	cachesToSync  []cache.InformerSynced
-	queue         workqueue.RateLimitingInterface
-	eventRecorder events.Recorder
 }
 
 // NewMonitoringResourceController creates a new backing resource controller.
@@ -56,32 +48,16 @@ func NewMonitoringResourceController(
 	kubeClient kubernetes.Interface,
 	dynamicClient dynamic.Interface,
 	eventRecorder events.Recorder,
-) *MonitoringResourceController {
+) factory.Controller {
 	c := &MonitoringResourceController{
-		targetNamespace:    targetNamespace,
-		operatorClient:     operatorClient,
-		eventRecorder:      eventRecorder.WithComponentSuffix("monitoring-resource-controller"),
-		serviceMonitorName: serviceMonitorName,
-
+		targetNamespace:          targetNamespace,
+		operatorClient:           operatorClient,
+		serviceMonitorName:       serviceMonitorName,
 		clusterRoleBindingLister: kubeInformersForTargetNamespace.Rbac().V1().ClusterRoleBindings().Lister(),
-		cachesToSync: []cache.InformerSynced{
-			kubeInformersForTargetNamespace.Core().V1().ServiceAccounts().Informer().HasSynced,
-			operatorClient.Informer().HasSynced,
-		},
-
-		queue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "MonitoringResourceController"),
-		kubeClient:    kubeClient,
-		dynamicClient: dynamicClient,
+		kubeClient:               kubeClient,
+		dynamicClient:            dynamicClient,
 	}
-
-	operatorClient.Informer().AddEventHandler(c.eventHandler())
-	// TODO: We need a dynamic informer here to observe changes to ServiceMonitor resource.
-	kubeInformersForTargetNamespace.Rbac().V1().ClusterRoleBindings().Informer().AddEventHandler(c.eventHandler())
-
-	c.cachesToSync = append(c.cachesToSync, operatorClient.Informer().HasSynced)
-	c.cachesToSync = append(c.cachesToSync, kubeInformersForTargetNamespace.Rbac().V1().ClusterRoleBindings().Informer().HasSynced)
-
-	return c
+	return factory.New().WithInformers(operatorClient.Informer(), kubeInformersForTargetNamespace.Rbac().V1().ClusterRoleBindings().Informer()).WithSync(c.sync).ToController("MonitoringResourceController", eventRecorder)
 }
 
 func (c MonitoringResourceController) mustTemplateAsset(name string) ([]byte, error) {
@@ -93,7 +69,7 @@ func (c MonitoringResourceController) mustTemplateAsset(name string) ([]byte, er
 	return assets.MustCreateAssetFromTemplate(name, bindata.MustAsset(filepath.Join(manifestDir, name)), config).Data, nil
 }
 
-func (c MonitoringResourceController) sync() error {
+func (c MonitoringResourceController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
 	operatorSpec, _, _, err := c.operatorClient.GetStaticPodOperatorState()
 	if err != nil {
 		return err
@@ -103,7 +79,7 @@ func (c MonitoringResourceController) sync() error {
 		return nil
 	}
 
-	directResourceResults := resourceapply.ApplyDirectly(resourceapply.NewKubeClientHolder(c.kubeClient), c.eventRecorder, c.mustTemplateAsset,
+	directResourceResults := resourceapply.ApplyDirectly(resourceapply.NewKubeClientHolder(c.kubeClient), syncCtx.Recorder(), c.mustTemplateAsset,
 		"manifests/prometheus-role.yaml",
 		"manifests/prometheus-role-binding.yaml",
 	)
@@ -119,7 +95,7 @@ func (c MonitoringResourceController) sync() error {
 	if err != nil {
 		errs = append(errs, fmt.Errorf("manifests/service-monitor.yaml: %v", err))
 	} else {
-		_, serviceMonitorErr := resourceapply.ApplyServiceMonitor(c.dynamicClient, c.eventRecorder, serviceMonitorBytes)
+		_, serviceMonitorErr := resourceapply.ApplyServiceMonitor(c.dynamicClient, syncCtx.Recorder(), serviceMonitorBytes)
 		// This is to handle 'the server could not find the requested resource' which occurs when the CRD is not available
 		// yet (the CRD is provided by prometheus operator). This produce noise and plenty of events.
 		if errors.IsNotFound(serviceMonitorErr) {
@@ -151,56 +127,4 @@ func (c MonitoringResourceController) sync() error {
 	}
 
 	return err
-}
-
-func (c *MonitoringResourceController) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
-	defer c.queue.ShutDown()
-
-	klog.Infof("Starting MonitoringResourceController")
-	defer klog.Infof("Shutting down MonitoringResourceController")
-	if !cache.WaitForCacheSync(ctx.Done(), c.cachesToSync...) {
-		return
-	}
-
-	// doesn't matter what workers say, only start one.
-	go wait.UntilWithContext(ctx, c.runWorker, time.Second)
-
-	<-ctx.Done()
-}
-
-func (c *MonitoringResourceController) runWorker(ctx context.Context) {
-	for c.processNextWorkItem() {
-	}
-}
-
-func (c *MonitoringResourceController) processNextWorkItem() bool {
-	dsKey, quit := c.queue.Get()
-	if quit {
-		return false
-	}
-	defer c.queue.Done(dsKey)
-
-	err := c.sync()
-	if err == nil {
-		c.queue.Forget(dsKey)
-		return true
-	}
-
-	if err != syntheticRequeueError {
-		utilruntime.HandleError(fmt.Errorf("%v failed with : %v", dsKey, err))
-	}
-
-	c.queue.AddRateLimited(dsKey)
-
-	return true
-}
-
-// eventHandler queues the operator to check spec and status
-func (c *MonitoringResourceController) eventHandler() cache.ResourceEventHandler {
-	return cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) { c.queue.Add(controllerWorkQueueKey) },
-		UpdateFunc: func(old, new interface{}) { c.queue.Add(controllerWorkQueueKey) },
-		DeleteFunc: func(obj interface{}) { c.queue.Add(controllerWorkQueueKey) },
-	}
 }

--- a/pkg/operator/staticpod/controller/monitoring/monitoring_resource_controller_test.go
+++ b/pkg/operator/staticpod/controller/monitoring/monitoring_resource_controller_test.go
@@ -1,14 +1,13 @@
 package monitoring
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/openshift/library-go/pkg/operator/v1helpers"
-
 	"github.com/ghodss/yaml"
-	"github.com/openshift/library-go/pkg/operator/events"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -18,8 +17,12 @@ import (
 	clienttesting "k8s.io/client-go/testing"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
+
 	"github.com/openshift/library-go/pkg/assets"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/staticpod/controller/monitoring/bindata"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
 
 func mustAssetServiceMonitor(namespace string) runtime.Object {
@@ -130,7 +133,7 @@ func TestNewMonitoringResourcesController(t *testing.T) {
 				eventRecorder,
 			)
 
-			syncErr := c.sync()
+			syncErr := c.Sync(context.TODO(), factory.NewSyncContext("MonitoringResourceController", eventRecorder))
 			if len(tc.expectSyncError) > 0 && syncErr == nil {
 				t.Errorf("expected %q error", tc.expectSyncError)
 				return

--- a/pkg/operator/staticpod/controller/node/node_controller_test.go
+++ b/pkg/operator/staticpod/controller/node/node_controller_test.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -8,10 +9,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/condition"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
@@ -130,7 +132,6 @@ func TestNodeControllerDegradedConditionType(t *testing.T) {
 		t.Run(scenario.name, func(t *testing.T) {
 			kubeClient := fake.NewSimpleClientset(scenario.masterNodes...)
 			fakeLister := v1helpers.NewFakeNodeLister(kubeClient)
-			kubeInformers := informers.NewSharedInformerFactory(kubeClient, 1*time.Minute)
 			fakeStaticPodOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(
 				&operatorv1.StaticPodOperatorSpec{
 					OperatorSpec: operatorv1.OperatorSpec{
@@ -146,10 +147,11 @@ func TestNodeControllerDegradedConditionType(t *testing.T) {
 
 			eventRecorder := events.NewRecorder(kubeClient.CoreV1().Events("test"), "test-operator", &corev1.ObjectReference{})
 
-			c := NewNodeController(fakeStaticPodOperatorClient, kubeInformers, eventRecorder)
-			// override the lister so we don't have to run the informer to list nodes
-			c.nodeLister = fakeLister
-			if err := c.sync(); err != nil {
+			c := &NodeController{
+				operatorClient: fakeStaticPodOperatorClient,
+				nodeLister:     fakeLister,
+			}
+			if err := c.sync(context.TODO(), factory.NewSyncContext("NodeController", eventRecorder)); err != nil {
 				t.Fatal(err)
 			}
 
@@ -240,7 +242,6 @@ func TestNewNodeController(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			kubeClient := fake.NewSimpleClientset(test.startNodes...)
 			fakeLister := v1helpers.NewFakeNodeLister(kubeClient)
-			kubeInformers := informers.NewSharedInformerFactory(kubeClient, 1*time.Minute)
 			fakeStaticPodOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(
 				&operatorv1.StaticPodOperatorSpec{
 					OperatorSpec: operatorv1.OperatorSpec{
@@ -257,10 +258,13 @@ func TestNewNodeController(t *testing.T) {
 
 			eventRecorder := events.NewRecorder(kubeClient.CoreV1().Events("test"), "test-operator", &corev1.ObjectReference{})
 
-			c := NewNodeController(fakeStaticPodOperatorClient, kubeInformers, eventRecorder)
+			c := &NodeController{
+				operatorClient: fakeStaticPodOperatorClient,
+				nodeLister:     fakeLister,
+			}
 			// override the lister so we don't have to run the informer to list nodes
 			c.nodeLister = fakeLister
-			if err := c.sync(); err != nil {
+			if err := c.sync(context.TODO(), factory.NewSyncContext("NodeController", eventRecorder)); err != nil {
 				t.Fatal(err)
 			}
 

--- a/pkg/operator/staticpod/controller/prune/prune_controller_test.go
+++ b/pkg/operator/staticpod/controller/prune/prune_controller_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
@@ -200,17 +200,6 @@ func TestPruneAPIResources(t *testing.T) {
 		)
 		eventRecorder := events.NewRecorder(kubeClient.CoreV1().Events("test"), "test-operator", &v1.ObjectReference{})
 
-		operatorStatus := &operatorv1.StaticPodOperatorStatus{
-			LatestAvailableRevision: 1,
-			NodeStatuses: []operatorv1.NodeStatus{
-				{
-					NodeName:        "test-node-1",
-					CurrentRevision: 1,
-					TargetRevision:  0,
-				},
-			},
-		}
-
 		c := &PruneController{
 			targetNamespace:   tc.targetNamespace,
 			podResourcePrefix: "test-pod",
@@ -218,7 +207,6 @@ func TestPruneAPIResources(t *testing.T) {
 			configMapGetter:   kubeClient.CoreV1(),
 			secretGetter:      kubeClient.CoreV1(),
 			podGetter:         kubeClient.CoreV1(),
-			eventRecorder:     eventRecorder,
 			operatorClient:    fakeStaticPodOperatorClient,
 		}
 		c.ownerRefsFn = func(revision int32) ([]metav1.OwnerReference, error) {
@@ -232,7 +220,7 @@ func TestPruneAPIResources(t *testing.T) {
 		}
 		failedLimit, succeededLimit := getRevisionLimits(operatorSpec)
 
-		excludedRevisions, err := c.excludedRevisionHistory(operatorStatus, failedLimit, succeededLimit)
+		excludedRevisions, err := c.excludedRevisionHistory(eventRecorder, failedLimit, succeededLimit)
 		if err != nil {
 			t.Fatalf("unexpected error %q", err)
 		}
@@ -431,7 +419,6 @@ func TestPruneDiskResources(t *testing.T) {
 				configMapGetter:   kubeClient.CoreV1(),
 				secretGetter:      kubeClient.CoreV1(),
 				podGetter:         kubeClient.CoreV1(),
-				eventRecorder:     eventRecorder,
 				operatorClient:    fakeStaticPodOperatorClient,
 			}
 			c.ownerRefsFn = func(revision int32) ([]metav1.OwnerReference, error) {
@@ -445,11 +432,11 @@ func TestPruneDiskResources(t *testing.T) {
 			}
 			failedLimit, succeededLimit := getRevisionLimits(operatorSpec)
 
-			excludedRevisions, err := c.excludedRevisionHistory(operatorStatus, failedLimit, succeededLimit)
+			excludedRevisions, err := c.excludedRevisionHistory(eventRecorder, failedLimit, succeededLimit)
 			if err != nil {
 				t.Fatalf("unexpected error %q", err)
 			}
-			if diskErr := c.pruneDiskResources(operatorStatus, excludedRevisions, excludedRevisions[len(excludedRevisions)-1]); diskErr != nil {
+			if diskErr := c.pruneDiskResources(eventRecorder, operatorStatus, excludedRevisions, excludedRevisions[len(excludedRevisions)-1]); diskErr != nil {
 				t.Fatalf("unexpected error %q", diskErr)
 			}
 

--- a/pkg/operator/staticpod/controllers.go
+++ b/pkg/operator/staticpod/controllers.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
 
+	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/loglevel"
 	"github.com/openshift/library-go/pkg/operator/revisioncontroller"
@@ -26,10 +27,6 @@ import (
 	"github.com/openshift/library-go/pkg/operator/unsupportedconfigoverridescontroller"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
-
-type RunnableController interface {
-	Run(ctx context.Context, workers int)
-}
 
 type staticPodOperatorControllerBuilder struct {
 	// clients and related
@@ -88,7 +85,7 @@ type Builder interface {
 	WithCerts(certDir string, certConfigMaps, certSecrets []revisioncontroller.RevisionResource) Builder
 	WithInstaller(command []string) Builder
 	WithPruning(command []string, staticPodPrefix string) Builder
-	ToControllers() (RunnableController, error)
+	ToControllers() (factory.Controller, error)
 }
 
 func (b *staticPodOperatorControllerBuilder) WithEvents(eventRecorder events.Recorder) Builder {
@@ -137,7 +134,7 @@ func (b *staticPodOperatorControllerBuilder) WithPruning(command []string, stati
 	return b
 }
 
-func (b *staticPodOperatorControllerBuilder) ToControllers() (RunnableController, error) {
+func (b *staticPodOperatorControllerBuilder) ToControllers() (factory.Controller, error) {
 	controllers := &staticPodOperatorControllers{}
 
 	eventRecorder := b.eventRecorder
@@ -275,17 +272,24 @@ func (b *staticPodOperatorControllerBuilder) ToControllers() (RunnableController
 }
 
 type staticPodOperatorControllers struct {
-	controllers []RunnableController
+	controllers      []factory.Controller
+	shutdownContexts []context.Context
 }
 
-func (o *staticPodOperatorControllers) add(controller RunnableController) {
-	o.controllers = append(o.controllers, controller)
+// Sync implements the factory.Controller interface
+func (c *staticPodOperatorControllers) Sync(_ context.Context, _ factory.SyncContext) error {
+	return nil
 }
 
-func (o *staticPodOperatorControllers) Run(ctx context.Context, workers int) {
-	for i := range o.controllers {
-		go o.controllers[i].Run(ctx, workers)
+func (c *staticPodOperatorControllers) add(controller factory.Controller) {
+	c.controllers = append(c.controllers, controller)
+}
+
+func (c *staticPodOperatorControllers) Run(ctx context.Context, workers int) {
+	for i := range c.controllers {
+		go func(index int) {
+			c.controllers[index].Run(ctx, workers)
+		}(i)
 	}
-
 	<-ctx.Done()
 }

--- a/pkg/operator/staticresourcecontroller/static_resource_controller.go
+++ b/pkg/operator/staticresourcecontroller/static_resource_controller.go
@@ -6,12 +6,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/openshift/api"
-	operatorv1 "github.com/openshift/api/operator/v1"
-	"github.com/openshift/library-go/pkg/operator/events"
-	"github.com/openshift/library-go/pkg/operator/management"
-	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
-	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	"k8s.io/klog"
+
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -19,12 +15,17 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
-	"k8s.io/klog"
+
+	"github.com/openshift/api"
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/management"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
 
 const (
@@ -49,9 +50,9 @@ type StaticResourceController struct {
 	operatorClient v1helpers.OperatorClient
 	clients        *resourceapply.ClientHolder
 
-	cachesToSync  []cache.InformerSynced
-	queue         workqueue.RateLimitingInterface
 	eventRecorder events.Recorder
+
+	factory *factory.Factory
 }
 
 // NewStaticResourceController returns a controller that maintains certain static manifests. Most "normal" types are supported,
@@ -73,10 +74,9 @@ func NewStaticResourceController(
 		clients:        clients,
 
 		eventRecorder: eventRecorder.WithComponentSuffix(strings.ToLower(name)),
-		queue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), name),
-	}
 
-	c.operatorClient.Informer().AddEventHandler(c.eventHandler())
+		factory: factory.New().WithInformers(operatorClient.Informer()).ResyncEvery(1 * time.Minute),
+	}
 
 	return c
 }
@@ -152,57 +152,16 @@ func (c *StaticResourceController) AddKubeInformers(kubeInformersByNamespace v1h
 }
 
 func (c *StaticResourceController) AddInformer(informer cache.SharedIndexInformer) *StaticResourceController {
-	informer.AddEventHandler(c.eventHandler())
-	c.cachesToSync = append(c.cachesToSync, informer.HasSynced)
+	c.factory.WithInformers(informer)
 	return c
 }
 
 func (c *StaticResourceController) AddNamespaceInformer(informer cache.SharedIndexInformer, namespaces ...string) *StaticResourceController {
-	interestingNamespaces := sets.NewString(namespaces...)
-	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			ns, ok := obj.(*corev1.Namespace)
-			if !ok {
-				c.queue.Add(workQueueKey)
-			}
-			if interestingNamespaces.Has(ns.Name) {
-				c.queue.Add(workQueueKey)
-			}
-		},
-		UpdateFunc: func(old, new interface{}) {
-			ns, ok := old.(*corev1.Namespace)
-			if !ok {
-				c.queue.Add(workQueueKey)
-			}
-			if interestingNamespaces.Has(ns.Name) {
-				c.queue.Add(workQueueKey)
-			}
-		},
-		DeleteFunc: func(obj interface{}) {
-			ns, ok := obj.(*corev1.Namespace)
-			if !ok {
-				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-				if !ok {
-					utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
-					return
-				}
-				ns, ok = tombstone.Obj.(*corev1.Namespace)
-				if !ok {
-					utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Namespace %#v", obj))
-					return
-				}
-			}
-			if interestingNamespaces.Has(ns.Name) {
-				c.queue.Add(workQueueKey)
-			}
-		},
-	})
-	c.cachesToSync = append(c.cachesToSync, informer.HasSynced)
-
+	c.factory.WithNamespaceInformer(informer, namespaces...)
 	return c
 }
 
-func (c StaticResourceController) Sync() error {
+func (c StaticResourceController) Sync(ctx context.Context, syncContext factory.SyncContext) error {
 	operatorSpec, _, _, err := c.operatorClient.GetOperatorState()
 	if err != nil {
 		return err
@@ -212,7 +171,7 @@ func (c StaticResourceController) Sync() error {
 	}
 
 	errors := []error{}
-	directResourceResults := resourceapply.ApplyDirectly(c.clients, c.eventRecorder, c.manifests, c.files...)
+	directResourceResults := resourceapply.ApplyDirectly(c.clients, syncContext.Recorder(), c.manifests, c.files...)
 	for _, currResult := range directResourceResults {
 		if currResult.Error != nil {
 			errors = append(errors, fmt.Errorf("%q (%T): %v", currResult.File, currResult.Type, currResult.Error))
@@ -254,57 +213,5 @@ func appendErrors(_ *operatorv1.OperatorStatus, _ bool, err error) []error {
 }
 
 func (c *StaticResourceController) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
-	defer c.queue.ShutDown()
-
-	klog.Infof("Starting %s", c.name)
-	defer klog.Infof("Shutting down %s", c.name)
-
-	if !cache.WaitForCacheSync(ctx.Done(), c.cachesToSync...) {
-		return
-	}
-
-	// doesn't matter what workers say, only start one.
-	go wait.Until(c.runWorker, time.Second, ctx.Done())
-
-	// add time based trigger
-	go wait.PollImmediateUntil(time.Minute, func() (bool, error) {
-		c.queue.Add(workQueueKey)
-		return false, nil
-	}, ctx.Done())
-
-	<-ctx.Done()
-}
-
-func (c *StaticResourceController) runWorker() {
-	for c.processNextWorkItem() {
-	}
-}
-
-func (c *StaticResourceController) processNextWorkItem() bool {
-	dsKey, quit := c.queue.Get()
-	if quit {
-		return false
-	}
-	defer c.queue.Done(dsKey)
-
-	err := c.Sync()
-	if err == nil {
-		c.queue.Forget(dsKey)
-		return true
-	}
-
-	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", dsKey, err))
-	c.queue.AddRateLimited(dsKey)
-
-	return true
-}
-
-// eventHandler queues the operator to check spec and status
-func (c *StaticResourceController) eventHandler() cache.ResourceEventHandler {
-	return cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) { c.queue.Add(workQueueKey) },
-		UpdateFunc: func(old, new interface{}) { c.queue.Add(workQueueKey) },
-		DeleteFunc: func(obj interface{}) { c.queue.Add(workQueueKey) },
-	}
+	c.factory.WithSync(c.Sync).ToController("", c.eventRecorder).Run(ctx, workers)
 }


### PR DESCRIPTION
Background: As we keep adding more controllers to operators, we keep copying a single boiler plate for new controllers. The boilerplate usually include the Run() function, event handler registration to informers, workers and shutdown handling. 
Problem: It is pretty easy to add an informer to this code and forget to wait for its cache to sync. Refactoring all controllers to do proper graceful shutdown, where all workers are properly terminated (and we wait until they finish their job) is hard as there is no single place to change this but dozen of controllers have to be modified.

This change introduces a "factory" pattern when creating new controllers. In 95% of our controllers, we only observe change on resource(s) via informer and run the "Sync()" function that has main logic.
Adding a new controllers now means you only have to write the `Sync()` function and you don't have to worry about graceful shutdown, informer caches or event handlers anymore.

For example, this is unsupported config overrides controller:

```go
c := &UnsupportedConfigOverridesController{operatorClient: operatorClient}
return factory.New().Informers(operatorClient.Informer()).
             Sync(c.sync).
             Controller("UnsupportedConfigOverridesController", eventRecorder)
```