### PR TITLE
config-observers: prune returned config

### DIFF
--- a/pkg/operator/configobserver/apiserver/observe_tlssecurityprofile.go
+++ b/pkg/operator/configobserver/apiserver/observe_tlssecurityprofile.go
@@ -26,11 +26,14 @@ type APIServerLister interface {
 
 // ObserveTLSSecurityProfile observes APIServer.Spec.TLSSecurityProfile field and sets
 // the ServingInfo.MinTLSVersion, ServingInfo.CipherSuites fields
-func ObserveTLSSecurityProfile(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (map[string]interface{}, []error) {
+func ObserveTLSSecurityProfile(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (ret map[string]interface{}, _ []error) {
 	var (
 		minTlSVersionPath = []string{"servingInfo", "minTLSVersion"}
 		cipherSuitesPath  = []string{"servingInfo", "cipherSuites"}
 	)
+	defer func() {
+		ret = configobserver.Pruned(ret, minTlSVersionPath, cipherSuitesPath)
+	}()
 
 	listers := genericListers.(APIServerLister)
 	errs := []error{}

--- a/pkg/operator/configobserver/cloudprovider/observe_cloudprovider.go
+++ b/pkg/operator/configobserver/cloudprovider/observe_cloudprovider.go
@@ -45,30 +45,13 @@ type cloudProviderObserver struct {
 }
 
 // ObserveCloudProviderNames observes the cloud provider from the global cluster infrastructure resource.
-func (c *cloudProviderObserver) ObserveCloudProviderNames(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (map[string]interface{}, []error) {
+func (c *cloudProviderObserver) ObserveCloudProviderNames(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (ret map[string]interface{}, _ []error) {
+	defer func() {
+		ret = configobserver.Pruned(ret, c.cloudProviderConfigPath, c.cloudProviderNamePath)
+	}()
+
 	listers := genericListers.(InfrastructureLister)
 	var errs []error
-	cloudProvidersPath := c.cloudProviderNamePath
-	cloudProviderConfPath := c.cloudProviderConfigPath
-	previouslyObservedConfig := map[string]interface{}{}
-
-	existingCloudConfig, _, err := unstructured.NestedStringSlice(existingConfig, cloudProviderConfPath...)
-	if err != nil {
-		return previouslyObservedConfig, append(errs, err)
-	}
-
-	if currentCloudProvider, _, _ := unstructured.NestedStringSlice(existingConfig, cloudProvidersPath...); len(currentCloudProvider) > 0 {
-		if err := unstructured.SetNestedStringSlice(previouslyObservedConfig, currentCloudProvider, cloudProvidersPath...); err != nil {
-			errs = append(errs, err)
-		}
-	}
-
-	if len(existingCloudConfig) > 0 {
-		if err := unstructured.SetNestedStringSlice(previouslyObservedConfig, existingCloudConfig, cloudProviderConfPath...); err != nil {
-			errs = append(errs, err)
-		}
-	}
-
 	observedConfig := map[string]interface{}{}
 
 	infrastructure, err := listers.InfrastructureLister().Get("cluster")
@@ -78,12 +61,12 @@ func (c *cloudProviderObserver) ObserveCloudProviderNames(genericListers configo
 	}
 	if err != nil {
 		errs = append(errs, err)
-		return previouslyObservedConfig, errs
+		return existingConfig, errs
 	}
 
 	cloudProvider := getPlatformName(infrastructure.Status.Platform, recorder)
 	if len(cloudProvider) > 0 {
-		if err := unstructured.SetNestedStringSlice(observedConfig, []string{cloudProvider}, cloudProvidersPath...); err != nil {
+		if err := unstructured.SetNestedStringSlice(observedConfig, []string{cloudProvider}, c.cloudProviderNamePath...); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -124,9 +107,14 @@ func (c *cloudProviderObserver) ObserveCloudProviderNames(genericListers configo
 	// usually key will be simply config but we should refer it just in case
 	staticCloudConfFile := fmt.Sprintf(cloudProviderConfFilePath, infrastructure.Spec.CloudConfig.Key)
 
-	if err := unstructured.SetNestedStringSlice(observedConfig, []string{staticCloudConfFile}, cloudProviderConfPath...); err != nil {
+	if err := unstructured.SetNestedStringSlice(observedConfig, []string{staticCloudConfFile}, c.cloudProviderConfigPath...); err != nil {
 		recorder.Warningf("ObserveCloudProviderNames", "Failed setting cloud-config : %v", err)
 		errs = append(errs, err)
+	}
+
+	existingCloudConfig, _, err := unstructured.NestedStringSlice(existingConfig, c.cloudProviderConfigPath...)
+	if err != nil {
+		return existingConfig, append(errs, err)
 	}
 
 	if !equality.Semantic.DeepEqual(existingCloudConfig, []string{staticCloudConfFile}) {

--- a/pkg/operator/configobserver/featuregates/observe_featuregates.go
+++ b/pkg/operator/configobserver/featuregates/observe_featuregates.go
@@ -41,20 +41,13 @@ type featureFlags struct {
 }
 
 // ObserveFeatureFlags fills in --feature-flags for the kube-apiserver
-func (f *featureFlags) ObserveFeatureFlags(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (map[string]interface{}, []error) {
+func (f *featureFlags) ObserveFeatureFlags(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (ret map[string]interface{}, _ []error) {
+	defer func() {
+		ret = configobserver.Pruned(ret, f.configPath)
+	}()
+
 	listers := genericListers.(FeatureGateLister)
 	errs := []error{}
-	prevObservedConfig := map[string]interface{}{}
-
-	currentConfigValue, _, err := unstructured.NestedStringSlice(existingConfig, f.configPath...)
-	if err != nil {
-		errs = append(errs, err)
-	}
-	if len(currentConfigValue) > 0 {
-		if err := unstructured.SetNestedStringSlice(prevObservedConfig, currentConfigValue, f.configPath...); err != nil {
-			errs = append(errs, err)
-		}
-	}
 
 	observedConfig := map[string]interface{}{}
 	configResource, err := listers.FeatureGateLister().Get("cluster")
@@ -70,13 +63,17 @@ func (f *featureFlags) ObserveFeatureFlags(genericListers configobserver.Listers
 		}
 	} else if err != nil {
 		errs = append(errs, err)
-		return prevObservedConfig, errs
+		return existingConfig, errs
 	}
 
 	newConfigValue, err := f.getWhitelistedFeatureNames(configResource)
 	if err != nil {
 		errs = append(errs, err)
-		return prevObservedConfig, errs
+		return existingConfig, errs
+	}
+	currentConfigValue, _, err := unstructured.NestedStringSlice(existingConfig, f.configPath...)
+	if err != nil {
+		errs = append(errs, err)
 	}
 	if !reflect.DeepEqual(currentConfigValue, newConfigValue) {
 		recorder.Eventf("ObserveFeatureFlagsUpdated", "Updated %v to %s", strings.Join(f.configPath, "."), strings.Join(newConfigValue, ","))

--- a/pkg/operator/configobserver/proxy/observe_proxy.go
+++ b/pkg/operator/configobserver/proxy/observe_proxy.go
@@ -43,20 +43,20 @@ func (f *observeProxyFlags) ObserveProxyConfig(genericListers configobserver.Lis
 		return observedConfig, errs
 	}
 	if err != nil {
-		errs = append(errs, err)
-		return existingConfig, errs
+		return existingConfig, append(errs, err)
 	}
 
 	newProxyMap := proxyToMap(proxyConfig)
 	if newProxyMap != nil {
 		if err := unstructured.SetNestedStringMap(observedConfig, newProxyMap, f.configPath...); err != nil {
-			errs = append(errs, err)
+			return existingConfig, append(errs, err)
 		}
 	}
 
 	currentProxyMap, _, err := unstructured.NestedStringMap(existingConfig, f.configPath...)
 	if err != nil {
-		return existingConfig, append(errs, err)
+		errs = append(errs, err)
+		// keep going on read error from existing config
 	}
 
 	if !reflect.DeepEqual(currentProxyMap, newProxyMap) {

--- a/pkg/operator/configobserver/unstructured.go
+++ b/pkg/operator/configobserver/unstructured.go
@@ -1,0 +1,45 @@
+package configobserver
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// Pruned returns the unstructured filtered by the given paths, i.e. everything
+// outside of them will be dropped. The returned data structure might overlap
+// with the input, but the input is not mutated. In case of error for a path,
+// that path is dropped.
+func Pruned(obj map[string]interface{}, pths ...[]string) map[string]interface{} {
+	if obj == nil || len(pths) == 0 {
+		return obj
+	}
+
+	ret := map[string]interface{}{}
+	if len(pths) == 1 {
+		x, found, err := unstructured.NestedFieldCopy(obj, pths[0]...)
+		if err != nil || !found {
+			return ret
+		}
+		unstructured.SetNestedField(ret, x, pths[0]...)
+		return ret
+	}
+
+	for i, p := range pths {
+		x, found, err := unstructured.NestedFieldCopy(obj, p...)
+		if err != nil {
+			continue
+		}
+		if !found {
+			continue
+		}
+		if i < len(pths)-1 {
+			// this might be overwritten by a later path
+			x = runtime.DeepCopyJSONValue(x)
+		}
+		if err := unstructured.SetNestedField(ret, x, p...); err != nil {
+			continue
+		}
+	}
+
+	return ret
+}


### PR DESCRIPTION
Config observers are supposed to return the existing config in case of error. This is not uniformely implemented. Some observers even return the entire observed config, including fields from other observers.

This PR switch existing config reconstruction trivial by just filter the whole observed config by the keys the observer is interested in. This is a three liner in each observer, super simple and uniform.