### PR TITLE
add cached client capabilities to stay out of qps jail

### DIFF
--- a/pkg/operator/resource/resourceapply/generic.go
+++ b/pkg/operator/resource/resourceapply/generic.go
@@ -47,6 +47,14 @@ type ClientHolder struct {
 	kubeInformers       v1helpers.KubeInformersForNamespaces
 }
 
+func NewClientHolder() *ClientHolder {
+	return &ClientHolder{}
+}
+
+func NewKubeClientHolder(client kubernetes.Interface) *ClientHolder {
+	return NewClientHolder().WithKubernetes(client)
+}
+
 func (c *ClientHolder) WithKubernetes(client kubernetes.Interface) *ClientHolder {
 	c.kubeClient = client
 	return c

--- a/pkg/operator/staticpod/controller/backingresource/backing_resource_controller_test.go
+++ b/pkg/operator/staticpod/controller/backingresource/backing_resource_controller_test.go
@@ -180,7 +180,7 @@ func TestBackingResourceController(t *testing.T) {
 					"manifests/installer-sa.yaml",
 					"manifests/installer-cluster-rolebinding.yaml",
 				},
-				(&resourceapply.ClientHolder{}).WithKubernetes(kubeClient),
+				resourceapply.NewKubeClientHolder(kubeClient),
 				tc.operatorClient,
 				eventRecorder,
 			)

--- a/pkg/operator/staticpod/controller/monitoring/monitoring_resource_controller.go
+++ b/pkg/operator/staticpod/controller/monitoring/monitoring_resource_controller.go
@@ -103,7 +103,7 @@ func (c MonitoringResourceController) sync() error {
 		return nil
 	}
 
-	directResourceResults := resourceapply.ApplyDirectly((&resourceapply.ClientHolder{}).WithKubernetes(c.kubeClient), c.eventRecorder, c.mustTemplateAsset,
+	directResourceResults := resourceapply.ApplyDirectly(resourceapply.NewKubeClientHolder(c.kubeClient), c.eventRecorder, c.mustTemplateAsset,
 		"manifests/prometheus-role.yaml",
 		"manifests/prometheus-role-binding.yaml",
 	)

--- a/pkg/operator/staticpod/controllers.go
+++ b/pkg/operator/staticpod/controllers.go
@@ -251,7 +251,7 @@ func (b *staticPodOperatorControllerBuilder) ToControllers() (RunnableController
 			"manifests/installer-sa.yaml",
 			"manifests/installer-cluster-rolebinding.yaml",
 		},
-		(&resourceapply.ClientHolder{}).WithKubernetes(b.kubeClient),
+		resourceapply.NewKubeClientHolder(b.kubeClient),
 		b.staticPodOperatorClient,
 		eventRecorder,
 	).AddKubeInformers(b.kubeInformers))

--- a/pkg/operator/staticresourcecontroller/static_resource_controller.go
+++ b/pkg/operator/staticresourcecontroller/static_resource_controller.go
@@ -82,6 +82,9 @@ func NewStaticResourceController(
 }
 
 func (c *StaticResourceController) AddKubeInformers(kubeInformersByNamespace v1helpers.KubeInformersForNamespaces) *StaticResourceController {
+	// set the informers so we can have caching clients
+	c.clients = c.clients.WithKubernetesInformers(kubeInformersByNamespace)
+
 	ret := c
 	for _, file := range c.files {
 		objBytes, err := c.manifests(file)

--- a/pkg/operator/v1helpers/core_getters.go
+++ b/pkg/operator/v1helpers/core_getters.go
@@ -1,11 +1,19 @@
 package v1helpers
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
+)
+
+var (
+	emptyGetOptions  = metav1.GetOptions{}
+	emptyListOptions = metav1.ListOptions{}
 )
 
 type combinedConfigMapGetter struct {
@@ -35,13 +43,21 @@ func (g combinedConfigMapGetter) ConfigMaps(namespace string) corev1client.Confi
 }
 
 func (g combinedConfigMapInterface) Get(name string, options metav1.GetOptions) (*corev1.ConfigMap, error) {
+	if !equality.Semantic.DeepEqual(options, emptyGetOptions) {
+		return nil, fmt.Errorf("GetOptions are not honored by cached client: %#v", options)
+	}
+
 	ret, err := g.lister.Get(name)
 	if err != nil {
 		return nil, err
 	}
 	return ret.DeepCopy(), nil
 }
-func (g combinedConfigMapInterface) List(opts metav1.ListOptions) (*corev1.ConfigMapList, error) {
+func (g combinedConfigMapInterface) List(options metav1.ListOptions) (*corev1.ConfigMapList, error) {
+	if !equality.Semantic.DeepEqual(options, emptyListOptions) {
+		return nil, fmt.Errorf("ListOptions are not honored by cached client: %#v", options)
+	}
+
 	list, err := g.lister.List(labels.Everything())
 	if err != nil {
 		return nil, err
@@ -81,6 +97,10 @@ func (g combinedSecretGetter) Secrets(namespace string) corev1client.SecretInter
 }
 
 func (g combinedSecretInterface) Get(name string, options metav1.GetOptions) (*corev1.Secret, error) {
+	if !equality.Semantic.DeepEqual(options, emptyGetOptions) {
+		return nil, fmt.Errorf("GetOptions are not honored by cached client: %#v", options)
+	}
+
 	ret, err := g.lister.Get(name)
 	if err != nil {
 		return nil, err
@@ -88,7 +108,11 @@ func (g combinedSecretInterface) Get(name string, options metav1.GetOptions) (*c
 	return ret.DeepCopy(), nil
 }
 
-func (g combinedSecretInterface) List(opts metav1.ListOptions) (*corev1.SecretList, error) {
+func (g combinedSecretInterface) List(options metav1.ListOptions) (*corev1.SecretList, error) {
+	if !equality.Semantic.DeepEqual(options, emptyListOptions) {
+		return nil, fmt.Errorf("ListOptions are not honored by cached client: %#v", options)
+	}
+
 	list, err := g.lister.List(labels.Everything())
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Alright, I think this is the last one in the chain.  We have

1. static resource management for the most common types
2. automatic informers get wired into the controller and the cache waiting
3. automatic status reporting for operators with aggregated status.
4. allow static resource management of CRDs
5. update CRD handling to support v1
6. add the ability to use cached clients based on the namespaced informers.

/assign @mfojtik 