### PR TITLE
Bug 1801437: Add unknownRevisionStatus limit to static pod operator prune controllers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -71,3 +71,5 @@ require (
 )
 
 replace github.com/kubernetes-sigs/kube-storage-version-migrator => github.com/openshift/kubernetes-kube-storage-version-migrator v0.0.3-0.20200312103335-32e07ea4f8ca
+
+replace github.com/openshift/api => github.com/damemi/api v0.0.0-20200512160453-172279894583

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/coreos/pkg v0.0.0-20180108230652-97fdf19511ea h1:n2Ltr3SrfQlf/9nOna1D
 github.com/coreos/pkg v0.0.0-20180108230652-97fdf19511ea/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
+github.com/damemi/api v0.0.0-20200512160453-172279894583 h1:X8DJ3W/1qUvrkNvns1oN4QmEZ0WvIwZOZ2c/PLBnTg0=
+github.com/damemi/api v0.0.0-20200512160453-172279894583/go.mod h1:VnbEzX8SAaRj7Yfl836NykdQIlbEjfL6/CD+AaJQg5Q=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -322,11 +324,6 @@ github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVo
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/runc v0.0.0-20191031171055-b133feaeeb2e h1:NKMVwQeEqNOp8DVM4J1HjpZHRcQO7MAVfZwFxs+Bqec=
 github.com/opencontainers/runc v0.0.0-20191031171055-b133feaeeb2e/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
-github.com/openshift/api v0.0.0-20200326152221-912866ddb162/go.mod h1:RKMJ5CBnljLfnej+BJ/xnOWc3kZDvJUaIAEq2oKSPtE=
-github.com/openshift/api v0.0.0-20200424083944-0422dc17083e h1:VDcwVyMEVbLyekLmtob1TEf8GfP454Afc2hO3FkgBps=
-github.com/openshift/api v0.0.0-20200424083944-0422dc17083e/go.mod h1:VnbEzX8SAaRj7Yfl836NykdQIlbEjfL6/CD+AaJQg5Q=
-github.com/openshift/build-machinery-go v0.0.0-20200211121458-5e3d6e570160 h1:V4E6yt4XWiBEPKnJbs/E8pgUq9AjZqzQfsL3eeT84Qs=
-github.com/openshift/build-machinery-go v0.0.0-20200211121458-5e3d6e570160/go.mod h1:1CkcsT3aVebzRBzVTSbiKSkJMsC/CASqxesfqEMfJEc=
 github.com/openshift/build-machinery-go v0.0.0-20200424080330-082bf86082cc h1:Bu1p7+ItPqhJhmMve7sVluKCYV+o+x1Ede0WY2/BI8Q=
 github.com/openshift/build-machinery-go v0.0.0-20200424080330-082bf86082cc/go.mod h1:1CkcsT3aVebzRBzVTSbiKSkJMsC/CASqxesfqEMfJEc=
 github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0 h1:kMiuiZXH1GdfbiMwsuAQOqGaMxlo9NCUk0wT4XAdfNM=

--- a/vendor/github.com/openshift/api/config/v1/0000_10_config-operator_01_apiserver.crd.yaml
+++ b/vendor/github.com/openshift/api/config/v1/0000_10_config-operator_01_apiserver.crd.yaml
@@ -40,6 +40,7 @@ spec:
         metadata:
           type: object
         spec:
+          description: spec holds user settable values for configuration
           type: object
           properties:
             additionalCORSAllowedOrigins:
@@ -226,4 +227,6 @@ spec:
                   - Modern
                   - Custom
         status:
+          description: status holds observed values from the cluster. They may not
+            be overridden.
           type: object

--- a/vendor/github.com/openshift/api/config/v1/0000_10_config-operator_01_oauth.crd.yaml
+++ b/vendor/github.com/openshift/api/config/v1/0000_10_config-operator_01_oauth.crd.yaml
@@ -40,7 +40,7 @@ spec:
         metadata:
           type: object
         spec:
-          description: OAuthSpec contains desired cluster auth configuration
+          description: spec holds user settable values for configuration
           type: object
           properties:
             identityProviders:
