### PR TITLE
Bug 1792501: Increase revision pruner pod memory request

### DIFF
--- a/pkg/operator/staticpod/controller/prune/bindata/bindata.go
+++ b/pkg/operator/staticpod/controller/prune/bindata/bindata.go
@@ -63,9 +63,9 @@ spec:
     imagePullPolicy: IfNotPresent
     resources:
       requests:
-        memory: 100M
+        memory: 200M
       limits:
-        memory: 100M
+        memory: 200M
     securityContext:
       privileged: true
       runAsUser: 0

--- a/pkg/operator/staticpod/controller/prune/manifests/pruner-pod.yaml
+++ b/pkg/operator/staticpod/controller/prune/manifests/pruner-pod.yaml
@@ -16,9 +16,9 @@ spec:
     imagePullPolicy: IfNotPresent
     resources:
       requests:
-        memory: 100M
+        memory: 200M
       limits:
-        memory: 100M
+        memory: 200M
     securityContext:
       privileged: true
       runAsUser: 0


### PR DESCRIPTION
Originally added in https://github.com/openshift/library-go/pull/683, we are still seeing revision pruners get OOMKilled, so attempting to increase the memory request again