### PR TITLE
Migrate controllers to factory

### DIFF
--- a/pkg/config/leaderelection/leaderelection.go
+++ b/pkg/config/leaderelection/leaderelection.go
@@ -3,6 +3,7 @@ package leaderelection
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"strings"
 	"time"
 
@@ -64,7 +65,8 @@ func ToConfigMapLeaderElection(clientConfig *rest.Config, config configv1.Leader
 		RetryPeriod:     config.RetryPeriod.Duration,
 		Callbacks: leaderelection.LeaderCallbacks{
 			OnStoppedLeading: func() {
-				klog.Fatalf("leaderelection lost")
+				defer os.Exit(0)
+				klog.Warningf("leader election lost")
 			},
 		},
 	}, nil

--- a/pkg/controller/factory/controller_context.go
+++ b/pkg/controller/factory/controller_context.go
@@ -17,12 +17,9 @@ import (
 // syncContext implements SyncContext and provide user access to queue and object that caused
 // the sync to be triggered.
 type syncContext struct {
-	queue         workqueue.RateLimitingInterface
 	eventRecorder events.Recorder
-
-	// queueRuntimeObject holds the object we got from informer
-	// There is no direct access to this object to prevent cache mutation.
-	queueRuntimeObject runtime.Object
+	queue         workqueue.RateLimitingInterface
+	queueKey      string
 }
 
 var _ SyncContext = syncContext{}
@@ -35,30 +32,16 @@ func NewSyncContext(name string, recorder events.Recorder) SyncContext {
 	}
 }
 
-// GetObject gives the object from the queue.
-// For controllers generated without WithRuntimeObject() this always return nil.
-func (c syncContext) GetObject() runtime.Object {
-	if c.queueRuntimeObject == nil {
-		return nil
-	}
-	return c.queueRuntimeObject.DeepCopyObject()
-}
-
 func (c syncContext) Queue() workqueue.RateLimitingInterface {
 	return c.queue
 }
 
