### PR TITLE
bug 1800321: add substitution for NODE_NAME inside of static pods

### DIFF
--- a/pkg/operator/staticpod/controller/installer/bindata/bindata.go
+++ b/pkg/operator/staticpod/controller/installer/bindata/bindata.go
@@ -69,6 +69,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
       terminationMessagePolicy: FallbackToLogsOnError
       volumeMounts:
         - mountPath: /etc/kubernetes/
@@ -87,7 +91,8 @@ spec:
   volumes:
     - hostPath:
         path: /etc/kubernetes/
-      name: kubelet-dir`)
+      name: kubelet-dir
+`)
 
 func pkgOperatorStaticpodControllerInstallerManifestsInstallerPodYamlBytes() ([]byte, error) {
 	return _pkgOperatorStaticpodControllerInstallerManifestsInstallerPodYaml, nil

--- a/pkg/operator/staticpod/controller/installer/manifests/installer-pod.yaml
+++ b/pkg/operator/staticpod/controller/installer/manifests/installer-pod.yaml
@@ -22,6 +22,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
       terminationMessagePolicy: FallbackToLogsOnError
       volumeMounts:
         - mountPath: /etc/kubernetes/

--- a/pkg/operator/staticpod/installerpod/cmd.go
+++ b/pkg/operator/staticpod/installerpod/cmd.go
@@ -32,6 +32,7 @@ type InstallOptions struct {
 	KubeClient kubernetes.Interface
 
 	Revision  string
+	NodeName  string
 	Namespace string
 
 	PodConfigMapNamePrefix        string
@@ -131,12 +132,19 @@ func (o *InstallOptions) Complete() error {
 	if err != nil {
 		return err
 	}
+
+	// set via downward API
+	o.NodeName = os.Getenv("NODE_NAME")
+
 	return nil
 }
 
 func (o *InstallOptions) Validate() error {
 	if len(o.Revision) == 0 {
 		return fmt.Errorf("--revision is required")
+	}
+	if len(o.NodeName) == 0 {
+		return fmt.Errorf("env var NODE_NAME is required")
 	}
 	if len(o.Namespace) == 0 {
 		return fmt.Errorf("--namespace is required")
@@ -294,7 +302,9 @@ func (o *InstallOptions) copyContent(ctx context.Context) error {
 		if !exists {
 			return true, fmt.Errorf("required 'pod.yaml' key does not exist in configmap")
 		}
-		podContent = strings.Replace(podData, "REVISION", o.Revision, -1)
+		podContent = strings.ReplaceAll(podData, "REVISION", o.Revision)
+		podContent = strings.ReplaceAll(podContent, "NODE_NAME", o.NodeName)
+		podContent = strings.ReplaceAll(podContent, "NODE_ENVVAR_NAME", strings.ReplaceAll(strings.ReplaceAll(o.NodeName, "-", "_"), ".", "_"))
 		return true, nil
 	})
 	if err != nil {


### PR DESCRIPTION
by substituting the NODE_NAME, we can select which env vars and arguments we want to use in commands.  This allows a single static pod template to be used on nodes that must have different arguments
