### PR TITLE
factory: add customizable operator conditions

### DIFF
--- a/pkg/controller/factory/base_controller.go
+++ b/pkg/controller/factory/base_controller.go
@@ -7,25 +7,24 @@ import (
 	"time"
 
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
 
-	operatorv1 "github.com/openshift/api/operator/v1"
-
-	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
 )
 
 // baseController represents generic Kubernetes controller boiler-plate
 type baseController struct {
-	name               string
-	cachesToSync       []cache.InformerSynced
-	sync               func(ctx context.Context, controllerContext SyncContext) error
-	syncContext        SyncContext
-	syncDegradedClient operatorv1helpers.OperatorClient
-	resyncEvery        time.Duration
-	postStartHooks     []PostStartHook
+	name                string
+	cachesToSync        []cache.InformerSynced
+	sync                func(ctx context.Context, controllerContext SyncContext) error
+	syncContext         SyncContext
+	syncOperatorClient  operatorv1helpers.OperatorClient
+	syncConditionsTypes sets.String
+	resyncEvery         time.Duration
+	postStartHooks      []PostStartHook
 }
 
 var _ Controller = &baseController{}
@@ -137,28 +136,10 @@ func (c *baseController) runWorker(queueCtx context.Context) {
 // reconcile wraps the sync() call and if operator client is set, it handle the degraded condition if sync() returns an error.
 func (c *baseController) reconcile(ctx context.Context, syncCtx SyncContext) error {
 	err := c.sync(ctx, syncCtx)
-	if c.syncDegradedClient == nil {
+	if c.syncOperatorClient == nil {
 		return err
 	}
-	if err != nil {
-		_, _, updateErr := v1helpers.UpdateStatus(c.syncDegradedClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
-			Type:    c.name + "Degraded",
-			Status:  operatorv1.ConditionTrue,
-			Reason:  "SyncError",
-			Message: err.Error(),
-		}))
-		if updateErr != nil {
-			klog.Warningf("Updating status of %q failed: %w", c.Name(), updateErr)
-		}
-		return err
-	}
-	_, _, updateErr := v1helpers.UpdateStatus(c.syncDegradedClient,
-		v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
-			Type:   c.name + "Degraded",
-			Status: operatorv1.ConditionFalse,
-			Reason: "AsExpected",
-		}))
-	return updateErr
+	return handleErrorConditions(c.syncOperatorClient, c.name, c.syncConditionsTypes, err)
 }
 
 func (c *baseController) processNextWorkItem(queueCtx context.Context) {

--- a/pkg/controller/factory/base_controller_test.go
+++ b/pkg/controller/factory/base_controller_test.go
@@ -43,7 +43,7 @@ func TestBaseController_Reconcile(t *testing.T) {
 	)
 	c := &baseController{
 		name:               "TestController",
-		syncDegradedClient: operatorClient,
+		syncOperatorClient: operatorClient,
 	}
 
 	c.sync = func(ctx context.Context, controllerContext SyncContext) error {

--- a/pkg/controller/factory/conditions.go
+++ b/pkg/controller/factory/conditions.go
@@ -1,0 +1,187 @@
+package factory
+
+import (
+	"fmt"
+	"strings"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+type degradedError struct {
+	conditionError
+}
+
+type unavailableError struct {
+	conditionError
+}
+
+type notUpgradeableError struct {
+	conditionError
+}
+
+// NewDegradedError returns an error that will cause the operator to go to Degraded=True state if returned from the sync() function.
+func (syncContext) NewDegradedConditionError(condType, reason, message string) error {
+	if !strings.HasSuffix(condType, "Degraded") {
+		condType += "Degraded"
+	}
+	return &degradedError{conditionError{condType: condType, reason: reason, message: message}}
+}
+
+// NewAvailableError returns an error that will cause the operator to go to Available=False state if returned from the sync() function.
+func (syncContext) NewAvailableConditionError(condType, reason, message string) error {
+	if !strings.HasSuffix(condType, "Available") {
+		condType += "Available"
+	}
+	return &unavailableError{conditionError{condType: condType, reason: reason, message: message}}
+}
+
+// NewUpgradeableError returns an error that will cause the operator to go to Upgradeable=False state if returned from the sync() function.
+func (syncContext) NewUpgradeableConditionError(condType, reason, message string) error {
+	if !strings.HasSuffix(condType, "Upgradeable") {
+		condType += "Upgradeable"
+	}
+	return &notUpgradeableError{conditionError{condType: condType, reason: reason, message: message}}
+}
+
+// IsDegradedConditionError returns true if error passed indicates that operator should report Degraded=True.
+func IsDegradedConditionError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if c, ok := err.(*conditionError); ok && strings.HasSuffix(c.condType, "Degraded") {
+		return true
+	}
+	_, ok := err.(*degradedError)
+	return ok
+}
+
+// IsAvailableConditionError returns true if error passed indicates that operator should report Available=False.
+func IsAvailableConditionError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if c, ok := err.(*conditionError); ok && strings.HasSuffix(c.condType, "Available") {
+		return true
+	}
+	_, ok := err.(*unavailableError)
+	return ok
+}
+
+// IsUpgradeableConditionError returns true if error passed indicates that operator should report Upgradeable=False.
+func IsUpgradeableConditionError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if c, ok := err.(*conditionError); ok && strings.HasSuffix(c.condType, "Upgradeable") {
+		return true
+	}
+	_, ok := err.(*notUpgradeableError)
+	return ok
+}
+
+// conditionError contains all
+type conditionError struct {
+	condType string
+	reason   string
+	message  string
+}
+
+func (d *conditionError) Error() string {
+	switch {
+	case IsDegradedConditionError(d):
+		return fmt.Sprintf("operator is degraded: %q (%s)", d.reason, d.message)
+	case IsUpgradeableConditionError(d):
+		return fmt.Sprintf("operator is not upgreadable: %q (%s)", d.reason, d.message)
+	case IsAvailableConditionError(d):
+		return fmt.Sprintf("operator is not available: %q (%s)", d.reason, d.message)
+	}
+	return fmt.Sprintf("operator unknown condition type: %q", d.condType)
+}
+
+func (d *conditionError) condition(status operatorv1.ConditionStatus) operatorv1.OperatorCondition {
+	return operatorv1.OperatorCondition{
+		Type:    d.condType,
+		Status:  status,
+		Reason:  d.reason,
+		Message: d.message,
+	}
+}
+
+func findConditionErrors(name string, err error) []operatorv1.OperatorCondition {
+	foundConditions := []operatorv1.OperatorCondition{}
+	switch e := err.(type) {
+	case *degradedError:
+		foundConditions = append(foundConditions, e.condition(operatorv1.ConditionTrue))
+	case *unavailableError:
+		foundConditions = append(foundConditions, e.condition(operatorv1.ConditionFalse))
+	case *notUpgradeableError:
+		foundConditions = append(foundConditions, e.condition(operatorv1.ConditionFalse))
+	case errors.Aggregate:
+		for _, err := range e.Errors() {
+			foundConditions = append(foundConditions, findConditionErrors(name, err)...)
+		}
+	default:
+		// if this condition already exists, append error messages.
+		// this allows to aggregate multiple go errors together and report all of them inside single condition.
+		existing := v1helpers.FindOperatorCondition(foundConditions, name+"Degraded")
+		messages := []string{}
+		if existing != nil {
+			messages = []string{existing.Message}
+		}
+		messages = append(messages, err.Error())
+		foundConditions = append(foundConditions, operatorv1.OperatorCondition{
+			Type:    name + "Degraded",
+			Status:  operatorv1.ConditionTrue,
+			Reason:  "SyncError",
+			Message: strings.Join(messages, ","),
+		})
+	}
+
+	return foundConditions
+}
+
+// handleErrorConditions is used by reconcile() to report operator conditions based on the error.
+func handleErrorConditions(client operatorv1helpers.OperatorClient, controllerName string, knownConditionsTypes sets.String, err error) error {
+	allKnownConditions := sets.NewString(append([]string{controllerName + "Degraded"}, knownConditionsTypes.List()...)...)
+	foundConditions := []operatorv1.OperatorCondition{}
+
+	if err != nil {
+		foundConditions = findConditionErrors(controllerName, err)
+		// If we don't know about this condition type, then instead of setting it forever, error out.
+		// Note: This is a programmer error, where the WithSyncErrorConditionTypes() have not listed the condition type used.
+		for _, c := range foundConditions {
+			if !allKnownConditions.Has(c.Type) {
+				return fmt.Errorf("unknown condition type %+v requested (known: %#v)", c.Type, allKnownConditions.List())
+			}
+		}
+	}
+
+	updateConditionFuncs := []v1helpers.UpdateStatusFunc{}
+	// clean up existing conditions first
+	for _, conditionType := range allKnownConditions.List() {
+		conditionDefaultStatus := operatorv1.ConditionTrue
+		if strings.HasSuffix(conditionType, "Degraded") {
+			conditionDefaultStatus = operatorv1.ConditionFalse
+		}
+		updatedCondition := operatorv1.OperatorCondition{
+			Type:   conditionType,
+			Status: conditionDefaultStatus,
+			Reason: "AsExpected",
+		}
+		if condition := v1helpers.FindOperatorCondition(foundConditions, conditionType); condition != nil {
+			updatedCondition = *condition
+		}
+		updateConditionFuncs = append(updateConditionFuncs, v1helpers.UpdateConditionFn(updatedCondition))
+	}
+
+	// update operator conditions
+	if _, _, updateErr := v1helpers.UpdateStatus(client, updateConditionFuncs...); updateErr != nil {
+		return updateErr
+	}
+	return err
+}