-func (c syncContext) Recorder() events.Recorder {
-	return c.eventRecorder
+func (c syncContext) QueueKey() string {
+	return c.queueKey
 }
 
-// withRuntimeObject make a copy of existing sync context and set the queueRuntimeObject.
-func (c syncContext) withRuntimeObject(obj runtime.Object) SyncContext {
-	return syncContext{
-		eventRecorder:      c.Recorder(),
-		queue:              c.Queue(),
-		queueRuntimeObject: obj,
-	}
+func (c syncContext) Recorder() events.Recorder {
+	return c.eventRecorder
 }
 
 func (c syncContext) isInterestingNamespace(obj interface{}, interestingNamespaces sets.String) (bool, bool) {
@@ -76,78 +59,46 @@ func (c syncContext) isInterestingNamespace(obj interface{}, interestingNamespac
 }
 
 // eventHandler provides default event handler that is added to an informers passed to controller factory.
-func (c syncContext) eventHandler(keyName string, objectQueue bool, interestingNamespaces sets.String) cache.ResourceEventHandler {
+func (c syncContext) eventHandler(queueKeyFunc ObjectQueueKeyFunc, interestingNamespaces sets.String) cache.ResourceEventHandler {
 	return cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			isNamespace, isInteresting := c.isInterestingNamespace(obj, interestingNamespaces)
-			if !objectQueue {
-				if !isNamespace {
-					c.Queue().Add(keyName)
-				} else if isInteresting {
-					c.Queue().Add(keyName)
-				}
-				return
-			}
 			runtimeObj, ok := obj.(runtime.Object)
 			if !ok {
 				utilruntime.HandleError(fmt.Errorf("added object %+v is not runtime Object", obj))
 				return
 			}
-			if !isNamespace {
-				c.Queue().Add(runtimeObj)
-			} else if isInteresting {
-				c.Queue().Add(runtimeObj)
+			if !isNamespace || (isNamespace && isInteresting) {
+				c.Queue().Add(queueKeyFunc(runtimeObj))
 			}
 		},
 		UpdateFunc: func(old, new interface{}) {
 			isNamespace, isInteresting := c.isInterestingNamespace(new, interestingNamespaces)
-			if !objectQueue {
-				if !isNamespace {
-					c.Queue().Add(keyName)
-				} else if isInteresting {
-					c.Queue().Add(keyName)
-				}
-				return
-			}
 			runtimeObj, ok := new.(runtime.Object)
 			if !ok {
 				utilruntime.HandleError(fmt.Errorf("updated object %+v is not runtime Object", runtimeObj))
 				return
 			}
-			if !isNamespace {
-				c.Queue().Add(runtimeObj)
-			} else if isInteresting {
-				c.Queue().Add(runtimeObj)
+			if !isNamespace || (isNamespace && isInteresting) {
+				c.Queue().Add(queueKeyFunc(runtimeObj))
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
 			isNamespace, isInteresting := c.isInterestingNamespace(obj, interestingNamespaces)
-			if !objectQueue {
-				if !isNamespace {
-					c.Queue().Add(keyName)
-				} else if isInteresting {
-					c.Queue().Add(keyName)
-				}
-				return
-			}
 			runtimeObj, ok := obj.(runtime.Object)
 			if !ok {
 				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 				if ok {
-					if !isNamespace {
-						c.Queue().Add(tombstone.Obj.(runtime.Object))
-					} else if isInteresting {
-						c.Queue().Add(tombstone.Obj.(runtime.Object))
+					if !isNamespace || (isNamespace && isInteresting) {
+						c.Queue().Add(queueKeyFunc(tombstone.Obj.(runtime.Object)))
 					}
 					return
 				}
 				utilruntime.HandleError(fmt.Errorf("updated object %+v is not runtime Object", runtimeObj))
 				return
 			}
-			if !isNamespace {
-				c.Queue().Add(runtimeObj)
-			} else if isInteresting {
-				c.Queue().Add(runtimeObj)
+			if !isNamespace || (isNamespace && isInteresting) {
+				c.Queue().Add(queueKeyFunc(runtimeObj))
 			}
 		},
 	}

--- a/pkg/controller/factory/factory.go
+++ b/pkg/controller/factory/factory.go
@@ -4,11 +4,15 @@ import (
 	"context"
 	"time"
 
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/openshift/library-go/pkg/operator/events"
 )
+
+// DefaultQueueKey is the queue key used for string trigger based controllers.
+const DefaultQueueKey = "key"
 
 // Factory is generator that generate standard Kubernetes controllers.
 // Factory is really generic and should be only used for simple controllers that does not require special stuff..
@@ -16,8 +20,8 @@ type Factory struct {
 	sync                  SyncFunc
 	syncContext           SyncContext
 	resyncInterval        time.Duration
-	objectQueue           bool
 	informers             []Informer
+	informerQueueKeys     []informersWithQueueKey
 	postStartHooks        []PostStartHook
 	namespaceInformers    []*namespaceInformer
 	cachesToSync          []cache.InformerSynced
@@ -36,10 +40,20 @@ type namespaceInformer struct {
 	namespaces sets.String
 }
 
+type informersWithQueueKey struct {
+	informers  []Informer
+	queueKeyFn ObjectQueueKeyFunc
+}
+
 // PostStartHook specify a function that will run after controller is started.
 // The context is cancelled when the controller is asked to shutdown and the post start hook should terminate as well.
 // The syncContext allow access to controller queue and event recorder.
 type PostStartHook func(ctx context.Context, syncContext SyncContext) error
+
+// ObjectQueueKeyFunc is used to make a string work queue key out of the runtime object that is passed to it.
+// This can extract the "namespace/name" if you need to or just return "key" if you building controller that only use string
+// triggers.
+type ObjectQueueKeyFunc func(runtime.Object) string
 
 // New return new factory instance.
 func New() *Factory {
@@ -61,8 +75,20 @@ func (f *Factory) WithInformers(informers ...Informer) *Factory {
 	return f
 }
 
-// WithPostRunHooks allows to register functions that will run asynchronously after the controller is started via Run command.
-func (f *Factory) WithPostRunHooks(hooks ...PostStartHook) *Factory {
+// WithInformersQueueKeyFunc is used to register event handlers and get the caches synchronized functions.
+// Pass informers you want to use to react to changes on resources. If informer event is observed, then the Sync() function
+// is called.
+// Pass the queueKeyFn you want to use to transform the informer runtime.Object into string key used by work queue.
+func (f *Factory) WithInformersQueueKeyFunc(queueKeyFn ObjectQueueKeyFunc, informers ...Informer) *Factory {
+	f.informerQueueKeys = append(f.informerQueueKeys, informersWithQueueKey{
+		informers:  informers,
+		queueKeyFn: queueKeyFn,
+	})
+	return f
+}
+
+// WithPostStartHooks allows to register functions that will run asynchronously after the controller is started via Run command.
+func (f *Factory) WithPostStartHooks(hooks ...PostStartHook) *Factory {
 	f.postStartHooks = append(f.postStartHooks, hooks...)
 	return f
 }
@@ -85,14 +111,6 @@ func (f *Factory) WithNamespaceInformer(informer Informer, interestingNamespaces
 //       This can be used to detect periodical resyncs, but normal Sync() have to be cautious about `nil` objects.
 func (f *Factory) ResyncEvery(interval time.Duration) *Factory {
 	f.resyncInterval = interval
-	return f
-}
-
-// WithRuntimeObject cause the factory to produce controller that pass the runtime.Object from event handler that was
-// triggered to queue (instead of requeue using simple string key). This allow to access this object, however storing
-// object in queue might increase memory usage (?).
-func (f *Factory) WithRuntimeObject() *Factory {
-	f.objectQueue = true
 	return f
 }
 
@@ -124,14 +142,27 @@ func (f *Factory) ToController(name string, eventRecorder events.Recorder) Contr
 		syncContext: ctx,
 	}
 
+	for i := range f.informerQueueKeys {
+		for d := range f.informerQueueKeys[i].informers {
+			informer := f.informerQueueKeys[i].informers[d]
+			queueKeyFn := f.informerQueueKeys[i].queueKeyFn
+			informer.AddEventHandler(c.syncContext.(syncContext).eventHandler(queueKeyFn, sets.NewString()))
+			c.cachesToSync = append(f.cachesToSync, informer.HasSynced)
+		}
+	}
+
 	for i := range f.informers {
-		f.informers[i].AddEventHandler(c.syncContext.(syncContext).eventHandler(QueueKey(name), f.objectQueue, sets.NewString()))
+		f.informers[i].AddEventHandler(c.syncContext.(syncContext).eventHandler(func(runtime.Object) string {
+			return DefaultQueueKey
+		}, sets.NewString()))
 		c.cachesToSync = append(f.cachesToSync, f.informers[i].HasSynced)
 	}
 
 	for i := range f.namespaceInformers {
-		f.namespaceInformers[i].informer.AddEventHandler(c.syncContext.(syncContext).eventHandler(QueueKey(name), f.objectQueue, f.namespaceInformers[i].namespaces))
-		c.cachesToSync = append(f.cachesToSync, f.informers[i].HasSynced)
+		f.namespaceInformers[i].informer.AddEventHandler(c.syncContext.(syncContext).eventHandler(func(runtime.Object) string {
+			return DefaultQueueKey
+		}, f.namespaceInformers[i].namespaces))
+		c.cachesToSync = append(f.cachesToSync, f.namespaceInformers[i].informer.HasSynced)
 	}
 
 	return c

--- a/pkg/controller/factory/interfaces.go
+++ b/pkg/controller/factory/interfaces.go
@@ -3,7 +3,6 @@ package factory
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/util/workqueue"
 
 	"github.com/openshift/library-go/pkg/operator/events"
@@ -35,9 +34,8 @@ type SyncContext interface {
 	// an error, the object is automatically re-queued. Use with caution.
 	Queue() workqueue.RateLimitingInterface
 
-	// GetObject provides access to current synced object deep copy.
-	// It is safe to mutate this object inside Sync().
-	GetObject() runtime.Object
+	// QueueKey represents the queue key passed to the Sync function.
+	QueueKey() string
 
 	// Recorder provide access to event recorder.
 	Recorder() events.Recorder

--- a/pkg/operator/apiserver/controller/apiservice/apiservice_controller.go
+++ b/pkg/operator/apiserver/controller/apiservice/apiservice_controller.go
@@ -9,13 +9,9 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/errors"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/wait"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	apiregistrationv1client "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1"
@@ -24,20 +20,17 @@ import (
 	operatorsv1 "github.com/openshift/api/operator/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	operatorlistersv1 "github.com/openshift/client-go/operator/listers/operator/v1"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
-)
-
-const (
-	workQueueKey = "key"
 )
 
 type GetAPIServicesToMangeFunc func() ([]*apiregistrationv1.APIService, error)
 type apiServicesPreconditionFuncType func([]*apiregistrationv1.APIService) (bool, error)
 
 type APIServiceController struct {
-	name                     string
 	getAPIServicesToManageFn GetAPIServicesToMangeFunc
 	// precondition must return true before the apiservices will be created
 	precondition apiServicesPreconditionFuncType
@@ -45,10 +38,6 @@ type APIServiceController struct {
 	operatorClient          v1helpers.OperatorClient
 	kubeClient              kubernetes.Interface
 	apiregistrationv1Client apiregistrationv1client.ApiregistrationV1Interface
-	eventRecorder           events.Recorder
-
-	// queue only ever has one item, but it has nice error handling backoff/retry semantics
-	queue workqueue.RateLimitingInterface
 }
 
 func NewAPIServiceController(
@@ -60,29 +49,24 @@ func NewAPIServiceController(
 	kubeInformersForOperandNamespace kubeinformers.SharedInformerFactory,
 	kubeClient kubernetes.Interface,
 	eventRecorder events.Recorder,
-) *APIServiceController {
-	fullname := "APIServiceController_" + name
+) factory.Controller {
 	c := &APIServiceController{
-		name:                     fullname,
 		precondition:             newEndpointPrecondition(kubeInformersForOperandNamespace),
 		getAPIServicesToManageFn: getAPIServicesToManageFunc,
 
 		operatorClient:          operatorClient,
 		apiregistrationv1Client: apiregistrationv1Client,
 		kubeClient:              kubeClient,
-		eventRecorder:           eventRecorder.WithComponentSuffix("apiservice-" + name + "-controller"),
-
-		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), fullname),
 	}
 
-	kubeInformersForOperandNamespace.Core().V1().Services().Informer().AddEventHandler(c.eventHandler())
-	kubeInformersForOperandNamespace.Core().V1().Endpoints().Informer().AddEventHandler(c.eventHandler())
-	apiregistrationInformers.Apiregistration().V1().APIServices().Informer().AddEventHandler(c.eventHandler())
-
-	return c
+	return factory.New().WithSync(c.sync).ResyncEvery(10*time.Second).WithInformers(
+		kubeInformersForOperandNamespace.Core().V1().Services().Informer(),
+		kubeInformersForOperandNamespace.Core().V1().Endpoints().Informer(),
+		apiregistrationInformers.Apiregistration().V1().APIServices().Informer(),
+	).ToController("APIServiceController_"+name, eventRecorder.WithComponentSuffix("apiservice-"+name+"-controller"))
 }
 
-func (c *APIServiceController) sync() error {
+func (c *APIServiceController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
 	operatorConfigSpec, _, _, err := c.operatorClient.GetOperatorState()
 	if err != nil {
 		return err
@@ -106,7 +90,7 @@ func (c *APIServiceController) sync() error {
 		}
 		return errors.NewAggregate(errs)
 	default:
-		c.eventRecorder.Warningf("ManagementStateUnknown", "Unrecognized operator management state %q", operatorConfigSpec.ManagementState)
+		syncCtx.Recorder().Warningf("ManagementStateUnknown", "Unrecognized operator management state %q", operatorConfigSpec.ManagementState)
 		return nil
 	}
 
@@ -116,25 +100,29 @@ func (c *APIServiceController) sync() error {
 	}
 	ready, err := c.precondition(apiServices)
 	if err != nil {
-		v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
+		if _, _, updateErr := v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
 			Type:    "APIServicesAvailable",
 			Status:  operatorv1.ConditionFalse,
 			Reason:  "ErrorCheckingPrecondition",
 			Message: err.Error(),
-		}))
+		})); updateErr != nil {
+			return errors.NewAggregate([]error{err, updateErr})
+		}
 		return err
 	}
 	if !ready {
-		v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
+		if _, _, updateErr := v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
 			Type:    "APIServicesAvailable",
 			Status:  operatorv1.ConditionFalse,
 			Reason:  "PreconditionNotReady",
 			Message: "PreconditionNotReady",
-		}))
+		})); updateErr != nil {
+			return errors.NewAggregate([]error{err, updateErr})
+		}
 		return err
 	}
 
-	err = c.syncAPIServices(apiServices)
+	err = c.syncAPIServices(apiServices, syncCtx.Recorder())
 
 	// update failing condition
 	cond := operatorv1.OperatorCondition{
@@ -155,13 +143,13 @@ func (c *APIServiceController) sync() error {
 	return err
 }
 
-func (c *APIServiceController) syncAPIServices(apiServices []*apiregistrationv1.APIService) error {
+func (c *APIServiceController) syncAPIServices(apiServices []*apiregistrationv1.APIService, recorder events.Recorder) error {
 	errs := []error{}
 	var availableConditionMessages []string
 
 	for _, apiService := range apiServices {
 		apiregistrationv1.SetDefaults_ServiceReference(apiService.Spec.Service)
-		apiService, _, err := resourceapply.ApplyAPIService(c.apiregistrationv1Client, c.eventRecorder, apiService)
+		apiService, _, err := resourceapply.ApplyAPIService(c.apiregistrationv1Client, recorder, apiService)
 		if err != nil {
 			errs = append(errs, err)
 			continue
@@ -187,7 +175,7 @@ func (c *APIServiceController) syncAPIServices(apiServices []*apiregistrationv1.
 	// if the apiservices themselves check out ok, try to actually hit the discovery endpoints.  We have a history in clusterup
 	// of something delaying them.  This isn't perfect because of round-robining, but let's see if we get an improvement
 	if c.kubeClient.Discovery().RESTClient() != nil {
-		missingAPIMessages := checkDiscoveryForByAPIServices(c.eventRecorder, c.kubeClient.Discovery().RESTClient(), apiServices)
+		missingAPIMessages := checkDiscoveryForByAPIServices(recorder, c.kubeClient.Discovery().RESTClient(), apiServices)
 		availableConditionMessages = append(availableConditionMessages, missingAPIMessages...)
 	}
 
@@ -197,54 +185,6 @@ func (c *APIServiceController) syncAPIServices(apiServices []*apiregistrationv1.
 	}
 
 	return nil
-}
-
-// Run starts the openshift-apiserver and blocks until stopCh is closed.
-// The number of workers is ignored
-func (c *APIServiceController) Run(ctx context.Context, _ int) {
-	defer utilruntime.HandleCrash()
-	defer c.queue.ShutDown()
-
-	klog.Infof("Starting %v", c.name)
-	defer klog.Infof("Shutting down %v", c.name)
-
-	// doesn't matter what workers say, only start one.
-	go wait.Until(c.runWorker, time.Second, ctx.Done())
-
-	<-ctx.Done()
-}
-
-func (c *APIServiceController) runWorker() {
-	for c.processNextWorkItem() {
-	}
-}
-
-func (c *APIServiceController) processNextWorkItem() bool {
-	dsKey, quit := c.queue.Get()
-	if quit {
-		return false
-	}
-	defer c.queue.Done(dsKey)
-
-	err := c.sync()
-	if err == nil {
-		c.queue.Forget(dsKey)
-		return true
-	}
-
-	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", dsKey, err))
-	c.queue.AddRateLimited(dsKey)
-
-	return true
-}
-
-// eventHandler queues the operator to check spec and status
-func (c *APIServiceController) eventHandler() cache.ResourceEventHandler {
-	return cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) { c.queue.Add(workQueueKey) },
-		UpdateFunc: func(old, new interface{}) { c.queue.Add(workQueueKey) },
-		DeleteFunc: func(obj interface{}) { c.queue.Add(workQueueKey) },
-	}
 }
 
 // APIServicesToMange preserve state and clients required to return an authoritative list of API services this operate must manage

--- a/pkg/operator/apiserver/controller/nsfinalizer/finalizer_controller.go
+++ b/pkg/operator/apiserver/controller/nsfinalizer/finalizer_controller.go
@@ -6,20 +6,17 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/openshift/library-go/pkg/operator/events"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
 	kubeinformers "k8s.io/client-go/informers"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	appsv1lister "k8s.io/client-go/listers/apps/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
-	"k8s.io/klog"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
 )
 
 type finalizerController struct {
@@ -29,12 +26,6 @@ type finalizerController struct {
 	namespaceGetter v1.NamespacesGetter
 	podLister       corev1listers.PodLister
 	dsLister        appsv1lister.DaemonSetLister
-	eventRecorder   events.Recorder
-
-	preRunHasSynced []cache.InformerSynced
-
-	// queue only ever has one item, but it has nice error handling backoff/retry semantics
-	queue workqueue.RateLimitingInterface
 }
 
 // NewFinalizerController is here because
@@ -49,31 +40,23 @@ func NewFinalizerController(
 	kubeInformersForTargetNamespace kubeinformers.SharedInformerFactory,
 	namespaceGetter v1.NamespacesGetter,
 	eventRecorder events.Recorder,
-) *finalizerController {
+) factory.Controller {
 	fullname := "NamespaceFinalizerController_" + namespaceName
 	c := &finalizerController{
-		name:          fullname,
-		namespaceName: namespaceName,
-
+		name:            fullname,
+		namespaceName:   namespaceName,
 		namespaceGetter: namespaceGetter,
 		podLister:       kubeInformersForTargetNamespace.Core().V1().Pods().Lister(),
 		dsLister:        kubeInformersForTargetNamespace.Apps().V1().DaemonSets().Lister(),
-		eventRecorder:   eventRecorder.WithComponentSuffix("finalizer-controller"),
-
-		preRunHasSynced: []cache.InformerSynced{
-			kubeInformersForTargetNamespace.Core().V1().Pods().Informer().HasSynced,
-			kubeInformersForTargetNamespace.Apps().V1().DaemonSets().Informer().HasSynced,
-		},
-		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), fullname),
 	}
 
-	kubeInformersForTargetNamespace.Core().V1().Pods().Informer().AddEventHandler(c.eventHandler())
-	kubeInformersForTargetNamespace.Apps().V1().DaemonSets().Informer().AddEventHandler(c.eventHandler())
-
-	return c
+	return factory.New().ResyncEvery(time.Second).WithSync(c.sync).WithInformers(
+		kubeInformersForTargetNamespace.Core().V1().Pods().Informer(),
+		kubeInformersForTargetNamespace.Apps().V1().DaemonSets().Informer(),
+	).ToController(fullname, eventRecorder.WithComponentSuffix("finalizer-controller"))
 }
 
-func (c finalizerController) sync() error {
+func (c finalizerController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
 	ns, err := c.namespaceGetter.Namespaces().Get(c.namespaceName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		return nil
@@ -89,7 +72,7 @@ func (c finalizerController) sync() error {
 	// TODO now that we have conditions, we may be able to check specific conditions
 	deletedMoreThanAMinute := ns.DeletionTimestamp.Time.Add(1 * time.Minute).Before(time.Now())
 	if !deletedMoreThanAMinute {
-		c.queue.AddAfter(c.namespaceName, 1*time.Minute)
+		syncCtx.Queue().AddAfter(c.namespaceName, 1*time.Minute)
 		return nil
 	}
 
@@ -120,62 +103,7 @@ func (c finalizerController) sync() error {
 	}
 	ns.Spec.Finalizers = newFinalizers
 
-	c.eventRecorder.Event("NamespaceFinalization", fmt.Sprintf("clearing namespace finalizer on %q", c.namespaceName))
+	syncCtx.Recorder().Event("NamespaceFinalization", fmt.Sprintf("clearing namespace finalizer on %q", c.namespaceName))
 	_, err = c.namespaceGetter.Namespaces().Finalize(ns)
 	return err
-}
-
-// Run starts the openshift-apiserver and blocks until stopCh is closed.
-func (c *finalizerController) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
-	defer c.queue.ShutDown()
-
-	klog.Infof("Starting %v", c.name)
-	defer klog.Infof("Shutting down %v", c.name)
-
-	if !cache.WaitForCacheSync(ctx.Done(), c.preRunHasSynced...) {
-		utilruntime.HandleError(fmt.Errorf("caches did not sync"))
-		return
-	}
-
-	// always kick at least once in case we started after the namespace was cleared
-	c.queue.Add(c.namespaceName)
-
-	// doesn't matter what workers say, only start one.
-	go wait.Until(c.runWorker, time.Second, ctx.Done())
-
-	<-ctx.Done()
-}
-
-func (c *finalizerController) runWorker() {
-	for c.processNextWorkItem() {
-	}
-}
-
-func (c *finalizerController) processNextWorkItem() bool {
-	dsKey, quit := c.queue.Get()
-	if quit {
-		return false
-	}
-	defer c.queue.Done(dsKey)
-
-	err := c.sync()
-	if err == nil {
-		c.queue.Forget(dsKey)
-		return true
-	}
-
-	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", dsKey, err))
-	c.queue.AddRateLimited(dsKey)
-
-	return true
-}
-
-// eventHandler queues the operator to check spec and status
-func (c *finalizerController) eventHandler() cache.ResourceEventHandler {
-	return cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) { c.queue.Add(c.namespaceName) },
-		UpdateFunc: func(old, new interface{}) { c.queue.Add(c.namespaceName) },
-		DeleteFunc: func(obj interface{}) { c.queue.Add(c.namespaceName) },
-	}
 }

--- a/pkg/operator/configobserver/config_observer_controller.go
+++ b/pkg/operator/configobserver/config_observer_controller.go
@@ -14,19 +14,16 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/rand"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/condition"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
-
-const configObserverWorkKey = "key"
 
 // Listers is an interface which will be passed to the config observer funcs.  It is expected to be hard-cast to the "correct" type
 type Listers interface {
@@ -42,7 +39,6 @@ type Listers interface {
 type ObserveConfigFunc func(listers Listers, recorder events.Recorder, existingConfig map[string]interface{}) (observedConfig map[string]interface{}, errs []error)
 
 type ConfigObserver struct {
-
 	// observers are called in an undefined order and their results are merged to
 	// determine the observed configuration.
 	observers []ObserveConfigFunc
@@ -50,9 +46,6 @@ type ConfigObserver struct {
 	operatorClient v1helpers.OperatorClient
 	// listers are used by config observers to retrieve necessary resources
 	listers Listers
-
-	queue         workqueue.RateLimitingInterface
-	eventRecorder events.Recorder
 }
 
 func NewConfigObserver(
@@ -60,21 +53,18 @@ func NewConfigObserver(
 	eventRecorder events.Recorder,
 	listers Listers,
 	observers ...ObserveConfigFunc,
-) *ConfigObserver {
-	return &ConfigObserver{
+) factory.Controller {
+	c := &ConfigObserver{
 		operatorClient: operatorClient,
-		eventRecorder:  eventRecorder.WithComponentSuffix("config-observer"),
-
-		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "ConfigObserver"),
-
-		observers: observers,
-		listers:   listers,
+		observers:      observers,
+		listers:        listers,
 	}
+	return factory.New().ResyncEvery(time.Second).WithSync(c.sync).WithInformers(listersToInformer(listers)...).ToController("ConfigObserver", eventRecorder.WithComponentSuffix("config-observer"))
 }
 
 // sync reacts to a change in prereqs by finding information that is required to match another value in the cluster. This
 // must be information that is logically "owned" by another component.
-func (c ConfigObserver) sync() error {
+func (c ConfigObserver) sync(ctx context.Context, syncCtx factory.SyncContext) error {
 	originalSpec, _, _, err := c.operatorClient.GetOperatorState()
 	if err != nil {
 		return err
@@ -91,7 +81,7 @@ func (c ConfigObserver) sync() error {
 	var observedConfigs []map[string]interface{}
 	for _, i := range rand.Perm(len(c.observers)) {
 		var currErrs []error
-		observedConfig, currErrs := c.observers[i](c.listers, c.eventRecorder, existingConfig)
+		observedConfig, currErrs := c.observers[i](c.listers, syncCtx.Recorder(), existingConfig)
 		observedConfigs = append(observedConfigs, observedConfig)
 		errs = append(errs, currErrs...)
 	}
@@ -115,12 +105,12 @@ func (c ConfigObserver) sync() error {
 	}
 
 	if !equality.Semantic.DeepEqual(existingConfig, mergedObservedConfig) {
-		c.eventRecorder.Eventf("ObservedConfigChanged", "Writing updated observed config: %v", diff.ObjectDiff(existingConfig, mergedObservedConfig))
+		syncCtx.Recorder().Eventf("ObservedConfigChanged", "Writing updated observed config: %v", diff.ObjectDiff(existingConfig, mergedObservedConfig))
 		if _, _, err := v1helpers.UpdateSpec(c.operatorClient, v1helpers.UpdateObservedConfigFn(mergedObservedConfig)); err != nil {
 			// At this point we failed to write the updated config. If we are permanently broken, do not pile the errors from observers
 			// but instead reset the errors and only report single error condition.
 			errs = []error{fmt.Errorf("error writing updated observed config: %v", err)}
-			c.eventRecorder.Warningf("ObservedConfigWriteError", "Failed to write observed config: %v", err)
+			syncCtx.Recorder().Warningf("ObservedConfigWriteError", "Failed to write observed config: %v", err)
 		}
 	}
 	configError := v1helpers.NewMultiLineAggregate(errs)
@@ -142,52 +132,23 @@ func (c ConfigObserver) sync() error {
 	return configError
 }
 
-func (c *ConfigObserver) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
-	defer c.queue.ShutDown()
-
-	klog.Infof("Starting ConfigObserver")
-	defer klog.Infof("Shutting down ConfigObserver")
-	if !cache.WaitForCacheSync(ctx.Done(), c.listers.PreRunHasSynced()...) {
-		utilruntime.HandleError(fmt.Errorf("caches did not sync"))
-		return
+// listersToInformer converts the Listers interface to informer with empty AddEventHandler as we only care about synced caches in the Run.
+func listersToInformer(l Listers) []factory.Informer {
+	result := make([]factory.Informer, len(l.PreRunHasSynced()))
+	for i := range l.PreRunHasSynced() {
+		result[i] = &listerInformer{cacheSynced: l.PreRunHasSynced()[i]}
 	}
-
-	// doesn't matter what workers say, only start one.
-	go wait.UntilWithContext(ctx, c.runWorker, time.Second)
-
-	<-ctx.Done()
+	return result
 }
 
-func (c *ConfigObserver) runWorker(_ context.Context) {
-	for c.processNextWorkItem() {
-	}
+type listerInformer struct {
+	cacheSynced cache.InformerSynced
 }
 
-func (c *ConfigObserver) processNextWorkItem() bool {
-	dsKey, quit := c.queue.Get()
-	if quit {
-		return false
-	}
-	defer c.queue.Done(dsKey)
-
-	err := c.sync()
-	if err == nil {
-		c.queue.Forget(dsKey)
-		return true
-	}
-
-	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", dsKey, err))
-	c.queue.AddRateLimited(dsKey)
-
-	return true
+func (l *listerInformer) AddEventHandler(cache.ResourceEventHandler) {
+	return
 }
 
-// eventHandler queues the operator to check spec and status
-func (c *ConfigObserver) EventHandler() cache.ResourceEventHandler {
-	return cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) { c.queue.Add(configObserverWorkKey) },
-		UpdateFunc: func(old, new interface{}) { c.queue.Add(configObserverWorkKey) },
-		DeleteFunc: func(obj interface{}) { c.queue.Add(configObserverWorkKey) },
-	}
+func (l *listerInformer) HasSynced() bool {
+	return l.cacheSynced()
 }

--- a/pkg/operator/configobserver/config_observer_controller_test.go
+++ b/pkg/operator/configobserver/config_observer_controller_test.go
@@ -1,11 +1,13 @@
 package configobserver
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/condition"
 	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
 
@@ -20,6 +22,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
+
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
@@ -208,9 +211,8 @@ func TestSyncStatus(t *testing.T) {
 				listers:        &fakeLister{},
 				operatorClient: operatorConfigClient,
 				observers:      tc.observers,
-				eventRecorder:  events.NewRecorder(eventClient.CoreV1().Events("test"), "test-operator", &corev1.ObjectReference{}),
 			}
-			err := configObserver.sync()
+			err := configObserver.sync(context.TODO(), factory.NewSyncContext("test", events.NewRecorder(eventClient.CoreV1().Events("test"), "test-operator", &corev1.ObjectReference{})))
 			if tc.expectError && err == nil {
 				t.Fatal("error expected")
 			}

--- a/pkg/operator/management/management_state_controller.go
+++ b/pkg/operator/management/management_state_controller.go
@@ -3,26 +3,18 @@ package management
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
-	"k8s.io/klog"
-
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 
+	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/condition"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
 )
-
-var workQueueKey = "instance"
 
 // ManagementStateController watches changes of `managementState` field and react in case that field is set to an unsupported value.
 // As each operator can opt-out from supporting `unmanaged` or `removed` states, this controller will add failing condition when the
@@ -30,36 +22,24 @@ var workQueueKey = "instance"
 type ManagementStateController struct {
 	operatorName   string
 	operatorClient operatorv1helpers.OperatorClient
-
-	cachesToSync  []cache.InformerSynced
-	queue         workqueue.RateLimitingInterface
-	eventRecorder events.Recorder
 }
 
 func NewOperatorManagementStateController(
 	name string,
 	operatorClient operatorv1helpers.OperatorClient,
 	recorder events.Recorder,
-) *ManagementStateController {
+) factory.Controller {
 	c := &ManagementStateController{
 		operatorName:   name,
 		operatorClient: operatorClient,
-		eventRecorder:  recorder,
-
-		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "ManagementStateController_"+strings.Replace(name, "-", "_", -1)),
 	}
-
-	operatorClient.Informer().AddEventHandler(c.eventHandler())
-
-	c.cachesToSync = append(c.cachesToSync, operatorClient.Informer().HasSynced)
-
-	return c
+	return factory.New().WithInformers(operatorClient.Informer()).WithSync(c.sync).ResyncEvery(time.Second).ToController("ManagementStateController", recorder.WithComponentSuffix("management-state-recorder"))
 }
 
-func (c ManagementStateController) sync() error {
+func (c ManagementStateController) sync(ctx context.Context, syncContext factory.SyncContext) error {
 	detailedSpec, _, _, err := c.operatorClient.GetOperatorState()
 	if apierrors.IsNotFound(err) {
-		c.eventRecorder.Warningf("StatusNotFound", "Unable to determine current operator status for %s", c.operatorName)
+		syncContext.Recorder().Warningf("StatusNotFound", "Unable to determine current operator status for %s", c.operatorName)
 		return nil
 	}
 
@@ -93,53 +73,4 @@ func (c ManagementStateController) sync() error {
 	}
 
 	return nil
-}
-
-func (c *ManagementStateController) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
-	defer c.queue.ShutDown()
-
-	klog.Infof("Starting management-state-controller-" + c.operatorName)
-	defer klog.Infof("Shutting down management-state-controller-" + c.operatorName)
-	if !cache.WaitForCacheSync(ctx.Done(), c.cachesToSync...) {
-		return
-	}
-
-	// doesn't matter what workers say, only start one.
-	go wait.UntilWithContext(ctx, c.runWorker, time.Second)
-
-	<-ctx.Done()
-}
-
-func (c *ManagementStateController) runWorker(_ context.Context) {
-	for c.processNextWorkItem() {
-	}
-}
-
-func (c *ManagementStateController) processNextWorkItem() bool {
-	dsKey, quit := c.queue.Get()
-	if quit {
-		return false
-	}
-	defer c.queue.Done(dsKey)
-
-	err := c.sync()
-	if err == nil {
-		c.queue.Forget(dsKey)
-		return true
-	}
-
-	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", dsKey, err))
-	c.queue.AddRateLimited(dsKey)
-
-	return true
-}
-
-// eventHandler queues the operator to check spec and status
-func (c *ManagementStateController) eventHandler() cache.ResourceEventHandler {
-	return cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) { c.queue.Add(workQueueKey) },
-		UpdateFunc: func(old, new interface{}) { c.queue.Add(workQueueKey) },
-		DeleteFunc: func(obj interface{}) { c.queue.Add(workQueueKey) },
-	}
 }

--- a/pkg/operator/management/management_state_controller_test.go
+++ b/pkg/operator/management/management_state_controller_test.go
@@ -1,11 +1,13 @@
 package management
 
 import (
+	"context"
 	"testing"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
 )
 
@@ -71,12 +73,12 @@ func TestOperatorManagementStateController(t *testing.T) {
 					Conditions: tc.initialConditions,
 				},
 			}
+			recorder := events.NewInMemoryRecorder("status")
 			controller := &ManagementStateController{
 				operatorName:   "OPERATOR_NAME",
 				operatorClient: statusClient,
-				eventRecorder:  events.NewInMemoryRecorder("status"),
 			}
-			if err := controller.sync(); err != nil {
+			if err := controller.sync(context.TODO(), factory.NewSyncContext("test", recorder)); err != nil {
 				t.Errorf("unexpected sync error: %v", err)
 				return
 			}

--- a/pkg/operator/resourcesynccontroller/resourcesync_controller.go
+++ b/pkg/operator/resourcesynccontroller/resourcesync_controller.go
@@ -104,7 +104,7 @@ func (c *ResourceSyncController) SyncConfigMap(destination, source ResourceLocat
 	c.configMapSyncRules[destination] = source
 
 	// make sure the new rule is picked up
-	c.queue.Add(factory.QueueKey(c.Name()))
+	c.queue.Add(factory.DefaultQueueKey)
 	return nil
 }
 
@@ -121,7 +121,7 @@ func (c *ResourceSyncController) SyncSecret(destination, source ResourceLocation
 	c.secretSyncRules[destination] = source
 
 	// make sure the new rule is picked up
-	c.queue.Add(factory.QueueKey(c.Name()))
+	c.queue.Add(factory.DefaultQueueKey)
 	return nil
 }
 

--- a/pkg/operator/status/status_controller.go
+++ b/pkg/operator/status/status_controller.go
@@ -2,34 +2,27 @@ package status
 
 import (
 	"context"
-	"fmt"
-	"strings"
 	"time"
 
 	"k8s.io/klog"
-
-	"k8s.io/apimachinery/pkg/api/equality"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
 	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	configv1helpers "github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers"
+	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/management"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
 )
-
-var workQueueKey = "instance"
 
 type VersionGetter interface {
 	// SetVersion is a way to set the version for an operand.  It must be thread-safe
@@ -49,10 +42,15 @@ type StatusSyncer struct {
 	clusterOperatorClient configv1client.ClusterOperatorsGetter
 	clusterOperatorLister configv1listers.ClusterOperatorLister
 
-	cachesToSync    []cache.InformerSynced
-	queue           workqueue.RateLimitingInterface
-	eventRecorder   events.Recorder
-	degradedInertia Inertia
+	controllerFactory *factory.Factory
+	recorder          events.Recorder
+	degradedInertia   Inertia
+}
+
+var _ factory.Controller = &StatusSyncer{}
+
+func (c *StatusSyncer) Name() string {
+	return c.clusterOperatorName
 }
 
 func NewClusterOperatorStatusController(
@@ -64,26 +62,24 @@ func NewClusterOperatorStatusController(
 	versionGetter VersionGetter,
 	recorder events.Recorder,
 ) *StatusSyncer {
-	c := &StatusSyncer{
+	return &StatusSyncer{
 		clusterOperatorName:   name,
 		relatedObjects:        relatedObjects,
 		versionGetter:         versionGetter,
 		clusterOperatorClient: clusterOperatorClient,
 		clusterOperatorLister: clusterOperatorInformer.Lister(),
 		operatorClient:        operatorClient,
-		eventRecorder:         recorder.WithComponentSuffix("status-controller"),
 		degradedInertia:       MustNewInertia(2 * time.Minute).Inertia,
-
-		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "StatusSyncer_"+strings.Replace(name, "-", "_", -1)),
+		controllerFactory: factory.New().ResyncEvery(time.Second).WithInformers(
+			operatorClient.Informer(),
+			clusterOperatorInformer.Informer(),
+		),
+		recorder: recorder.WithComponentSuffix("status-controller"),
 	}
+}
 
-	operatorClient.Informer().AddEventHandler(c.eventHandler())
-	clusterOperatorInformer.Informer().AddEventHandler(c.eventHandler())
-
-	c.cachesToSync = append(c.cachesToSync, operatorClient.Informer().HasSynced)
-	c.cachesToSync = append(c.cachesToSync, clusterOperatorInformer.Informer().HasSynced)
-
-	return c
+func (c *StatusSyncer) Run(ctx context.Context, workers int) {
+	c.controllerFactory.WithPostStartHooks(c.watchVersionGetterPostRunHook).WithSync(c.Sync).ToController("StatusSyncer_"+c.Name(), c.recorder).Run(ctx, workers)
 }
 
 // WithDegradedInertia returns a copy of the StatusSyncer with the
@@ -96,10 +92,10 @@ func (c *StatusSyncer) WithDegradedInertia(inertia Inertia) *StatusSyncer {
 
 // sync reacts to a change in prereqs by finding information that is required to match another value in the cluster. This
 // must be information that is logically "owned" by another component.
-func (c StatusSyncer) sync() error {
+func (c StatusSyncer) Sync(ctx context.Context, syncCtx factory.SyncContext) error {
 	detailedSpec, currentDetailedStatus, _, err := c.operatorClient.GetOperatorState()
 	if apierrors.IsNotFound(err) {
-		c.eventRecorder.Warningf("StatusNotFound", "Unable to determine current operator status for clusteroperator/%s", c.clusterOperatorName)
+		syncCtx.Recorder().Warningf("StatusNotFound", "Unable to determine current operator status for clusteroperator/%s", c.clusterOperatorName)
 		if err := c.clusterOperatorClient.ClusterOperators().Delete(c.clusterOperatorName, nil); err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
@@ -111,7 +107,7 @@ func (c StatusSyncer) sync() error {
 
 	originalClusterOperatorObj, err := c.clusterOperatorLister.Get(c.clusterOperatorName)
 	if err != nil && !apierrors.IsNotFound(err) {
-		c.eventRecorder.Warningf("StatusFailed", "Unable to get current operator status for clusteroperator/%s: %v", c.clusterOperatorName, err)
+		syncCtx.Recorder().Warningf("StatusFailed", "Unable to get current operator status for clusteroperator/%s: %v", c.clusterOperatorName, err)
 		return err
 	}
 
@@ -125,11 +121,11 @@ func (c StatusSyncer) sync() error {
 		if apierrors.IsNotFound(createErr) {
 			// this means that the API isn't present.  We did not fail.  Try again later
 			klog.Infof("ClusterOperator API not created")
-			c.queue.AddRateLimited(workQueueKey)
+			syncCtx.Queue().AddRateLimited(factory.DefaultQueueKey)
 			return nil
 		}
 		if createErr != nil {
-			c.eventRecorder.Warningf("StatusCreateFailed", "Failed to create operator status: %v", err)
+			syncCtx.Recorder().Warningf("StatusCreateFailed", "Failed to create operator status: %v", err)
 			return createErr
 		}
 	}
@@ -149,7 +145,7 @@ func (c StatusSyncer) sync() error {
 		if _, updateErr := c.clusterOperatorClient.ClusterOperators().UpdateStatus(clusterOperatorObj); err != nil {
 			return updateErr
 		}
-		c.eventRecorder.Eventf("OperatorStatusChanged", "Status for operator %s changed: %s", c.clusterOperatorName, configv1helpers.GetStatusDiff(originalClusterOperatorObj.Status, clusterOperatorObj.Status))
+		syncCtx.Recorder().Eventf("OperatorStatusChanged", "Status for operator %s changed: %s", c.clusterOperatorName, configv1helpers.GetStatusDiff(originalClusterOperatorObj.Status, clusterOperatorObj.Status))
 		return nil
 	}
 
@@ -165,7 +161,7 @@ func (c StatusSyncer) sync() error {
 		previousVersion := operatorv1helpers.SetOperandVersion(&clusterOperatorObj.Status.Versions, configv1.OperandVersion{Name: operand, Version: version})
 		if previousVersion != version {
 			// having this message will give us a marker in events when the operator updated compared to when the operand is updated
-			c.eventRecorder.Eventf("OperatorVersionChanged", "clusteroperator/%s version %q changed from %q to %q", c.clusterOperatorName, operand, previousVersion, version)
+			syncCtx.Recorder().Eventf("OperatorVersionChanged", "clusteroperator/%s version %q changed from %q to %q", c.clusterOperatorName, operand, previousVersion, version)
 		}
 	}
 
@@ -178,7 +174,7 @@ func (c StatusSyncer) sync() error {
 	if _, updateErr := c.clusterOperatorClient.ClusterOperators().UpdateStatus(clusterOperatorObj); err != nil {
 		return updateErr
 	}
-	c.eventRecorder.Eventf("OperatorStatusChanged", "Status for clusteroperator/%s changed: %s", c.clusterOperatorName, configv1helpers.GetStatusDiff(originalClusterOperatorObj.Status, clusterOperatorObj.Status))
+	syncCtx.Recorder().Eventf("OperatorStatusChanged", "Status for clusteroperator/%s changed: %s", c.clusterOperatorName, configv1helpers.GetStatusDiff(originalClusterOperatorObj.Status, clusterOperatorObj.Status))
 	return nil
 }
 
@@ -192,71 +188,19 @@ func OperatorConditionToClusterOperatorCondition(condition operatorv1.OperatorCo
 	}
 }
 
-func (c *StatusSyncer) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
-	defer c.queue.ShutDown()
-
-	klog.Infof("Starting StatusSyncer-" + c.clusterOperatorName)
-	defer klog.Infof("Shutting down StatusSyncer-" + c.clusterOperatorName)
-	if !cache.WaitForCacheSync(ctx.Done(), c.cachesToSync...) {
-		return
-	}
-
-	// start watching for version changes
-	go c.watchVersionGetter(ctx.Done())
-
-	// doesn't matter what workers say, only start one.
-	go wait.UntilWithContext(ctx, c.runWorker, time.Second)
-
-	<-ctx.Done()
-}
-
-func (c *StatusSyncer) watchVersionGetter(stopCh <-chan struct{}) {
+func (c *StatusSyncer) watchVersionGetterPostRunHook(ctx context.Context, syncCtx factory.SyncContext) error {
 	defer utilruntime.HandleCrash()
 
 	versionCh := c.versionGetter.VersionChangedChannel()
 	// always kick at least once
-	c.queue.Add(workQueueKey)
+	syncCtx.Queue().Add(factory.DefaultQueueKey)
 
 	for {
 		select {
-		case <-stopCh:
-			return
+		case <-ctx.Done():
+			return nil
 		case <-versionCh:
-			c.queue.Add(workQueueKey)
+			syncCtx.Queue().Add(factory.DefaultQueueKey)
 		}
-	}
-}
-
-func (c *StatusSyncer) runWorker(_ context.Context) {
-	for c.processNextWorkItem() {
-	}
-}
-
-func (c *StatusSyncer) processNextWorkItem() bool {
-	dsKey, quit := c.queue.Get()
-	if quit {
-		return false
-	}
-	defer c.queue.Done(dsKey)
-
-	err := c.sync()
-	if err == nil {
-		c.queue.Forget(dsKey)
-		return true
-	}
-
-	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", dsKey, err))
-	c.queue.AddRateLimited(dsKey)
-
-	return true
-}
-
-// eventHandler queues the operator to check spec and status
-func (c *StatusSyncer) eventHandler() cache.ResourceEventHandler {
-	return cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) { c.queue.Add(workQueueKey) },
-		UpdateFunc: func(old, new interface{}) { c.queue.Add(workQueueKey) },
-		DeleteFunc: func(obj interface{}) { c.queue.Add(workQueueKey) },
 	}
 }

--- a/pkg/operator/status/status_controller_test.go
+++ b/pkg/operator/status/status_controller_test.go
@@ -1,6 +1,7 @@
 package status
 
 import (
+	"context"
 	"reflect"
 	"regexp"
 	"strings"
@@ -17,6 +18,7 @@ import (
 	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
 
 	"github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers"
+	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
 )
 
@@ -296,7 +298,6 @@ func TestDegraded(t *testing.T) {
 				clusterOperatorClient: clusterOperatorClient.ConfigV1(),
 				clusterOperatorLister: configv1listers.NewClusterOperatorLister(indexer),
 				operatorClient:        statusClient,
-				eventRecorder:         events.NewInMemoryRecorder("status"),
 				versionGetter:         NewVersionGetter(),
 			}
 			controller = controller.WithDegradedInertia(MustNewInertia(
@@ -310,7 +311,7 @@ func TestDegraded(t *testing.T) {
 					Duration:             time.Minute,
 				},
 			).Inertia)
-			if err := controller.sync(); err != nil {
+			if err := controller.Sync(context.TODO(), factory.NewSyncContext("test", events.NewInMemoryRecorder("status"))); err != nil {
 				t.Errorf("unexpected sync error: %v", err)
 				return
 			}


### PR DESCRIPTION
This moves more controllers to controller factory.
It also makes one more extension point in factory, which is `PostRunHook`. This allows to register custom triggers or other asynchronous code to run **after** the controller us run.