### PR TITLE
factory: add mechanism to allow synthetic requeue without error

### DIFF
--- a/pkg/operator/staticpod/controller/installer/installer_controller.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller.go
@@ -817,7 +817,7 @@ func (c InstallerController) Sync(ctx context.Context, syncCtx factory.SyncConte
 	if err == nil {
 		requeue, syncErr := c.manageInstallationPods(ctx, operatorSpec, operatorStatus, resourceVersion)
 		if requeue && syncErr == nil {
-			return fmt.Errorf("synthetic requeue request")
+			return factory.SyntheticRequeueError
 		}
 		err = syncErr
 	}

--- a/pkg/operator/staticpod/controller/monitoring/monitoring_resource_controller.go
+++ b/pkg/operator/staticpod/controller/monitoring/monitoring_resource_controller.go
@@ -28,8 +28,6 @@ const (
 	manifestDir = "pkg/operator/staticpod/controller/monitoring"
 )
 
-var syntheticRequeueError = fmt.Errorf("synthetic requeue request")
-
 type MonitoringResourceController struct {
 	targetNamespace          string
 	serviceMonitorName       string
@@ -100,7 +98,7 @@ func (c MonitoringResourceController) sync(ctx context.Context, syncCtx factory.
 		// yet (the CRD is provided by prometheus operator). This produce noise and plenty of events.
 		if errors.IsNotFound(serviceMonitorErr) {
 			klog.V(4).Infof("Unable to apply service monitor: %v", err)
-			return syntheticRequeueError
+			return factory.SyntheticRequeueError
 		} else if serviceMonitorErr != nil {
 			errs = append(errs, serviceMonitorErr)
 		}


### PR DESCRIPTION
This change will remove errors like this from the log:

> E0604 15:58:52.824104   14930 base_controller.go:180] "TargetConfigController" controller failed to sync "key", err: synthetic requeue request

Developers can use `factory.SyntheticRequeueError` to trigger this from `sync()`.