### PR TITLE
pkg/operator/status: Use warning events for concerning status changes

### DIFF
--- a/pkg/config/clusteroperator/v1helpers/status.go
+++ b/pkg/config/clusteroperator/v1helpers/status.go
@@ -14,6 +14,16 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 )
 
+// HappyConditionStatus indicates the happy condition status for
+// each condition type.  For instance, Available=True is good, and
+// Degraded=False is good.
+var HappyConditionStatus = map[configv1.ClusterStatusConditionType]configv1.ConditionStatus{
+	configv1.OperatorAvailable:   configv1.ConditionTrue,
+	configv1.OperatorDegraded:    configv1.ConditionFalse,
+	configv1.OperatorProgressing: configv1.ConditionFalse,
+	configv1.OperatorUpgradeable: configv1.ConditionTrue,
+}
+
 // SetStatusCondition sets the corresponding condition in conditions to newCondition.
 func SetStatusCondition(conditions *[]configv1.ClusterOperatorStatusCondition, newCondition configv1.ClusterOperatorStatusCondition) {
 	if conditions == nil {

--- a/pkg/config/clusteroperator/v1helpers/status_test.go
+++ b/pkg/config/clusteroperator/v1helpers/status_test.go
@@ -14,71 +14,243 @@ func TestGetStatusConditionDiff(t *testing.T) {
 		newConditions    []configv1.ClusterOperatorStatusCondition
 		oldConditions    []configv1.ClusterOperatorStatusCondition
 		expectedMessages []string
+		expectedWarning  bool
 	}{
 		{
-			name: "new condition",
+			name: "new happy condition",
 			newConditions: []configv1.ClusterOperatorStatusCondition{
 				{
-					Type:    configv1.RetrievedUpdates,
+					Type:    configv1.OperatorAvailable,
 					Status:  configv1.ConditionTrue,
 					Message: "test",
 				},
 			},
-			expectedMessages: []string{`RetrievedUpdates set to True ("test")`},
+			expectedMessages: []string{`Available set to True ("test")`},
 		},
 		{
-			name: "condition status change",
+			name: "new sad condition",
 			newConditions: []configv1.ClusterOperatorStatusCondition{
 				{
-					Type:    configv1.RetrievedUpdates,
-					Status:  configv1.ConditionFalse,
+					Type:    configv1.OperatorDegraded,
+					Status:  configv1.ConditionTrue,
 					Message: "test",
+				},
+			},
+			expectedMessages: []string{`Degraded set to True ("test")`},
+			expectedWarning:  true,
+		},
+		{
+			name: "happy condition status change",
+			newConditions: []configv1.ClusterOperatorStatusCondition{
+				{
+					Type:    configv1.OperatorAvailable,
+					Status:  configv1.ConditionTrue,
+					Message: "laugh",
 				},
 			},
 			oldConditions: []configv1.ClusterOperatorStatusCondition{
 				{
-					Type:    configv1.RetrievedUpdates,
-					Status:  configv1.ConditionTrue,
-					Message: "test",
+					Type:    configv1.OperatorAvailable,
+					Status:  configv1.ConditionFalse,
+					Message: "cry",
 				},
 			},
-			expectedMessages: []string{`RetrievedUpdates changed from True to False ("test")`},
+			expectedMessages: []string{`Available changed from False to True ("laugh")`},
 		},
 		{
-			name: "condition message change",
+			name: "sad condition status change",
 			newConditions: []configv1.ClusterOperatorStatusCondition{
 				{
-					Type:    configv1.RetrievedUpdates,
+					Type:    configv1.OperatorAvailable,
+					Status:  configv1.ConditionFalse,
+					Message: "cry",
+				},
+			},
+			oldConditions: []configv1.ClusterOperatorStatusCondition{
+				{
+					Type:    configv1.OperatorAvailable,
 					Status:  configv1.ConditionTrue,
+					Message: "laugh",
+				},
+			},
+			expectedMessages: []string{`Available changed from True to False ("cry")`},
+			expectedWarning:  true,
+		},
+		{
+			name: "happy condition reason change",
+			newConditions: []configv1.ClusterOperatorStatusCondition{
+				{
+					Type:    configv1.OperatorAvailable,
+					Status:  configv1.ConditionTrue,
+					Reason:  "SuccessB",
 					Message: "foo",
 				},
 			},
 			oldConditions: []configv1.ClusterOperatorStatusCondition{
 				{
-					Type:    configv1.RetrievedUpdates,
+					Type:    configv1.OperatorAvailable,
 					Status:  configv1.ConditionTrue,
+					Reason:  "SuccessA",
 					Message: "bar",
 				},
 			},
-			expectedMessages: []string{`RetrievedUpdates message changed from "bar" to "foo"`},
+			expectedMessages: []string{`Available=True reason changed from "SuccessA" to "SuccessB" ("foo")`},
+		},
+		{
+			name: "sad condition reason change",
+			newConditions: []configv1.ClusterOperatorStatusCondition{
+				{
+					Type:    configv1.OperatorDegraded,
+					Status:  configv1.ConditionTrue,
+					Reason:  "FailureB",
+					Message: "foo",
+				},
+			},
+			oldConditions: []configv1.ClusterOperatorStatusCondition{
+				{
+					Type:    configv1.OperatorDegraded,
+					Status:  configv1.ConditionTrue,
+					Reason:  "FailureA",
+					Message: "bar",
+				},
+			},
+			expectedMessages: []string{`Degraded=True reason changed from "FailureA" to "FailureB" ("foo")`},
+			expectedWarning:  true,
+		},
+		{
+			name: "unknown condition reason change",
+			newConditions: []configv1.ClusterOperatorStatusCondition{
+				{
+					Type:    configv1.ClusterStatusConditionType("CustomType"),
+					Status:  configv1.ConditionTrue,
+					Reason:  "SuccessB",
+					Message: "foo",
+				},
+			},
+			oldConditions: []configv1.ClusterOperatorStatusCondition{
+				{
+					Type:    configv1.ClusterStatusConditionType("CustomType"),
+					Status:  configv1.ConditionTrue,
+					Reason:  "SuccessA",
+					Message: "bar",
+				},
+			},
+			expectedMessages: []string{`CustomType=True reason changed from "SuccessA" to "SuccessB" ("foo")`},
+		},
+		{
+			name: "happy condition message change",
+			newConditions: []configv1.ClusterOperatorStatusCondition{
+				{
+					Type:    configv1.OperatorAvailable,
+					Status:  configv1.ConditionTrue,
+					Reason:  "Success",
+					Message: "foo",
+				},
+			},
+			oldConditions: []configv1.ClusterOperatorStatusCondition{
+				{
+					Type:    configv1.OperatorAvailable,
+					Status:  configv1.ConditionTrue,
+					Reason:  "Success",
+					Message: "bar",
+				},
+			},
+			expectedMessages: []string{`Available=True Success message changed from "bar" to "foo"`},
+		},
+		{
+			name: "sad condition message change",
+			newConditions: []configv1.ClusterOperatorStatusCondition{
+				{
+					Type:    configv1.OperatorDegraded,
+					Status:  configv1.ConditionTrue,
+					Reason:  "Failure",
+					Message: "foo",
+				},
+			},
+			oldConditions: []configv1.ClusterOperatorStatusCondition{
+				{
+					Type:    configv1.OperatorDegraded,
+					Status:  configv1.ConditionTrue,
+					Reason:  "Failure",
+					Message: "bar",
+				},
+			},
+			expectedMessages: []string{`Degraded=True Failure message changed from "bar" to "foo"`},
+			expectedWarning:  true,
+		},
+		{
+			name: "unknown condition message change",
+			newConditions: []configv1.ClusterOperatorStatusCondition{
+				{
+					Type:    configv1.ClusterStatusConditionType("CustomType"),
+					Status:  configv1.ConditionTrue,
+					Reason:  "Success",
+					Message: "foo",
+				},
+			},
+			oldConditions: []configv1.ClusterOperatorStatusCondition{
+				{
+					Type:    configv1.ClusterStatusConditionType("CustomType"),
+					Status:  configv1.ConditionTrue,
+					Reason:  "Success",
+					Message: "bar",
+				},
+			},
+			expectedMessages: []string{`CustomType=True Success message changed from "bar" to "foo"`},
+		},
+		{
+			name: "happy condition message change on still-sad status",
+			newConditions: []configv1.ClusterOperatorStatusCondition{
+				{
+					Type:    configv1.OperatorAvailable,
+					Status:  configv1.ConditionTrue,
+					Reason:  "Success",
+					Message: "I'm available",
+				},
+				{
+					Type:    configv1.OperatorDegraded,
+					Status:  configv1.ConditionTrue,
+					Reason:  "Failure",
+					Message: "I'm degraded",
+				},
+			},
+			oldConditions: []configv1.ClusterOperatorStatusCondition{
+				{
+					Type:    configv1.OperatorAvailable,
+					Status:  configv1.ConditionFalse,
+					Reason:  "Failure",
+					Message: "I'm not available",
+				},
+				{
+					Type:    configv1.OperatorDegraded,
+					Status:  configv1.ConditionTrue,
+					Reason:  "Failure",
+					Message: "I'm degraded",
+				},
+			},
+			expectedMessages: []string{`Available changed from False to True ("I'm available")`},
 		},
 		{
 			name: "condition message deleted",
 			oldConditions: []configv1.ClusterOperatorStatusCondition{
 				{
-					Type:    configv1.RetrievedUpdates,
+					Type:    configv1.OperatorAvailable,
 					Status:  configv1.ConditionTrue,
 					Message: "test",
 				},
 			},
-			expectedMessages: []string{"RetrievedUpdates was removed"},
+			expectedMessages: []string{"Available was removed"},
+			expectedWarning:  true,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result := GetStatusDiff(configv1.ClusterOperatorStatus{Conditions: test.oldConditions}, configv1.ClusterOperatorStatus{Conditions: test.newConditions})
+			result, warning := GetStatusDiff(configv1.ClusterOperatorStatus{Conditions: test.oldConditions}, configv1.ClusterOperatorStatus{Conditions: test.newConditions})
 			if !reflect.DeepEqual(test.expectedMessages, strings.Split(result, ",")) {
-				t.Errorf("expected %#v, got %#v", test.expectedMessages, result)
+				t.Errorf("expected message %#v, got %#v", test.expectedMessages, result)
+			}
+			if warning != test.expectedWarning {
+				t.Errorf("expected warning %t, got %t", test.expectedWarning, warning)
 			}
 		})
 	}

--- a/pkg/operator/status/status_controller.go
+++ b/pkg/operator/status/status_controller.go
@@ -150,10 +150,10 @@ func (c StatusSyncer) Sync(ctx context.Context, syncCtx factory.SyncContext) err
 	}
 
 	clusterOperatorObj.Status.RelatedObjects = c.relatedObjects
