### PR TITLE
use a hostname in leader election id so we can the leaseholder

### DIFF
--- a/pkg/config/leaderelection/leaderelection.go
+++ b/pkg/config/leaderelection/leaderelection.go
@@ -30,7 +30,13 @@ func ToConfigMapLeaderElection(clientConfig *rest.Config, config configv1.Leader
 	}
 
 	if len(identity) == 0 {
-		identity = string(uuid.NewUUID())
+		if hostname, err := os.Hostname(); err != nil {
+			// on errors, make sure we're unique
+			identity = string(uuid.NewUUID())
+		} else {
+			// add a uniquifier so that two processes on the same host don't accidentally both become active
+			identity = hostname + "_" + string(uuid.NewUUID())
+		}
 	}
 	if len(config.Namespace) == 0 {
 		return leaderelection.LeaderElectionConfig{}, fmt.Errorf("namespace may not be empty")


### PR DESCRIPTION
compare to https://github.com/kubernetes/kubernetes/blob/0d674c4edb3af80a5630223819d9203e43679ba5/cmd/kube-controller-manager/app/controllermanager.go#L264-L270

@jsafrane see if this helps you.

/assign @mfojtik 

