### PR TITLE
apiserver: add prefix to tls and cors observers

### DIFF
--- a/pkg/operator/configobserver/apiserver/observe_cors_test.go
+++ b/pkg/operator/configobserver/apiserver/observe_cors_test.go
@@ -1,6 +1,7 @@
 package apiserver
 
 import (
+	"reflect"
 	"sort"
 	"testing"
 
@@ -80,11 +81,10 @@ func TestObserveAdditionalCORSAllowedOrigins(t *testing.T) {
 				}
 
 				gotCors, _, _ := unstructured.NestedStringSlice(gotConfig, corsPath...)
-				for i := range tt.expectedCORS {
-					if gotCors[i] != tt.expectedCORS[i] {
-						t.Fatalf("got = %v, want %v", gotCors, tt.expectedCORS)
-					}
+				if !reflect.DeepEqual(gotCors, tt.expectedCORS) {
+					t.Fatalf("got = %v, want %v", gotCors, tt.expectedCORS)
 				}
+
 			})
 		}
 	}


### PR DESCRIPTION
This is to support config observation for CAO where one operator deploys two different payloads

Used in https://github.com/openshift/cluster-authentication-operator/pull/242