--- a/pkg/controller/factory/conditions_test.go
+++ b/pkg/controller/factory/conditions_test.go
@@ -1,0 +1,215 @@
+package factory
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/openshift/library-go/pkg/operator/events/eventstesting"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+func TestHandleErrorConditions(t *testing.T) {
+	asDegradedError := func(err error, t *testing.T) {
+		if !IsDegradedConditionError(err) {
+			t.Errorf("expected degraded error, got %v", err)
+		}
+	}
+	asUnavailableError := func(err error, t *testing.T) {
+		if !IsAvailableConditionError(err) {
+			t.Errorf("expected unavailable error, got %v", err)
+		}
+	}
+	asNotUpgradeableError := func(err error, t *testing.T) {
+		if !IsUpgradeableConditionError(err) {
+			t.Errorf("expected not upgradeable error, got %v", err)
+		}
+	}
+
+	ctx := NewSyncContext("test", eventstesting.NewTestingEventRecorder(t))
+
+	tests := []struct {
+		name                   string
+		syncErr                error
+		knownConditions        sets.String
+		expectedCondition      *operatorv1.OperatorCondition
+		expectedConditionNames sets.String
+		evalError              func(error, *testing.T)
+	}{
+		{
+			name:            "degraded",
+			syncErr:         ctx.NewDegradedConditionError("OperatorDegraded", "TestReason", "TestMessage"),
+			knownConditions: sets.NewString("OperatorDegraded"),
+			evalError:       asDegradedError,
+			expectedCondition: &operatorv1.OperatorCondition{
+				Type:    "OperatorDegraded",
+				Status:  operatorv1.ConditionTrue,
+				Reason:  "TestReason",
+				Message: "TestMessage",
+			},
+		},
+		{
+			name:            "degraded unknown",
+			syncErr:         ctx.NewDegradedConditionError("OperatorDegraded", "TestReason", "TestMessage"),
+			knownConditions: sets.NewString(),
+			evalError: func(err error, t *testing.T) {
+				if !strings.Contains(err.Error(), "unknown condition type") {
+					t.Errorf("expected unknown condition type error, got %q", err)
+				}
+			},
+		},
+		{
+			name:            "degraded multiple",
+			syncErr:         ctx.NewDegradedConditionError("Operator", "TestReason", "TestMessage"),
+			knownConditions: sets.NewString("OperatorDegraded", "AnotherOperatorDegraded"),
+			evalError:       asDegradedError,
+			expectedCondition: &operatorv1.OperatorCondition{
+				Type:    "OperatorDegraded",
+				Status:  operatorv1.ConditionTrue,
+				Reason:  "TestReason",
+				Message: "TestMessage",
+			},
+		},
+		{
+			name:            "available",
+			syncErr:         ctx.NewAvailableConditionError("OperatorAvailable", "TestReason", "TestMessage"),
+			knownConditions: sets.NewString("OperatorAvailable"),
+			evalError:       asUnavailableError,
+			expectedCondition: &operatorv1.OperatorCondition{
+				Type:    "OperatorAvailable",
+				Status:  operatorv1.ConditionFalse,
+				Reason:  "TestReason",
+				Message: "TestMessage",
+			},
+		},
+		{
+			name:            "upgradeable",
+			syncErr:         ctx.NewUpgradeableConditionError("OperatorUpgradeable", "TestReason", "TestMessage"),
+			knownConditions: sets.NewString("OperatorUpgradeable"),
+			evalError:       asNotUpgradeableError,
+			expectedCondition: &operatorv1.OperatorCondition{
+				Type:    "OperatorUpgradeable",
+				Status:  operatorv1.ConditionFalse,
+				Reason:  "TestReason",
+				Message: "TestMessage",
+			},
+		},
+		{
+			name:            "upgradeable defaulted",
+			syncErr:         nil,
+			knownConditions: sets.NewString("OperatorUpgradeable"),
+			expectedCondition: &operatorv1.OperatorCondition{
+				Type:   "OperatorUpgradeable",
+				Status: operatorv1.ConditionTrue,
+				Reason: "AsExpected",
+			},
+		},
+		{
+			name:            "degraded on error",
+			syncErr:         fmt.Errorf("sync error"),
+			knownConditions: sets.NewString("TestDegraded"), // ControllerName+Degraded
+			evalError: func(err error, t *testing.T) {
+				if err.Error() != "sync error" {
+					t.Errorf("expected original sync error, got %v", err)
+				}
+			},
+			expectedCondition: &operatorv1.OperatorCondition{
+				Type:    "TestDegraded",
+				Status:  operatorv1.ConditionTrue,
+				Reason:  "SyncError",
+				Message: "sync error",
+			},
+		},
+		{
+			name:            "aggregated degraded",
+			syncErr:         errors.NewAggregate([]error{ctx.NewDegradedConditionError("FirstOperator", "FirstReason", "message"), ctx.NewDegradedConditionError("SecondOperator", "SecondReason", "message")}),
+			knownConditions: sets.NewString("FirstOperatorDegraded", "SecondOperatorDegraded"),
+			evalError: func(err error, t *testing.T) {
+				if strings.Contains(err.Error(), "FirstReason") && strings.Contains(err.Error(), "SecondReason") {
+					return
+				}
+				t.Errorf("expected error to have both conditions, got %#v", err.Error())
+			},
+			expectedConditionNames: sets.NewString("FirstOperatorDegraded", "SecondOperatorDegraded"),
+			expectedCondition: &operatorv1.OperatorCondition{
+				Type:    "FirstOperatorDegraded",
+				Status:  operatorv1.ConditionTrue,
+				Reason:  "FirstReason",
+				Message: "message",
+			},
+		},
+		{
+			name:            "aggregated multiple conditions",
+			syncErr:         errors.NewAggregate([]error{ctx.NewDegradedConditionError("FirstOperator", "FirstReason", "message"), ctx.NewAvailableConditionError("NotAvailable", "AvailableReason", "message")}),
+			knownConditions: sets.NewString("FirstOperatorDegraded", "NotAvailable"),
+			evalError: func(err error, t *testing.T) {
+				if strings.Contains(err.Error(), "FirstReason") && strings.Contains(err.Error(), "AvailableReason") {
+					return
+				}
+				t.Errorf("expected error to have both conditions, got %#v", err.Error())
+			},
+			expectedConditionNames: sets.NewString("FirstOperatorDegraded", "NotAvailable"),
+			expectedCondition: &operatorv1.OperatorCondition{
+				Type:    "NotAvailable",
+				Status:  operatorv1.ConditionFalse,
+				Reason:  "AvailableReason",
+				Message: "message",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := v1helpers.NewFakeOperatorClient(&operatorv1.OperatorSpec{}, &operatorv1.OperatorStatus{}, nil)
+
+			err := handleErrorConditions(client, "Test", test.knownConditions, test.syncErr)
+			if test.evalError != nil {
+				test.evalError(err, t)
+			} else if err != nil {
+				t.Fatal(err)
+			}
+
+			_, status, _, _ := client.GetOperatorState()
+
+			if test.expectedCondition != nil {
+				currentCondition := v1helpers.FindOperatorCondition(status.Conditions, test.expectedCondition.Type)
+				if currentCondition == nil {
+					t.Fatalf("expected condition %q not found", test.expectedCondition.Type)
+				}
+				if currentCondition.Reason != test.expectedCondition.Reason {
+					t.Errorf("expected condition reason %q is %q", test.expectedCondition.Reason, currentCondition.Reason)
+				}
+				if currentCondition.Message != test.expectedCondition.Message {
+					t.Errorf("expected condition message %q is %q", test.expectedCondition.Message, currentCondition.Message)
+				}
+				if currentCondition.Status != test.expectedCondition.Status {
+					t.Errorf("expected condition status %q is %q", test.expectedCondition.Status, currentCondition.Status)
+				}
+			}
+
+			for _, c := range status.Conditions {
+				if test.expectedCondition != nil && test.expectedConditionNames.Len() == 0 && c.Type == test.expectedCondition.Type {
+					continue
+				}
+				if test.expectedConditionNames.Has(c.Type) {
+					continue
+				}
+				if c.Reason != "AsExpected" {
+					t.Errorf("expected condition %q reason to be AsExpected, got %q", c.Type, c.Reason)
+				}
+				expectedStatus := operatorv1.ConditionTrue
+				if strings.HasSuffix(c.Type, "Degraded") {
+					expectedStatus = operatorv1.ConditionFalse
+				}
+				if c.Status != expectedStatus {
+					t.Errorf("expected condition %q status to be %q, got %q", c.Type, expectedStatus, c.Status)
+				}
+			}
+
+		})
+	}
+}

