### PR TITLE
resourcesynccontroller: fix race in unit test

### DIFF
--- a/pkg/operator/resourcesynccontroller/resourcesync_controller_test.go
+++ b/pkg/operator/resourcesynccontroller/resourcesync_controller_test.go
@@ -81,9 +81,9 @@ func TestSyncSecret(t *testing.T) {
 				destinationSecretBarChecked = true
 				destinationSecretBarCheckedMutex.Unlock()
 			case "empty-source":
-				destinationSecretBarCheckedMutex.Lock()
+				destinationSecretEmptySourceCheckedMutex.Lock()
 				destinationSecretEmptySourceChecked = true
-				destinationSecretBarCheckedMutex.Unlock()
+				destinationSecretEmptySourceCheckedMutex.Unlock()
 			}
 		}
 		return false, nil, nil


### PR DESCRIPTION
Fixing a typo in mutex name inside unit test.