### PR TITLE
pkg/operator/status/condition: Say "All is well" with no interesting conditions

### DIFF
--- a/pkg/operator/status/condition.go
+++ b/pkg/operator/status/condition.go
@@ -64,6 +64,9 @@ func UnionCondition(conditionType string, defaultConditionStatus operatorv1.Cond
 	if len(elderBadConditions) == 0 {
 		unionedCondition.Status = defaultConditionStatus
 		unionedCondition.Message = unionMessage(interestingConditions)
+		if unionedCondition.Message == "" {
+			unionedCondition.Message = "All is well"
+		}
 		unionedCondition.Reason = "AsExpected"
 		unionedCondition.LastTransitionTime = latestTransitionTime(interestingConditions)
 


### PR DESCRIPTION
If none of the interesting conditions have anything to say, and nothing bad is happening, explicitly say "All is well".  This makes a clearer distinction between "nothing is wrong" and "some things are concerning, but inertia or sub-condition status are keeping me from actually going degraded yet".