### PR TITLE
Fix ApplySecret for Type changes

### DIFF
--- a/pkg/operator/certrotation/signer_test.go
+++ b/pkg/operator/certrotation/signer_test.go
@@ -55,6 +55,7 @@ func TestEnsureSigningCertKeyPair(t *testing.T) {
 			name: "update no annotations",
 			initialSecret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "signer"},
+				Type:       corev1.SecretTypeTLS,
 			},
 			verifyActions: func(t *testing.T, client *kubefake.Clientset) {
 				t.Helper()

--- a/pkg/operator/certrotation/target_test.go
+++ b/pkg/operator/certrotation/target_test.go
@@ -174,6 +174,7 @@ func TestEnsureTargetCertKeyPair(t *testing.T) {
 				caBundleSecret := &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "target-secret"},
 					Data:       map[string][]byte{},
+					Type:       corev1.SecretTypeTLS,
 				}
 				return caBundleSecret
 			},
@@ -356,6 +357,7 @@ func TestEnsureTargetSignerCertKeyPair(t *testing.T) {
 				caBundleSecret := &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "target-secret"},
 					Data:       map[string][]byte{},
+					Type:       corev1.SecretTypeTLS,
 				}
 				return caBundleSecret
 			},

--- a/pkg/operator/encryption/controllers/state_controller_test.go
+++ b/pkg/operator/encryption/controllers/state_controller_test.go
@@ -780,6 +780,7 @@ func validateSecretWithEncryptionConfig(actualSecret *corev1.Secret, expectedEnc
 			Finalizers: []string{"encryption.apiserver.operator.openshift.io/deletion-protection"},
 		},
 		Data: actualSecret.Data,
+		Type: corev1.SecretTypeOpaque,
 	}
 
 	// those are filled by the server

--- a/pkg/operator/encryption/encryptionconfig/secret.go
+++ b/pkg/operator/encryption/encryptionconfig/secret.go
@@ -70,5 +70,6 @@ func ToSecret(ns, name string, encryptionCfg *apiserverconfigv1.EncryptionConfig
 		Data: map[string][]byte{
 			EncryptionConfSecretName: rawEncryptionCfg,
 		},
+		Type: corev1.SecretTypeOpaque,
 	}, nil
 }

--- a/pkg/operator/encryption/secrets/secrets.go
+++ b/pkg/operator/encryption/secrets/secrets.go
@@ -98,6 +98,7 @@ func FromKeyState(component string, ks state.KeyState) (*corev1.Secret, error) {
 		Data: map[string][]byte{
 			EncryptionSecretKeyDataKey: bs,
 		},
+		Type: corev1.SecretTypeOpaque,
 	}
 
 	if !ks.Migrated.Timestamp.IsZero() {

--- a/pkg/operator/encryption/testing/helpers.go
+++ b/pkg/operator/encryption/testing/helpers.go
@@ -48,6 +48,7 @@ func CreateEncryptionKeySecretNoDataWithMode(targetNS string, grs []schema.Group
 			Finalizers: []string{"encryption.apiserver.operator.openshift.io/deletion-protection"},
 		},
 		Data: map[string][]byte{},
+		Type: corev1.SecretTypeOpaque,
 	}
 
 	if len(grs) > 0 {

--- a/pkg/operator/resourcesynccontroller/resourcesync_controller_test.go
+++ b/pkg/operator/resourcesynccontroller/resourcesync_controller_test.go
@@ -30,9 +30,11 @@ func TestSyncSecret(t *testing.T) {
 	kubeClient := fake.NewSimpleClientset(
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Namespace: "config", Name: "foo"},
+			Type:       corev1.SecretTypeOpaque,
 		},
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Namespace: "operator", Name: "to-remove"},
+			Type:       corev1.SecretTypeOpaque,
 		},
 	)
 


### PR DESCRIPTION
Kubernetes validation silently ignores secret changes and doesn't return an error.
https://github.com/kubernetes/kubernetes/blob/98e65951dccfd40d3b4f31949c2ab8df5912d93e/pkg/apis/core/validation/validation.go#L5048
This leads to the resource sync controller constantly trying to update to the desired state. (mutating admission vs. DeepEqual)

/cc @deads2k  