### PR TITLE
certrotation: check the context value for nil

### DIFF
--- a/pkg/operator/certrotation/client_cert_rotation_controller.go
+++ b/pkg/operator/certrotation/client_cert_rotation_controller.go
@@ -77,7 +77,8 @@ func (c CertRotationController) Sync(ctx context.Context, syncCtx factory.SyncCo
 	syncErr := c.syncWorker()
 
 	// running this function with RunOnceContextKey value context will make this "run-once" without updating status.
-	if ctx.Value(RunOnceContextKey).(bool) == true {
+	isRunOnce, ok := ctx.Value(RunOnceContextKey).(bool)
+	if ok && isRunOnce {
 		return syncErr
 	}
 


### PR DESCRIPTION
Fixes panic in bootstrap:

```
panic: interface conversion: interface {} is nil, not bool

goroutine 1249 [running]:
github.com/openshift/library-go/pkg/operator/certrotation.CertRotationController.Sync(0x219cac1, 0x13, 0x21b9933, 0x21, 0x21a8e3d, 0x19, 0x126ad20e840000, 0x9356907420000, 0x0, 0x256fd00, ...)
	github.com/openshift/library-go@v0.0.0-20200313123224-fc1c562fafc7/pkg/operator/certrotation/client_cert_rotation_controller.go:80 +0x3f4
```

Found in https://github.com/openshift/cluster-kube-apiserver-operator/pull/794