### PR TITLE
Process Secret.StringData when reading manifests

### DIFF
--- a/pkg/operator/resource/resourceread/core.go
+++ b/pkg/operator/resource/resourceread/core.go
@@ -30,7 +30,20 @@ func ReadSecretV1OrDie(objBytes []byte) *corev1.Secret {
 	if err != nil {
 		panic(err)
 	}
-	return requiredObj.(*corev1.Secret)
+
+	secret := requiredObj.(*corev1.Secret)
+	if len(secret.StringData) > 0 {
+		if secret.Data == nil {
+			secret.Data = map[string][]byte{}
+		}
+		for k, v := range secret.StringData {
+			secret.Data[k] = []byte(v)
+		}
+
+		secret.StringData = nil
+	}
+
+	return secret
 }
 
 func ReadNamespaceV1OrDie(objBytes []byte) *corev1.Namespace {


### PR DESCRIPTION
When manifests contain secret with `stringData` we need to merge it into `Data` so any logic can process it in unified way. `ApplySecret` explicitly forbids `stringData` (for obvious apply/DeepEqual issues) 
https://github.com/openshift/library-go/blob/609e1511d2de69e6d84afb1f3e8a5a6b3c805fc2/pkg/operator/resource/resourceapply/core.go#L238-L240

/cc @deads2k 