### PR TITLE
Bug 1813894: Fix staticpod controller to use service ca from prometheus

### DIFF
--- a/pkg/operator/staticpod/controller/monitoring/bindata/bindata.go
+++ b/pkg/operator/staticpod/controller/monitoring/bindata/bindata.go
@@ -126,7 +126,7 @@ spec:
       port: https
       scheme: https
       tlsConfig:
-        caFile: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
         serverName: apiserver.{{ .TargetNamespace }}.svc
   jobLabel: component
   namespaceSelector:

--- a/pkg/operator/staticpod/controller/monitoring/manifests/service-monitor.yaml
+++ b/pkg/operator/staticpod/controller/monitoring/manifests/service-monitor.yaml
@@ -15,7 +15,7 @@ spec:
       port: https
       scheme: https
       tlsConfig:
-        caFile: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
         serverName: apiserver.{{ .TargetNamespace }}.svc
   jobLabel: component
   namespaceSelector:


### PR DESCRIPTION
Previously the staticpod controller was configuring the service monitor to source the service ca from the service account token configmap. As of 4.5 the service ca will no longer be set in token
configmap, so its necessary to source the service ca from the prometheus configmap (as per the example of most operators).

/cc @deads2k @sttts