### PR TITLE
Fortify build machinery

### DIFF
--- a/alpha-build-machinery/Makefile
+++ b/alpha-build-machinery/Makefile
@@ -1,4 +1,5 @@
 SHELL :=/bin/bash
+
 all: verify
 .PHONY: all
 
@@ -45,7 +46,7 @@ update-makefiles:
 	$(foreach f,$(examples),$(call check-makefile-log,$(f),,$(dir $(f))))
 .PHONY: update-makefiles
 
-verify-makefiles: tmp_dir:=$(shell mktemp -d)
+verify-makefiles: tmp_dir:=$(shell mktemp -d)$(call error_if_shell_failed,can't create tmp dir))
 verify-makefiles:
 	$(foreach f,$(makefiles),$(call check-makefile-log,$(f),help,$(tmp_dir)/$(dir $(f))))
 	$(foreach f,$(examples),$(call check-makefile-log,$(f),,$(tmp_dir)/$(dir $(f))))
@@ -57,5 +58,5 @@ verify: verify-makefiles
 update: update-makefiles
 .PHONY: update
 
-
 include ./make/targets/help.mk
+include ./make/lib/shellstatus.mk

--- a/alpha-build-machinery/make/lib/golang.mk
+++ b/alpha-build-machinery/make/lib/golang.mk
@@ -1,19 +1,22 @@
-GO ?=go
-GOPATH ?=$(shell $(GO) env GOPATH)
-GO_PACKAGE ?=$(shell $(GO) list -m -f '{{ .Path }}' || echo 'no_package_detected')
+include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
+	shellstatus.mk \
+)
 
