### PR TITLE
Bug 1845766: Add status code to ErrNotV2Registry

### DIFF
--- a/pkg/image/registryclient/client.go
+++ b/pkg/image/registryclient/client.go
@@ -38,10 +38,11 @@ type RepositoryRetriever interface {
 // ErrNotV2Registry is returned when the server does not report itself as a V2 Docker registry
 type ErrNotV2Registry struct {
 	Registry string
+	Status   string
 }
 
 func (e *ErrNotV2Registry) Error() string {
-	return fmt.Sprintf("endpoint %q does not support v2 API", e.Registry)
+	return fmt.Sprintf("endpoint %q does not support v2 API (got %s)", e.Registry, e.Status)
 }
 
 type AuthHandlersFunc func(transport http.RoundTripper, registry *url.URL, repoName string) []auth.AuthenticationHandler
@@ -260,7 +261,10 @@ func (c *Context) ping(registry url.URL, insecure bool, transport http.RoundTrip
 		case resp.StatusCode == http.StatusUnauthorized, resp.StatusCode == http.StatusForbidden:
 			// v2
 		default:
-			return nil, &ErrNotV2Registry{Registry: registry.String()}
+			return nil, &ErrNotV2Registry{
+				Registry: registry.String(),
+				Status:   resp.Status,
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR adds information about why the client thinks that the registry doesn't support v2 API. The information may be provided back to the registry administrators if the registry is expected to support v2 API, but sometimes the /v2/ endpoint misbehaves.