-	configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, UnionClusterCondition("Degraded", operatorv1.ConditionFalse, c.degradedInertia, currentDetailedStatus.Conditions...))
-	configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, UnionClusterCondition("Progressing", operatorv1.ConditionFalse, nil, currentDetailedStatus.Conditions...))
-	configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, UnionClusterCondition("Available", operatorv1.ConditionTrue, nil, currentDetailedStatus.Conditions...))
-	configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, UnionClusterCondition("Upgradeable", operatorv1.ConditionTrue, nil, currentDetailedStatus.Conditions...))
+	configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, UnionClusterCondition("Degraded", c.degradedInertia, currentDetailedStatus.Conditions...))
+	configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, UnionClusterCondition("Progressing", nil, currentDetailedStatus.Conditions...))
+	configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, UnionClusterCondition("Available", nil, currentDetailedStatus.Conditions...))
+	configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, UnionClusterCondition("Upgradeable", nil, currentDetailedStatus.Conditions...))
 
 	// TODO work out removal.  We don't always know the existing value, so removing early seems like a bad idea.  Perhaps a remove flag.
 	versions := c.versionGetter.GetVersions()

--- a/pkg/operator/status/status_controller.go
+++ b/pkg/operator/status/status_controller.go
@@ -145,7 +145,13 @@ func (c StatusSyncer) Sync(ctx context.Context, syncCtx factory.SyncContext) err
 		if _, err := c.clusterOperatorClient.ClusterOperators().UpdateStatus(ctx, clusterOperatorObj, metav1.UpdateOptions{}); err != nil {
 			return err
 		}
