### PR TITLE
resourceapply: Allow removing run-level labels from namespaces

### DIFF
--- a/pkg/operator/resource/resourceapply/core.go
+++ b/pkg/operator/resource/resourceapply/core.go
@@ -22,8 +22,10 @@ import (
 func ApplyNamespace(client coreclientv1.NamespacesGetter, recorder events.Recorder, required *corev1.Namespace) (*corev1.Namespace, bool, error) {
 	existing, err := client.Namespaces().Get(required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		actual, err := client.Namespaces().Create(required)
-		reportCreateEvent(recorder, required, err)
+		requiredCopy := required.DeepCopy()
+		actual, err := client.Namespaces().
+			Create(resourcemerge.WithCleanLabelsAndAnnotations(requiredCopy).(*corev1.Namespace))
+		reportCreateEvent(recorder, requiredCopy, err)
 		return actual, true, err
 	}
 	if err != nil {
@@ -53,8 +55,10 @@ func ApplyNamespace(client coreclientv1.NamespacesGetter, recorder events.Record
 func ApplyService(client coreclientv1.ServicesGetter, recorder events.Recorder, required *corev1.Service) (*corev1.Service, bool, error) {
 	existing, err := client.Services(required.Namespace).Get(required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		actual, err := client.Services(required.Namespace).Create(required)
-		reportCreateEvent(recorder, required, err)
+		requiredCopy := required.DeepCopy()
+		actual, err := client.Services(requiredCopy.Namespace).
+			Create(resourcemerge.WithCleanLabelsAndAnnotations(requiredCopy).(*corev1.Service))
+		reportCreateEvent(recorder, requiredCopy, err)
 		return actual, true, err
 	}
 	if err != nil {
@@ -94,8 +98,10 @@ func ApplyService(client coreclientv1.ServicesGetter, recorder events.Recorder, 
 func ApplyPod(client coreclientv1.PodsGetter, recorder events.Recorder, required *corev1.Pod) (*corev1.Pod, bool, error) {
 	existing, err := client.Pods(required.Namespace).Get(required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		actual, err := client.Pods(required.Namespace).Create(required)
-		reportCreateEvent(recorder, required, err)
+		requiredCopy := required.DeepCopy()
+		actual, err := client.Pods(requiredCopy.Namespace).
+			Create(resourcemerge.WithCleanLabelsAndAnnotations(requiredCopy).(*corev1.Pod))
+		reportCreateEvent(recorder, requiredCopy, err)
 		return actual, true, err
 	}
 	if err != nil {
@@ -123,8 +129,10 @@ func ApplyPod(client coreclientv1.PodsGetter, recorder events.Recorder, required
 func ApplyServiceAccount(client coreclientv1.ServiceAccountsGetter, recorder events.Recorder, required *corev1.ServiceAccount) (*corev1.ServiceAccount, bool, error) {
 	existing, err := client.ServiceAccounts(required.Namespace).Get(required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		actual, err := client.ServiceAccounts(required.Namespace).Create(required)
-		reportCreateEvent(recorder, required, err)
+		requiredCopy := required.DeepCopy()
+		actual, err := client.ServiceAccounts(requiredCopy.Namespace).
+			Create(resourcemerge.WithCleanLabelsAndAnnotations(requiredCopy).(*corev1.ServiceAccount))
+		reportCreateEvent(recorder, requiredCopy, err)
 		return actual, true, err
 	}
 	if err != nil {
@@ -150,8 +158,10 @@ func ApplyServiceAccount(client coreclientv1.ServiceAccountsGetter, recorder eve
 func ApplyConfigMap(client coreclientv1.ConfigMapsGetter, recorder events.Recorder, required *corev1.ConfigMap) (*corev1.ConfigMap, bool, error) {
 	existing, err := client.ConfigMaps(required.Namespace).Get(required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		actual, err := client.ConfigMaps(required.Namespace).Create(required)
-		reportCreateEvent(recorder, required, err)
+		requiredCopy := required.DeepCopy()
+		actual, err := client.ConfigMaps(requiredCopy.Namespace).
+			Create(resourcemerge.WithCleanLabelsAndAnnotations(requiredCopy).(*corev1.ConfigMap))
+		reportCreateEvent(recorder, requiredCopy, err)
 		return actual, true, err
 	}
 	if err != nil {
@@ -230,8 +240,10 @@ func ApplySecret(client coreclientv1.SecretsGetter, recorder events.Recorder, re
 
 	existing, err := client.Secrets(required.Namespace).Get(required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		actual, err := client.Secrets(required.Namespace).Create(required)
-		reportCreateEvent(recorder, required, err)
+		requiredCopy := required.DeepCopy()
+		actual, err := client.Secrets(requiredCopy.Namespace).
+			Create(resourcemerge.WithCleanLabelsAndAnnotations(requiredCopy).(*corev1.Secret))
+		reportCreateEvent(recorder, requiredCopy, err)
 		return actual, true, err
 	}
 	if err != nil {

--- a/pkg/operator/resource/resourcemerge/object_merger.go
+++ b/pkg/operator/resource/resourcemerge/object_merger.go
@@ -2,6 +2,7 @@ package resourcemerge
 
 import (
 	"reflect"
+	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -13,6 +14,23 @@ func EnsureObjectMeta(modified *bool, existing *metav1.ObjectMeta, required meta
 	SetStringIfSet(modified, &existing.Name, required.Name)
 	MergeMap(modified, &existing.Labels, required.Labels)
 	MergeMap(modified, &existing.Annotations, required.Annotations)
+}
+
+// WithCleanLabelsAndAnnotations cleans the metadata off the removal annotations/labels
+// (those that end with trailing "-")
+func WithCleanLabelsAndAnnotations(obj metav1.Object) metav1.Object {
+	obj.SetAnnotations(cleanRemovalKeys(obj.GetAnnotations()))
+	obj.SetLabels(cleanRemovalKeys(obj.GetLabels()))
+	return obj
+}
+
+func cleanRemovalKeys(required map[string]string) map[string]string {
+	for k := range required {
+		if strings.HasSuffix(k, "-") {
+			delete(required, k)
+		}
+	}
+	return required
 }
 
 func stringPtr(val string) *string {
@@ -124,7 +142,13 @@ func MergeMap(modified *bool, existing *map[string]string, required map[string]s
 	for k, v := range required {
 		if existingV, ok := (*existing)[k]; !ok || v != existingV {
 			*modified = true
-			(*existing)[k] = v
+			// if "required" map contains a key with "-" as suffix, remove that
+			// key from the existing map instead of replacing the value
+			if strings.HasSuffix(k, "-") {
+				delete(*existing, strings.TrimRight(k, "-"))
+			} else {
+				(*existing)[k] = v
+			}
 		}
 	}
 }


### PR DESCRIPTION
A couple of components were using run-level labels on their
namespaces even though they did not have to. Make it possible
to remove this label with the library-go functions while not
changing the other labels/annotations in case these are maintained
automatically by a different controller.