### PR TITLE
eventwatch: add controller

### DIFF
--- a/pkg/operator/eventwatch/controller.go
+++ b/pkg/operator/eventwatch/controller.go
@@ -1,0 +1,152 @@
+package eventwatch
+
+import (
+	"context"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/informers"
+	corev1typed "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/klog"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+)
+
+const (
+	// eventAckAnnotationName is an annotation we place on event that was processed by this controller.
+	// This is used to not process same event multiple times.
+	eventAckAnnotationName = "eventwatch.openshift.io/acknowledged"
+)
+
+// Controller observes the events in given informer namespaces and match them with configured event handlers.
+// If the event reason and namespace match the configured, then the process() function is called in handler on that event.
+// The event is then acknowledged via annotation update, so each interesting event is only processed once.
+// The process() function will received the observed event and can update Prometheus counter or manage operator conditions.
+type Controller struct {
+	events      []eventHandler
+	eventClient corev1typed.EventsGetter
+}
+
+type eventHandler struct {
+	reason    string
+	namespace string
+	process   func(event *corev1.Event) error
+}
+
+type Builder struct {
+	eventConfig []eventHandler
+}
+
+// New returns a new event watch controller builder that allow to specify event handlers.
+func New() *Builder {
+	return &Builder{}
+}
+
+// WithEventHandler add handler for event matching the namespace and the reason.
+// This can be called multiple times.
+func (b *Builder) WithEventHandler(namespace, reason string, processEvent func(event *corev1.Event) error) *Builder {
+	b.eventConfig = append(b.eventConfig, eventHandler{
+		reason:    reason,
+		namespace: namespace,
+		process:   processEvent,
+	})
+	return b
+}
+
+// ToController returns a factory controller that can be run.
+// The kubeInformersForTargetNamespace must have informer for namespaces which matching the registered event handlers.
+// The event client is used to update/acknowledge events.
+func (b *Builder) ToController(kubeInformersForTargetNamespace informers.SharedInformerFactory, eventClient corev1typed.EventsGetter, recorder events.Recorder) factory.Controller {
+	c := &Controller{
+		events:      b.eventConfig,
+		eventClient: eventClient,
+	}
+	return factory.New().
+		WithSync(c.sync).
+		WithInformersQueueKeyFunc(func(obj runtime.Object) string {
+			event, ok := obj.(*corev1.Event)
+			if !ok {
+				return ""
+			}
+			return eventKeyFunc(event.Namespace, event.Name, event.Reason)
+		}, kubeInformersForTargetNamespace.Core().V1().Events().Informer()).
+		ToController("EventWatchController", recorder)
+}
+
+func eventKeyFunc(namespace, name, reason string) string {
+	if len(namespace) == 0 || len(name) == 0 || len(reason) == 0 {
+		return ""
+	}
+	return strings.Join([]string{namespace, name, reason}, "/")
+}
+
+func decomposeEventKey(key string) (string, string, string, bool) {
+	parts := strings.Split(key, "/")
+	if len(parts) != 3 {
+		return "", "", "", false
+	}
+	return parts[0], parts[1], parts[2], true
+}
+
+func (c *Controller) getEventHandler(eventKey string) *eventHandler {
+	namespace, _, reason, ok := decomposeEventKey(eventKey)
+	if !ok {
+		return nil
+	}
+	for i := range c.events {
+		if c.events[i].namespace == namespace && c.events[i].reason == reason {
+			return &c.events[i]
+		}
+	}
+	return nil
+}
+
+func isAcknowledgedEvent(e *corev1.Event) bool {
+	if e.Annotations == nil {
+		return false
+	}
+	_, ok := e.Annotations[eventAckAnnotationName]
+	return ok
+}
+
+func (c *Controller) sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	eventHandler := c.getEventHandler(syncCtx.QueueKey())
+	if eventHandler == nil {
+		return nil
+	}
+
+	namespace, name, _, ok := decomposeEventKey(syncCtx.QueueKey())
+	if !ok {
+		klog.Errorf("Unexpected queue key %q", syncCtx.QueueKey())
+		return nil
+	}
+
+	event, err := c.eventClient.Events(namespace).Get(ctx, name, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		klog.Errorf("Event not found %s/%s: %v", namespace, name, err)
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	if isAcknowledgedEvent(event) {
+		return nil
+	}
+
+	// acknowledge the event, so we won't process it multiple times
+	seenEvent := event.DeepCopy()
+	if seenEvent.Annotations == nil {
+		seenEvent.Annotations = map[string]string{}
+	}
+	seenEvent.Annotations[eventAckAnnotationName] = "true"
+	if _, err := c.eventClient.Events(namespace).Update(ctx, seenEvent, metav1.UpdateOptions{}); err != nil {
+		return err
+	}
+
+	return eventHandler.process(event)
+}