-		syncCtx.Recorder().Eventf("OperatorStatusChanged", "Status for operator %s changed: %s", c.clusterOperatorName, configv1helpers.GetStatusDiff(originalClusterOperatorObj.Status, clusterOperatorObj.Status))
+
+		statusDiff, warning := configv1helpers.GetStatusDiff(originalClusterOperatorObj.Status, clusterOperatorObj.Status)
+		if warning {
+			syncCtx.Recorder().Warningf("OperatorStatusChanged", "Status for operator %s changed: %s", c.clusterOperatorName, statusDiff)
+		} else {
+			syncCtx.Recorder().Eventf("OperatorStatusChanged", "Status for operator %s changed: %s", c.clusterOperatorName, statusDiff)
+		}
 		return nil
 	}
 
@@ -174,7 +180,12 @@ func (c StatusSyncer) Sync(ctx context.Context, syncCtx factory.SyncContext) err
 	if _, updateErr := c.clusterOperatorClient.ClusterOperators().UpdateStatus(ctx, clusterOperatorObj, metav1.UpdateOptions{}); err != nil {
 		return updateErr
 	}
-	syncCtx.Recorder().Eventf("OperatorStatusChanged", "Status for clusteroperator/%s changed: %s", c.clusterOperatorName, configv1helpers.GetStatusDiff(originalClusterOperatorObj.Status, clusterOperatorObj.Status))
+	statusDiff, warning := configv1helpers.GetStatusDiff(originalClusterOperatorObj.Status, clusterOperatorObj.Status)
+	if warning {
+		syncCtx.Recorder().Warningf("OperatorStatusChanged", "Status for clusteroperator/%s changed: %s", c.clusterOperatorName, statusDiff)
+	} else {
+		syncCtx.Recorder().Eventf("OperatorStatusChanged", "Status for clusteroperator/%s changed: %s", c.clusterOperatorName, statusDiff)
+	}
 	return nil
 }
 


### PR DESCRIPTION
And provide more context in the event messages, to make it easier to distinguish "we're slightly concerned, but not actually degraded" events from "we're actually sad" events.  For examples where I was distracted by the former, see [rhbz#1775970][1] and [rhbz#1779429][2].

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1775970
[2]: https://bugzilla.redhat.com/show_bug.cgi?id=1779429