### PR TITLE
Controller manager

### DIFF
--- a/pkg/controller/controllercmd/builder_test.go
+++ b/pkg/controller/controllercmd/builder_test.go
@@ -1,0 +1,132 @@
+package controllercmd
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestControllerBuilder_OnLeadingFunc(t *testing.T) {
+	nonZeroExitCh := make(chan struct{})
+	startedCh := make(chan struct{})
+	ctx, shutdown := context.WithCancel(context.Background())
+
+	b := &ControllerBuilder{
+		nonZeroExitFn: func(args ...interface{}) {
+			t.Logf("non-zero exit detected: %+v", args)
+			close(nonZeroExitCh)
+		},
+		startFunc: func(ctx context.Context, controllerContext *ControllerContext) error {
+			close(startedCh)
+			<-ctx.Done()
+			return nil
+		},
+	}
+
+	// wait for controller to run, then give it 1s and shutdown
+	go func() {
+		defer shutdown()
+		<-startedCh
+		time.Sleep(time.Second)
+	}()
+
+	stopCh := make(chan struct{})
+	go func() {
+		defer close(stopCh)
+		b.getOnStartedLeadingFunc(ctx, &ControllerContext{}, 10*time.Second)(ctx)
+	}()
+
+	select {
+	case <-nonZeroExitCh:
+		t.Fatal("unexpected non-zero shutdown")
+	case <-stopCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("unexpected timeout while terminating")
+	}
+}
+
+func TestControllerBuilder_OnLeadingFunc_ControllerError(t *testing.T) {
+	startedCh := make(chan struct{})
+	stopCh := make(chan struct{})
+	ctx := context.Background()
+
+	fatals := []string{}
+
+	b := &ControllerBuilder{
+		nonZeroExitFn: func(args ...interface{}) {
+			fatals = append(fatals, fmt.Sprintf("%v", args[0]))
+			t.Logf("non-zero exit detected: %+v", args)
+		},
+		startFunc: func(ctx context.Context, controllerContext *ControllerContext) error {
+			defer close(startedCh)
+			return fmt.Errorf("controller failed")
+		},
+	}
+
+	go func() {
+		defer close(stopCh)
+		b.getOnStartedLeadingFunc(ctx, &ControllerContext{}, 10*time.Second)(ctx)
+	}()
+
+	<-startedCh
+
+	select {
+	case <-stopCh:
+		if len(fatals) == 0 {
+			t.Fatal("expected non-zero exit, got none")
+		}
+		found := false
+		// this is weird, but normally klog.Fatal() just terminate process.
+		// however, since we mock the klog.Fatal() we will see both controller failure
+		// and "controllers terminated prematurely"...
+		for _, msg := range fatals {
+			if msg == `controllers failed with error: controller failed` {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("controller failed message not found in fatals: %#v", fatals)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("unexpected timeout while terminating")
+	}
+}
+
+func TestControllerBuilder_OnLeadingFunc_NonZeroExit(t *testing.T) {
+	nonZeroExitCh := make(chan struct{})
+	startedCh := make(chan struct{})
+	ctx, shutdown := context.WithCancel(context.Background())
+
+	b := &ControllerBuilder{
+		nonZeroExitFn: func(args ...interface{}) {
+			t.Logf("non-zero exit detected: %+v", args)
+			close(nonZeroExitCh)
+		},
+		startFunc: func(ctx context.Context, controllerContext *ControllerContext) error {
+			close(startedCh)
+			<-ctx.Done()
+			time.Sleep(10 * time.Second) // simulate controllers taking too much time to finish
+			return nil
+		},
+	}
+
+	// wait for controller to run, then give it 1s and shutdown
+	go func() {
+		defer shutdown()
+		<-startedCh
+		time.Sleep(2 * time.Second)
+	}()
+
+	go func() {
+		b.getOnStartedLeadingFunc(ctx, &ControllerContext{}, time.Second)(ctx) // graceful time is just 1s
+	}()
+
+	select {
+	case <-nonZeroExitCh:
+		t.Logf("got non-zero exit")
+		return
+	case <-time.After(5 * time.Second):
+		t.Fatal("unexpected timeout while terminating")
+	}
+}

--- a/pkg/controller/factory/base_controller.go
+++ b/pkg/controller/factory/base_controller.go
@@ -24,6 +24,10 @@ type baseController struct {
 
 var _ Controller = &baseController{}
 
+func (c baseController) Name() string {
+	return c.name
+}
+
 func (c *baseController) Run(ctx context.Context, workers int) {
 	// HandleCrash recovers panics
 	defer utilruntime.HandleCrash()

--- a/pkg/controller/factory/interfaces.go
+++ b/pkg/controller/factory/interfaces.go
@@ -22,6 +22,9 @@ type Controller interface {
 	// Sync contain the main controller logic.
 	// This should not be called directly, but can be used in unit tests to exercise the sync.
 	Sync(ctx context.Context, controllerContext SyncContext) error
+
+	// Name returns the controller name string.
+	Name() string
 }
 
 // SyncContext interface represents a context given to the Sync() function where the main controller logic happen.

--- a/pkg/controller/manager/controller_manager.go
+++ b/pkg/controller/manager/controller_manager.go
@@ -2,24 +2,56 @@ package manager
 
 import (
 	"context"
+	"sync"
+
+	"k8s.io/klog"
 
 	"github.com/openshift/library-go/pkg/controller/factory"
 )
 
 type ControllerManager interface {
-	Run(ctx context.Context)
+	Start(ctx context.Context)
+	Add(controller factory.Controller, workers int) ControllerManager
+}
+
+// NewControllerManager returns new controller manager.
+func NewControllerManager() ControllerManager {
+	return &controllerManager{}
+}
+
+// runnableController represents single controller runnable configuration.
+type runnableController struct {
+	run          func(ctx context.Context, workers int)
+	workersCount int
+	name         string
 }
 
 type controllerManager struct {
-	controllers []factory.Controller
+	controllers []runnableController
 }
 
-func (c *controllerManager) Run(ctx context.Context) {
+var _ ControllerManager = &controllerManager{}
+
+func (c *controllerManager) Add(controller factory.Controller, workers int) ControllerManager {
+	c.controllers = append(c.controllers, runnableController{
+		run:          controller.Run,
+		workersCount: workers,
+		name:         controller.Name(),
+	})
+	return c
+}
+
+// Start will run all managed controllers and block until all controllers shutdown.
+// When the context passed is cancelled, all controllers are signalled to shutdown.
+func (c controllerManager) Start(ctx context.Context) {
+	var wg sync.WaitGroup
+	wg.Add(len(c.controllers))
 	for i := range c.controllers {
 		go func(index int) {
-			// TODO: Usually
-			c.controllers[index].Run(ctx, 1)
+			defer klog.Infof("%s controller terminated", c.controllers[index].name)
+			defer wg.Done()
+			c.controllers[index].run(ctx, c.controllers[index].workersCount)
 		}(i)
 	}
-	panic("implement me")
+	wg.Wait()
 }

--- a/pkg/operator/staticpod/controller/installer/installer_controller.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller.go
@@ -145,7 +145,11 @@ func NewInstallerController(
 }
 
 func (c *InstallerController) Run(ctx context.Context, workers int) {
-	c.factory.WithSync(c.Sync).ToController("InstallerController", c.eventRecorder).Run(ctx, workers)
+	c.factory.WithSync(c.Sync).ToController(c.Name(), c.eventRecorder).Run(ctx, workers)
+}
+
+func (c InstallerController) Name() string {
+	return "InstallerController"
 }
 
 func (c *InstallerController) getStaticPodState(nodeName string) (state staticPodState, revision, reason string, errors []string, err error) {

--- a/pkg/operator/staticpod/controllers.go
+++ b/pkg/operator/staticpod/controllers.go
@@ -1,9 +1,9 @@
 package staticpod
 
 import (
-	"context"
 	"fmt"
 
+	"github.com/openshift/library-go/pkg/controller/manager"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/openshift/library-go/pkg/operator/staticresourcecontroller"
 
@@ -12,7 +12,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
 
-	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/loglevel"
 	"github.com/openshift/library-go/pkg/operator/revisioncontroller"
@@ -85,7 +84,7 @@ type Builder interface {
 	WithCerts(certDir string, certConfigMaps, certSecrets []revisioncontroller.RevisionResource) Builder
 	WithInstaller(command []string) Builder
 	WithPruning(command []string, staticPodPrefix string) Builder
-	ToControllers() (factory.Controller, error)
+	ToControllers() (manager.ControllerManager, error)
 }
 
 func (b *staticPodOperatorControllerBuilder) WithEvents(eventRecorder events.Recorder) Builder {
@@ -134,8 +133,8 @@ func (b *staticPodOperatorControllerBuilder) WithPruning(command []string, stati
 	return b
 }
 
-func (b *staticPodOperatorControllerBuilder) ToControllers() (factory.Controller, error) {
-	controllers := &staticPodOperatorControllers{}
+func (b *staticPodOperatorControllerBuilder) ToControllers() (manager.ControllerManager, error) {
+	controllers := manager.NewControllerManager()
 
 	eventRecorder := b.eventRecorder
 	if eventRecorder == nil {
@@ -156,7 +155,7 @@ func (b *staticPodOperatorControllerBuilder) ToControllers() (factory.Controller
 	var errs []error
 
 	if len(b.operandNamespace) > 0 {
-		controllers.add(revisioncontroller.NewRevisionController(
+		controllers.Add(revisioncontroller.NewRevisionController(
 			b.operandNamespace,
 			b.revisionConfigMaps,
 			b.revisionSecrets,
@@ -165,13 +164,13 @@ func (b *staticPodOperatorControllerBuilder) ToControllers() (factory.Controller
 			configMapClient,
 			secretClient,
 			eventRecorder,
-		))
+		), 1)
 	} else {
 		errs = append(errs, fmt.Errorf("missing revisionController; cannot proceed"))
 	}
 
 	if len(b.installCommand) > 0 {
-		controllers.add(installer.NewInstallerController(
+		controllers.Add(installer.NewInstallerController(
 			b.operandNamespace,
 			b.staticPodName,
 			b.revisionConfigMaps,
@@ -187,23 +186,23 @@ func (b *staticPodOperatorControllerBuilder) ToControllers() (factory.Controller
 			b.certDir,
 			b.certConfigMaps,
 			b.certSecrets,
-		))
+		), 1)
 
-		controllers.add(installerstate.NewInstallerStateController(
+		controllers.Add(installerstate.NewInstallerStateController(
 			operandInformers,
 			podClient,
 			eventsClient,
 			b.staticPodOperatorClient,
 			b.operandNamespace,
 			eventRecorder,
-		))
+		), 1)
 	} else {
 		errs = append(errs, fmt.Errorf("missing installerController; cannot proceed"))
 	}
 
 	if len(b.operandName) > 0 {
 		// TODO add handling for operator configmap changes to get version-mapping changes
-		controllers.add(staticpodstate.NewStaticPodStateController(
+		controllers.Add(staticpodstate.NewStaticPodStateController(
 			b.operandNamespace,
 			b.staticPodName,
 			b.operatorNamespace,
@@ -214,13 +213,13 @@ func (b *staticPodOperatorControllerBuilder) ToControllers() (factory.Controller
 			podClient,
 			versionRecorder,
 			eventRecorder,
-		))
+		), 1)
 	} else {
 		eventRecorder.Warning("StaticPodStateControllerMissing", "not enough information provided, not all functionality is present")
 	}
 
 	if len(b.pruneCommand) > 0 {
-		controllers.add(prune.NewPruneController(
+		controllers.Add(prune.NewPruneController(
 			b.operandNamespace,
 			b.staticPodPrefix,
 			b.pruneCommand,
@@ -229,19 +228,19 @@ func (b *staticPodOperatorControllerBuilder) ToControllers() (factory.Controller
 			podClient,
 			b.staticPodOperatorClient,
 			eventRecorder,
-		))
+		), 1)
 	} else {
 		eventRecorder.Warning("PruningControllerMissing", "not enough information provided, not all functionality is present")
 	}
 
-	controllers.add(node.NewNodeController(
+	controllers.Add(node.NewNodeController(
 		b.staticPodOperatorClient,
 		clusterInformers,
 		eventRecorder,
-	))
+	), 1)
 
 	// this cleverly sets the same condition that used to be set because of the way that the names are constructed
-	controllers.add(staticresourcecontroller.NewStaticResourceController(
+	controllers.Add(staticresourcecontroller.NewStaticResourceController(
 		"BackingResourceController",
 		backingresource.StaticPodManifests(b.operandNamespace),
 		[]string{
@@ -251,10 +250,10 @@ func (b *staticPodOperatorControllerBuilder) ToControllers() (factory.Controller
 		resourceapply.NewKubeClientHolder(b.kubeClient),
 		b.staticPodOperatorClient,
 		eventRecorder,
-	).AddKubeInformers(b.kubeInformers))
+	).AddKubeInformers(b.kubeInformers), 1)
 
 	if b.dynamicClient != nil && b.enableServiceMonitorController {
-		controllers.add(monitoring.NewMonitoringResourceController(
+		controllers.Add(monitoring.NewMonitoringResourceController(
 			b.operandNamespace,
 			b.operandNamespace,
 			b.staticPodOperatorClient,
@@ -262,34 +261,11 @@ func (b *staticPodOperatorControllerBuilder) ToControllers() (factory.Controller
 			b.kubeClient,
 			b.dynamicClient,
 			eventRecorder,
-		))
+		), 1)
 	}
 
-	controllers.add(unsupportedconfigoverridescontroller.NewUnsupportedConfigOverridesController(b.staticPodOperatorClient, eventRecorder))
-	controllers.add(loglevel.NewClusterOperatorLoggingController(b.staticPodOperatorClient, eventRecorder))
+	controllers.Add(unsupportedconfigoverridescontroller.NewUnsupportedConfigOverridesController(b.staticPodOperatorClient, eventRecorder), 1)
+	controllers.Add(loglevel.NewClusterOperatorLoggingController(b.staticPodOperatorClient, eventRecorder), 1)
 
 	return controllers, errors.NewAggregate(errs)
-}
-
-type staticPodOperatorControllers struct {
-	controllers      []factory.Controller
-	shutdownContexts []context.Context
-}
-
-// Sync implements the factory.Controller interface
-func (c *staticPodOperatorControllers) Sync(_ context.Context, _ factory.SyncContext) error {
-	return nil
-}
-
-func (c *staticPodOperatorControllers) add(controller factory.Controller) {
-	c.controllers = append(c.controllers, controller)
-}
-
-func (c *staticPodOperatorControllers) Run(ctx context.Context, workers int) {
-	for i := range c.controllers {
-		go func(index int) {
-			c.controllers[index].Run(ctx, workers)
-		}(i)
-	}
-	<-ctx.Done()
 }

--- a/pkg/operator/staticresourcecontroller/static_resource_controller.go
+++ b/pkg/operator/staticresourcecontroller/static_resource_controller.go
@@ -212,6 +212,10 @@ func appendErrors(_ *operatorv1.OperatorStatus, _ bool, err error) []error {
 	return []error{}
 }
 
+func (c *StaticResourceController) Name() string {
+	return "StaticResourceController"
+}
+
 func (c *StaticResourceController) Run(ctx context.Context, workers int) {
-	c.factory.WithSync(c.Sync).ToController("", c.eventRecorder).Run(ctx, workers)
+	c.factory.WithSync(c.Sync).ToController(c.Name(), c.eventRecorder).Run(ctx, workers)
 }


### PR DESCRIPTION
This builds on #666 and add graceful termination to all controllers via leader election. This will cause operators to exit zero. We exit non-zero, when graceful period is passed (we need to check operator workloads if we set this) or the controllers return error/panic before we ask them to die.

/cc @tnozicka 