### PR TITLE
cmd: add WithVersion to StartController

### DIFF
--- a/pkg/controller/controllercmd/cmd.go
+++ b/pkg/controller/controllercmd/cmd.go
@@ -266,6 +266,7 @@ func (c *ControllerCommandConfig) StartController(ctx context.Context) error {
 		WithKubeConfigFile(c.basicFlags.KubeConfigFile, nil).
 		WithComponentNamespace(c.basicFlags.Namespace).
 		WithLeaderElection(config.LeaderElection, c.basicFlags.Namespace, c.componentName+"-lock").
+		WithVersion(c.version).
 		WithRestartOnChange(exitOnChangeReactorCh, startingFileContent, observedFiles...)
 
 	if !c.DisableServing {


### PR DESCRIPTION
Note, after this change, the pkg/version in each operator that receives this change must change and they must drop the `func init()` and only leave the `func Get()` in this package.

Failing to do that will result in panic during operator/binary runtime as the version metric will be registered twice.