### PR TITLE
pkg/operator/status/condition: Default to Upgradeable=True AsExpected

### DIFF
--- a/pkg/operator/status/condition.go
+++ b/pkg/operator/status/condition.go
@@ -44,8 +44,13 @@ func UnionCondition(conditionType string, defaultConditionStatus operatorv1.Cond
 
 	unionedCondition := operatorv1.OperatorCondition{Type: conditionType, Status: operatorv1.ConditionUnknown}
 	if len(interestingConditions) == 0 {
-		unionedCondition.Status = operatorv1.ConditionUnknown
-		unionedCondition.Reason = "NoData"
+		if conditionType == "Upgradeable" {
+			unionedCondition.Status = defaultConditionStatus
+			unionedCondition.Reason = "AsExpected"
+		} else {
+			unionedCondition.Status = operatorv1.ConditionUnknown
+			unionedCondition.Reason = "NoData"
+		}
 		return unionedCondition
 	}
 


### PR DESCRIPTION
Having `Unknown` and `NoData` for other conditions is reasonable, because all operators should have strong opinions on `Available`, `Degraded`, and `Progressing`.  But it's possible to have operators which will never set `Upgradeable=False`, and it seems tedious to force them to declare an opinion to avoid a potentially alarming message ("why don't they have data?  Is something broken?").  This commit will get us `Upgradeable=True` `AsExpected` for operators like:

```console
$ JQ='.items[] | .unknown = ([.status.conditions[] | select(.status != "True" and .status != "False") | {type, status, reason}]) | select((.unknown | length) > 0) | .metadata.name + " " + (.unknown | tostring)'
$ curl -s https://storage.googleapis.com/origin-ci-test/logs/release-openshift-origin-installer-launch-aws/11222/artifacts/launch/clusteroperators.json | jq -r "${JQ}"
kube-storage-version-migrator [{"type":"Upgradeable","status":"Unknown","reason":"NoData"}]
openshift-controller-manager [{"type":"Upgradeable","status":"Unknown","reason":"NoData"}]
service-ca [{"type":"Upgradeable","status":"Unknown","reason":"NoData"}]
$ curl -s https://storage.googleapis.com/origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-4.5/2086/artifacts/e2e-aws/clusteroperators.json | jq -r "${JQ}"
kube-storage-version-migrator [{"type":"Upgradeable","status":"Unknown","reason":"NoData"}]
openshift-controller-manager [{"type":"Upgradeable","status":"Unknown","reason":"NoData"}]
service-ca [{"type":"Upgradeable","status":"Unknown","reason":"NoData"}]
```

where the examples are from [a 4.4.3 -> 4.4.4 promotion test][1] and [a 4.5 nightly test][2] respectively.

[1]: https://deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gcs/origin-ci-test/logs/release-openshift-origin-installer-launch-aws/11222
[2]: https://deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gcs/origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-4.5/2086