### PR TITLE
Add CSIDriver to resourceread and resourceapply

### DIFF
--- a/pkg/operator/resource/resourceapply/storage.go
+++ b/pkg/operator/resource/resourceapply/storage.go
@@ -6,10 +6,12 @@ import (
 	"k8s.io/klog"
 
 	storagev1 "k8s.io/api/storage/v1"
+	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	storageclientv1 "k8s.io/client-go/kubernetes/typed/storage/v1"
+	storageclientv1beta1 "k8s.io/client-go/kubernetes/typed/storage/v1beta1"
 
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
@@ -47,6 +49,35 @@ func ApplyStorageClass(client storageclientv1.StorageClassesGetter, recorder eve
 
 	// TODO if provisioner, parameters, reclaimpolicy, or volumebindingmode are different, update will fail so delete and recreate
 	actual, err := client.StorageClasses().Update(context.TODO(), existingCopy, metav1.UpdateOptions{})
+	reportUpdateEvent(recorder, required, err)
+	return actual, true, err
+}
+
+// ApplyCSIDriverV1Beta1 merges objectmeta, does not worry about anything else
+func ApplyCSIDriverV1Beta1(client storageclientv1beta1.CSIDriversGetter, recorder events.Recorder, required *storagev1beta1.CSIDriver) (*storagev1beta1.CSIDriver, bool, error) {
+	existing, err := client.CSIDrivers().Get(context.TODO(), required.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		actual, err := client.CSIDrivers().Create(context.TODO(), required, metav1.CreateOptions{})
+		reportCreateEvent(recorder, required, err)
+		return actual, true, err
+	}
+	if err != nil {
+		return nil, false, err
+	}
+
+	modified := resourcemerge.BoolPtr(false)
+	existingCopy := existing.DeepCopy()
+
+	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
+	if !*modified {
+		return existingCopy, false, nil
+	}
+
+	if klog.V(4) {
+		klog.Infof("CSIDriver %q changes: %v", required.Name, JSONPatchNoError(existing, existingCopy))
+	}
+
+	actual, err := client.CSIDrivers().Update(context.TODO(), existingCopy, metav1.UpdateOptions{})
 	reportUpdateEvent(recorder, required, err)
 	return actual, true, err
 }

--- a/pkg/operator/resource/resourceapply/storage_test.go
+++ b/pkg/operator/resource/resourceapply/storage_test.go
@@ -1,0 +1,124 @@
+package resourceapply
+
+import (
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
+	storagev1beta1 "k8s.io/api/storage/v1beta1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+func TestApplyCSIDriver(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing []runtime.Object
+		input    *storagev1beta1.CSIDriver
+
+		expectedModified bool
+		verifyActions    func(actions []clienttesting.Action, t *testing.T)
+	}{
+		{
+			name: "create",
+			input: &storagev1beta1.CSIDriver{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo", Annotations: map[string]string{"my.csi.driver/foo": "bar"}},
+			},
+
+			expectedModified: true,
+			verifyActions: func(actions []clienttesting.Action, t *testing.T) {
+				if len(actions) != 2 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("get", "csidrivers") || actions[0].(clienttesting.GetAction).GetName() != "foo" {
+					t.Error(spew.Sdump(actions))
+				}
+				if !actions[1].Matches("create", "csidrivers") {
+					t.Error(spew.Sdump(actions))
+				}
+				expected := &storagev1beta1.CSIDriver{
+					ObjectMeta: metav1.ObjectMeta{Name: "foo", Annotations: map[string]string{"my.csi.driver/foo": "bar"}},
+				}
+				actual := actions[1].(clienttesting.CreateAction).GetObject().(*storagev1beta1.CSIDriver)
+				if !equality.Semantic.DeepEqual(expected, actual) {
+					t.Error(JSONPatchNoError(expected, actual))
+				}
+			},
+		},
+		{
+			name: "update on missing label",
+			existing: []runtime.Object{
+				&storagev1beta1.CSIDriver{
+					ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				},
+			},
+			input: &storagev1beta1.CSIDriver{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo", Labels: map[string]string{"new": "merge"}},
+			},
+			expectedModified: true,
+			verifyActions: func(actions []clienttesting.Action, t *testing.T) {
+				if len(actions) != 2 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("get", "csidrivers") || actions[0].(clienttesting.GetAction).GetName() != "foo" {
+					t.Error(spew.Sdump(actions))
+				}
+				if !actions[1].Matches("update", "csidrivers") {
+					t.Error(spew.Sdump(actions))
+				}
+				expected := &storagev1beta1.CSIDriver{
+					ObjectMeta: metav1.ObjectMeta{Name: "foo", Labels: map[string]string{"new": "merge"}},
+				}
+				actual := actions[1].(clienttesting.CreateAction).GetObject().(*storagev1beta1.CSIDriver)
+				if !equality.Semantic.DeepEqual(expected, actual) {
+					t.Error(JSONPatchNoError(expected, actual))
+				}
+			},
+		},
+		{
+			name: "don't mutate spec",
+			existing: []runtime.Object{
+				&storagev1beta1.CSIDriver{
+					ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+					Spec: storagev1beta1.CSIDriverSpec{
+						AttachRequired: resourcemerge.BoolPtr(true),
+						PodInfoOnMount: resourcemerge.BoolPtr(true),
+					},
+				},
+			},
+			input: &storagev1beta1.CSIDriver{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec: storagev1beta1.CSIDriverSpec{
+					AttachRequired: resourcemerge.BoolPtr(false),
+					PodInfoOnMount: resourcemerge.BoolPtr(false),
+				},
+			},
+			expectedModified: false,
+			verifyActions: func(actions []clienttesting.Action, t *testing.T) {
+				if len(actions) != 1 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("get", "csidrivers") || actions[0].(clienttesting.GetAction).GetName() != "foo" {
+					t.Error(spew.Sdump(actions))
+				}
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := fake.NewSimpleClientset(test.existing...)
+			_, actualModified, err := ApplyCSIDriverV1Beta1(client.StorageV1beta1(), events.NewInMemoryRecorder("test"), test.input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if test.expectedModified != actualModified {
+				t.Errorf("expected %v, got %v", test.expectedModified, actualModified)
+			}
+			test.verifyActions(client.Actions(), t)
+		})
+	}
+}

--- a/pkg/operator/resource/resourceread/storage.go
+++ b/pkg/operator/resource/resourceread/storage.go
@@ -2,8 +2,10 @@ package resourceread
 
 import (
 	storagev1 "k8s.io/api/storage/v1"
+	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
 
 var (
@@ -12,9 +14,8 @@ var (
 )
 
 func init() {
-	if err := storagev1.AddToScheme(storageScheme); err != nil {
-		panic(err)
-	}
+	utilruntime.Must(storagev1.AddToScheme(storageScheme))
+	utilruntime.Must(storagev1beta1.AddToScheme(storageScheme))
 }
 
 func ReadStorageClassV1OrDie(objBytes []byte) *storagev1.StorageClass {
@@ -23,4 +24,12 @@ func ReadStorageClassV1OrDie(objBytes []byte) *storagev1.StorageClass {
 		panic(err)
 	}
 	return requiredObj.(*storagev1.StorageClass)
+}
+
+func ReadCSIDriverV1Beta1OrDie(objBytes []byte) *storagev1beta1.CSIDriver {
+	requiredObj, err := runtime.Decode(storageCodecs.UniversalDecoder(storagev1beta1.SchemeGroupVersion), objBytes)
+	if err != nil {
+		panic(err)
+	}
+	return requiredObj.(*storagev1beta1.CSIDriver)
 }


### PR DESCRIPTION
The CSIDriver object contains information about a CSI driver.

Up until recenty, this object was created by the cluster-driver-registrar sidecar container, however, this sidecar has been deprecated. As a result, operators need to create this object when installing a CSI driver.

CC @openshift/storage 