### PR TITLE
Bug 1793267: Add -mod=vendor fallback for `go list`

### DIFF
--- a/alpha-build-machinery/make/lib/golang.mk
+++ b/alpha-build-machinery/make/lib/golang.mk
@@ -22,11 +22,6 @@ ifneq "$(GO_REQUIRED_MIN_VERSION)" ""
 $(call require_minimal_version,$(GO),GO_REQUIRED_MIN_VERSION,$(go_version))
 endif
 
-GO_PACKAGE ?=$(shell $(GO) list -m -f '{{ .Path }}' || echo 'no_package_detected')
-GO_PACKAGES ?=./...
-GO_TEST_PACKAGES ?=$(GO_PACKAGES)
-GO_FILES ?=$(shell find . -name '*.go' -not -path '*/vendor/*' -not -path '*/_output/*' -print)
-
 # Projects not using modules can clear the variable, but by default we want to prevent
 # our projects with modules to unknowingly ignore vendor folder until golang is fixed to use
 # vendor folder by default if present.
@@ -38,6 +33,12 @@ GO_MOD_FLAGS ?=
 else
 GO_MOD_FLAGS ?=-mod=vendor
 endif
+
+GO_PACKAGE ?=$(shell $(GO) list $(GO_MOD_FLAGS) -m -f '{{ .Path }}' || echo 'no_package_detected')
+GO_PACKAGES ?=./...
+GO_TEST_PACKAGES ?=$(GO_PACKAGES)
+GO_FILES ?=$(shell find . -name '*.go' -not -path '*/vendor/*' -not -path '*/_output/*' -print)
+
 
 GO_BUILD_PACKAGES ?=./cmd/...
 GO_BUILD_PACKAGES_EXPANDED ?=$(shell $(GO) list $(GO_MOD_FLAGS) $(GO_BUILD_PACKAGES))

--- a/alpha-build-machinery/make/targets/openshift/deps.mk
+++ b/alpha-build-machinery/make/targets/openshift/deps.mk
@@ -6,7 +6,7 @@ include $(addprefix $(self_dir), \
 	../../lib/golang.mk \
 )
 
-ifneq "$(GO) list -m" ""
+ifneq "$(GO) list $(GO_MOD_FLAGS) -m" ""
 include $(deps_gomod_mkfile)
 else
 include $(deps_glide_mkfile)


### PR DESCRIPTION
if built without network connectivity, `go list` without `-mod=vendor` flag fails and GO_PACKAGE would be empty

/cc @soltysh 