@@ -637,17 +637,8 @@ spec:
               type: object
               properties:
                 accessTokenInactivityTimeoutSeconds:
-                  description: 'accessTokenInactivityTimeoutSeconds defines the default
-                    token inactivity timeout for tokens granted by any client. The
-                    value represents the maximum amount of time that can occur between
-                    consecutive uses of the token. Tokens become invalid if they are
-                    not used within this temporal window. The user will need to acquire
-                    a new token to regain access once a token times out. Valid values
-                    are integer values:   x < 0  Tokens time out is enabled but tokens
-                    never timeout unless configured per client (e.g. `-1`)   x = 0  Tokens
-                    time out is disabled (default)   x > 0  Tokens time out if there
-                    is no activity for x seconds The current minimum allowed value
-                    for X is 300 (5 minutes)'
+                  description: 'accessTokenInactivityTimeoutSeconds - DEPRECATED:
+                    setting this field has no effect.'
                   type: integer
                   format: int32
                 accessTokenMaxAgeSeconds:
@@ -656,6 +647,6 @@ spec:
                   type: integer
                   format: int32
         status:
-          description: OAuthStatus shows current known state of OAuth server in the
-            cluster
+          description: status holds observed values from the cluster. They may not
+            be overridden.
           type: object

--- a/vendor/github.com/openshift/api/config/v1/types_apiserver.go
+++ b/vendor/github.com/openshift/api/config/v1/types_apiserver.go
@@ -14,9 +14,11 @@ import (
 type APIServer struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
+	// spec holds user settable values for configuration
 	// +kubebuilder:validation:Required
 	// +required
 	Spec APIServerSpec `json:"spec"`
+	// status holds observed values from the cluster. They may not be overridden.
 	// +optional
 	Status APIServerStatus `json:"status"`
 }

--- a/vendor/github.com/openshift/api/config/v1/types_oauth.go
+++ b/vendor/github.com/openshift/api/config/v1/types_oauth.go
@@ -14,10 +14,11 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 type OAuth struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
-
+	// spec holds user settable values for configuration
 	// +kubebuilder:validation:Required
 	// +required
 	Spec OAuthSpec `json:"spec"`
+	// status holds observed values from the cluster. They may not be overridden.
 	// +optional
 	Status OAuthStatus `json:"status"`
 }
@@ -47,17 +48,7 @@ type TokenConfig struct {
 	// accessTokenMaxAgeSeconds defines the maximum age of access tokens
 	AccessTokenMaxAgeSeconds int32 `json:"accessTokenMaxAgeSeconds"`
 
-	// accessTokenInactivityTimeoutSeconds defines the default token
-	// inactivity timeout for tokens granted by any client.
-	// The value represents the maximum amount of time that can occur between
-	// consecutive uses of the token. Tokens become invalid if they are not
-	// used within this temporal window. The user will need to acquire a new
-	// token to regain access once a token times out.
-	// Valid values are integer values:
-	//   x < 0  Tokens time out is enabled but tokens never timeout unless configured per client (e.g. `-1`)
-	//   x = 0  Tokens time out is disabled (default)
-	//   x > 0  Tokens time out if there is no activity for x seconds
-	// The current minimum allowed value for X is 300 (5 minutes)
+	// accessTokenInactivityTimeoutSeconds - DEPRECATED: setting this field has no effect.
 	// +optional
 	AccessTokenInactivityTimeoutSeconds int32 `json:"accessTokenInactivityTimeoutSeconds,omitempty"`
 }

