### PR TITLE
Make sure there are some packages to be build

### DIFF
--- a/alpha-build-machinery/make/targets/golang/build.mk
+++ b/alpha-build-machinery/make/targets/golang/build.mk
@@ -10,6 +10,7 @@ endef
 
 # We need to build each package separately so go build creates appropriate binaries
 build:
+	$(if $(strip $(GO_BUILD_PACKAGES_EXPANDED)),,$(error no packages to build: GO_BUILD_PACKAGES_EXPANDED var is empty))
 	$(foreach package,$(GO_BUILD_PACKAGES_EXPANDED),$(call build-package,$(package)))
 .PHONY: build
 

--- a/alpha-build-machinery/make/targets/openshift/crd-schema-gen.mk
+++ b/alpha-build-machinery/make/targets/openshift/crd-schema-gen.mk
@@ -39,7 +39,7 @@ update-codegen-crds-$(1): ensure-controller-gen ensure-yq
 update-codegen-crds: update-codegen-crds-$(1)
 .PHONY: update-codegen-crds
 
-verify-codegen-crds-$(1): VERIFY_CODEGEN_CRD_TMP_DIR:=$(shell mktemp -d)
+verify-codegen-crds-$(1): VERIFY_CODEGEN_CRD_TMP_DIR:=$$(shell mktemp -d)
 verify-codegen-crds-$(1): ensure-controller-gen ensure-yq
 	$(call run-crd-gen,$(2),$(3),$$(VERIFY_CODEGEN_CRD_TMP_DIR))
 	$$(foreach p,$$(wildcard $(3)/*.crd.yaml),$$(call diff-file,$$(p),$$(subst $(3),$$(VERIFY_CODEGEN_CRD_TMP_DIR),$$(p))))


### PR DESCRIPTION
build-machinery supports only golang >=1.13
(Yes, we have come to a point where we need this enforced. Version check is on my list next.)

There was a case when someone was building it with 1.12 which resulted in silently failing `go list` in a subshell and `GO_BUILD_PACKAGES_EXPANDED` being empty. Since the time we have added building multiple packages and introduced a for loop, with empty var it executes nothing, but ends with exit code `0`. That made the image build continue. Unfortunately this was combined with a bug in the image builder that also didn't error out on `COPY` instruction missing the files.

```
RUN make build --warn-undefined-variables
build flag -mod=vendor only valid when using modules
make: Nothing to be done for `build'.
```

We need to fix our part to be resilient and also follow up on the image builder issue separately.

/cc @mfojtik @soltysh 