### PR TITLE
logging: properly set log level

### DIFF
--- a/pkg/operator/loglevel/logging_controller.go
+++ b/pkg/operator/loglevel/logging_controller.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
-
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
 	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
@@ -12,11 +11,19 @@ import (
 
 type LogLevelController struct {
 	operatorClient operatorv1helpers.OperatorClient
+
+	// for unit tests only
+	setLogLevelFn func(operatorv1.LogLevel) error
+	getLogLevelFn func() (operatorv1.LogLevel, bool)
 }
 
 // sets the klog level based on desired state
 func NewClusterOperatorLoggingController(operatorClient operatorv1helpers.OperatorClient, recorder events.Recorder) factory.Controller {
-	c := &LogLevelController{operatorClient: operatorClient}
+	c := &LogLevelController{
+		operatorClient: operatorClient,
+		setLogLevelFn:  SetLogLEvel,
+		getLogLevelFn:  GetLogLevel,
+	}
 	return factory.New().WithInformers(operatorClient.Informer()).WithSync(c.sync).ToController("LoggingSyncer", recorder)
 }
 
@@ -28,24 +35,36 @@ func (c LogLevelController) sync(ctx context.Context, syncCtx factory.SyncContex
 		return err
 	}
 
-	currentLogLevel := CurrentLogLevel()
+	currentLogLevel, isUnknown := c.getLogLevelFn()
 	desiredLogLevel := detailedSpec.OperatorLogLevel
 
+	// if operator operatorSpec OperatorLogLevel is empty, default to "Normal"
+	// TODO: This should be probably done by defaulting the CR field?
 	if len(desiredLogLevel) == 0 {
 		desiredLogLevel = operatorv1.Normal
 	}
 
-	// When the current loglevel is the desired one, do nothing
-	if currentLogLevel == desiredLogLevel {
+	// correct log level is set and it matches the expected log level from operator operatorSpec, do nothing.
+	if !isUnknown && currentLogLevel == desiredLogLevel {
 		return nil
 	}
 
-	// Set the new loglevel if the operator spec changed
-	if err := SetVerbosityValue(desiredLogLevel); err != nil {
-		syncCtx.Recorder().Warningf("OperatorLoglevelChangeFailed", "Unable to change operator log level from %q to %q: %v", currentLogLevel, desiredLogLevel, err)
+	// log level is not specified in operatorSpec and the log verbosity is not set (0), default the log level to V(2).
+	if len(desiredLogLevel) == 0 {
+		desiredLogLevel = currentLogLevel
+	}
+
+	// Set the new loglevel if the operator operatorSpec changed
+	if err := c.setLogLevelFn(desiredLogLevel); err != nil {
+		syncCtx.Recorder().Warningf("OperatorLogLevelChangeFailed", "Unable to change operator log level from %q to %q: %v", currentLogLevel, desiredLogLevel, err)
 		return err
 	}
 
-	syncCtx.Recorder().Eventf("OperatorLoglevelChange", "Operator log level changed from %q to %q", currentLogLevel, desiredLogLevel)
+	// Do not fire event on every restart.
+	if isUnknown {
+		return nil
+	}
+
+	syncCtx.Recorder().Eventf("OperatorLogLevelChange", "Operator log level changed from %q to %q", currentLogLevel, desiredLogLevel)
 	return nil
 }

--- a/pkg/operator/loglevel/logging_controller_test.go
+++ b/pkg/operator/loglevel/logging_controller_test.go
@@ -2,69 +2,152 @@ package loglevel
 
 import (
 	"context"
+	"strings"
+	"sync"
 	"testing"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog"
 
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
 
+type fakeLogger struct {
+	verbosity klog.Level
+}
+
+func (l *fakeLogger) V(v klog.Level) klog.Verbose {
+	return l.verbosity == v
+}
+
+var fakeLog = &fakeLogger{verbosity: 0}
+
+func init() {
+	verbosityFn = fakeLog.V
+}
+
 func TestClusterOperatorLoggingController(t *testing.T) {
-	if err := SetVerbosityValue(operatorv1.Normal); err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		name              string
+		operatorSpec      operatorv1.OperatorSpec
+		evalEvents        func([]*corev1.Event, *testing.T)
+		startingVerbosity klog.Level
+		expectedVerbosity klog.Level
+		retrySyncTimes    int
+	}{
+		{
+			name: "when OperatorLogLevel is set to Debug operator must set V(4)",
+			operatorSpec: operatorv1.OperatorSpec{
+				OperatorLogLevel: "Debug",
+			},
+			startingVerbosity: 0,
+			expectedVerbosity: 4,
+		},
+		{
+			name: "when OperatorLogLevel is set to Debug operator must set V(4) when it is currently V(2)",
+			operatorSpec: operatorv1.OperatorSpec{
+				OperatorLogLevel: "Debug",
+			},
+			startingVerbosity: 2,
+			expectedVerbosity: 4,
+			retrySyncTimes:    5,
+			evalEvents: func(events []*corev1.Event, t *testing.T) {
+				if len(events) != 1 {
+					t.Errorf("expected exactly one event, got %d", len(events))
+					return
+				}
+				if !strings.Contains(events[0].Message, `Operator log level changed from "Normal" to "Debug"`) {
+					t.Errorf("expected message to be %q, got %q", `Operator log level changed from "Normal" to "Debug"`, events[0].Message)
+				}
+			},
+		},
+		{
+			name: "when OperatorLogLevel is set to Debug operator must stay on V(4)",
+			operatorSpec: operatorv1.OperatorSpec{
+				OperatorLogLevel: "Debug",
+			},
+			retrySyncTimes:    5,
+			startingVerbosity: 4,
+			expectedVerbosity: 4,
+			evalEvents: func(events []*corev1.Event, t *testing.T) {
+				if len(events) != 0 {
+					t.Errorf("expected no events, got %d", len(events))
+				}
+			},
+		},
+		{
+			name: "when OperatorLogLevel is set to Unknown operator must set V(2)",
+			operatorSpec: operatorv1.OperatorSpec{
+				OperatorLogLevel: "Unknown",
+			},
+			startingVerbosity: 4,
+			expectedVerbosity: 2,
+		},
+		{
+			name: "when OperatorLogLevel is set to Normal operator must set V(2) once",
+			operatorSpec: operatorv1.OperatorSpec{
+				OperatorLogLevel: "Normal",
+			},
+			retrySyncTimes:    5,
+			expectedVerbosity: 2,
+		},
+		{
+			name: "when OperatorLogLevel is not set operator must set default V(2)",
+			operatorSpec: operatorv1.OperatorSpec{
+				OperatorLogLevel: "",
+			},
+			startingVerbosity: 0,
+			expectedVerbosity: 2,
+		},
+		{
+			name: "when OperatorLogLevel is not set operator must set default V(2) just once",
+			operatorSpec: operatorv1.OperatorSpec{
+				OperatorLogLevel: "",
+			},
+			retrySyncTimes:    5,
+			startingVerbosity: 0,
+			expectedVerbosity: 2,
+		},
 	}
 
-	operatorSpec := &operatorv1.OperatorSpec{
-		ManagementState: operatorv1.Managed,
-	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// always rest the log level
+			fakeLog.verbosity = test.startingVerbosity
+			fakeStaticPodOperatorClient := v1helpers.NewFakeOperatorClient(
+				&test.operatorSpec,
+				&operatorv1.OperatorStatus{},
+				nil,
+			)
+			setLogLevel := func(level operatorv1.LogLevel) error {
+				(&sync.Once{}).Do(func() {
+					fakeLog.verbosity = klog.Level(LogLevelToVerbosity(level))
+				})
+				return nil
+			}
+			recorder := events.NewInMemoryRecorder("")
 
-	fakeStaticPodOperatorClient := v1helpers.NewFakeOperatorClient(
-		operatorSpec,
-		&operatorv1.OperatorStatus{},
-		nil,
-	)
-
-	recorder := events.NewInMemoryRecorder("")
-
-	controller := NewClusterOperatorLoggingController(fakeStaticPodOperatorClient, recorder)
-
-	// no-op, desired == current
-	// When OperatorLogLevel is "" we assume the loglevel is Normal.
-	if err := controller.Sync(context.TODO(), factory.NewSyncContext("LoggingController", recorder)); err != nil {
-		t.Fatal(err)
-	}
-
-	if len(recorder.Events()) > 0 {
-		t.Fatalf("expected zero events, got %d", len(recorder.Events()))
-	}
-
-	// change the log level to trace should 1 emit event
-	operatorSpec.OperatorLogLevel = operatorv1.Trace
-	if err := controller.Sync(context.TODO(), factory.NewSyncContext("LoggingController", recorder)); err != nil {
-		t.Fatal(err)
-	}
-
-	if operatorEvents := recorder.Events(); len(operatorEvents) == 1 {
-		expectedEventMessage := `Operator log level changed from "Normal" to "Trace"`
-		if message := operatorEvents[0].Message; message != expectedEventMessage {
-			t.Fatalf("expected event message %q, got %q", expectedEventMessage, message)
-		}
-	} else {
-		t.Fatalf("expected 1 event, got %d", len(operatorEvents))
-	}
-
-	// next sync should not produce any extra event
-	if err := controller.Sync(context.TODO(), factory.NewSyncContext("LoggingController", recorder)); err != nil {
-		t.Fatal(err)
-	}
-
-	if operatorEvents := recorder.Events(); len(operatorEvents) != 1 {
-		t.Fatalf("expected 1 event recorded, got %d", len(operatorEvents))
-	}
-
-	if current := CurrentLogLevel(); current != operatorv1.Trace {
-		t.Fatalf("expected log level 'Trace', got %v", current)
+			c := &LogLevelController{
+				operatorClient: fakeStaticPodOperatorClient,
+				setLogLevelFn:  setLogLevel,
+				getLogLevelFn:  GetLogLevel,
+			}
+			syncCtx := factory.NewSyncContext("LoggingController", recorder)
+			for i := 0; i <= test.retrySyncTimes; i++ {
+				if err := c.sync(context.TODO(), syncCtx); err != nil {
+					t.Errorf("sync failed: %v", err)
+					return
+				}
+			}
+			if test.expectedVerbosity != fakeLog.verbosity {
+				t.Errorf("expected log level %d to be set, got %d", test.expectedVerbosity, fakeLog.verbosity)
+			}
+			if test.evalEvents != nil {
+				test.evalEvents(recorder.Events(), t)
+			}
+		})
 	}
 }

--- a/pkg/operator/staticpod/controller/installer/installer_controller.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller.go
@@ -660,7 +660,7 @@ func (c *InstallerController) ensureInstallerPod(nodeName string, operatorSpec *
 	}
 
 	args := []string{
-		fmt.Sprintf("-v=%d", loglevel.LogLevelToKlog(operatorSpec.LogLevel)),
+		fmt.Sprintf("-v=%d", loglevel.LogLevelToVerbosity(operatorSpec.LogLevel)),
 		fmt.Sprintf("--revision=%d", revision),
 		fmt.Sprintf("--namespace=%s", pod.Namespace),
 		fmt.Sprintf("--pod=%s", c.configMaps[0].Name),


### PR DESCRIPTION
Properly determine the current log level and set the `klog.V()` level so we don't run with `V(0)`.
Also add unit tests to make sure this never break.