--- a/pkg/controller/factory/interfaces.go
+++ b/pkg/controller/factory/interfaces.go
@@ -39,6 +39,15 @@ type SyncContext interface {
 
 	// Recorder provide access to event recorder.
 	Recorder() events.Recorder
+
+	// NewDegradedConditionError when returned from the sync() function cause the operator Degraded condition go to True.
+	NewDegradedConditionError(conditionType, reason, message string) error
+
+	// NewAvailableConditionError when returned from the sync() function cause the operator Available condition go to False.
+	NewAvailableConditionError(conditionType, reason, message string) error
+
+	// NewUpgradeableConditionError when returned from the sync() function cause the operator Upgradeable condition go to False.
+	NewUpgradeableConditionError(conditionType, reason, message string) error
 }
 
 // SyncFunc is a function that contain main controller logic.


### PR DESCRIPTION
This add ability to return custom operator conditions based on the sync() errors. 

```golang
factory.New().WithOperatorClient(client).WithSyncErrorConditionTypes("OperatorDegraded")

func sync(ctx context.Context, syncCtx factory.SyncContext) error {
  return syncCtx.NewDegradedConditionError("OperatorDegraded", "SomethingFailed", "Something failed terribly")
}
```

In this case, the operator goes `Degraded=True` with `SomethingFailed` as "reason".
In addition you can use `factory.NewUnavailable()` and `factory.NewNotUpgreadable()` errors to signal different condition types.
The conditions are automatically reset on every sync if the error is not returned. 

Bonus:

If you want to set multiple conditions, the `errors.NewAggregate()` will work!

```
func sync(...) {
  errs := []error{}
  ...
  errs = append(errs, syncCtx.NewDegradedError("SomethingBad", reason, msg))
  ...
  errs = append(errs, syncCtx.NewDegradedError("SomethingElseBad", reason, msg))
  ...
  ...
  errs = append(errs, syncCtx.NewUnavailableError("SomethingHorrible", reason, msg))
  ...
  return errors.NewAggregate(errs)
}
```

In this case, you will see two Degraded=True conditions set and one Available=False. 