### PR TITLE
Properly terminate controllers on leader election lost/shutdown

### DIFF
--- a/pkg/controller/controllercmd/builder.go
+++ b/pkg/controller/controllercmd/builder.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"sync"
 	"time"
 
@@ -70,6 +71,11 @@ type ControllerBuilder struct {
 	authenticationConfig *operatorv1alpha1.DelegatedAuthentication
 	authorizationConfig  *operatorv1alpha1.DelegatedAuthorization
 	healthChecks         []healthz.HealthChecker
+
+	// nonZeroExitFn takes a function that exit the process with non-zero code.
+	// This stub exists for unit test where we can check if the graceful termination work properly.
+	// Default function will klog.Warning(args) and os.Exit(1).
+	nonZeroExitFn func(args ...interface{})
 }
 
 // NewController returns a builder struct for constructing the command you want to run
@@ -78,6 +84,10 @@ func NewController(componentName string, startFunc StartFunc) *ControllerBuilder
 		startFunc:        startFunc,
 		componentName:    componentName,
 		observerInterval: defaultObserverInterval,
+		nonZeroExitFn: func(args ...interface{}) {
+			klog.Warning(args...)
+			os.Exit(1)
+		},
 	}
 }
 
@@ -204,9 +214,9 @@ func (b *ControllerBuilder) Run(ctx context.Context, config *unstructured.Unstru
 
 		go func() {
 			if err := server.PrepareRun().Run(ctx.Done()); err != nil {
-				klog.Error(err)
+				klog.Fatal(err)
 			}
-			klog.Fatal("server exited")
+			klog.Info("server exited")
 		}()
 	}
 
@@ -226,7 +236,7 @@ func (b *ControllerBuilder) Run(ctx context.Context, config *unstructured.Unstru
 		if err := b.startFunc(ctx, controllerContext); err != nil {
 			return err
 		}
-		return fmt.Errorf("exited")
+		return nil
 	}
 
 	// ensure blocking TCP connections don't block the leader election
@@ -238,13 +248,41 @@ func (b *ControllerBuilder) Run(ctx context.Context, config *unstructured.Unstru
 		return err
 	}
 
