### PR TITLE
bug 1798725:  allow static pod operator to be composed

### DIFF
--- a/pkg/operator/condition/condition.go
+++ b/pkg/operator/condition/condition.go
@@ -30,6 +30,9 @@ const (
 	// This condition is set to False when the pods change state to running and are observed ready.
 	StaticPodsDegradedConditionType = "StaticPodsDegraded"
 
+	// StaticPodsAvailableConditionType is true when the static pod is available on at least one node.
+	StaticPodsAvailableConditionType = "StaticPodsAvailable"
+
 	// ConfigObservationDegradedConditionType is true when the operator failed to observe or process configuration change.
 	// This is not transient condition and normally a correction or manual intervention is required on the config custom resource.
 	ConfigObservationDegradedConditionType = "ConfigObservationDegraded"
@@ -54,6 +57,9 @@ const (
 	// The AllNodesAtLatestRevision reason is set when all master nodes are updated to the latest revision. It is false when some masters are pending revision.
 	// ZeroNodesActive reason is set to True when no active master nodes are observed. Is set to False when there is at least one active master node.
 	NodeInstallerDegradedConditionType = "NodeInstallerDegraded"
+
+	// NodeInstallerProgressingConditionType is true when the operator is moving nodes to a new revision.
+	NodeInstallerProgressingConditionType = "NodeInstallerProgressing"
 
 	// RevisionControllerDegradedConditionType is true when the operator is not able to create new desired revision because an error occurred when
 	// the operator attempted to created required resource(s) (secrets, configmaps, ...).

--- a/pkg/operator/staticpod/controller/installer/installer_controller.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller.go
@@ -459,13 +459,13 @@ func setAvailableProgressingNodeInstallerFailingConditions(newStatus *operatorv1
 
 	if numAvailable > 0 {
 		v1helpers.SetOperatorCondition(&newStatus.Conditions, operatorv1.OperatorCondition{
-			Type:    operatorv1.OperatorStatusTypeAvailable,
+			Type:    condition.StaticPodsAvailableConditionType,
 			Status:  operatorv1.ConditionTrue,
 			Message: fmt.Sprintf("%d nodes are active; %s", numAvailable, revisionDescription),
 		})
 	} else {
 		v1helpers.SetOperatorCondition(&newStatus.Conditions, operatorv1.OperatorCondition{
-			Type:    operatorv1.OperatorStatusTypeAvailable,
+			Type:    condition.StaticPodsAvailableConditionType,
 			Status:  operatorv1.ConditionFalse,
 			Reason:  "ZeroNodesActive",
 			Message: fmt.Sprintf("%d nodes are active; %s", numAvailable, revisionDescription),
@@ -475,13 +475,13 @@ func setAvailableProgressingNodeInstallerFailingConditions(newStatus *operatorv1
 	// Progressing means that the any node is not at the latest available revision
 	if numProgressing > 0 {
 		v1helpers.SetOperatorCondition(&newStatus.Conditions, operatorv1.OperatorCondition{
-			Type:    operatorv1.OperatorStatusTypeProgressing,
+			Type:    condition.NodeInstallerProgressingConditionType,
 			Status:  operatorv1.ConditionTrue,
 			Message: fmt.Sprintf("%s", revisionDescription),
 		})
 	} else {
 		v1helpers.SetOperatorCondition(&newStatus.Conditions, operatorv1.OperatorCondition{
-			Type:    operatorv1.OperatorStatusTypeProgressing,
+			Type:    condition.NodeInstallerProgressingConditionType,
 			Status:  operatorv1.ConditionFalse,
 			Reason:  "AllNodesAtLatestRevision",
 			Message: fmt.Sprintf("%s", revisionDescription),

--- a/pkg/operator/staticpod/controller/installer/installer_controller_test.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller_test.go
@@ -231,10 +231,10 @@ func TestNewNodeStateForInstallInProgress(t *testing.T) {
 		t.Error(errors)
 	}
 
-	if v1helpers.FindOperatorCondition(currStatus.Conditions, operatorv1.OperatorStatusTypeProgressing) == nil {
+	if v1helpers.FindOperatorCondition(currStatus.Conditions, condition.NodeInstallerProgressingConditionType) == nil {
 		t.Error("missing Progressing")
 	}
-	if v1helpers.FindOperatorCondition(currStatus.Conditions, operatorv1.OperatorStatusTypeAvailable) == nil {
+	if v1helpers.FindOperatorCondition(currStatus.Conditions, condition.StaticPodsAvailableConditionType) == nil {
 		t.Error("missing Available")
 	}
 }
@@ -1353,14 +1353,14 @@ func TestSetConditions(t *testing.T) {
 			}
 			setAvailableProgressingNodeInstallerFailingConditions(status)
 
-			availableCondition := v1helpers.FindOperatorCondition(status.Conditions, operatorv1.OperatorStatusTypeAvailable)
+			availableCondition := v1helpers.FindOperatorCondition(status.Conditions, condition.StaticPodsAvailableConditionType)
 			if availableCondition == nil {
 				t.Error("Available condition: not found")
 			} else if availableCondition.Status != tc.expectedAvailableStatus {
 				t.Errorf("Available condition: expected status %v, actual status %v", tc.expectedAvailableStatus, availableCondition.Status)
 			}
 
-			pendingCondition := v1helpers.FindOperatorCondition(status.Conditions, operatorv1.OperatorStatusTypeProgressing)
+			pendingCondition := v1helpers.FindOperatorCondition(status.Conditions, condition.NodeInstallerProgressingConditionType)
 			if pendingCondition == nil {
 				t.Error("Progressing condition: not found")
 			} else if pendingCondition.Status != tc.expectedProgressingStatus {


### PR DESCRIPTION
the static pod operator directly sets available and progressing, which makes it impossible to appropriately compose the conditions inside of an operator.