### PR TITLE
Bug 1775224: Allow controllers to shutdown gracefully

### DIFF
--- a/pkg/controller/controllercmd/builder.go
+++ b/pkg/controller/controllercmd/builder.go
@@ -207,7 +207,7 @@ func (b *ControllerBuilder) Run(ctx context.Context, config *unstructured.Unstru
 		if err := server.PrepareRun().Run(ctx.Done()); err != nil {
 			klog.Error(err)
 		}
-		klog.Fatal("server exited")
+		klog.Error("server exited")
 	}()
 
 	protoConfig := rest.CopyConfig(clientConfig)
@@ -240,7 +240,7 @@ func (b *ControllerBuilder) Run(ctx context.Context, config *unstructured.Unstru
 
 	leaderElection.Callbacks.OnStartedLeading = func(ctx context.Context) {
 		if err := b.startFunc(ctx, controllerContext); err != nil {
-			klog.Fatal(err)
+			klog.Error(err)
 		}
 	}
 	leaderelection.RunOrDie(ctx, leaderElection)

--- a/pkg/controller/fileobserver/observer_polling.go
+++ b/pkg/controller/fileobserver/observer_polling.go
@@ -133,7 +133,7 @@ func (o *pollingObserver) processReactors(stopCh <-chan struct{}) {
 		return false, nil
 	})
 	if err != nil {
-		klog.Fatalf("file observer failed: %v", err)
+		klog.Errorf("file observer failed: %v", err)
 	}
 }
 


### PR DESCRIPTION
It is noticed that when operators are restarted during upgrades or file observer reactions, even though it is supposed to be a graceful shutdown and all resources are expected to be released, leader election lock that is acquired by this operator is not released and remains to be a stale entity until the lease expires. This results in almost a minute delay for operator to acquire a new lease when it restarts. Upgrades and dev workflows can be sped up if the operator is allowed to do graceful shutdown instead of killing the process abruptly with `klog.Fatal(f)`

When these changes were tested with `service-ca-operator`,log messages indicating that operator is waiting to acquire lease are not seen anymore.