### PR TITLE
bump: openshift/build-machinery-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/opencontainers/runc v0.0.0-20191031171055-b133feaeeb2e // indirect
 	github.com/openshift/api v0.0.0-20200210091934-a0e53e94816b
-	github.com/openshift/build-machinery-go v0.0.0-20200205161356-ef115f5adc73
+	github.com/openshift/build-machinery-go v0.0.0-20200211121458-5e3d6e570160
 	github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240
 	github.com/pkg/profile v1.3.0
 	github.com/prometheus/client_golang v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -324,8 +324,8 @@ github.com/openshift/api v0.0.0-20200116145750-0e2ff1e215dd h1:WIrzR6PXOptxWGafi
 github.com/openshift/api v0.0.0-20200116145750-0e2ff1e215dd/go.mod h1:fT6U/JfG8uZzemTRwZA2kBDJP5nWz7v05UHnty/D+pk=
 github.com/openshift/api v0.0.0-20200210091934-a0e53e94816b h1:BERD6sZj7w9Tt0RBpuw87AC0+SppyxEUgUG/Of5rI+E=
 github.com/openshift/api v0.0.0-20200210091934-a0e53e94816b/go.mod h1:fT6U/JfG8uZzemTRwZA2kBDJP5nWz7v05UHnty/D+pk=
-github.com/openshift/build-machinery-go v0.0.0-20200205161356-ef115f5adc73 h1:WCvABw620V2FqeNoRJWeuAATqGjsrzb0UQ3tL0RHcXw=
-github.com/openshift/build-machinery-go v0.0.0-20200205161356-ef115f5adc73/go.mod h1:1CkcsT3aVebzRBzVTSbiKSkJMsC/CASqxesfqEMfJEc=
+github.com/openshift/build-machinery-go v0.0.0-20200211121458-5e3d6e570160 h1:V4E6yt4XWiBEPKnJbs/E8pgUq9AjZqzQfsL3eeT84Qs=
+github.com/openshift/build-machinery-go v0.0.0-20200211121458-5e3d6e570160/go.mod h1:1CkcsT3aVebzRBzVTSbiKSkJMsC/CASqxesfqEMfJEc=
 github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240 h1:XYfJWv2Ch+qInGLDEedHRtDsJwnxyU1L8U7SY56NcA8=
 github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240/go.mod h1:4riOwdj99Hd/q+iAcJZfNCsQQQMwURnZV6RL4WHYS5w=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=

--- a/vendor/github.com/openshift/build-machinery-go/OWNERS
+++ b/vendor/github.com/openshift/build-machinery-go/OWNERS
@@ -1,4 +1,10 @@
 reviewers:
-  - tnozicka 
+  - tnozicka
+  - sttts
+  - mfojtik
+  - soltysh
 approvers:
-  - tnozicka 
+  - tnozicka
+  - sttts
+  - mfojtik
+  - soltysh

--- a/vendor/github.com/openshift/build-machinery-go/make/lib/golang.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/lib/golang.mk
@@ -17,7 +17,7 @@ GOFMT_FLAGS ?=-s -l
 GOLINT ?=golint
 
 go_version :=$(shell $(GO) version | sed -E -e 's/.*go([0-9]+.[0-9]+.[0-9]+).*/\1/')
-GO_REQUIRED_MIN_VERSION ?=1.13.5
+GO_REQUIRED_MIN_VERSION ?=1.13.4
 ifneq "$(GO_REQUIRED_MIN_VERSION)" ""
 $(call require_minimal_version,$(GO),GO_REQUIRED_MIN_VERSION,$(go_version))
 endif

--- a/vendor/github.com/openshift/build-machinery-go/make/lib/version.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/lib/version.mk
@@ -1,7 +1,7 @@
 # $1 - required version
 # $2 - current version
 define is_equal_or_higher_version
-$(strip $(filter $(2),$(firstword $(shell set -euo pipefail && echo -e '$(1)\n$(2)' | sort -V -r -b))))
+$(strip $(filter $(2),$(firstword $(shell set -euo pipefail && printf '%s\n%s' '$(1)' '$(2)' | sort -V -r -b))))
 endef
 
 # $1 - program name

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/deps-gomod.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/deps-gomod.mk
@@ -15,14 +15,14 @@ endef
 verify-deps: tmp_dir:=$(shell mktemp -d)
 verify-deps:
 	$(call restore-deps,$(tmp_dir))
-	$(deps_diff) "$(tmp_dir)"/{current,updated}/go.mod || echo '`go.mod` content is incorrect - did you run `go mod tidy`?'
-	$(deps_diff) "$(tmp_dir)"/{current,updated}/go.sum || echo '`go.sum` content is incorrect - did you run `go mod tidy`?'
+	$(deps_diff) "$(tmp_dir)"/{current,updated}/go.mod || ( echo '`go.mod` content is incorrect - did you run `go mod tidy`?' && false )
+	$(deps_diff) "$(tmp_dir)"/{current,updated}/go.sum || ( echo '`go.sum` content is incorrect - did you run `go mod tidy`?' && false )
 	@echo $(deps_diff) '$(tmp_dir)'/{current,updated}/deps.diff
 	@     $(deps_diff) '$(tmp_dir)'/{current,updated}/deps.diff || ( \
 		echo "ERROR: Content of 'vendor/' directory doesn't match 'go.mod' configuration and the overrides in 'deps.diff'!" && \
 		echo 'Did you run `go mod vendor`?' && \
 		echo "If this is an intentional change (a carry patch) please update the 'deps.diff' using 'make update-deps-overrides'." && \
-		exit 1 \
+		false \
 	)
 .PHONY: verify-deps
 
@@ -39,4 +39,3 @@ update-deps-overrides:
 include $(addprefix $(self_dir), \
 	../../lib/golang.mk \
 )
-

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -270,7 +270,7 @@ github.com/openshift/api/template/v1
 github.com/openshift/api/unidling/v1alpha1
 github.com/openshift/api/user
 github.com/openshift/api/user/v1
-# github.com/openshift/build-machinery-go v0.0.0-20200205161356-ef115f5adc73
+# github.com/openshift/build-machinery-go v0.0.0-20200211121458-5e3d6e570160
 github.com/openshift/build-machinery-go
 github.com/openshift/build-machinery-go/make
 github.com/openshift/build-machinery-go/make/lib


### PR DESCRIPTION
We need to pick the PR lowering go version after CI went back, builder fixes for Mac and fixing verify-deps exit codes.

/cc @soltysh @mfojtik 