### PR TITLE
Fix ClusterOperator event when version changes

### DIFF
--- a/pkg/config/clusteroperator/v1helpers/status.go
+++ b/pkg/config/clusteroperator/v1helpers/status.go
@@ -92,6 +92,10 @@ func GetStatusDiff(oldStatus configv1.ClusterOperatorStatus, newStatus configv1.
 		messages = append(messages, fmt.Sprintf("status.extension changed from %q to %q", oldStatus.Extension, newStatus.Extension))
 	}
 
+	if !equality.Semantic.DeepEqual(oldStatus.Versions, newStatus.Versions) {
+		messages = append(messages, fmt.Sprintf("status.versions changed from %q to %q", oldStatus.Versions, newStatus.Versions))
+	}
+
 	if len(messages) == 0 {
 		// ignore errors
 		originalJSON := &bytes.Buffer{}


### PR DESCRIPTION
Don't show ugly JSON diff when only the operator version changes.

Before this PR, when only `Versions` changed in a ClusterOperator:

```
Status for clusteroperator/csi-snapshot-controller changed: {"conditions":[{"type":"Degraded","status":"False","lastTransitionTime":"2020-04-29T11:32:49Z","reason":"AsExpected"},{"type":"Progressing","status":"False","lastTransitionTime":"2020-04-29T11:34:04Z","reason":"AsExpected"},{"type":"Available","status":"True","lastTransitionTime":"2020-04-29T11:34:04Z","reason":"AsExpected"},{"type":"Upgradeable","status":"True","lastTransitionTime":"2020-04-29T11:32:49Z","reason":"AsExpected"}],"

A: relatedObjects":[{"group":"","resource":"namespaces","name":"openshift-cluster-storage-operator"},{"group":"","resource":"namespaces","name":"openshift-cluster-storage-operator"},{"group":"operator.openshift.io","resource":"csisnapshotcontrollers","name":"cluster"}],"extension":null}


B: versions":[{"name":"csi-snapshot-controller","version":"v2.3.4"},{"name":"operator","version":"v1.2.3"}],"relatedObjects":[{"group":"","resource":"namespaces","name":"openshift-cluster-storage-operator"},{"group":"","resource":"namespaces","name":"openshift-cluster-storage-operator"},{"group":"operator.openshift.io","resource":"csisnapshotcontrollers","name":"cluster"}],"extension":null}
```

With this PR:
`Status for clusteroperator/csi-snapshot-controller changed: status.versions changed from [] to [{"operator" "v1.2.3"} {"csi-snapshot-controller" "v2.3.4"}]`

Related to https://bugzilla.redhat.com/show_bug.cgi?id=1829320