--- a/vendor/github.com/openshift/api/config/v1/zz_generated.swagger_doc_generated.go
+++ b/vendor/github.com/openshift/api/config/v1/zz_generated.swagger_doc_generated.go
@@ -244,7 +244,9 @@ func (StringSourceSpec) SwaggerDoc() map[string]string {
 }
 
 var map_APIServer = map[string]string{
-	"": "APIServer holds configuration (like serving certificates, client CA and CORS domains) shared by all API servers in the system, among them especially kube-apiserver and openshift-apiserver. The canonical name of an instance is 'cluster'.",
+	"":       "APIServer holds configuration (like serving certificates, client CA and CORS domains) shared by all API servers in the system, among them especially kube-apiserver and openshift-apiserver. The canonical name of an instance is 'cluster'.",
+	"spec":   "spec holds user settable values for configuration",
+	"status": "status holds observed values from the cluster. They may not be overridden.",
 }
 
 func (APIServer) SwaggerDoc() map[string]string {
@@ -1114,7 +1116,9 @@ func (LDAPIdentityProvider) SwaggerDoc() map[string]string {
 }
 
 var map_OAuth = map[string]string{
-	"": "OAuth holds cluster-wide information about OAuth.  The canonical name is `cluster`. It is used to configure the integrated OAuth server. This configuration is only honored when the top level Authentication config has type set to IntegratedOAuth.",
+	"":       "OAuth holds cluster-wide information about OAuth.  The canonical name is `cluster`. It is used to configure the integrated OAuth server. This configuration is only honored when the top level Authentication config has type set to IntegratedOAuth.",
+	"spec":   "spec holds user settable values for configuration",
+	"status": "status holds observed values from the cluster. They may not be overridden.",
 }
 
 func (OAuth) SwaggerDoc() map[string]string {
@@ -1208,7 +1212,7 @@ func (RequestHeaderIdentityProvider) SwaggerDoc() map[string]string {
 var map_TokenConfig = map[string]string{
 	"":                                    "TokenConfig holds the necessary configuration options for authorization and access tokens",
 	"accessTokenMaxAgeSeconds":            "accessTokenMaxAgeSeconds defines the maximum age of access tokens",
-	"accessTokenInactivityTimeoutSeconds": "accessTokenInactivityTimeoutSeconds defines the default token inactivity timeout for tokens granted by any client. The value represents the maximum amount of time that can occur between consecutive uses of the token. Tokens become invalid if they are not used within this temporal window. The user will need to acquire a new token to regain access once a token times out. Valid values are integer values:\n  x < 0  Tokens time out is enabled but tokens never timeout unless configured per client (e.g. `-1`)\n  x = 0  Tokens time out is disabled (default)\n  x > 0  Tokens time out if there is no activity for x seconds\nThe current minimum allowed value for X is 300 (5 minutes)",
+	"accessTokenInactivityTimeoutSeconds": "accessTokenInactivityTimeoutSeconds - DEPRECATED: setting this field has no effect.",
 }
 
 func (TokenConfig) SwaggerDoc() map[string]string {

--- a/vendor/github.com/openshift/api/operator/v1/0000_20_kube-apiserver-operator_01_config.crd.yaml
+++ b/vendor/github.com/openshift/api/operator/v1/0000_20_kube-apiserver-operator_01_config.crd.yaml
@@ -76,6 +76,13 @@ spec:
                 0 or unset = 5 (default)
               format: int32
               type: integer
+            unknownRevisionLimit:
+              description: unknownRevisionLimit is the number of static pod installer
+                revisions in an unknown state (anything besides failed, succeeded,
+                or inprogress) to keep on disk and in the api. -1 = unlimited, 0 or
+                unset = 5 (default)
+              format: int32
+              type: integer
             unsupportedConfigOverrides:
               description: 'unsupportedConfigOverrides holds a sparse config that
                 will override any previously set options.  It only needs to be the

--- a/vendor/github.com/openshift/api/operator/v1/0000_25_kube-controller-manager-operator_01_config.crd.yaml
+++ b/vendor/github.com/openshift/api/operator/v1/0000_25_kube-controller-manager-operator_01_config.crd.yaml
@@ -78,6 +78,13 @@ spec:
                 0 or unset = 5 (default)
               format: int32
               type: integer
+            unknownRevisionLimit:
+              description: unknownRevisionLimit is the number of static pod installer
+                revisions in an unknown state (anything besides failed, succeeded,
+                or inprogress) to keep on disk and in the api. -1 = unlimited, 0 or
+                unset = 5 (default)
+              format: int32
+              type: integer
             unsupportedConfigOverrides:
               description: 'unsupportedConfigOverrides holds a sparse config that
                 will override any previously set options.  It only needs to be the

--- a/vendor/github.com/openshift/api/operator/v1/0000_25_kube-scheduler-operator_01_config.crd.yaml
+++ b/vendor/github.com/openshift/api/operator/v1/0000_25_kube-scheduler-operator_01_config.crd.yaml
@@ -78,6 +78,13 @@ spec:
                 0 or unset = 5 (default)
               format: int32
               type: integer
+            unknownRevisionLimit:
+              description: unknownRevisionLimit is the number of static pod installer
+                revisions in an unknown state (anything besides failed, succeeded,
+                or inprogress) to keep on disk and in the api. -1 = unlimited, 0 or
+                unset = 5 (default)
+              format: int32
+              type: integer
             unsupportedConfigOverrides:
               description: 'unsupportedConfigOverrides holds a sparse config that
                 will override any previously set options.  It only needs to be the

--- a/vendor/github.com/openshift/api/operator/v1/types.go
+++ b/vendor/github.com/openshift/api/operator/v1/types.go
@@ -177,6 +177,10 @@ type StaticPodOperatorSpec struct {
 	// succeededRevisionLimit is the number of successful static pod installer revisions to keep on disk and in the api
 	// -1 = unlimited, 0 or unset = 5 (default)
 	SucceededRevisionLimit int32 `json:"succeededRevisionLimit,omitempty"`
+	// unknownRevisionLimit is the number of static pod installer revisions in an unknown state (anything besides
+	// failed, succeeded, or inprogress) to keep on disk and in the api.
+	// -1 = unlimited, 0 or unset = 5 (default)
+	UnknownRevisionLimit int32 `json:"unknownRevisionLimit,omitempty"`
 }
 
 // StaticPodOperatorStatus is status for controllers that manage static pods.  There are different needs because individual

--- a/vendor/github.com/openshift/api/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/vendor/github.com/openshift/api/operator/v1/zz_generated.swagger_doc_generated.go
@@ -84,6 +84,7 @@ var map_StaticPodOperatorSpec = map[string]string{
 	"forceRedeploymentReason": "forceRedeploymentReason can be used to force the redeployment of the operand by providing a unique string. This provides a mechanism to kick a previously failed deployment and provide a reason why you think it will work this time instead of failing again on the same config.",
 	"failedRevisionLimit":     "failedRevisionLimit is the number of failed static pod installer revisions to keep on disk and in the api -1 = unlimited, 0 or unset = 5 (default)",
 	"succeededRevisionLimit":  "succeededRevisionLimit is the number of successful static pod installer revisions to keep on disk and in the api -1 = unlimited, 0 or unset = 5 (default)",
+	"unknownRevisionLimit":    "unknownRevisionLimit is the number of static pod installer revisions in an unknown state (anything besides failed, succeeded, or inprogress) to keep on disk and in the api. -1 = unlimited, 0 or unset = 5 (default)",
 }
 
 func (StaticPodOperatorSpec) SwaggerDoc() map[string]string {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -220,7 +220,7 @@ github.com/opencontainers/image-spec/specs-go/v1
 # github.com/opencontainers/runc v0.0.0-20191031171055-b133feaeeb2e
 github.com/opencontainers/runc/libcontainer/system
 github.com/opencontainers/runc/libcontainer/user
-# github.com/openshift/api v0.0.0-20200424083944-0422dc17083e
+# github.com/openshift/api v0.0.0-20200424083944-0422dc17083e => github.com/damemi/api v0.0.0-20200512160453-172279894583
 github.com/openshift/api
 github.com/openshift/api/apps
 github.com/openshift/api/apps/v1


### PR DESCRIPTION
This depends on https://github.com/openshift/api/pull/643

Considers the new `unknownRevisionLimit` field in the static pod operator spec provided by the above PR when calculating revision resources to exclude from pruning. Previously, this just excluded all unknown revisions meaning they were never pruned.