### PR TITLE
Bug 1812126: double memory resource request and limits values

### DIFF
--- a/pkg/operator/staticpod/controller/installer/bindata/bindata.go
+++ b/pkg/operator/staticpod/controller/installer/bindata/bindata.go
@@ -88,10 +88,10 @@ spec:
           name: kubelet-dir
       resources:
         requests:
-          memory: 100M
+          memory: 200M
           cpu: 150m
         limits:
-          memory: 100M
+          memory: 200M
           cpu: 150m
   restartPolicy: Never
   priorityClassName: system-node-critical

--- a/pkg/operator/staticpod/controller/installer/manifests/installer-pod.yaml
+++ b/pkg/operator/staticpod/controller/installer/manifests/installer-pod.yaml
@@ -32,10 +32,10 @@ spec:
           name: kubelet-dir
       resources:
         requests:
-          memory: 100M
+          memory: 200M
           cpu: 150m
         limits:
-          memory: 100M
+          memory: 200M
           cpu: 150m
   restartPolicy: Never
   priorityClassName: system-node-critical

--- a/pkg/operator/staticpod/controller/prune/bindata/bindata.go
+++ b/pkg/operator/staticpod/controller/prune/bindata/bindata.go
@@ -72,10 +72,10 @@ spec:
     imagePullPolicy: IfNotPresent
     resources:
       requests:
-        memory: 100M
+        memory: 200M
         cpu: 150m
       limits:
-        memory: 100M
+        memory: 200M
         cpu: 150m
     securityContext:
       privileged: true

--- a/pkg/operator/staticpod/controller/prune/manifests/pruner-pod.yaml
+++ b/pkg/operator/staticpod/controller/prune/manifests/pruner-pod.yaml
@@ -16,10 +16,10 @@ spec:
     imagePullPolicy: IfNotPresent
     resources:
       requests:
-        memory: 100M
+        memory: 200M
         cpu: 150m
       limits:
-        memory: 100M
+        memory: 200M
         cpu: 150m
     securityContext:
       privileged: true


### PR DESCRIPTION
Doubling the resource and limits values to avoid installer and pruner pod OOMKills on ppc64le machines