### PR TITLE
Make cluster operator diff messages shorter for events

### DIFF
--- a/pkg/operator/status/status_controller.go
+++ b/pkg/operator/status/status_controller.go
@@ -145,7 +145,8 @@ func (c StatusSyncer) Sync(ctx context.Context, syncCtx factory.SyncContext) err
 		if _, updateErr := c.clusterOperatorClient.ClusterOperators().UpdateStatus(ctx, clusterOperatorObj, metav1.UpdateOptions{}); err != nil {
 			return updateErr
 		}
-		syncCtx.Recorder().Eventf("OperatorStatusChanged", "Status for operator %s changed: %s", c.clusterOperatorName, configv1helpers.GetStatusDiff(originalClusterOperatorObj.Status, clusterOperatorObj.Status))
+		syncCtx.Recorder().Eventf("OperatorStatusChanged", "Status for operator %s changed: %s", c.clusterOperatorName, configv1helpers.GetStatusDiff(originalClusterOperatorObj.Status, clusterOperatorObj.Status, true))
+		klog.Infof("Status for operator %s changed: %s", c.clusterOperatorName, configv1helpers.GetStatusDiff(originalClusterOperatorObj.Status, clusterOperatorObj.Status, false))
 		return nil
 	}
 
@@ -174,7 +175,8 @@ func (c StatusSyncer) Sync(ctx context.Context, syncCtx factory.SyncContext) err
 	if _, updateErr := c.clusterOperatorClient.ClusterOperators().UpdateStatus(ctx, clusterOperatorObj, metav1.UpdateOptions{}); err != nil {
 		return updateErr
 	}
-	syncCtx.Recorder().Eventf("OperatorStatusChanged", "Status for clusteroperator/%s changed: %s", c.clusterOperatorName, configv1helpers.GetStatusDiff(originalClusterOperatorObj.Status, clusterOperatorObj.Status))
+	syncCtx.Recorder().Eventf("OperatorStatusChanged", "Status for clusteroperator/%s changed: %s", c.clusterOperatorName, configv1helpers.GetStatusDiff(originalClusterOperatorObj.Status, clusterOperatorObj.Status, true))
+	klog.Infof("Status for clusteroperator/%s changed: %s", c.clusterOperatorName, configv1helpers.GetStatusDiff(originalClusterOperatorObj.Status, clusterOperatorObj.Status, true))
 	return nil
 }
 


### PR DESCRIPTION
This will make messages like this shorter:

`"Status for clusteroperator/kube-apiserver changed: Degraded message changed from \"NodeControllerDegraded: The master nodes not ready: node \\\"ip-10-0-132-198.us-east-2.compute.internal\\\" not ready since 2020-04-23 08:34:47 +0000 UTC because KubeletNotReady (runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?), node \\\"ip-10-0-159-150.us-east-2.compute.internal\\\" not ready since 2020-04-23 08:34:56 +0000 UTC because KubeletNotReady (runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?)\\nInstallerControllerDegraded: missing required resources: [configmaps: aggregator-client-ca,client-ca, configmaps: bound-sa-token-signing-certs-1,config-1,etcd-serving-ca-1,kube-apiserver-cert-syncer-kubeconfig-1,kube-apiserver-pod-1,kubelet-serving-ca-1,sa-token-signing-certs-1, secrets: aggregator-client,bound-service-account-signing-key,external-loadbalancer-serving-certkey,internal-loadbalancer-serving-certkey,localhost-serving-cert-certkey,service-network-serving-certkey, secrets: etcd-client-1,kubelet-client-1,localhost-recovery-client-token-1,localhost-recovery-serving-certkey-1]\\nCertRotation_KubeControllerManagerClient_Degraded: configmaps \\\"kube-control-plane-signer-ca\\\" already exists\\nRevisionControllerDegraded: configmaps \\\"kube-apiserver-pod\\\" not found\" to \"NodeControllerDegraded: The master nodes not ready: node \\\"ip-10-0-132-198.us-east-2.compute.internal\\\" not ready since 2020-04-23 08:34:47 +0000 UTC because KubeletNotReady (runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?), node \\\"ip-10-0-159-150.us-east-2.compute.internal\\\" not ready since 2020-04-23 08:34:56 +0000 UTC because KubeletNotReady (runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?)\\nInstallerControllerDegraded: missing required resources: [configmaps: aggregator-client-ca,client-ca, configmaps: bound-sa-token-signing-certs-1,config-1,etcd-serving-ca-1,kube-apiserver-cert-syncer-kubeconfig-1,kube-apiserver-pod-1,kubelet-serving-ca-1,sa-token-signing-certs-1, secrets: aggregator-client,bound-service-account-signing-key,external-loadbalancer-serving-certkey,internal-loadbalancer-serving-certkey,localhost-serving-cert-certkey,service-network-serving-certkey, secrets: etcd-client-1,kubelet-client-1,localhost-recovery-client-token-1,localhost-recovery-serving-certkey-1]\\nCertRotation_KubeControllerManagerClient_Degraded: configmaps \\\"kube-control-plane-signer-ca\\\" already exists\\nRevisionControllerDegraded: configmaps \\\"kube-apiserver-pod\\\" not found\\nCertRotation_ExternalLoadBalancerServing_Degraded: configmaps \\\"loadbalancer-serving-ca\\\" already exists\""`