### PR TITLE
Bug 1810528: Allow setting if a CA is required or optional when creating the bundle

### DIFF
--- a/pkg/operator/resourcesynccontroller/core.go
+++ b/pkg/operator/resourcesynccontroller/core.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/util/cert"
+	"k8s.io/klog"
 
 	"github.com/openshift/library-go/pkg/crypto"
 )
@@ -18,16 +19,23 @@ func CombineCABundleConfigMaps(destinationConfigMap ResourceLocation, lister cor
 	certificates := []*x509.Certificate{}
 	for _, input := range inputConfigMaps {
 		inputConfigMap, err := lister.ConfigMaps(input.Namespace).Get(input.Name)
-		if apierrors.IsNotFound(err) {
-			continue
-		}
 		if err != nil {
-			return nil, err
+			if apierrors.IsNotFound(err) && !input.Required {
+				klog.V(2).Infof("Optional ConfigMap %s/%s doesn't exist yet. Skipping.", input.Namespace, input.Name)
+				continue
+			} else {
+				return nil, err
+			}
 		}
 
 		// configmaps must conform to this
 		inputContent := inputConfigMap.Data["ca-bundle.crt"]
 		if len(inputContent) == 0 {
+			if input.Required {
+				return nil, fmt.Errorf("configmap %s/%s doesn't contain 'ca-bundle.crt'", input.Namespace, input.Name)
+			}
+
+			klog.V(2).Infof("Optional ConfigMap %s/%s doesn't contain 'ca-bundle.crt' yet. Skipping.", input.Namespace, input.Name)
 			continue
 		}
 		inputCerts, err := cert.ParseCertsPEM([]byte(inputContent))

--- a/pkg/operator/resourcesynccontroller/core_test.go
+++ b/pkg/operator/resourcesynccontroller/core_test.go
@@ -1,0 +1,195 @@
+package resourcesynccontroller
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/openshift/library-go/pkg/crypto"
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+func generateCACert(cn string) (*x509.Certificate, error) {
+	priv, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return nil, err
+	}
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, _ := rand.Int(rand.Reader, serialNumberLimit)
+
+	template := &x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-1 * time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, template, template, priv.Public(), priv)
+	if err != nil {
+		return nil, err
+	}
+	cert, err := x509.ParseCertificate(derBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return cert, nil
+}
+
+func TestCombineCABundleConfigMaps(t *testing.T) {
+	cert1, err := generateCACert("ca1")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	ca1, err := crypto.EncodeCertificates(cert1)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	cert2, err := generateCACert("ca2")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	ca2, err := crypto.EncodeCertificates(cert2)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	tt := []struct {
+		name          string
+		destination   ResourceLocation
+		inputs        []ResourceLocation
+		configmaps    []*corev1.ConfigMap
+		expectedCA    *corev1.ConfigMap
+		expectedError error
+	}{
+		{
+			name: "continues with optional cm missing",
+			destination: ResourceLocation{
+				Namespace: "default",
+				Name:      "bundle",
+			},
+			inputs: []ResourceLocation{
+				{
+					Namespace: "default",
+					Name:      "cm1",
+					Required:  true,
+				},
+				{
+					Namespace: "default",
+					Name:      "cm2",
+					Required:  false,
+				},
+			},
+			configmaps: []*corev1.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "cm1",
+					},
+					Data: map[string]string{
+						"ca-bundle.crt": string(ca1),
+					},
+				},
+			},
+			expectedCA: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "bundle",
+				},
+				Data: map[string]string{
+					"ca-bundle.crt": func() string {
+						bundle, err := crypto.EncodeCertificates(cert1)
+						if err != nil {
+							t.Fatal(err)
+						}
+						return string(bundle)
+					}(),
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "fails if required cm isn't present",
+			destination: ResourceLocation{
+				Namespace: "default",
+				Name:      "bundle",
+			},
+			inputs: []ResourceLocation{
+				{
+					Namespace: "default",
+					Name:      "cm1",
+					Required:  true,
+				},
+				{
+					Namespace: "default",
+					Name:      "cm2",
+					Required:  false,
+				},
+			},
+			configmaps: []*corev1.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "cm2",
+					},
+					Data: map[string]string{
+						"ca-bundle.crt": string(ca2),
+					},
+				},
+			},
+			expectedError: apierrors.NewNotFound(corev1.Resource("configmap"), "cm1"),
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			configMapIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			for _, cm := range tc.configmaps {
+				err := configMapIndexer.Add(cm)
+				if err != nil {
+					t.Error(err)
+				}
+			}
+			configmapLister := corev1listers.NewConfigMapLister(configMapIndexer)
+			ca, err := CombineCABundleConfigMaps(tc.destination, configmapLister, tc.inputs...)
+			if !reflect.DeepEqual(err, tc.expectedError) {
+				t.Errorf("expected error %v, got %v", tc.expectedError, err)
+				return
+			}
+			if err != nil {
+				return
+			}
+
+			if ca.Namespace != tc.destination.Namespace {
+				t.Errorf("expected namespace %q, got %q", tc.destination.Namespace, ca.Namespace)
+			}
+
+			if ca.Name != tc.destination.Name {
+				t.Errorf("expected name %q, got %q", tc.destination.Name, ca.Name)
+			}
+
+			if !apiequality.Semantic.DeepEqual(ca, tc.expectedCA) {
+				t.Errorf("expected CA %#v\n        got %v\ndiff: %s", tc.expectedError, err, cmp.Diff(tc.expectedError, err))
+			}
+		})
+	}
+}

--- a/pkg/operator/resourcesynccontroller/interfaces.go
+++ b/pkg/operator/resourcesynccontroller/interfaces.go
@@ -4,6 +4,7 @@ package resourcesynccontroller
 type ResourceLocation struct {
 	Namespace string `json:"namespace"`
 	Name      string `json:"name"`
+	Required  bool   `json:"required,omitempty"`
 }
 
 var emptyResourceLocation = ResourceLocation{}


### PR DESCRIPTION
When operators are creating CA bundles from particular CAs, some are required and some are optional. So far all were optional and we managed to deploy kube-scheduler with CA bundle not having kube-apiserver's CAs which is essential for the pod to work.

The question is if we keep the default to be required or optional but required seems safer. The optional (but required) case manifests in races, while if we make required something that doesn't have to be and isn't running at the time we need it we fail in CI and fix it before merging.

If we agree on changing the default from optional to required, I'll let the other operator maintainers know so they are not surprised on bumps.

/cc @deads2k @soltysh 
@openshift/sig-master 