### PR TITLE
bug 1800609: add cpu limits to become guaranteed

### DIFF
--- a/pkg/operator/staticpod/controller/installer/bindata/bindata.go
+++ b/pkg/operator/staticpod/controller/installer/bindata/bindata.go
@@ -76,8 +76,10 @@ spec:
       resources:
         requests:
           memory: 100M
+          cpu: 150m
         limits:
           memory: 100M
+          cpu: 150m
   restartPolicy: Never
   priorityClassName: system-node-critical
   tolerations:
@@ -87,7 +89,8 @@ spec:
   volumes:
     - hostPath:
         path: /etc/kubernetes/
-      name: kubelet-dir`)
+      name: kubelet-dir
+`)
 
 func pkgOperatorStaticpodControllerInstallerManifestsInstallerPodYamlBytes() ([]byte, error) {
 	return _pkgOperatorStaticpodControllerInstallerManifestsInstallerPodYaml, nil

--- a/pkg/operator/staticpod/controller/installer/manifests/installer-pod.yaml
+++ b/pkg/operator/staticpod/controller/installer/manifests/installer-pod.yaml
@@ -29,8 +29,10 @@ spec:
       resources:
         requests:
           memory: 100M
+          cpu: 150m
         limits:
           memory: 100M
+          cpu: 150m
   restartPolicy: Never
   priorityClassName: system-node-critical
   tolerations:

--- a/pkg/operator/staticpod/controller/prune/bindata/bindata.go
+++ b/pkg/operator/staticpod/controller/prune/bindata/bindata.go
@@ -64,8 +64,10 @@ spec:
     resources:
       requests:
         memory: 100M
+        cpu: 150m
       limits:
         memory: 100M
+        cpu: 150m
     securityContext:
       privileged: true
       runAsUser: 0

--- a/pkg/operator/staticpod/controller/prune/manifests/pruner-pod.yaml
+++ b/pkg/operator/staticpod/controller/prune/manifests/pruner-pod.yaml
@@ -17,8 +17,10 @@ spec:
     resources:
       requests:
         memory: 100M
+        cpu: 150m
       limits:
         memory: 100M
+        cpu: 150m
     securityContext:
       privileged: true
       runAsUser: 0


### PR DESCRIPTION
The kubelet requires cpu and memory limits both specified to become guaranteed.