-GOOS ?=$(shell $(GO) env GOOS)
-GOHOSTOS ?=$(shell $(GO) env GOHOSTOS)
-GOARCH ?=$(shell $(GO) env GOARCH)
-GOHOSTARCH ?=$(shell $(GO) env GOHOSTARCH)
-GOEXE ?=$(shell $(GO) env GOEXE)
-GOFLAGS ?=$(shell $(GO) env GOFLAGS)
+GO ?=go
+GOPATH ?=$(shell $(GO) xenv GOPATH)$(call error_if_shell_failed,can't detect GOPATH)
+GO_PACKAGE ?=$(shell $(GO) list -m -f '{{ .Path }}')$(call error_if_shell_failed,can't detect GO_PACKAGE)
+GOOS ?=$(shell $(GO) env GOOS)$(call error_if_shell_failed)
+GOHOSTOS ?=$(shell $(GO) env GOHOSTOS)$(call error_if_shell_failed,can't detect env GOHOSTOS)
+GOARCH ?=$(shell $(GO) env GOARCH)$(call error_if_shell_failed,can't detect env GOARCH)
+GOHOSTARCH ?=$(shell $(GO) env GOHOSTARCH)$(call error_if_shell_failed,can't detect env GOHOSTARCH)
+GOEXE ?=$(shell $(GO) env GOEXE)$(call error_if_shell_failed,can't detect env GOEXE)
+GOFLAGS ?=$(shell $(GO) env GOFLAGS)$(call error_if_shell_failed,can't detect env GOFLAGS)
 
 GOFMT ?=gofmt
 GOFMT_FLAGS ?=-s -l
 GOLINT ?=golint
 
-GO_FILES ?=$(shell find . -name '*.go' -not -path '*/vendor/*' -not -path '*/_output/*' -print)
+GO_FILES ?=$(shell find . -name '*.go' -not -path '*/vendor/*' -not -path '*/_output/*' -print)$(call error_if_shell_failed,can't find go files)
 GO_PACKAGES ?=./...
 GO_TEST_PACKAGES ?=$(GO_PACKAGES)
 
@@ -30,7 +33,7 @@ GO_MOD_FLAGS ?=-mod=vendor
 endif
 
 GO_BUILD_PACKAGES ?=./cmd/...
-GO_BUILD_PACKAGES_EXPANDED ?=$(shell $(GO) list $(GO_MOD_FLAGS) $(GO_BUILD_PACKAGES))
+GO_BUILD_PACKAGES_EXPANDED ?=$(shell $(GO) list $(GO_MOD_FLAGS) $(GO_BUILD_PACKAGES))$(call error_if_shell_failed,can't expand packages)
 go_build_binaries =$(notdir $(GO_BUILD_PACKAGES_EXPANDED))
 GO_BUILD_FLAGS ?=
 GO_BUILD_BINDIR ?=
@@ -40,13 +43,14 @@ GO_TEST_FLAGS ?=-race
 GO_LD_EXTRAFLAGS ?=
 
 SOURCE_GIT_TAG ?=$(shell git describe --long --tags --abbrev=7 --match 'v[0-9]*' || echo 'v0.0.0-unknown')
-SOURCE_GIT_COMMIT ?=$(shell git rev-parse --short "HEAD^{commit}" 2>/dev/null)
+SOURCE_GIT_COMMIT ?=$(shell git rev-parse --short "HEAD^{commit}" 2>/dev/null || 'unknown_commit')
 SOURCE_GIT_TREE_STATE ?=$(shell ( ( [ ! -d ".git/" ] || git diff --quiet ) && echo 'clean' ) || echo 'dirty')
+source_git_build_date :=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')$(call error_if_shell_failed,can't detect date)
 
 define version-ldflags
 -X $(1).versionFromGit="$(SOURCE_GIT_TAG)" \
 -X $(1).commitFromGit="$(SOURCE_GIT_COMMIT)" \
 -X $(1).gitTreeState="$(SOURCE_GIT_TREE_STATE)" \
--X $(1).buildDate="$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')"
+-X $(1).buildDate="$(source_git_build_date)"
 endef
 GO_LD_FLAGS ?=-ldflags "-s -w $(call version-ldflags,$(GO_PACKAGE)/pkg/version) $(GO_LD_EXTRAFLAGS)"

--- a/alpha-build-machinery/make/lib/shellstatus.mk
+++ b/alpha-build-machinery/make/lib/shellstatus.mk
@@ -1,0 +1,17 @@
+missing_shellstatus_message :=Your make version "$(MAKE_VERSION)" doesn't support `.SHELLSTATUS`. `.SHELLSTATUS` requires GNU make >= 4.2.
+
+$(shell true)
+ifndef .SHELLSTATUS
+ifndef IGNORE_SUBSHELL_EXITCODES
+$(error $(missing_shellstatus_message) To force running it without `.SHELLSTATUS` use `make IGNORE_SUBSHELL_EXITCODES=yes` or set it as environment variable `export IGNORE_SUBSHELL_EXITCODES=yes`)
+else
+ifndef ignore_subshell_exitcodes_warning_shown
+$(warning $(missing_shellstatus_message) Overriden by setting IGNORE_SUBSHELL_EXITCODES variable.)
+ignore_subshell_exitcodes_warning_shown :=yes
+endif
+endif
+endif
+
+define error_if_shell_failed
+$(if $(filter $(.SHELLSTATUS),0),,$(error $(1)))
+endef

--- a/alpha-build-machinery/make/targets/golang/build.mk
+++ b/alpha-build-machinery/make/targets/golang/build.mk
@@ -10,6 +10,7 @@ endef
 
 # We need to build each package separately so go build creates appropriate binaries
 build:
+	$(if $(strip $(GO_BUILD_PACKAGES_EXPANDED)),,$(error no packages to build: GO_BUILD_PACKAGES_EXPANDED var is empty))
 	$(foreach package,$(GO_BUILD_PACKAGES_EXPANDED),$(call build-package,$(package)))
 .PHONY: build
 

--- a/alpha-build-machinery/make/targets/openshift/bindata.mk
+++ b/alpha-build-machinery/make/targets/openshift/bindata.mk
@@ -1,4 +1,8 @@
-TMP_GOPATH :=$(shell mktemp -d)
+include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
+	../../lib/shellstatus.mk \
+)
+
+TMP_GOPATH :=$(shell mktemp -d)$(call error_if_shell_failed,can't create tmp dir))
 
 
 .ensure-go-bindata:
@@ -35,7 +39,7 @@ update-bindata: update-bindata-$(1)
 
 
 verify-bindata-$(1): .ensure-go-bindata
-verify-bindata-$(1): TMP_DIR := $$(shell mktemp -d)
+verify-bindata-$(1): TMP_DIR := $$(shell mktemp -d)$$(call error_if_shell_failed,can't create tmp dir))
 verify-bindata-$(1):
 	$(call run-bindata,$(2),$(3),$(4),$(5),$$(TMP_DIR)/) && \
 	diff -Naup {.,$$(TMP_DIR)}/$(5)

--- a/alpha-build-machinery/make/targets/openshift/crd-schema-gen.mk
+++ b/alpha-build-machinery/make/targets/openshift/crd-schema-gen.mk
@@ -39,7 +39,7 @@ update-codegen-crds-$(1): ensure-controller-gen ensure-yq
 update-codegen-crds: update-codegen-crds-$(1)
 .PHONY: update-codegen-crds
 
-verify-codegen-crds-$(1): VERIFY_CODEGEN_CRD_TMP_DIR:=$(shell mktemp -d)
+verify-codegen-crds-$(1): VERIFY_CODEGEN_CRD_TMP_DIR:=$$(shell mktemp -d)
 verify-codegen-crds-$(1): ensure-controller-gen ensure-yq
 	$(call run-crd-gen,$(2),$(3),$$(VERIFY_CODEGEN_CRD_TMP_DIR))
 	$$(foreach p,$$(wildcard $(3)/*.crd.yaml),$$(call diff-file,$$(p),$$(subst $(3),$$(VERIFY_CODEGEN_CRD_TMP_DIR),$$(p))))

--- a/alpha-build-machinery/make/targets/openshift/crd-schema-gen.mk
+++ b/alpha-build-machinery/make/targets/openshift/crd-schema-gen.mk
@@ -1,4 +1,11 @@
-self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
+include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
+	../../lib/golang.mk \
+	../../lib/tmp.mk \
+	../../targets/openshift/controller-gen.mk \
+	../../targets/openshift/yq.mk \
+	../../lib/shellstatus.mk \
+)
+
 
 # $1 - crd file
 # $2 - patch file
@@ -39,7 +46,7 @@ update-codegen-crds-$(1): ensure-controller-gen ensure-yq
 update-codegen-crds: update-codegen-crds-$(1)
 .PHONY: update-codegen-crds
 
-verify-codegen-crds-$(1): VERIFY_CODEGEN_CRD_TMP_DIR:=$$(shell mktemp -d)
+verify-codegen-crds-$(1): VERIFY_CODEGEN_CRD_TMP_DIR:=$$(shell mktemp -d)$$(call error_if_shell_failed,can't create tmp dir))
 verify-codegen-crds-$(1): ensure-controller-gen ensure-yq
 	$(call run-crd-gen,$(2),$(3),$$(VERIFY_CODEGEN_CRD_TMP_DIR))
 	$$(foreach p,$$(wildcard $(3)/*.crd.yaml),$$(call diff-file,$$(p),$$(subst $(3),$$(VERIFY_CODEGEN_CRD_TMP_DIR),$$(p))))
@@ -67,14 +74,3 @@ verify: verify-generated
 define add-crd-gen
 $(eval $(call add-crd-gen-internal,$(1),$(2),$(3),$(4)))
 endef
-
-
-# We need to be careful to expand all the paths before any include is done
-# or self_dir could be modified for the next include by the included file.
-# Also doing this at the end of the file allows us to use self_dir before it could be modified.
-include $(addprefix $(self_dir), \
-	../../lib/golang.mk \
-	../../lib/tmp.mk \
-	../../targets/openshift/controller-gen.mk \
-	../../targets/openshift/yq.mk \
-)

--- a/alpha-build-machinery/make/targets/openshift/deps-glide.mk
+++ b/alpha-build-machinery/make/targets/openshift/deps-glide.mk
@@ -1,5 +1,8 @@
-self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
-scripts_dir :=$(self_dir)/../../../scripts
+scripts_dir :=$(dir $(lastword $(MAKEFILE_LIST)))/../../../scripts
+include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
+	../../lib/shellstatus.mk \
+)
+
 
 # We need to force localle so different envs sort files the same way for recursive traversals
 deps_diff :=LC_COLLATE=C diff --no-dereference -N
@@ -17,7 +20,7 @@ define restore-deps
 	cd "$(1)" && $(deps_diff) -r {current,updated}/vendor/ > updated/glide.diff || true
 endef
 
-verify-deps: tmp_dir:=$(shell mktemp -d)
+verify-deps: tmp_dir:=$(shell mktemp -d)$(call error_if_shell_failed,can't create tmp dir))
 verify-deps:
 	$(call restore-deps,$(tmp_dir))
 	@echo $(deps_diff) '$(tmp_dir)'/{current,updated}/glide.diff
@@ -28,7 +31,7 @@ verify-deps:
 	)
 .PHONY: verify-deps
 
-update-deps-overrides: tmp_dir:=$(shell mktemp -d)
+update-deps-overrides: tmp_dir:=$(shell mktemp -d)$(call error_if_shell_failed,can't create tmp dir))
 update-deps-overrides:
 	$(call restore-deps,$(tmp_dir))
 	cp "$(tmp_dir)"/{updated,current}/glide.diff

--- a/alpha-build-machinery/make/targets/openshift/deps-gomod.mk
+++ b/alpha-build-machinery/make/targets/openshift/deps-gomod.mk
@@ -1,4 +1,7 @@
-self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
+include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
+	../../lib/golang.mk \
+	../../lib/shellstatus.mk \
+)
 
 # We need to force localle so different envs sort files the same way for recursive traversals
 deps_diff :=LC_COLLATE=C diff --no-dereference -N
@@ -12,7 +15,7 @@ define restore-deps
 	cd "$(1)" && $(deps_diff) -r {current,updated}/vendor/ > updated/deps.diff || true
 endef
 
-verify-deps: tmp_dir:=$(shell mktemp -d)
+verify-deps: tmp_dir:=$(shell mktemp -d)$(call error_if_shell_failed,can't create tmp dir))
 verify-deps:
 	$(call restore-deps,$(tmp_dir))
 	$(deps_diff) "$(tmp_dir)"/{current,updated}/go.mod || echo '`go.mod` content is incorrect - did you run `go mod tidy`?'
@@ -26,17 +29,8 @@ verify-deps:
 	)
 .PHONY: verify-deps
 
-update-deps-overrides: tmp_dir:=$(shell mktemp -d)
+update-deps-overrides: tmp_dir:=$(shell mktemp -d)$(call error_if_shell_failed,can't create tmp dir1))
 update-deps-overrides:
 	$(call restore-deps,$(tmp_dir))
 	cp "$(tmp_dir)"/{updated,current}/deps.diff
 .PHONY: update-deps-overrides
-
-
-# We need to be careful to expand all the paths before any include is done
-# or self_dir could be modified for the next include by the included file.
-# Also doing this at the end of the file allows us to use self_dir before it could be modified.
-include $(addprefix $(self_dir), \
-	../../lib/golang.mk \
-)
-

--- a/alpha-build-machinery/make/targets/openshift/rpm.mk
+++ b/alpha-build-machinery/make/targets/openshift/rpm.mk
@@ -1,3 +1,7 @@
+include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
+	../../lib/golang.mk \
+)
+
 RPM_OUTPUT_DIR ?=_output
 RPM_TOPDIR ?=$(abspath ./)
 RPM_BUILDDIR ?=$(RPM_TOPDIR)
@@ -32,10 +36,3 @@ clean-rpms:
 .PHONY: clean-rpms
 
 clean: clean-rpms
-
-# We need to be careful to expand all the paths before any include is done
-# or self_dir could be modified for the next include by the included file.
-# Also doing this at the end of the file allows us to use self_dir before it could be modified.
-include $(addprefix $(self_dir), \
-	../../lib/golang.mk \
-)


### PR DESCRIPTION
build-machinery supports only golang >=1.13
(Yes, we have come to a point where we need this enforced. Version check is on my list next.)

There was a case when someone was building it with 1.12 which resulted in silently failing `go list` in a subshell and `GO_BUILD_PACKAGES_EXPANDED` being empty. Since the time we have added building multiple packages and introduced a for loop, with empty var it executes nothing, but ends with exit code `0`. That made the image build continue. Unfortunately this was combined with a bug in the image builder that also didn't error out on `COPY` instruction missing the files.

```
RUN make build --warn-undefined-variables
build flag -mod=vendor only valid when using modules
make: Nothing to be done for `build'.
```

We need to fix our part to be resilient and also follow up on the image builder issue separately.

I understand this doesn't look extra nice, but correctness and checking exit codes should take precedence

Requires:
 - [ ] bumping CI to centos:8 to get make 4.2

/cc @mfojtik @soltysh 

@mfojtik this needs `GNU Make 4.2`, try how it goes on your Mac

@openshift/sig-master 