### PR TITLE
Bug 1792501: Add memory request and limit to revision pruner pod

### DIFF
--- a/pkg/operator/staticpod/controller/prune/bindata/bindata.go
+++ b/pkg/operator/staticpod/controller/prune/bindata/bindata.go
@@ -61,6 +61,11 @@ spec:
     args: # Value set by operator
     image: # Value set by operator
     imagePullPolicy: IfNotPresent
+    resources:
+      requests:
+        memory: 100M
+      limits:
+        memory: 100M
     securityContext:
       privileged: true
       runAsUser: 0

--- a/pkg/operator/staticpod/controller/prune/manifests/pruner-pod.yaml
+++ b/pkg/operator/staticpod/controller/prune/manifests/pruner-pod.yaml
@@ -14,6 +14,11 @@ spec:
     args: # Value set by operator
     image: # Value set by operator
     imagePullPolicy: IfNotPresent
+    resources:
+      requests:
+        memory: 100M
+      limits:
+        memory: 100M
     securityContext:
       privileged: true
       runAsUser: 0


### PR DESCRIPTION
Adds a 100M memory request/limit to revision pruners, taken from the installer pod's requests: https://github.com/openshift/library-go/blob/941707e97d/pkg/operator/staticpod/controller/installer/manifests/installer-pod.yaml#L29-L33