--- a/pkg/operator/eventwatch/controller_test.go
+++ b/pkg/operator/eventwatch/controller_test.go
@@ -1,0 +1,170 @@
+package eventwatch
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+
+	"github.com/openshift/library-go/pkg/operator/events"
+)
+
+func TestController(t *testing.T) {
+	tests := []struct {
+		name                 string
+		handlers             []eventHandler
+		sendEvents           func(recorder events.Recorder)
+		expectedEventsKeys   []string
+		expectedProcessCount int
+		evalActions          func(t *testing.T, actions []ktesting.Action)
+	}{
+		{
+			name: "got test reason",
+			handlers: []eventHandler{
+				{
+					reason:    "TestReason",
+					namespace: "test",
+				},
+			},
+			sendEvents: func(recorder events.Recorder) {
+				recorder.Warningf("TestReason", "Test")
+			},
+			expectedProcessCount: 1,
+			expectedEventsKeys: []string{
+				"test/name/TestReason",
+			},
+		},
+		{
+			name: "ignore other events",
+			handlers: []eventHandler{
+				{
+					reason:    "TestReason",
+					namespace: "test",
+				},
+			},
+			sendEvents: func(recorder events.Recorder) {
+				recorder.Warningf("TestReason", "Test")
+				recorder.Warningf("OtherEvent", "Test")
+			},
+			expectedProcessCount: 1,
+			expectedEventsKeys: []string{
+				"test/name/TestReason",
+			},
+		},
+		{
+			name: "test reason event acknowledged",
+			handlers: []eventHandler{
+				{
+					reason:    "TestReason",
+					namespace: "test",
+				},
+			},
+			sendEvents: func(recorder events.Recorder) {
+				recorder.Warningf("TestReason", "Test")
+				recorder.Warningf("TestReason", "Test")
+				recorder.Warningf("TestReason", "Test")
+			},
+			expectedProcessCount: 1,
+			expectedEventsKeys: []string{
+				"test/name/TestReason",
+			},
+			evalActions: func(t *testing.T, actions []ktesting.Action) {
+				acked := false
+				for _, action := range actions {
+					if action.GetVerb() == "update" {
+						update := action.(ktesting.UpdateAction)
+						event, ok := update.GetObject().(*corev1.Event)
+						if ok && event.Reason == "TestReason" && event.Annotations != nil {
+							_, acked = event.Annotations[eventAckAnnotationName]
+						}
+					}
+				}
+				if !acked {
+					t.Errorf("expected event to be acknowledged")
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			eventProcessedChan := make(chan string)
+			b := New()
+
+			processCount := 0
+			var processCountLock sync.Mutex
+			for _, h := range test.handlers {
+				b = b.WithEventHandler(h.namespace, h.reason, func(event *corev1.Event) error {
+					defer func() {
+						processCountLock.Lock()
+						processCount++
+						processCountLock.Unlock()
+					}()
+					var err error
+					if h.process != nil {
+						err = h.process(event)
+					}
+					key := eventKeyFunc(event.Namespace, "name", event.Reason) // name is random
+					if key == "" {
+						close(eventProcessedChan)
+					}
+					eventProcessedChan <- key
+					return err
+				})
+			}
+
+			kubeClient := fake.NewSimpleClientset()
+			eventRecorder := events.NewRecorder(kubeClient.CoreV1().Events("test"), "test-operator", &corev1.ObjectReference{
+				Namespace: "test",
+			})
+			informer := informers.NewSharedInformerFactoryWithOptions(kubeClient, 1*time.Minute, informers.WithNamespace("test"))
+
+			controller := b.ToController(informer, kubeClient.CoreV1(), eventRecorder)
+
+			ctx, shutdown := context.WithCancel(context.Background())
+			defer shutdown()
+
+			informer.Start(ctx.Done())
+			go controller.Run(ctx, 1)
+
+			test.sendEvents(eventRecorder)
+
+			recvKeys := sets.NewString()
+			finish := false
+			for !finish {
+				select {
+				case eventKey := <-eventProcessedChan:
+					recvKeys.Insert(eventKey)
+					if len(test.expectedEventsKeys) == recvKeys.Len() {
+						finish = true
+						break
+					}
+				case <-time.After(30 * time.Second):
+					t.Fatal("timeout")
+				}
+			}
+
+			if !recvKeys.Equal(sets.NewString(test.expectedEventsKeys...)) {
+				t.Errorf("received keys (%#v) does not have all expected keys: %#v", recvKeys.List(), test.expectedEventsKeys)
+			}
+
+			if test.evalActions != nil {
+				test.evalActions(t, kubeClient.Actions())
+			}
+			if test.expectedProcessCount > 0 {
+				processCountLock.Lock()
+				if test.expectedProcessCount != processCount {
+					t.Errorf("expected %d process() calls, got %d", test.expectedProcessCount, processCount)
+				}
+				processCountLock.Unlock()
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
This controller can be used to filter interesting event reasons and take action on them.
For example, this allow to register handler, that will update Prometheus counter when an interesting event is observed (or update operator conditions, etc..).

Example:

```golang
eventwatch.New().WithEventHandler("kube-apiserver", "Reason", func(*corev1.Event) error {
  // prometheusCounter++
  return nil
}).ToController(informers, eventClient, eventRecorder)
```