### PR TITLE
Remove unused post-bootstrap config override from rendering

### DIFF
--- a/pkg/operator/render/options/config.go
+++ b/pkg/operator/render/options/config.go
@@ -32,9 +32,6 @@ type FileConfig struct {
 	// BootstrapConfig holds the rendered control plane component config file for bootstrapping (phase 1).
 	BootstrapConfig []byte
 
-	// PostBootstrapConfig holds the rendered control plane component config file after bootstrapping (phase 2).
-	PostBootstrapConfig []byte
-
 	// Assets holds the loaded assets like certs and keys.
 	Assets map[string][]byte
 }

--- a/pkg/operator/render/options/generic.go
+++ b/pkg/operator/render/options/generic.go
@@ -18,7 +18,6 @@ import (
 type GenericOptions struct {
 	DefaultFile                   string
 	BootstrapOverrideFile         string
-	PostBootstrapOverrideFile     string
 	AdditionalConfigOverrideFiles []string
 
 	ConfigOutputFile string
@@ -82,16 +81,12 @@ func (o *GenericOptions) Validate() error {
 }
 
 // ApplyTo applies the options ot the given config struct using the provides text/template data.
-func (o *GenericOptions) ApplyTo(cfg *FileConfig, defaultConfig, bootstrapOverrides, postBootstrapOverrides Template, templateData interface{}, specialCases map[string]resourcemerge.MergeFunc) error {
+func (o *GenericOptions) ApplyTo(cfg *FileConfig, defaultConfig, bootstrapOverrides Template, templateData interface{}, specialCases map[string]resourcemerge.MergeFunc) error {
 	var err error
 
 	cfg.BootstrapConfig, err = o.configFromDefaultsPlusOverride(defaultConfig, bootstrapOverrides, templateData, specialCases)
 	if err != nil {
 		return fmt.Errorf("failed to generate bootstrap config (phase 1): %v", err)
-	}
-
-	if cfg.PostBootstrapConfig, err = o.configFromDefaultsPlusOverride(defaultConfig, postBootstrapOverrides, templateData, specialCases); err != nil {
-		return fmt.Errorf("failed to generate post-bootstrap config (phase 2): %v", err)
 	}
 
 	// load and render templates


### PR DESCRIPTION
Cluster operators do not use this - they manage post-bootstrap config separately.

Canaries: 
 - https://github.com/openshift/cluster-kube-apiserver-operator/pull/732