### PR TITLE
WIP: Add simple prometheus query observer controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240
 	github.com/pkg/profile v1.3.0
 	github.com/prometheus/client_golang v1.1.0
+	github.com/prometheus/common v0.6.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5

--- a/pkg/metrics/client/client.go
+++ b/pkg/metrics/client/client.go
@@ -1,0 +1,102 @@
+package client
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/transport"
+
+	prometheusapi "github.com/prometheus/client_golang/api"
+	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+
+	routeclient "github.com/openshift/client-go/route/clientset/versioned"
+	routev1client "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
+)
+
+// DEPRECATED: This function is left only for test library compatibility.
+func DeprecatedPrometheusClient(kubeClient *kubernetes.Clientset, routeClient *routeclient.Clientset) (prometheusv1.API, error) {
+	return NewPrometheusClient(kubeClient.CoreV1(), kubeClient.CoreV1(), kubeClient.CoreV1(), routeClient.RouteV1())
+}
+
+// NewPrometheusClient returns Prometheus API or error
+// Note: with thanos-querier you must pass an entire Alert as a query. Partial queries return an error, so have to pass the entire alert.
+// Example query for an Alert:
+// `ALERTS{alertname="PodDisruptionBudgetAtLimit",alertstate="pending",namespace="pdbnamespace",poddisruptionbudget="pdbname",prometheus="openshift-monitoring/k8s",service="kube-state-metrics",severity="warning"}==1`
+// Example query:
+// `scheduler_scheduling_duration_seconds_sum`
+func NewPrometheusClient(serviceClient corev1client.ServicesGetter, secretsClient corev1client.SecretsGetter, configsClient corev1client.ConfigMapsGetter, routeClient routev1client.RoutesGetter) (prometheusv1.API, error) {
+	_, err := serviceClient.Services("openshift-monitoring").Get("prometheus-k8s", metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	route, err := routeClient.Routes("openshift-monitoring").Get("thanos-querier", metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	host := route.Status.Ingress[0].Host
+	var bearerToken string
+	secrets, err := secretsClient.Secrets("openshift-monitoring").List(metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("could not list secrets in openshift-monitoring namespace")
+	}
+	for _, s := range secrets.Items {
+		if s.Type != corev1.SecretTypeServiceAccountToken ||
+			!strings.HasPrefix(s.Name, "prometheus-k8s") {
+			continue
+		}
+		bearerToken = string(s.Data[corev1.ServiceAccountTokenKey])
+		break
+	}
+	if len(bearerToken) == 0 {
+		return nil, fmt.Errorf("prometheus service account not found")
+	}
+
+	return createClient(configsClient, host, bearerToken)
+}
+
+func createClient(configClient corev1client.ConfigMapsGetter, host, bearerToken string) (prometheusv1.API, error) {
+	// retrieve router CA
+	routerCAConfigMap, err := configClient.ConfigMaps("openshift-config-managed").Get("router-ca", metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	bundlePEM := []byte(routerCAConfigMap.Data["ca-bundle.crt"])
+
+	// make a client connection configured with the provided bundle.
+	roots := x509.NewCertPool()
+	roots.AppendCertsFromPEM(bundlePEM)
+
+	// prometheus API client, configured for route host and bearer token auth
+	client, err := prometheusapi.NewClient(prometheusapi.Config{
+		Address: "https://" + net.JoinHostPort(host, "443"),
+		RoundTripper: transport.NewBearerAuthRoundTripper(
+			bearerToken,
+			&http.Transport{
+				Proxy: http.ProxyFromEnvironment,
+				DialContext: (&net.Dialer{
+					Timeout:   30 * time.Second,
+					KeepAlive: 30 * time.Second,
+				}).DialContext,
+				TLSHandshakeTimeout: 10 * time.Second,
+				TLSClientConfig: &tls.Config{
+					RootCAs:    roots,
+					ServerName: host,
+				},
+			},
+		),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return prometheusv1.NewAPI(client), nil
+}

--- a/pkg/metrics/observer/query_observer.go
+++ b/pkg/metrics/observer/query_observer.go
@@ -1,0 +1,141 @@
+package observer
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	errorutil "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/klog"
+
+	routev1client "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
+	metricsclient "github.com/openshift/library-go/pkg/metrics/client"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+var defaultPollingDuration = 30 * time.Second
+
+type HandlerFunc = func(ctx context.Context, recorder events.Recorder, client prometheusv1.API) error
+
+// Handler represents a single Prometheus query and a handler function that should run on result of given query.
+type Handler struct {
+	// name represents human readable name for this handler (this will be used when reporting errors) eg. "FsyncDurationSeconds"
+	Name string
+	// handler is used to send query to prometheus and interpret the results.
+	Handler HandlerFunc
+}
+
+type prometheusMetricObserver struct {
+	operatorClient v1helpers.StaticPodOperatorClient
+	queryHandlers  []Handler
+
+	serviceClient corev1client.ServicesGetter
+	secretsClient corev1client.SecretsGetter
+	configsClient corev1client.ConfigMapsGetter
+	routeClient   routev1client.RoutesGetter
+
+	// allow to mock the client in unit tests
+	prometheusClientFn func(corev1client.ServicesGetter, corev1client.SecretsGetter, corev1client.ConfigMapsGetter, routev1client.RoutesGetter) (prometheusv1.API, error)
+}
+
+// NewPrometheusMetricObserver allows to continuously observe particular Prometheus query result value and react to it.
+// The name should be unique name for this observer.
+// The queryHandlers represents list of Prometheus queries and handlers where the result value and type are passed.
+// The clients are needed to initialize that prometheus API client.
+func NewPrometheusMetricObserver(name string, queryHandlers []Handler, serviceClient corev1client.ServicesGetter, secretsClient corev1client.SecretsGetter, configsClient corev1client.ConfigMapsGetter,
+	routeClient routev1client.RoutesGetter, recorder events.Recorder, operatorClient v1helpers.StaticPodOperatorClient) factory.Controller {
+	observer := &prometheusMetricObserver{
+		prometheusClientFn: metricsclient.NewPrometheusClient,
+		queryHandlers:      queryHandlers,
+		operatorClient:     operatorClient,
+		serviceClient:      serviceClient,
+		secretsClient:      secretsClient,
+		configsClient:      configsClient,
+		routeClient:        routeClient,
+	}
+	return factory.New().ResyncEvery(defaultPollingDuration).WithSync(observer.sync).ToController(name, recorder.WithComponentSuffix(name))
+}
+
+func (o *prometheusMetricObserver) sync(ctx context.Context, controllerContext factory.SyncContext) error {
+	var (
+		errors          []error
+		foundConditions []operatorv1.OperatorCondition
+	)
+
+	// list condition types we already know about
+	degradedConditionNames := sets.NewString("PrometheusObserverDegraded")
+
+	prometheusClient, prometheusClientErr := o.prometheusClientFn(o.serviceClient, o.secretsClient, o.configsClient, o.routeClient)
+	// do not error out if we can't get client, but report all handler degraded status as "unknown".
+	if prometheusClientErr != nil {
+		klog.Infof("Failed to get prometheus client: %v", prometheusClientErr)
+	}
+
+	for _, handler := range o.queryHandlers {
+		handlerConditionType := fmt.Sprintf("%s_PrometheusObserverDegraded", handler.Name)
+		// register handler name as operator degraded condition
+		degradedConditionNames.Insert(handlerConditionType)
+		// if we were not able to acquire prometheus client (service does not exists yet, upgrade, etc.) lets report 'unknown' for this condition
+		if prometheusClient == nil {
+			foundConditions = append(foundConditions, operatorv1.OperatorCondition{
+				Type:    handlerConditionType,
+				Status:  operatorv1.ConditionUnknown,
+				Reason:  "PrometheusUnavailable",
+				Message: fmt.Sprintf("Prometheus client is not available: %v", prometheusClientErr),
+			})
+			continue
+		}
+
+		// pass the polling interval to handler so callers know how often we execute this handler
+		handlerCtx := context.WithValue(ctx, "polling_interval", defaultPollingDuration)
+
+		if err := handler.Handler(handlerCtx, controllerContext.Recorder(), prometheusClient); err != nil {
+			// handler returning error means the operator should go degraded
+			foundConditions = append(foundConditions, operatorv1.OperatorCondition{
+				Type:    handlerConditionType,
+				Status:  operatorv1.ConditionTrue,
+				Reason:  "PrometheusQueryFailed",
+				Message: err.Error(),
+			})
+		}
+	}
+	syncErr := errorutil.NewAggregate(errors)
+
+	// if syncErr occurred, it means we failed to issue the prometheus query (connection problem) or the query result was nil (wrong query).
+	// in both cases, we go degraded with unknown status as we can't process the handler.
+	if syncErr != nil {
+		foundConditions = append(foundConditions, operatorv1.OperatorCondition{
+			Type:    "PrometheusObserverDegraded",
+			Status:  operatorv1.ConditionUnknown,
+			Reason:  "QueryFailed",
+			Message: syncErr.Error(),
+		})
+	}
+
+	var updateConditionFuncs []v1helpers.UpdateStaticPodStatusFunc
+	// check the supported degraded foundConditions and check if any pending pod matching them.
+	for _, degradedConditionName := range degradedConditionNames.List() {
+		// clean up existing foundConditions
+		updatedCondition := operatorv1.OperatorCondition{
+			Type:   degradedConditionName,
+			Status: operatorv1.ConditionFalse,
+		}
+		if condition := v1helpers.FindOperatorCondition(foundConditions, degradedConditionName); condition != nil {
+			updatedCondition = *condition
+		}
+		updateConditionFuncs = append(updateConditionFuncs, v1helpers.UpdateStaticPodConditionFn(updatedCondition))
+	}
+	if _, _, err := v1helpers.UpdateStaticPodStatus(o.operatorClient, updateConditionFuncs...); err != nil {
+		return err
+	}
+
+	return syncErr
+}

--- a/pkg/metrics/observer/query_observer_test.go
+++ b/pkg/metrics/observer/query_observer_test.go
@@ -1,0 +1,228 @@
+package observer
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/api"
+	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	routev1client "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/events/eventstesting"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+type fakeQueryResult struct {
+	query  string
+	result string
+	error  error
+}
+
+type fakePrometheusClient struct {
+	results      []fakeQueryResult
+	queriesCount int
+}
+
+func (f fakePrometheusClient) Alerts(ctx context.Context) (v1.AlertsResult, error) {
+	panic("implement me")
+}
+
+func (f fakePrometheusClient) AlertManagers(ctx context.Context) (v1.AlertManagersResult, error) {
+	panic("implement me")
+}
+
+func (f fakePrometheusClient) CleanTombstones(ctx context.Context) error {
+	panic("implement me")
+}
+
+func (f fakePrometheusClient) Config(ctx context.Context) (v1.ConfigResult, error) {
+	panic("implement me")
+}
+
+func (f fakePrometheusClient) DeleteSeries(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) error {
+	panic("implement me")
+}
+
+func (f fakePrometheusClient) Flags(ctx context.Context) (v1.FlagsResult, error) {
+	panic("implement me")
+}
+
+func (f fakePrometheusClient) LabelNames(ctx context.Context) ([]string, api.Warnings, error) {
+	panic("implement me")
+}
+
+func (f fakePrometheusClient) LabelValues(ctx context.Context, label string) (model.LabelValues, api.Warnings, error) {
+	panic("implement me")
+}
+
+func (f fakePrometheusClient) Query(ctx context.Context, query string, ts time.Time) (model.Value, api.Warnings, error) {
+	panic("implement me")
+}
+
+func (f *fakePrometheusClient) QueryRange(ctx context.Context, query string, _ v1.Range) (model.Value, api.Warnings, error) {
+	f.queriesCount++
+	for _, r := range f.results {
+		if r.query == query {
+			if r.error != nil {
+				return nil, nil, r.error
+			}
+			return &model.String{
+				Value:     r.result,
+				Timestamp: model.TimeFromUnix(time.Now().Unix()),
+			}, nil, nil
+		}
+	}
+	return nil, nil, fmt.Errorf("no matching result for query: %v", query)
+}
+
+func (f fakePrometheusClient) Series(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) ([]model.LabelSet, api.Warnings, error) {
+	panic("implement me")
+}
+
+func (f fakePrometheusClient) Snapshot(ctx context.Context, skipHead bool) (v1.SnapshotResult, error) {
+	panic("implement me")
+}
+
+func (f fakePrometheusClient) Rules(ctx context.Context) (v1.RulesResult, error) {
+	panic("implement me")
+}
+
+func (f fakePrometheusClient) Targets(ctx context.Context) (v1.TargetsResult, error) {
+	panic("implement me")
+}
+
+func (f fakePrometheusClient) TargetsMetadata(ctx context.Context, matchTarget string, metric string, limit string) ([]v1.MetricMetadata, error) {
+	panic("implement me")
+}
+
+func TestNewPrometheusMetricObserver(t *testing.T) {
+	tests := []struct {
+		name                  string
+		client                v1.API
+		expectErr             bool
+		expectQueryCount      int
+		expectEventCount      int
+		expectConditionStatus map[string]string
+		queryHandlers         []Handler
+	}{
+		{
+			name:             "simple query",
+			expectQueryCount: 1,
+			expectConditionStatus: map[string]string{
+				"FooSummary_PrometheusObserverDegraded": "False",
+			},
+			client: &fakePrometheusClient{results: []fakeQueryResult{
+				{
+					query:  "sum(foo)",
+					result: "10",
+				},
+			},
+			},
+			queryHandlers: []Handler{
+				{
+					Name: "FooSummary",
+					Handler: func(ctx context.Context, recorder events.Recorder, client prometheusv1.API) error {
+						result, _, _ := client.QueryRange(ctx, "sum(foo)", prometheusv1.Range{
+							Start: time.Now(),
+							End:   time.Now().Add(-ctx.Value("polling_interval").(time.Duration)),
+						})
+						if result.String() != "10" {
+							t.Errorf("expected current value %q, got %q", "10", result.String())
+						}
+						return nil
+					},
+				},
+			},
+		},
+		{
+			name:             "prometheus unavailable",
+			expectQueryCount: 1,
+			expectConditionStatus: map[string]string{
+				"PrometheusObserverDegraded":            "False",
+				"FooSummary_PrometheusObserverDegraded": "Unknown",
+			},
+			queryHandlers: []Handler{
+				{
+					Name: "FooSummary",
+					Handler: func(ctx context.Context, recorder events.Recorder, client prometheusv1.API) error {
+						return nil
+					},
+				},
+			},
+		},
+		{
+			name: "simple query but failed handler",
+			expectConditionStatus: map[string]string{
+				"FooSummary_PrometheusObserverDegraded": "True",
+			},
+			client: &fakePrometheusClient{results: []fakeQueryResult{
+				{
+					query:  "sum(foo)",
+					result: "10",
+				},
+			},
+			},
+			queryHandlers: []Handler{
+				{
+					Name: "FooSummary",
+					Handler: func(ctx context.Context, recorder events.Recorder, client prometheusv1.API) error {
+						return fmt.Errorf("handler for query failed")
+					},
+				},
+			},
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fakePromClient := func(corev1client.ServicesGetter, corev1client.SecretsGetter, corev1client.ConfigMapsGetter, routev1client.RoutesGetter) (prometheusv1.API, error) {
+				return test.client, nil
+			}
+			fakeStaticPodOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(&operatorv1.StaticPodOperatorSpec{}, &operatorv1.StaticPodOperatorStatus{}, nil, nil)
+			observer := &prometheusMetricObserver{prometheusClientFn: fakePromClient, queryHandlers: test.queryHandlers, operatorClient: fakeStaticPodOperatorClient}
+			memoryRecorder := events.NewInMemoryRecorder(fmt.Sprintf("test-%d", i))
+			recorder := eventstesting.NewEventRecorder(t, memoryRecorder)
+			err := observer.sync(context.Background(), factory.NewSyncContext(fmt.Sprintf("test-%d", i), recorder))
+			if test.expectErr && err == nil {
+				t.Errorf("expected error, got none")
+				return
+			} else if !test.expectErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if test.client != nil {
+				if c := test.client.(*fakePrometheusClient).queriesCount; c != test.expectQueryCount {
+					t.Errorf("expected %d queries, got %d", test.expectQueryCount, c)
+				}
+			}
+			if c := len(memoryRecorder.Events()); c != test.expectEventCount {
+				t.Errorf("expected %d events, got %d", test.expectEventCount, c)
+			}
+			_, status, _, err := fakeStaticPodOperatorClient.GetOperatorState()
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			for conditionName, conditionState := range test.expectConditionStatus {
+				found := false
+				for _, c := range status.Conditions {
+					if c.Type == conditionName && string(c.Status) == conditionState {
+						t.Logf("Found %s=%q", c.Type, c.Status)
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected %s=%q, got %#v", conditionName, conditionState, status.Conditions)
+				}
+			}
+		})
+	}
+}

--- a/test/library/metrics/query.go
+++ b/test/library/metrics/query.go
@@ -1,95 +1,9 @@
 package metrics
 
 import (
-	"crypto/tls"
-	"crypto/x509"
-	"fmt"
-	"net"
-	"net/http"
-	"strings"
-	"time"
-
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/transport"
-
-	prometheusapi "github.com/prometheus/client_golang/api"
-	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
-
-	routeclient "github.com/openshift/client-go/route/clientset/versioned"
+	"github.com/openshift/library-go/pkg/metrics/client"
 )
 
-// NewPrometheusClient returns Prometheus API or error
-// Note: with thanos-querier you must pass an entire Alert as a query. Partial queries return an error, so have to pass the entire alert.
-// Example query for an Alert:
-// `ALERTS{alertname="PodDisruptionBudgetAtLimit",alertstate="pending",namespace="pdbnamespace",poddisruptionbudget="pdbname",prometheus="openshift-monitoring/k8s",service="kube-state-metrics",severity="warning"}==1`
-// Example query:
-// `scheduler_scheduling_duration_seconds_sum`
-func NewPrometheusClient(kclient *kubernetes.Clientset, rc *routeclient.Clientset) (prometheusv1.API, error) {
-	_, err := kclient.CoreV1().Services("openshift-monitoring").Get("prometheus-k8s", metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	route, err := rc.RouteV1().Routes("openshift-monitoring").Get("thanos-querier", metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-	host := route.Status.Ingress[0].Host
-	var bearerToken string
-	secrets, err := kclient.CoreV1().Secrets("openshift-monitoring").List(metav1.ListOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("could not list secrets in openshift-monitoring namespace")
-	}
-	for _, s := range secrets.Items {
-		if s.Type != corev1.SecretTypeServiceAccountToken ||
-			!strings.HasPrefix(s.Name, "prometheus-k8s") {
-			continue
-		}
-		bearerToken = string(s.Data[corev1.ServiceAccountTokenKey])
-		break
-	}
-	if len(bearerToken) == 0 {
-		return nil, fmt.Errorf("prometheus service account not found")
-	}
-
-	return createClient(kclient, host, bearerToken)
-}
-
-func createClient(kclient *kubernetes.Clientset, host, bearerToken string) (prometheusv1.API, error) {
-	// retrieve router CA
-	routerCAConfigMap, err := kclient.CoreV1().ConfigMaps("openshift-config-managed").Get("router-ca", metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-	bundlePEM := []byte(routerCAConfigMap.Data["ca-bundle.crt"])
-
-	// make a client connection configured with the provided bundle.
-	roots := x509.NewCertPool()
-	roots.AppendCertsFromPEM(bundlePEM)
-
-	// prometheus API client, configured for route host and bearer token auth
-	client, err := prometheusapi.NewClient(prometheusapi.Config{
-		Address: "https://" + host,
-		RoundTripper: transport.NewBearerAuthRoundTripper(
-			bearerToken,
-			&http.Transport{
-				Proxy: http.ProxyFromEnvironment,
-				DialContext: (&net.Dialer{
-					Timeout:   30 * time.Second,
-					KeepAlive: 30 * time.Second,
-				}).DialContext,
-				TLSHandshakeTimeout: 10 * time.Second,
-				TLSClientConfig: &tls.Config{
-					RootCAs:    roots,
-					ServerName: host,
-				},
-			},
-		),
-	})
-	if err != nil {
-		return nil, err
-	}
-	return prometheusv1.NewAPI(client), nil
-}
+// This is left here for compatibility.
+// DEPRECATED: use metrics/client.NewPrometheusClient instead
+var NewPrometheusClient = client.DeprecatedPrometheusClient


### PR DESCRIPTION
This introduces simple prometheus query result observer that can react to query results.

An example usage would be an etcd-operator that watch the fsync metrics (`histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket[5m]))`) and if the etcd criteria are not met with the value returned, the operator can go degraded or unavailable.

Each query handler is identified by name and that name is then translated to degraded condition which fire if the handler return error and it is cleared when the handler return nil.