-	leaderElection.Callbacks.OnStartedLeading = func(ctx context.Context) {
-		if err := b.startFunc(ctx, controllerContext); err != nil {
-			klog.Fatal(err)
+	// 10s is the graceful termination time we give the controllers to finish their workers.
+	// when this time pass, we exit with non-zero code, killing all controller workers.
+	// NOTE: The pod must set the termination graceful time.
+	leaderElection.Callbacks.OnStartedLeading = b.getOnStartedLeadingFunc(controllerContext, 10*time.Second)
+
+	leaderelection.RunOrDie(ctx, leaderElection)
+	return nil
+}
+
+func (b ControllerBuilder) getOnStartedLeadingFunc(controllerContext *ControllerContext, gracefulTerminationDuration time.Duration) func(ctx context.Context) {
+	return func(ctx context.Context) {
+		stoppedCh := make(chan struct{})
+		go func() {
+			defer close(stoppedCh)
+			if err := b.startFunc(ctx, controllerContext); err != nil {
+				b.nonZeroExitFn(fmt.Sprintf("graceful termination failed, controllers failed with error: %v", err))
+			}
+		}()
+
+		select {
+		case <-ctx.Done(): // context closed means the process likely received signal to terminate
+		case <-stoppedCh:
+			// if context was not cancelled (it is not "done"), but the startFunc terminated, it means it terminated prematurely
+			// when this happen, it means the controllers terminated without error.
+			if ctx.Err() == nil {
+				b.nonZeroExitFn("graceful termination failed, controllers terminated prematurely")
+			}
+		}
+
+		select {
+		case <-time.After(gracefulTerminationDuration): // when context was closed above, give controllers extra time to terminate gracefully
+			b.nonZeroExitFn(fmt.Sprintf("graceful termination failed, some controllers failed to shutdown in %s", gracefulTerminationDuration))
+		case <-stoppedCh: // stoppedCh here means the controllers finished termination and we exit 0
 		}
 	}
-	leaderelection.RunOrDie(ctx, leaderElection)
-	return fmt.Errorf("exited")
 }
 
 func (b *ControllerBuilder) getComponentNamespace() (string, error) {

--- a/pkg/controller/controllercmd/builder_test.go
+++ b/pkg/controller/controllercmd/builder_test.go
@@ -1,0 +1,184 @@
+package controllercmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestControllerBuilder_getOnStartedLeadingFunc(t *testing.T) {
+	nonZeroExits := []string{}
+	b := ControllerBuilder{
+		nonZeroExitFn: func(args ...interface{}) {
+			nonZeroExits = append(nonZeroExits, fmt.Sprintf("%#v", args))
+		},
+		startFunc: func(ctx context.Context, controllerContext *ControllerContext) error {
+			time.Sleep(1 * time.Second)
+			return nil
+		},
+	}
+
+	// controllers finished prematurely, without being asked to finish
+	b.getOnStartedLeadingFunc(&ControllerContext{}, 3*time.Second)(context.TODO())
+	if len(nonZeroExits) != 1 || !strings.Contains(nonZeroExits[0], "controllers terminated prematurely") {
+		t.Errorf("expected controllers to exit prematurely, got %#v", nonZeroExits)
+	}
+
+	// controllers finished gracefully after context was cancelled, with zero exit status
+	nonZeroExits = []string{}
+	ctx, cancel := context.WithCancel(context.TODO())
+	go func() {
+		defer cancel()
+		time.Sleep(1 * time.Second)
+	}()
+	b.startFunc = func(ctx context.Context, controllerContext *ControllerContext) error {
+		time.Sleep(2 * time.Second)
+		return nil
+	}
+	b.getOnStartedLeadingFunc(&ControllerContext{}, 5*time.Second)(ctx)
+	if len(nonZeroExits) > 0 {
+		t.Errorf("expected controllers to exit gracefully, but got %#v", nonZeroExits)
+	}
+
+	// controllers passed the graceful termination duration and are force killed
+	nonZeroExits = []string{}
+	ctx, cancel = context.WithCancel(context.TODO())
+	go func() {
+		defer cancel()
+		time.Sleep(1 * time.Second)
+	}()
+	b.startFunc = func(ctx context.Context, controllerContext *ControllerContext) error {
+		time.Sleep(3 * time.Second)
+		return nil
+	}
+	b.getOnStartedLeadingFunc(&ControllerContext{}, 1*time.Second)(ctx)
+	if len(nonZeroExits) != 1 && !strings.Contains(nonZeroExits[0], "some controllers failed to shutdown in 1s") {
+		t.Errorf("expected controllers to failed finish in 1s, got %#v", nonZeroExits)
+	}
+}
+
+func TestControllerBuilder_GracefulShutdown(t *testing.T) {
+	nonZeroExitCh := make(chan struct{})
+	startedCh := make(chan struct{})
+	ctx, shutdown := context.WithCancel(context.Background())
+
+	b := &ControllerBuilder{
+		nonZeroExitFn: func(args ...interface{}) {
+			t.Logf("non-zero exit detected: %+v", args)
+			close(nonZeroExitCh)
+		},
+		startFunc: func(ctx context.Context, controllerContext *ControllerContext) error {
+			close(startedCh)
+			<-ctx.Done()
+			return nil
+		},
+	}
+
+	// wait for controller to run, then give it 1s and shutdown
+	go func() {
+		defer shutdown()
+		<-startedCh
+		time.Sleep(time.Second)
+	}()
+
+	stoppedCh := make(chan struct{})
+	go func() {
+		defer close(stoppedCh)
+		b.getOnStartedLeadingFunc(&ControllerContext{}, 10*time.Second)(ctx)
+	}()
+
+	select {
+	case <-nonZeroExitCh:
+		t.Fatal("unexpected non-zero shutdown")
+	case <-stoppedCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("unexpected timeout while terminating")
+	}
+}
+
+func TestControllerBuilder_OnLeadingFunc_ControllerError(t *testing.T) {
+	startedCh := make(chan struct{})
+	stoppedCh := make(chan struct{})
+	ctx := context.Background()
+
+	fatals := []string{}
+
+	b := &ControllerBuilder{
+		nonZeroExitFn: func(args ...interface{}) {
+			fatals = append(fatals, fmt.Sprintf("%v", args[0]))
+			t.Logf("non-zero exit detected: %+v", args)
+		},
+		startFunc: func(ctx context.Context, controllerContext *ControllerContext) error {
+			defer close(startedCh)
+			return fmt.Errorf("controller failed")
+		},
+	}
+
+	go func() {
+		defer close(stoppedCh)
+		b.getOnStartedLeadingFunc(&ControllerContext{}, 10*time.Second)(ctx)
+	}()
+
+	<-startedCh
+
+	select {
+	case <-stoppedCh:
+		if len(fatals) == 0 {
+			t.Fatal("expected non-zero exit, got none")
+		}
+		found := false
+		// this is weird, but normally klog.Fatal() just terminate process.
+		// however, since we mock the klog.Fatal() we will see both controller failure
+		// and "controllers terminated prematurely"...
+		for _, msg := range fatals {
+			if msg == `graceful termination failed, controllers failed with error: controller failed` {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("controller failed message not found in fatals: %#v", fatals)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("unexpected timeout while terminating")
+	}
+}
+
+func TestControllerBuilder_OnLeadingFunc_NonZeroExit(t *testing.T) {
+	nonZeroExitCh := make(chan struct{})
+	startedCh := make(chan struct{})
+	ctx, shutdown := context.WithCancel(context.Background())
+
+	b := &ControllerBuilder{
+		nonZeroExitFn: func(args ...interface{}) {
+			t.Logf("non-zero exit detected: %+v", args)
+			close(nonZeroExitCh)
+		},
+		startFunc: func(ctx context.Context, controllerContext *ControllerContext) error {
+			close(startedCh)
+			<-ctx.Done()
+			time.Sleep(10 * time.Second) // simulate controllers taking too much time to finish
+			return nil
+		},
+	}
+
+	// wait for controller to run, then give it 1s and shutdown
+	go func() {
+		defer shutdown()
+		<-startedCh
+		time.Sleep(2 * time.Second)
+	}()
+
+	go func() {
+		b.getOnStartedLeadingFunc(&ControllerContext{}, time.Second)(ctx) // graceful time is just 1s
+	}()
+
+	select {
+	case <-nonZeroExitCh:
+		t.Logf("got non-zero exit")
+		return
+	case <-time.After(5 * time.Second):
+		t.Fatal("unexpected timeout while terminating")
+	}
+}

--- a/pkg/controller/factory/base_controller.go
+++ b/pkg/controller/factory/base_controller.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"reflect"
 	"sync"
 	"time"
 

--- a/pkg/controller/factory/base_controller.go
+++ b/pkg/controller/factory/base_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"reflect"
 	"sync"
 	"time"
 
@@ -19,11 +20,15 @@ type baseController struct {
 	name         string
 	cachesToSync []cache.InformerSynced
 	sync         func(ctx context.Context, controllerContext SyncContext) error
-	resyncEvery  time.Duration
 	syncContext  SyncContext
+	resyncEvery  time.Duration
 }
 
 var _ Controller = &baseController{}
+
+func (c baseController) Name() string {
+	return c.name
+}
 
 func (c *baseController) Run(ctx context.Context, workers int) {
 	// HandleCrash recovers panics
@@ -84,6 +89,9 @@ func QueueKey(name string) string {
 }
 
 func (c *baseController) runPeriodicalResync(ctx context.Context, interval time.Duration) {
+	if interval == 0 {
+		return
+	}
 	go wait.UntilWithContext(ctx, func(ctx context.Context) {
 		c.syncContext.Queue().Add(QueueKey(c.name))
 	}, interval)

--- a/pkg/controller/factory/factory.go
+++ b/pkg/controller/factory/factory.go
@@ -1,7 +1,6 @@
 package factory
 
 import (
-	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -90,12 +89,6 @@ func (f *Factory) WithRuntimeObject() *Factory {
 func (f *Factory) WithSyncContext(ctx SyncContext) *Factory {
 	f.syncContext = ctx
 	return f
-}
-
-// QueueKey return queue key for given name.
-// Used in unit testing.
-func QueueKey(name string) string {
-	return strings.ToLower(name) + "Key"
 }
 
 // Controller produce a runnable controller.

--- a/pkg/controller/factory/factory.go
+++ b/pkg/controller/factory/factory.go
@@ -14,16 +14,24 @@ import (
 // Factory is really generic and should be only used for simple controllers that does not require special stuff..
 type Factory struct {
 	sync                  SyncFunc
+	syncContext           SyncContext
 	resyncInterval        time.Duration
 	objectQueue           bool
-	informers             []cache.SharedInformer
+	informers             []Informer
 	namespaceInformers    []*namespaceInformer
 	cachesToSync          []cache.InformerSynced
 	interestingNamespaces sets.String
 }
 
+// Informer represents any structure that allow to register event handlers and informs if caches are synced.
+// Any SharedInformer will comply.
+type Informer interface {
+	AddEventHandler(handler cache.ResourceEventHandler)
+	HasSynced() bool
+}
+
 type namespaceInformer struct {
-	informer   cache.SharedInformer
+	informer   Informer
 	namespaces sets.String
 }
 
@@ -42,7 +50,7 @@ func (f *Factory) WithSync(syncFn SyncFunc) *Factory {
 // WithInformers is used to register event handlers and get the caches synchronized functions.
 // Pass informers you want to use to react to changes on resources. If informer event is observed, then the Sync() function
 // is called.
-func (f *Factory) WithInformers(informers ...cache.SharedInformer) *Factory {
+func (f *Factory) WithInformers(informers ...Informer) *Factory {
 	f.informers = append(f.informers, informers...)
 	return f
 }
@@ -50,7 +58,7 @@ func (f *Factory) WithInformers(informers ...cache.SharedInformer) *Factory {
 // WithNamespaceInformer is used to register event handlers and get the caches synchronized functions.
 // The sync function will only trigger when the object observed by this informer is a namespace and its name matches the interestingNamespaces.
 // Do not use this to register non-namespace informers.
-func (f *Factory) WithNamespaceInformer(informer cache.SharedInformer, interestingNamespaces ...string) *Factory {
+func (f *Factory) WithNamespaceInformer(informer Informer, interestingNamespaces ...string) *Factory {
 	f.namespaceInformers = append(f.namespaceInformers, &namespaceInformer{
 		informer:   informer,
 		namespaces: sets.NewString(interestingNamespaces...),
@@ -76,13 +84,33 @@ func (f *Factory) WithRuntimeObject() *Factory {
 	return f
 }
 
+// WithSyncContext allows to specify custom, existing sync context for this factory.
+// This is useful during unit testing where you can override the default event recorder or mock the runtime objects.
+// If this function not called, a SyncContext is created by the factory automatically.
+func (f *Factory) WithSyncContext(ctx SyncContext) *Factory {
+	f.syncContext = ctx
+	return f
+}
+
+// QueueKey return queue key for given name.
+// Used in unit testing.
+func QueueKey(name string) string {
+	return strings.ToLower(name) + "Key"
+}
+
 // Controller produce a runnable controller.
 func (f *Factory) ToController(name string, eventRecorder events.Recorder) Controller {
 	if f.sync == nil {
 		panic("Sync() function must be called before making controller")
 	}
 
-	ctx := NewSyncContext(name, eventRecorder)
+	var ctx SyncContext
+	if f.syncContext != nil {
+		ctx = f.syncContext
+	} else {
+		ctx = NewSyncContext(name, eventRecorder)
+	}
+
 	c := &baseController{
 		name:        name,
 		sync:        f.sync,
@@ -91,12 +119,12 @@ func (f *Factory) ToController(name string, eventRecorder events.Recorder) Contr
 	}
 
 	for i := range f.informers {
-		f.informers[i].AddEventHandler(c.syncContext.(syncContext).eventHandler(strings.ToLower(name)+"Key", f.objectQueue, sets.NewString()))
+		f.informers[i].AddEventHandler(c.syncContext.(syncContext).eventHandler(QueueKey(name), f.objectQueue, sets.NewString()))
 		c.cachesToSync = append(f.cachesToSync, f.informers[i].HasSynced)
 	}
 
 	for i := range f.namespaceInformers {
-		f.namespaceInformers[i].informer.AddEventHandler(c.syncContext.(syncContext).eventHandler(strings.ToLower(name)+"Key", f.objectQueue, f.namespaceInformers[i].namespaces))
+		f.namespaceInformers[i].informer.AddEventHandler(c.syncContext.(syncContext).eventHandler(QueueKey(name), f.objectQueue, f.namespaceInformers[i].namespaces))
 		c.cachesToSync = append(f.cachesToSync, f.informers[i].HasSynced)
 	}
 

--- a/pkg/controller/factory/interfaces.go
+++ b/pkg/controller/factory/interfaces.go
@@ -22,6 +22,9 @@ type Controller interface {
 	// Sync contain the main controller logic.
 	// This should not be called directly, but can be used in unit tests to exercise the sync.
 	Sync(ctx context.Context, controllerContext SyncContext) error
+
+	// Name returns the controller name string.
+	Name() string
 }
 
 // SyncContext interface represents a context given to the Sync() function where the main controller logic happen.

--- a/pkg/controller/manager/controller_manager.go
+++ b/pkg/controller/manager/controller_manager.go
@@ -2,24 +2,56 @@ package manager
 
 import (
 	"context"
+	"sync"
+
+	"k8s.io/klog"
 
 	"github.com/openshift/library-go/pkg/controller/factory"
 )
 
 type ControllerManager interface {
-	Run(ctx context.Context)
+	Start(ctx context.Context)
+	WithController(controller factory.Controller, workers int) ControllerManager
+}
+
+// NewControllerManager returns new controller manager.
+func NewControllerManager() ControllerManager {
+	return &controllerManager{}
+}
+
+// runnableController represents single controller runnable configuration.
+type runnableController struct {
+	run          func(ctx context.Context, workers int)
+	workersCount int
+	name         string
 }
 
 type controllerManager struct {
-	controllers []factory.Controller
+	controllers []runnableController
 }
 
-func (c *controllerManager) Run(ctx context.Context) {
+var _ ControllerManager = &controllerManager{}
+
+func (c *controllerManager) WithController(controller factory.Controller, workers int) ControllerManager {
+	c.controllers = append(c.controllers, runnableController{
+		run:          controller.Run,
+		workersCount: workers,
+		name:         controller.Name(),
+	})
+	return c
+}
+
+// Start will run all managed controllers and block until all controllers shutdown.
+// When the context passed is cancelled, all controllers are signalled to shutdown.
+func (c controllerManager) Start(ctx context.Context) {
+	var wg sync.WaitGroup
+	wg.Add(len(c.controllers))
 	for i := range c.controllers {
 		go func(index int) {
-			// TODO: Usually
-			c.controllers[index].Run(ctx, 1)
+			defer klog.Infof("%s controller terminated", c.controllers[index].name)
+			defer wg.Done()
+			c.controllers[index].run(ctx, c.controllers[index].workersCount)
 		}(i)
 	}
-	panic("implement me")
+	wg.Wait()
 }

--- a/pkg/operator/resourcesynccontroller/resourcesync_controller.go
+++ b/pkg/operator/resourcesynccontroller/resourcesync_controller.go
@@ -10,26 +10,20 @@ import (
 	"sync"
 	"time"
 
+	operatorv1 "github.com/openshift/api/operator/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/wait"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
-	"k8s.io/klog"
 
-	operatorv1 "github.com/openshift/api/operator/v1"
-
+	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/condition"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/management"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
-
-const controllerWorkQueueKey = "key"
 
 // ResourceSyncController is a controller that will copy source configmaps and secrets to their destinations.
 // It will also mirror deletions by deleting destinations.
@@ -49,9 +43,9 @@ type ResourceSyncController struct {
 	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces
 	operatorConfigClient       v1helpers.OperatorClient
 
-	cachesToSync  []cache.InformerSynced
-	queue         workqueue.RateLimitingInterface
-	eventRecorder events.Recorder
+	recorder          events.Recorder
+	queue             workqueue.RateLimitingInterface
+	controllerFactory *factory.Factory
 }
 
 var _ ResourceSyncer = &ResourceSyncController{}
@@ -66,34 +60,33 @@ func NewResourceSyncController(
 ) *ResourceSyncController {
 	c := &ResourceSyncController{
 		operatorConfigClient: operatorConfigClient,
-		eventRecorder:        eventRecorder.WithComponentSuffix("resource-sync-controller"),
 
 		configMapSyncRules:         map[ResourceLocation]ResourceLocation{},
 		secretSyncRules:            map[ResourceLocation]ResourceLocation{},
 		kubeInformersForNamespaces: kubeInformersForNamespaces,
 		knownNamespaces:            kubeInformersForNamespaces.Namespaces(),
 
-		queue:           workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "ResourceSyncController"),
 		configMapGetter: configMapsGetter,
 		secretGetter:    secretsGetter,
+		recorder:        eventRecorder,
 	}
+
+	syncCtx := factory.NewSyncContext(c.Name(), eventRecorder.WithComponentSuffix("resource-sync-controller"))
+	c.controllerFactory = factory.New().ResyncEvery(time.Second).WithInformers(operatorConfigClient.Informer()).WithSyncContext(syncCtx)
+
+	// we need queue for ResourceSyncer interface so SyncConfigMap and SyncSecret can be called outside the controller.
+	c.queue = syncCtx.Queue()
 
 	for namespace := range kubeInformersForNamespaces.Namespaces() {
 		if len(namespace) == 0 {
 			continue
 		}
 		informers := kubeInformersForNamespaces.InformersFor(namespace)
-		informers.Core().V1().ConfigMaps().Informer().AddEventHandler(c.eventHandler())
-		informers.Core().V1().Secrets().Informer().AddEventHandler(c.eventHandler())
-
-		c.cachesToSync = append(c.cachesToSync, informers.Core().V1().ConfigMaps().Informer().HasSynced)
-		c.cachesToSync = append(c.cachesToSync, informers.Core().V1().Secrets().Informer().HasSynced)
+		c.controllerFactory.WithInformers(
+			informers.Core().V1().ConfigMaps().Informer(),
+			informers.Core().V1().Secrets().Informer(),
+		)
 	}
-
-	// we watch this just in case someone messes with our status
-	operatorConfigClient.Informer().AddEventHandler(c.eventHandler())
-
-	c.cachesToSync = append(c.cachesToSync, operatorConfigClient.Informer().HasSynced)
 
 	return c
 }
@@ -111,7 +104,7 @@ func (c *ResourceSyncController) SyncConfigMap(destination, source ResourceLocat
 	c.configMapSyncRules[destination] = source
 
 	// make sure the new rule is picked up
-	c.queue.Add(controllerWorkQueueKey)
+	c.queue.Add(factory.QueueKey(c.Name()))
 	return nil
 }
 
@@ -128,11 +121,20 @@ func (c *ResourceSyncController) SyncSecret(destination, source ResourceLocation
 	c.secretSyncRules[destination] = source
 
 	// make sure the new rule is picked up
-	c.queue.Add(controllerWorkQueueKey)
+	c.queue.Add(factory.QueueKey(c.Name()))
 	return nil
 }
 
-func (c *ResourceSyncController) sync() error {
+// Run is used for unit testing
+func (c *ResourceSyncController) Run(ctx context.Context, workers int) {
+	c.controllerFactory.WithSync(c.Sync).ToController(c.Name(), c.recorder.WithComponentSuffix("resource-sync-controller")).Run(ctx, workers)
+}
+
+func (c *ResourceSyncController) Name() string {
+	return "ResourceSyncController"
+}
+
+func (c *ResourceSyncController) Sync(ctx context.Context, syncCtx factory.SyncContext) error {
 	operatorSpec, _, _, err := c.operatorConfigClient.GetOperatorState()
 	if err != nil {
 		return err
@@ -162,7 +164,7 @@ func (c *ResourceSyncController) sync() error {
 			continue
 		}
 
-		_, _, err := resourceapply.SyncConfigMap(c.configMapGetter, c.eventRecorder, source.Namespace, source.Name, destination.Namespace, destination.Name, []metav1.OwnerReference{})
+		_, _, err := resourceapply.SyncConfigMap(c.configMapGetter, syncCtx.Recorder(), source.Namespace, source.Name, destination.Namespace, destination.Name, []metav1.OwnerReference{})
 		if err != nil {
 			errors = append(errors, err)
 		}
@@ -182,7 +184,7 @@ func (c *ResourceSyncController) sync() error {
 			continue
 		}
 
-		_, _, err := resourceapply.SyncSecret(c.secretGetter, c.eventRecorder, source.Namespace, source.Name, destination.Namespace, destination.Name, []metav1.OwnerReference{})
+		_, _, err := resourceapply.SyncSecret(c.secretGetter, syncCtx.Recorder(), source.Namespace, source.Name, destination.Namespace, destination.Name, []metav1.OwnerReference{})
 		if err != nil {
 			errors = append(errors, err)
 		}
@@ -209,55 +211,6 @@ func (c *ResourceSyncController) sync() error {
 		return updateError
 	}
 	return nil
-}
-
-func (c *ResourceSyncController) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
-	defer c.queue.ShutDown()
-
-	klog.Infof("Starting ResourceSyncController")
-	defer klog.Infof("Shutting down ResourceSyncController")
-	if !cache.WaitForCacheSync(ctx.Done(), c.cachesToSync...) {
-		return
-	}
-
-	// doesn't matter what workers say, only start one.
-	go wait.UntilWithContext(ctx, c.runWorker, time.Second)
-
-	<-ctx.Done()
-}
-
-func (c *ResourceSyncController) runWorker(_ context.Context) {
-	for c.processNextWorkItem() {
-	}
-}
-
-func (c *ResourceSyncController) processNextWorkItem() bool {
-	dsKey, quit := c.queue.Get()
-	if quit {
-		return false
-	}
-	defer c.queue.Done(dsKey)
-
-	err := c.sync()
-	if err == nil {
-		c.queue.Forget(dsKey)
-		return true
-	}
-
-	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", dsKey, err))
-	c.queue.AddRateLimited(dsKey)
-
-	return true
-}
-
-// eventHandler queues the operator to check spec and status
-func (c *ResourceSyncController) eventHandler() cache.ResourceEventHandler {
-	return cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) { c.queue.Add(controllerWorkQueueKey) },
-		UpdateFunc: func(old, new interface{}) { c.queue.Add(controllerWorkQueueKey) },
-		DeleteFunc: func(obj interface{}) { c.queue.Add(controllerWorkQueueKey) },
-	}
 }
 
 func NewDebugHandler(controller *ResourceSyncController) http.Handler {
@@ -295,7 +248,7 @@ type ControllerSyncRules struct {
 	Configs ResourceSyncRuleList `json:"configs"`
 }
 
-// ServeSyncRules provides a handler function to return the sync rules of the controller
+// ServeSyncRules provides a handler function to return the Sync rules of the controller
 func (h *debugHTTPHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	syncRules := ControllerSyncRules{ResourceSyncRuleList{}, ResourceSyncRuleList{}}
 

--- a/pkg/operator/staticpod/controller/installer/installer_controller.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller.go
@@ -145,7 +145,11 @@ func NewInstallerController(
 }
 
 func (c *InstallerController) Run(ctx context.Context, workers int) {
-	c.factory.WithSync(c.Sync).ToController("InstallerController", c.eventRecorder).Run(ctx, workers)
+	c.factory.WithSync(c.Sync).ToController(c.Name(), c.eventRecorder).Run(ctx, workers)
+}
+
+func (c InstallerController) Name() string {
+	return "InstallerController"
 }
 
 func (c *InstallerController) getStaticPodState(nodeName string) (state staticPodState, revision, reason string, errors []string, err error) {

--- a/pkg/operator/staticresourcecontroller/static_resource_controller.go
+++ b/pkg/operator/staticresourcecontroller/static_resource_controller.go
@@ -212,6 +212,10 @@ func appendErrors(_ *operatorv1.OperatorStatus, _ bool, err error) []error {
 	return []error{}
 }
 
+func (c *StaticResourceController) Name() string {
+	return "StaticResourceController"
+}
+
 func (c *StaticResourceController) Run(ctx context.Context, workers int) {
-	c.factory.WithSync(c.Sync).ToController("", c.eventRecorder).Run(ctx, workers)
+	c.factory.WithSync(c.Sync).ToController(c.Name(), c.eventRecorder).Run(ctx, workers)
 }


### PR DESCRIPTION
First commit add controller manager that groups multiple controllers and **wait** until all controllers are terminated. This is used later in leader election block for builder where we allow controllers to properly finish before terminating them forcefully. IF controllers exit cleanly and in time, we exit 0 (must be for graceful termination), otherwise we exit 1.

Additionally, this converts resourcesync controller to use factory and allow to build the SyncContext upfront for unit testing or for more tide control on event recorder.