### PR TITLE
Add batch/CronJob resource helpers

### DIFF
--- a/pkg/operator/resource/resourceapply/batch.go
+++ b/pkg/operator/resource/resourceapply/batch.go
@@ -1,0 +1,39 @@
+package resourceapply
+
+import (
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	batchclientv1beta1 "k8s.io/client-go/kubernetes/typed/batch/v1beta1"
+	"k8s.io/klog"
+)
+
+func ApplyCronJob(client batchclientv1beta1.CronJobsGetter, recorder events.Recorder, required *batchv1beta1.CronJob) (*batchv1beta1.CronJob, bool, error) {
+	existing, err := client.CronJobs(required.Namespace).Get(required.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		actual, err := client.CronJobs(required.Namespace).Create(required)
+		reportCreateEvent(recorder, required, err)
+		return actual, true, err
+	}
+	if err != nil {
+		return nil, false, err
+	}
+
+	modified := resourcemerge.BoolPtr(false)
+	existingCopy := existing.DeepCopy()
+
+	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
+	if !*modified {
+		return existingCopy, false, nil
+	}
+
+	if klog.V(4) {
+		klog.Infof("CronJob %q changes: %v", required.Namespace+"/"+required.Name, JSONPatchNoError(existing, required))
+	}
+
+	actual, err := client.CronJobs(required.Namespace).Update(existingCopy)
+	reportUpdateEvent(recorder, required, err)
+	return actual, true, err
+}

--- a/pkg/operator/resource/resourceread/batch.go
+++ b/pkg/operator/resource/resourceread/batch.go
@@ -1,0 +1,26 @@
+package resourceread
+
+import (
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+)
+
+var (
+	scheme = runtime.NewScheme()
+	codes  = serializer.NewCodecFactory(scheme)
+)
+
+func init() {
+	if err := batchv1beta1.AddToScheme(scheme); err != nil {
+		panic(err)
+	}
+}
+
+func ReadCronJobV1beta1OrDie(objBytes []byte) *batchv1beta1.CronJob {
+	requiredObj, err := runtime.Decode(coreCodecs.UniversalDecoder(batchv1beta1.SchemeGroupVersion), objBytes)
+	if err != nil {
+		panic(err)
+	}
+	return requiredObj.(*batchv1beta1.CronJob)
+}


### PR DESCRIPTION
These helpers would be beneficial to the descheduler operator, which works by creating a cronjob to run the descheduler image. Currently, it is creating this cronjob manually and switching to bindata (and these helpers) would clean up the code nicely