### PR TITLE
operatorclient: add metadata methods to interface

### DIFF
--- a/pkg/operator/configobserver/config_observer_controller_test.go
+++ b/pkg/operator/configobserver/config_observer_controller_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes/fake"
 	ktesting "k8s.io/client-go/testing"
@@ -25,6 +26,10 @@ import (
 
 func (c *fakeOperatorClient) Informer() cache.SharedIndexInformer {
 	return nil
+}
+
+func (c *fakeOperatorClient) GetObjectMeta() (*metav1.ObjectMeta, error) {
+	panic("not supported")
 }
 
 func (c *fakeOperatorClient) GetOperatorState() (spec *operatorv1.OperatorSpec, status *operatorv1.OperatorStatus, resourceVersion string, err error) {

--- a/pkg/operator/management/management_state_controller_test.go
+++ b/pkg/operator/management/management_state_controller_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/openshift/library-go/pkg/controller/factory"
@@ -114,6 +115,10 @@ type statusClient struct {
 func (c *statusClient) Informer() cache.SharedIndexInformer {
 	c.t.Log("Informer called")
 	return nil
+}
+
+func (c *statusClient) GetObjectMeta() (*metav1.ObjectMeta, error) {
+	panic("missing")
 }
 
 func (c *statusClient) GetOperatorState() (*operatorv1.OperatorSpec, *operatorv1.OperatorStatus, string, error) {

--- a/pkg/operator/status/status_controller_test.go
+++ b/pkg/operator/status/status_controller_test.go
@@ -355,6 +355,10 @@ func (c *statusClient) Informer() cache.SharedIndexInformer {
 	return nil
 }
 
+func (c *statusClient) GetObjectMeta() (*metav1.ObjectMeta, error) {
+	panic("missing")
+}
+
 func (c *statusClient) GetOperatorState() (*operatorv1.OperatorSpec, *operatorv1.OperatorStatus, string, error) {
 	return &c.spec, &c.status, "", nil
 }

--- a/pkg/operator/v1helpers/interfaces.go
+++ b/pkg/operator/v1helpers/interfaces.go
@@ -2,11 +2,14 @@ package v1helpers
 
 import (
 	operatorv1 "github.com/openshift/api/operator/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 )
 
 type OperatorClient interface {
 	Informer() cache.SharedIndexInformer
+	// GetObjectMeta return the operator metadata.
+	GetObjectMeta() (meta *metav1.ObjectMeta, err error)
 	// GetOperatorState returns the operator spec, status and the resource version, potentially from a lister.
 	GetOperatorState() (spec *operatorv1.OperatorSpec, status *operatorv1.OperatorStatus, resourceVersion string, err error)
 	// UpdateOperatorSpec updates the spec of the operator, assuming the given resource version.

--- a/pkg/operator/v1helpers/test_helpers.go
+++ b/pkg/operator/v1helpers/test_helpers.go
@@ -83,6 +83,10 @@ type fakeStaticPodOperatorClient struct {
 
 func (c *fakeStaticPodOperatorClient) Informer() cache.SharedIndexInformer {
 	return &fakeSharedIndexInformer{}
+
+}
+func (c *fakeStaticPodOperatorClient) GetObjectMeta() (*metav1.ObjectMeta, error) {
+	panic("not supported")
 }
 
 func (c *fakeStaticPodOperatorClient) GetStaticPodOperatorState() (*operatorv1.StaticPodOperatorSpec, *operatorv1.StaticPodOperatorStatus, string, error) {
@@ -199,6 +203,10 @@ type fakeOperatorClient struct {
 
 func (c *fakeOperatorClient) Informer() cache.SharedIndexInformer {
 	return &fakeSharedIndexInformer{}
+}
+
+func (c *fakeOperatorClient) GetObjectMeta() (*metav1.ObjectMeta, error) {
+	panic("not supported")
 }
 
 func (c *fakeOperatorClient) GetOperatorState() (*operatorv1.OperatorSpec, *operatorv1.OperatorStatus, string, error) {


### PR DESCRIPTION
This PR is intended to get more clarification. Will fix the tests once I know the direction.

Use case: we are creating a library to use in CSI operators. This library uses the `genericoperatorclient`. At some point, we need to update the CR status and set the right generation, like it's done here:

https://github.com/openshift/machine-api-operator/blob/5688547505e7963783f04ad0737740cfac4b6457/pkg/controller/machineset/status.go#L85-L89

As a result, I need access to the CR metadata as well (not only spec and status).

@deads2k @sttts could you take a look, please?

My main question is: is it OK to change the `OperatorClient`  interface to get the CR metadata? Or that should be done differently?