### PR TITLE
Bug 1779438: fix race for controller commands

### DIFF
--- a/pkg/controller/fileobserver/observer_polling_test.go
+++ b/pkg/controller/fileobserver/observer_polling_test.go
@@ -139,6 +139,14 @@ func TestObserverPolling(t *testing.T) {
 			startWithNoFile: true,
 		},
 		{
+			// This is what controllercmd.NewCommandWithContext currently does to avoid races
+			name:              "start with non-existing file with no change, force no starting hashing",
+			setInitialContent: true,
+			startFileContent:  emptyContent,
+			evaluateActions:   observedNoChanges,
+			startWithNoFile:   true,
+		},
+		{
 			name:              "start with non-existing file that is created as empty file",
 			evaluateActions:   observedSingleFileCreated,
 			startWithNoFile:   true,


### PR DESCRIPTION
Scenario:
a) AddDefaultRotationToConfig():
1. no serving cert and key found in expected directory
2. creates self-signed serving cert/key pair
3. serving-cert key-pair appears in the expected directory

b) WithRestartOnChange() -> AddReactor()

4. does not see starting content for the observed files
5. hashes for the expected cert/key pair are counted from the
   actual files but the controller will keep serving with the
   self-signed cert/key pair now

This was most probably caused by the line
```
    certDir = temporaryCertDir
```
which caused that starting content was added for wrong two files.
