### PR TITLE
return an image digest from DockerImageReference string

### DIFF
--- a/pkg/image/reference/reference.go
+++ b/pkg/image/reference/reference.go
@@ -1,6 +1,7 @@
 package reference
 
 import (
+	"fmt"
 	"net"
 	"net/url"
 	"strings"
@@ -60,6 +61,19 @@ func Parse(spec string) (DockerImageReference, error) {
 	}
 
 	return ref, nil
+}
+
+// GetSpecDigest returns the image digest from a DockerImageReference string.
+// example 'sha:22204fa2...' in an image 'registry/ocp/release@sha:22204fa2...'
+func GetSpecDigest(spec string) (string, error) {
+	namedRef, err := reference.ParseNamed(spec)
+	if err != nil {
+		return "", err
+	}
+	if named, ok := namedRef.(reference.Digested); ok {
+		return named.Digest().String(), nil
+	}
+	return "", fmt.Errorf("could not parse digest for spec: %v", spec)
 }
 
 // Equal returns true if the other DockerImageReference is equivalent to the


### PR DESCRIPTION
I've found I need this for oc here: https://github.com/openshift/oc/pull/395
This adds function to return an image digest from a string rather than going through a registry (to get the digest for tools from release payload mirrored from a registry you may not have access to in disconnected environments) 
ie, this requires registry access: https://github.com/openshift/oc/blob/master/pkg/cli/admin/release/info.go#L675