### PR TITLE
version: make sure to always have namespace when reporting version

### DIFF
--- a/pkg/controller/controllercmd/builder.go
+++ b/pkg/controller/controllercmd/builder.go
@@ -210,7 +210,7 @@ func (b *ControllerBuilder) Run(ctx context.Context, config *unstructured.Unstru
 	if b.versionInfo != nil {
 		buildInfo := metrics.NewGaugeVec(
 			&metrics.GaugeOpts{
-				Name: strings.Replace(b.componentNamespace, "-", "_", -1) + "_build_info",
+				Name: strings.Replace(namespace, "-", "_", -1) + "_build_info",
 				Help: "A metric with a constant '1' value labeled by major, minor, git version, git commit, git tree state, build date, Go version, " +
 					"and compiler from which " + b.componentName + " was built, and platform on which it is running.",
 				StabilityLevel: metrics.ALPHA,


### PR DESCRIPTION
Found these when checking something in Prometheus:

```

_build_info{buildDate="2020-04-21T15:28:33Z", endpoint="https", gitCommit="158288a", gitTreeState="dirty", gitVersion="v0.0.0-alpha.0-240-g158288a", instance="10.128.0.24:8443", job="metrics", namespace="openshift-config-operator", pod="openshift-config-operator-6b9855859b-pszjx", service="metrics"} | 1
-- | --
_build_info{buildDate="2020-04-22T06:02:43Z", endpoint="https", gitCommit="bc12831", gitVersion="v0.0.0-alpha.0-749-gbc12831", instance="10.130.0.2:8443", job="metrics", namespace="openshift-kube-controller-manager-operator", pod="kube-controller-manager-operator-56f7b794bf-fv8p9", service="metrics"} | 1
_build_info{buildDate="2020-04-21T22:37:27Z", endpoint="https", gitCommit="2a81dc6", gitTreeState="clean", gitVersion="v0.0.1-483-g2a81dc6", instance="10.130.0.3:8443", job="metrics", namespace="openshift-kube-scheduler-operator", pod="openshift-kube-scheduler-operator-65967c987f-542n4", service="metrics"} | 1
_build_info{endpoint="https", instance="10.130.0.11:8443", job="metrics", namespace="openshift-apiserver-operator", pod="openshift-apiserver-operator-8db8ffc58-kn7ps", service="metrics"} | 1
_build_info{buildDate="2020-04-22T08:30:30Z", endpoint="https", gitCommit="1435b50", gitVersion="v4.0.0-alpha.0-920-g1435b50", instance="10.128.0.44:8443", job="metrics", namespace="openshift-kube-apiserver-operator", pod="kube-apiserver-operator-5fc8659cc-vcnt5", service="metrics"}
```

Looks like the namespace in `_build_info` is missing, this will make sure we always have the namespace string when reporting this metric.