### PR TITLE
move the etcd config observer to library-go

### DIFF
--- a/pkg/operator/configobserver/apiserver/listers.go
+++ b/pkg/operator/configobserver/apiserver/listers.go
@@ -1,0 +1,9 @@
+package apiserver
+
+import (
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+)
+
+type APIServerLister interface {
+	APIServerLister() configlistersv1.APIServerLister
+}

--- a/pkg/operator/configobserver/apiserver/listers_test.go
+++ b/pkg/operator/configobserver/apiserver/listers_test.go
@@ -1,0 +1,23 @@
+package apiserver
+
+import (
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
+	"k8s.io/client-go/tools/cache"
+)
+
+type testLister struct {
+	apiLister configlistersv1.APIServerLister
+}
+
+func (l testLister) APIServerLister() configlistersv1.APIServerLister {
+	return l.apiLister
+}
+
+func (l testLister) ResourceSyncer() resourcesynccontroller.ResourceSyncer {
+	return nil
+}
+
+func (l testLister) PreRunHasSynced() []cache.InformerSynced {
+	return nil
+}

--- a/pkg/operator/configobserver/apiserver/observe_cors_test.go
+++ b/pkg/operator/configobserver/apiserver/observe_cors_test.go
@@ -66,7 +66,7 @@ func TestObserveAdditionalCORSAllowedOrigins(t *testing.T) {
 					}
 				}
 				listers := testLister{
-					lister: configlistersv1.NewAPIServerLister(indexer),
+					apiLister: configlistersv1.NewAPIServerLister(indexer),
 				}
 
 				var gotConfig map[string]interface{}

--- a/pkg/operator/configobserver/apiserver/observe_tlssecurityprofile.go
+++ b/pkg/operator/configobserver/apiserver/observe_tlssecurityprofile.go
@@ -6,23 +6,13 @@ import (
 
 	"k8s.io/klog"
 
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/client-go/tools/cache"
-
 	configv1 "github.com/openshift/api/config/v1"
-	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
-
 	"github.com/openshift/library-go/pkg/crypto"
 	"github.com/openshift/library-go/pkg/operator/configobserver"
 	"github.com/openshift/library-go/pkg/operator/events"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
-
-// APIServerLister lists APIServer information and allows resources to be synced
-type APIServerLister interface {
-	APIServerLister() configlistersv1.APIServerLister
-	PreRunHasSynced() []cache.InformerSynced
-}
 
 // ObserveTLSSecurityProfile observes APIServer.Spec.TLSSecurityProfile field and sets
 // the ServingInfo.MinTLSVersion, ServingInfo.CipherSuites fields of observed config

--- a/pkg/operator/configobserver/apiserver/observe_tlssecurityprofile_test.go
+++ b/pkg/operator/configobserver/apiserver/observe_tlssecurityprofile_test.go
@@ -13,24 +13,8 @@ import (
 
 	"github.com/openshift/library-go/pkg/crypto"
 	"github.com/openshift/library-go/pkg/operator/events"
-	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
 )
 
-type testLister struct {
-	lister configlistersv1.APIServerLister
-}
-
-func (l testLister) APIServerLister() configlistersv1.APIServerLister {
-	return l.lister
-}
-
-func (l testLister) ResourceSyncer() resourcesynccontroller.ResourceSyncer {
-	return nil
-}
-
-func (l testLister) PreRunHasSynced() []cache.InformerSynced {
-	return nil
-}
 func TestObserveTLSSecurityProfile(t *testing.T) {
 	existingTLSVersion := "VersionTLS11"
 	existingCipherSuites := []interface{}{"DES-CBC3-SHA"}
@@ -91,7 +75,7 @@ func TestObserveTLSSecurityProfile(t *testing.T) {
 					}
 				}
 				listers := testLister{
-					lister: configlistersv1.NewAPIServerLister(indexer),
+					apiLister: configlistersv1.NewAPIServerLister(indexer),
 				}
 
 				existingConfig := map[string]interface{}{}

--- a/pkg/operator/configobserver/etcd/OWNERS
+++ b/pkg/operator/configobserver/etcd/OWNERS
@@ -1,0 +1,8 @@
+reviewers:
+  - ironcladlou
+  - hexfusion
+  - retroflexer
+approvers:
+  - ironcladlou
+  - hexfusion
+  - retroflexer

--- a/pkg/operator/configobserver/etcd/listers.go
+++ b/pkg/operator/configobserver/etcd/listers.go
@@ -4,8 +4,8 @@ import (
 	corelistersv1 "k8s.io/client-go/listers/core/v1"
 )
 
-type ConfigmapLister interface {
-	ConfigmapLister() corelistersv1.ConfigMapLister
+type ConfigMapLister interface {
+	ConfigMapLister() corelistersv1.ConfigMapLister
 }
 
 type EndpointsLister interface {

--- a/pkg/operator/configobserver/etcd/listers.go
+++ b/pkg/operator/configobserver/etcd/listers.go
@@ -1,0 +1,13 @@
+package etcd
+
+import (
+	corelistersv1 "k8s.io/client-go/listers/core/v1"
+)
+
+type ConfigmapLister interface {
+	ConfigmapLister() corelistersv1.ConfigMapLister
+}
+
+type EndpointsLister interface {
+	EndpointsLister() corelistersv1.EndpointsLister
+}

--- a/pkg/operator/configobserver/etcd/listers_test.go
+++ b/pkg/operator/configobserver/etcd/listers_test.go
@@ -1,11 +1,15 @@
 package etcd
 
 import (
-	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
-	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
 	corelistersv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
 )
+
+var _ ConfigMapLister = testLister{}
+var _ EndpointsLister = testLister{}
 
 type testLister struct {
 	cmLister corelistersv1.ConfigMapLister
@@ -24,7 +28,7 @@ func (l testLister) PreRunHasSynced() []cache.InformerSynced {
 	return nil
 }
 
-func (l testLister) ConfigmapLister() corelistersv1.ConfigMapLister {
+func (l testLister) ConfigMapLister() corelistersv1.ConfigMapLister {
 	return l.cmLister
 }
 

--- a/pkg/operator/configobserver/etcd/listers_test.go
+++ b/pkg/operator/configobserver/etcd/listers_test.go
@@ -1,0 +1,33 @@
+package etcd
+
+import (
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
+	corelistersv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+type testLister struct {
+	cmLister corelistersv1.ConfigMapLister
+	epLister corelistersv1.EndpointsLister
+}
+
+func (l testLister) APIServerLister() configlistersv1.APIServerLister {
+	return nil
+}
+
+func (l testLister) ResourceSyncer() resourcesynccontroller.ResourceSyncer {
+	return nil
+}
+
+func (l testLister) PreRunHasSynced() []cache.InformerSynced {
+	return nil
+}
+
+func (l testLister) ConfigmapLister() corelistersv1.ConfigMapLister {
+	return l.cmLister
+}
+
+func (l testLister) EndpointsLister() corelistersv1.EndpointsLister {
+	return l.epLister
+}

--- a/pkg/operator/configobserver/etcd/observe_etcd_endpoints.go
+++ b/pkg/operator/configobserver/etcd/observe_etcd_endpoints.go
@@ -1,0 +1,192 @@
+package etcd
+
+import (
+	"fmt"
+	"net"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/openshift/library-go/pkg/operator/configobserver"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const (
+	EtcdEndpointNamespace = "openshift-etcd"
+	etcdEndpointName      = "etcd-endpoints"
+
+	// EtcdEndpointName points to the old host-etcd-2 endpoint applicable for clusters prior to 4.5
+	EtcdEndpointName = "host-etcd-2"
+)
+
+type fallBackObserverFn func(genericListers configobserver.Listers, recorder events.Recorder, currentConfig map[string]interface{}, storageConfigURLsPath []string) (map[string]interface{}, []error)
+
+// ObserveStorageURLs observes the storage config URLs and sets storageConfig field in the observerConfig.
+//  If there is a problem observing the current storage config URLs, then the previously observed storage config URLs will be re-used.
+func ObserveStorageURLs(genericListers configobserver.Listers, recorder events.Recorder, currentConfig map[string]interface{}) (map[string]interface{}, []error) {
+	return innerObserveStorageURLs(innerObserveStorageURLsFromOldEndPoint, genericListers, recorder, currentConfig, []string{"storageConfig", "urls"})
+}
+
+// ObserveStorageURLsToArguments observes the storage config URLs and sets etcd-servers field in observedConfig.apiServerArguments
+//  If there is a problem observing the current storage config URLs, then the previously observed storage config URLs will be re-used.
+func ObserveStorageURLsToArguments(genericListers configobserver.Listers, recorder events.Recorder, currentConfig map[string]interface{}) (map[string]interface{}, []error) {
+	return innerObserveStorageURLs(innerObserveStorageURLsFromOldEndPoint, genericListers, recorder, currentConfig, []string{"apiServerArguments", "etcd-servers"})
+}
+
+func innerObserveStorageURLs(fallbackObserver fallBackObserverFn, genericListers configobserver.Listers, recorder events.Recorder, currentConfig map[string]interface{}, storageConfigURLsPath []string) (ret map[string]interface{}, _ []error) {
+	defer func() {
+		ret = configobserver.Pruned(ret, storageConfigURLsPath)
+	}()
+
+	lister := genericListers.(ConfigmapLister)
+	var errs []error
+
+	previouslyObservedConfig := map[string]interface{}{}
+	currentEtcdURLs, found, err := unstructured.NestedStringSlice(currentConfig, storageConfigURLsPath...)
+	if err != nil {
+		errs = append(errs, err)
+	}
+	if found {
+		if err := unstructured.SetNestedStringSlice(previouslyObservedConfig, currentEtcdURLs, storageConfigURLsPath...); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	var etcdURLs []string
+	etcdEndpoints, err := lister.ConfigmapLister().ConfigMaps(EtcdEndpointNamespace).Get(etcdEndpointName)
+	if errors.IsNotFound(err) {
+		// In clusters prior to 4.5, fall back to reading the old host-etcd-2 endpoint
+		// resource, if possible. In 4.6 we can assume consumers have been updated to
+		// use the configmap, delete the fallback code, and throw an error if the
+		// configmap doesn't exist.
+		observedConfig, fallbackErrors := fallbackObserver(genericListers, recorder, currentConfig, storageConfigURLsPath)
+		if len(fallbackErrors) > 0 {
+			errs = append(errs, fallbackErrors...)
+			return previouslyObservedConfig, append(errs, fmt.Errorf("configmap %s/%s not found, and fallback observer failed", EtcdEndpointNamespace, etcdEndpointName))
+		}
+		return observedConfig, errs
+	}
+	if err != nil {
+		recorder.Warningf("ObserveStorageFailed", "Error getting %s/%s configmap: %v", EtcdEndpointNamespace, etcdEndpointName, err)
+		return previouslyObservedConfig, append(errs, err)
+	}
+
+	// note: etcd bootstrap should never be added to the in-cluster kube-apiserver
+	// this can result in some early pods crashlooping, but ensures that we never contact the bootstrap machine from
+	// the in-cluster kube-apiserver so we can safely teardown out of order.
+
+	for k := range etcdEndpoints.Data {
+		address := etcdEndpoints.Data[k]
+		ip := net.ParseIP(address)
+		if ip == nil {
+			ipErr := fmt.Errorf("configmaps/%s in the %s namespace: %v is not a valid IP address", etcdEndpointName, EtcdEndpointNamespace, address)
+			errs = append(errs, ipErr)
+			continue
+		}
+		// skip placeholder ip addresses used in previous versions where the hostname was used instead
+		if strings.HasPrefix(ip.String(), "192.0.2.") || strings.HasPrefix(ip.String(), "2001:db8:") {
+			// not considered an error
+			continue
+		}
+		// use the canonical representation of the ip address (not original input) when constructing the url
+		if ip.To4() != nil {
+			etcdURLs = append(etcdURLs, fmt.Sprintf("https://%s:2379", ip))
+		} else {
+			etcdURLs = append(etcdURLs, fmt.Sprintf("https://[%s]:2379", ip))
+		}
+	}
+
+	if len(etcdURLs) == 0 {
+		emptyURLErr := fmt.Errorf("configmaps %s/%s: no etcd endpoint addresses found", EtcdEndpointNamespace, etcdEndpointName)
+		recorder.Warning("ObserveStorageFailed", emptyURLErr.Error())
+		return previouslyObservedConfig, append(errs, emptyURLErr)
+	}
+
+	sort.Strings(etcdURLs)
+
+	observedConfig := map[string]interface{}{}
+	if err := unstructured.SetNestedStringSlice(observedConfig, etcdURLs, storageConfigURLsPath...); err != nil {
+		return previouslyObservedConfig, append(errs, err)
+	}
+
+	if !reflect.DeepEqual(currentEtcdURLs, etcdURLs) {
+		recorder.Eventf("ObserveStorageUpdated", "Updated storage urls to %s", strings.Join(etcdURLs, ","))
+	}
+
+	return observedConfig, errs
+}
+
+// innerObserveStorageURLsFromOldEndPoint observes the storage URL config.
+func innerObserveStorageURLsFromOldEndPoint(genericListers configobserver.Listers, recorder events.Recorder, currentConfig map[string]interface{}, storageConfigURLsPath []string) (map[string]interface{}, []error) {
+	lister := genericListers.(EndpointsLister)
+	var errs []error
+
+	previouslyObservedConfig := map[string]interface{}{}
+	currentEtcdURLs, _, err := unstructured.NestedStringSlice(currentConfig, storageConfigURLsPath...)
+	if err != nil {
+		errs = append(errs, err)
+	}
+	if len(currentEtcdURLs) > 0 {
+		if err := unstructured.SetNestedStringSlice(previouslyObservedConfig, currentEtcdURLs, storageConfigURLsPath...); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	observedConfig := map[string]interface{}{}
+
+	var etcdURLs sort.StringSlice
+	etcdEndpoints, err := lister.EndpointsLister().Endpoints(EtcdEndpointNamespace).Get(EtcdEndpointName)
+	if errors.IsNotFound(err) {
+		recorder.Warningf("ObserveStorageFailed", "Required endpoints/%s in the %s namespace not found.", EtcdEndpointName, EtcdEndpointNamespace)
+		errs = append(errs, fmt.Errorf("endpoints/%s in the %s namespace: not found", EtcdEndpointName, EtcdEndpointNamespace))
+		return previouslyObservedConfig, errs
+	}
+	if err != nil {
+		recorder.Warningf("ObserveStorageFailed", "Error getting endpoints/%s in the %s namespace: %v", EtcdEndpointName, EtcdEndpointNamespace, err)
+		errs = append(errs, err)
+		return previouslyObservedConfig, errs
+	}
+
+	for subsetIndex, subset := range etcdEndpoints.Subsets {
+		for addressIndex, address := range subset.Addresses {
+			ip := net.ParseIP(address.IP)
+			if ip == nil {
+				ipErr := fmt.Errorf("endpoints/%s in the %s namespace: subsets[%v]addresses[%v].IP is not a valid IP address", EtcdEndpointName, EtcdEndpointNamespace, subsetIndex, addressIndex)
+				errs = append(errs, ipErr)
+				continue
+			}
+			// skip placeholder ip addresses used in previous versions where the hostname was used instead
+			if strings.HasPrefix(ip.String(), "192.0.2.") || strings.HasPrefix(ip.String(), "2001:db8:") {
+				// not considered an error
+				continue
+			}
+			// use the canonical representation of the ip address (not original input) when constructing the url
+			if ip.To4() != nil {
+				etcdURLs = append(etcdURLs, fmt.Sprintf("https://%s:2379", ip))
+			} else {
+				etcdURLs = append(etcdURLs, fmt.Sprintf("https://[%s]:2379", ip))
+			}
+		}
+	}
+
+	// do not add empty storage urls slice to observed config, we don't want override defaults with an empty slice
+	if len(etcdURLs) > 0 {
+		etcdURLs.Sort()
+		if err := unstructured.SetNestedStringSlice(observedConfig, etcdURLs, storageConfigURLsPath...); err != nil {
+			errs = append(errs, err)
+			return previouslyObservedConfig, errs
+		}
+	} else {
+		err := fmt.Errorf("endpoints/%s in the %s namespace: no etcd endpoint addresses found, falling back to default etcd service", EtcdEndpointName, EtcdEndpointNamespace)
+		recorder.Warningf("ObserveStorageFallback", err.Error())
+		errs = append(errs, err)
+	}
+
+	if !reflect.DeepEqual(currentEtcdURLs, []string(etcdURLs)) {
+		recorder.Eventf("ObserveStorageUpdated", "Updated storage urls to %s", strings.Join(etcdURLs, ","))
+	}
+
+	return observedConfig, errs
+}

--- a/pkg/operator/configobserver/etcd/observe_etcd_endpoints_test.go
+++ b/pkg/operator/configobserver/etcd/observe_etcd_endpoints_test.go
@@ -211,7 +211,7 @@ func TestInnerObserveStorageURLs(t *testing.T) {
 			if tt.fallbackFor == nil {
 				tt.fallbackFor = fallbackFor(nil)
 			}
-			actual, errs := innerObserveStorageURLs(tt.fallbackFor(storageConfigURLsPath...), listers, events.NewInMemoryRecorder("test"), tt.currentConfigFor(storageConfigURLsPath...), storageConfigURLsPath)
+			actual, errs := innerObserveStorageURLs(tt.fallbackFor(storageConfigURLsPath...), false, listers, events.NewInMemoryRecorder("test"), tt.currentConfigFor(storageConfigURLsPath...), storageConfigURLsPath)
 			if tt.expectErrors && len(errs) == 0 {
 				t.Errorf("errors expectedConfigFor")
 			}

--- a/pkg/operator/configobserver/etcd/observe_etcd_endpoints_test.go
+++ b/pkg/operator/configobserver/etcd/observe_etcd_endpoints_test.go
@@ -1,0 +1,447 @@
+package etcd
+
+import (
+	"encoding/base64"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/openshift/library-go/pkg/operator/configobserver"
+	"github.com/openshift/library-go/pkg/operator/events"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/mergepatch"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestObserveStorageURLsAndObserveStorageURLsToArguments(t *testing.T) {
+	tests := []struct {
+		name              string
+		currentConfigFor  func(...string) map[string]interface{}
+		fallback          fallBackObserverFn
+		expectedConfigFor func(...string) map[string]interface{}
+		expectErrors      bool
+		endpoint          *v1.ConfigMap
+	}{
+		{
+			name:              "ValidIPv4",
+			currentConfigFor:  observedConfigFor(withStorageURLFor("https://previous.url:2379")),
+			endpoint:          endpoints(withAddress("10.0.0.1")),
+			expectedConfigFor: observedConfigFor(withStorageURLFor("https://10.0.0.1:2379")),
+		},
+		{
+			name:              "ValidIPv6",
+			currentConfigFor:  observedConfigFor(withStorageURLFor("https://previous.url:2379")),
+			endpoint:          endpoints(withAddress("FE80:CD00:0000:0CDE:1257:0000:211E:729C")),
+			expectedConfigFor: observedConfigFor(withStorageURLFor("https://[fe80:cd00:0:cde:1257:0:211e:729c]:2379")),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, useAPIServerArguments := range []bool{false, true} {
+				indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+				listers := testLister{
+					cmLister: corev1listers.NewConfigMapLister(indexer),
+				}
+				if tt.endpoint != nil {
+					if err := indexer.Add(tt.endpoint); err != nil {
+						t.Fatalf("error adding endpoint to store: %#v", err)
+					}
+				}
+
+				actual := map[string]interface{}{}
+				expected := map[string]interface{}{}
+				errs := []error{}
+				if useAPIServerArguments {
+					actual, errs = ObserveStorageURLsToArguments(listers, events.NewInMemoryRecorder("test"), tt.currentConfigFor("apiServerArguments", "etcd-servers"))
+					expected = tt.expectedConfigFor("apiServerArguments", "etcd-servers")
+				} else {
+					actual, errs = ObserveStorageURLs(listers, events.NewInMemoryRecorder("test"), tt.currentConfigFor("storageConfig", "urls"))
+					expected = tt.expectedConfigFor("storageConfig", "urls")
+				}
+				if tt.expectErrors && len(errs) == 0 {
+					t.Errorf("errors expectedConfigFor")
+				}
+				if !tt.expectErrors && len(errs) != 0 {
+					t.Errorf("unexpected errors: %v", errs)
+				}
+				if !reflect.DeepEqual(actual, expected) {
+					t.Errorf("ObserveStorageURLs() gotObservedConfig = %v, want %v", actual, expected)
+				}
+				if t.Failed() {
+					t.Log("\n" + mergepatch.ToYAMLOrError(actual))
+					for _, err := range errs {
+						t.Log(err)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestInnerObserveStorageURLs(t *testing.T) {
+	tests := []struct {
+		name              string
+		currentConfigFor  func(...string) map[string]interface{}
+		fallbackFor       func(...string) fallBackObserverFn
+		expectedConfigFor func(...string) map[string]interface{}
+		expectErrors      bool
+		endpoint          *v1.ConfigMap
+	}{
+		{
+			name:              "NoConfigMapSuccessfulFallback",
+			currentConfigFor:  observedConfigFor(withStorageURLFor("https://previous.url:2379")),
+			fallbackFor:       fallbackFor(observedConfigFor(withStorageURLFor("https://10.0.0.1:2379"))),
+			expectedConfigFor: observedConfigFor(withStorageURLFor("https://10.0.0.1:2379")),
+			expectErrors:      false,
+		},
+		{
+			name:              "NoConfigMapFailedFallback",
+			currentConfigFor:  observedConfigFor(withStorageURLFor("https://previous.url:2379")),
+			fallbackFor:       fallbackFor(observedConfigFor(withStorageURLFor("https://10.0.0.1:2379")), fmt.Errorf("endpoint not found")),
+			expectedConfigFor: observedConfigFor(withStorageURLFor("https://previous.url:2379")),
+			expectErrors:      true,
+		},
+		{
+			name:              "ValidIPv4",
+			currentConfigFor:  observedConfigFor(withStorageURLFor("https://previous.url:2379")),
+			endpoint:          endpoints(withAddress("10.0.0.1")),
+			expectedConfigFor: observedConfigFor(withStorageURLFor("https://10.0.0.1:2379")),
+		},
+		{
+			name:             "InvalidIPv4",
+			currentConfigFor: observedConfigFor(withStorageURLFor("https://previous.url:2379")),
+			endpoint: endpoints(
+				withAddress("10.0.0.1"),
+				withAddress("192.192.0.2.1"),
+			),
+			expectedConfigFor: observedConfigFor(withStorageURLFor("https://10.0.0.1:2379")),
+			expectErrors:      true,
+		},
+		{
+			name:              "ValidIPv6",
+			currentConfigFor:  observedConfigFor(withStorageURLFor("https://previous.url:2379")),
+			endpoint:          endpoints(withAddress("FE80:CD00:0000:0CDE:1257:0000:211E:729C")),
+			expectedConfigFor: observedConfigFor(withStorageURLFor("https://[fe80:cd00:0:cde:1257:0:211e:729c]:2379")),
+		},
+		{
+			name:             "InvalidIPv6",
+			currentConfigFor: observedConfigFor(withStorageURLFor("https://previous.url:2379")),
+			endpoint: endpoints(
+				withAddress("FE80:CD00:0000:0CDE:1257:0000:211E:729C"),
+				withAddress("FE80:CD00:0000:0CDE:1257:0000:211E:729C:invalid"),
+			),
+			expectedConfigFor: observedConfigFor(withStorageURLFor("https://[fe80:cd00:0:cde:1257:0:211e:729c]:2379")),
+			expectErrors:      true,
+		},
+		{
+			name:             "FakeIPv4",
+			currentConfigFor: observedConfigFor(withStorageURLFor("https://previous.url:2379")),
+			endpoint: endpoints(
+				withAddress("10.0.0.1"),
+				withAddress("192.0.2.1"),
+			),
+			expectedConfigFor: observedConfigFor(withStorageURLFor("https://10.0.0.1:2379")),
+		},
+		{
+			name:             "FakeIPv6",
+			currentConfigFor: observedConfigFor(withStorageURLFor("https://previous.url:2379")),
+			endpoint: endpoints(
+				withAddress("FE80:CD00:0000:0CDE:1257:0000:211E:729C"),
+				withAddress("2001:0DB8:0000:0CDE:1257:0000:211E:729C"),
+			),
+			expectedConfigFor: observedConfigFor(withStorageURLFor("https://[fe80:cd00:0:cde:1257:0:211e:729c]:2379")),
+		},
+		{
+			name:              "ValidIPv4AsIPv6Literal",
+			currentConfigFor:  observedConfigFor(withStorageURLFor("https://previous.url:2379")),
+			endpoint:          endpoints(withAddress("::ffff:a00:1")),
+			expectedConfigFor: observedConfigFor(withStorageURLFor("https://10.0.0.1:2379")),
+		},
+		{
+			name:             "FakeIPv4AsIPv6Literal",
+			currentConfigFor: observedConfigFor(withStorageURLFor("https://previous.url:2379")),
+			endpoint: endpoints(
+				withAddress("FE80:CD00:0000:0CDE:1257:0000:211E:729C"),
+				withAddress("::ffff:c000:201"),
+			),
+			expectedConfigFor: observedConfigFor(withStorageURLFor("https://[fe80:cd00:0:cde:1257:0:211e:729c]:2379")),
+		},
+		{
+			name:              "NoAddressesFound",
+			currentConfigFor:  observedConfigFor(withStorageURLFor("https://previous.url:2379")),
+			endpoint:          endpoints(),
+			expectedConfigFor: observedConfigFor(withStorageURLFor("https://previous.url:2379")),
+			expectErrors:      true,
+		},
+		{
+			name:             "OnlyFakeAddressesFound",
+			currentConfigFor: observedConfigFor(withStorageURLFor("https://previous.url:2379")),
+			endpoint: endpoints(
+				withAddress("192.0.2.1"),
+				withAddress("::ffff:c000:201"),
+			),
+			expectedConfigFor: observedConfigFor(withStorageURLFor("https://previous.url:2379")),
+			expectErrors:      true,
+		},
+		{
+			name:             "IgnoreBootstrap",
+			currentConfigFor: observedConfigFor(withStorageURLFor("https://previous.url:2379")),
+			endpoint: endpoints(
+				withBootstrap("10.0.0.2"),
+				withAddress("10.0.0.1"),
+			),
+			expectedConfigFor: observedConfigFor(withStorageURLFor("https://10.0.0.1:2379")),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			listers := testLister{
+				cmLister: corev1listers.NewConfigMapLister(indexer),
+			}
+			if tt.endpoint != nil {
+				if err := indexer.Add(tt.endpoint); err != nil {
+					t.Fatalf("error adding endpoint to store: %#v", err)
+				}
+			}
+			storageConfigURLsPath := []string{"storageConfig", "urls"}
+			if tt.fallbackFor == nil {
+				tt.fallbackFor = fallbackFor(nil)
+			}
+			actual, errs := innerObserveStorageURLs(tt.fallbackFor(storageConfigURLsPath...), listers, events.NewInMemoryRecorder("test"), tt.currentConfigFor(storageConfigURLsPath...), storageConfigURLsPath)
+			if tt.expectErrors && len(errs) == 0 {
+				t.Errorf("errors expectedConfigFor")
+			}
+			if !tt.expectErrors && len(errs) != 0 {
+				t.Errorf("unexpected errors: %v", errs)
+			}
+
+			expected := map[string]interface{}{}
+			expected = tt.expectedConfigFor(storageConfigURLsPath...)
+			if !reflect.DeepEqual(actual, expected) {
+				t.Errorf("ObserveStorageURLs() gotObservedConfig = %v, want %v", actual, expected)
+			}
+			if t.Failed() {
+				t.Log("\n" + mergepatch.ToYAMLOrError(actual))
+				for _, err := range errs {
+					t.Log(err)
+				}
+			}
+		})
+	}
+}
+
+func TestObserveStorageURLsFromOldEndPoint(t *testing.T) {
+	tests := []struct {
+		name              string
+		currentConfigFor  func(...string) map[string]interface{}
+		expectedConfigFor func(...string) map[string]interface{}
+		expectErrors      bool
+		endpoint          *v1.Endpoints
+	}{
+		{
+			name:              "NoEtcdHosts",
+			currentConfigFor:  observedConfigFor(withStorageURLFor("https://previous.url:2379")),
+			expectedConfigFor: observedConfigFor(withStorageURLFor("https://previous.url:2379")),
+			expectErrors:      true,
+		},
+		{
+			name:              "ValidIPv4",
+			currentConfigFor:  observedConfigFor(withStorageURLFor("https://previous.url:2379")),
+			endpoint:          endpointsOld(withAddressOld("test", "10.0.0.1")),
+			expectedConfigFor: observedConfigFor(withStorageURLFor("https://10.0.0.1:2379")),
+		},
+		{
+			name:             "InvalidIPv4",
+			currentConfigFor: observedConfigFor(withStorageURLFor("https://previous.url:2379")),
+			endpoint: endpointsOld(
+				withAddressOld("test-0", "10.0.0.1"),
+				withAddressOld("test-1", "192.192.0.2.1"),
+			),
+			expectedConfigFor: observedConfigFor(withStorageURLFor("https://10.0.0.1:2379")),
+			expectErrors:      true,
+		},
+		{
+			name:              "ValidIPv6",
+			currentConfigFor:  observedConfigFor(withStorageURLFor("https://previous.url:2379")),
+			endpoint:          endpointsOld(withAddressOld("test", "FE80:CD00:0000:0CDE:1257:0000:211E:729C")),
+			expectedConfigFor: observedConfigFor(withStorageURLFor("https://[fe80:cd00:0:cde:1257:0:211e:729c]:2379")),
+		},
+		{
+			name:             "InvalidIPv6",
+			currentConfigFor: observedConfigFor(withStorageURLFor("https://previous.url:2379")),
+			endpoint: endpointsOld(
+				withAddressOld("test-0", "FE80:CD00:0000:0CDE:1257:0000:211E:729C"),
+				withAddressOld("test-1", "FE80:CD00:0000:0CDE:1257:0000:211E:729C:invalid"),
+			),
+			expectedConfigFor: observedConfigFor(withStorageURLFor("https://[fe80:cd00:0:cde:1257:0:211e:729c]:2379")),
+			expectErrors:      true,
+		},
+		{
+			name:             "FakeIPv4",
+			currentConfigFor: observedConfigFor(withStorageURLFor("https://previous.url:2379")),
+			endpoint: endpointsOld(
+				withAddressOld("test-0", "10.0.0.1"),
+				withAddressOld("test-1", "192.0.2.1"),
+			),
+			expectedConfigFor: observedConfigFor(withStorageURLFor("https://10.0.0.1:2379")),
+		},
+		{
+			name:             "FakeIPv6",
+			currentConfigFor: observedConfigFor(withStorageURLFor("https://previous.url:2379")),
+			endpoint: endpointsOld(
+				withAddressOld("test-0", "FE80:CD00:0000:0CDE:1257:0000:211E:729C"),
+				withAddressOld("test-1", "2001:0DB8:0000:0CDE:1257:0000:211E:729C"),
+			),
+			expectedConfigFor: observedConfigFor(withStorageURLFor("https://[fe80:cd00:0:cde:1257:0:211e:729c]:2379")),
+		},
+		{
+			name:              "ValidIPv4AsIPv6Literal",
+			currentConfigFor:  observedConfigFor(withStorageURLFor("https://previous.url:2379")),
+			endpoint:          endpointsOld(withAddressOld("test", "::ffff:a00:1")),
+			expectedConfigFor: observedConfigFor(withStorageURLFor("https://10.0.0.1:2379")),
+		},
+		{
+			name:             "FakeIPv4AsIPv6Literal",
+			currentConfigFor: observedConfigFor(withStorageURLFor("https://previous.url:2379")),
+			endpoint: endpointsOld(
+				withAddressOld("test-0", "FE80:CD00:0000:0CDE:1257:0000:211E:729C"),
+				withAddressOld("test-1", "::ffff:c000:201"),
+			),
+			expectedConfigFor: observedConfigFor(withStorageURLFor("https://[fe80:cd00:0:cde:1257:0:211e:729c]:2379")),
+		},
+		{
+			name:              "NoAddressesFound",
+			currentConfigFor:  observedConfigFor(withStorageURLFor("https://previous.url:2379")),
+			endpoint:          endpointsOld(),
+			expectedConfigFor: observedConfigFor(),
+			expectErrors:      true,
+		},
+		{
+			name:             "OnlyFakeAddressesFound",
+			currentConfigFor: observedConfigFor(withStorageURLFor("https://previous.url:2379")),
+			endpoint: endpointsOld(
+				withAddressOld("test-0", "192.0.2.1"),
+				withAddressOld("test-1", "::ffff:c000:201"),
+			),
+			expectedConfigFor: observedConfigFor(),
+			expectErrors:      true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			lister := testLister{
+				epLister: corev1listers.NewEndpointsLister(indexer),
+			}
+			if tt.endpoint != nil {
+				if err := indexer.Add(tt.endpoint); err != nil {
+					t.Fatalf("error adding endpoint to store: %#v", err)
+				}
+			}
+			storageConfigURLsPath := []string{"storageConfig", "urls"}
+			actual, errs := innerObserveStorageURLsFromOldEndPoint(lister, events.NewInMemoryRecorder("test"), tt.currentConfigFor(storageConfigURLsPath...), storageConfigURLsPath)
+			if tt.expectErrors && len(errs) == 0 {
+				t.Errorf("errors expectedConfigFor")
+			}
+			if !tt.expectErrors && len(errs) != 0 {
+				t.Errorf("unexpected errors: %v", errs)
+			}
+			expected := map[string]interface{}{}
+			expected = tt.expectedConfigFor(storageConfigURLsPath...)
+			if !reflect.DeepEqual(actual, expected) {
+				t.Errorf("ObserveStorageURLs() gotObservedConfig = %v, want %v", actual, expected)
+			}
+			if t.Failed() {
+				t.Log("\n" + mergepatch.ToYAMLOrError(actual))
+				for _, err := range errs {
+					t.Log(err)
+				}
+			}
+		})
+	}
+}
+
+func observedConfigFor(configs ...func(map[string]interface{}, ...string)) func(...string) map[string]interface{} {
+	return func(fields ...string) map[string]interface{} {
+		observedConfig := map[string]interface{}{}
+		for _, config := range configs {
+			config(observedConfig, fields...)
+		}
+		return observedConfig
+	}
+}
+
+func withStorageURLFor(url string) func(map[string]interface{}, ...string) {
+	return func(observedConfig map[string]interface{}, fields ...string) {
+		urls, _, _ := unstructured.NestedStringSlice(observedConfig, fields...)
+		urls = append(urls, url)
+		_ = unstructured.SetNestedStringSlice(observedConfig, urls, fields...)
+	}
+}
+
+func endpoints(configs ...func(endpoints *v1.ConfigMap)) *v1.ConfigMap {
+	endpoints := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "etcd-endpoints",
+			Namespace: "openshift-etcd",
+		},
+		Data: map[string]string{},
+	}
+	for _, config := range configs {
+		config(endpoints)
+	}
+	return endpoints
+}
+
+func withBootstrap(ip string) func(*v1.ConfigMap) {
+	return func(endpoints *v1.ConfigMap) {
+		if endpoints.Annotations == nil {
+			endpoints.Annotations = map[string]string{}
+		}
+		endpoints.Annotations["alpha.installer.openshift.io/etcd-bootstrap"] = ip
+	}
+}
+
+func withAddress(ip string) func(*v1.ConfigMap) {
+	return func(endpoints *v1.ConfigMap) {
+		endpoints.Data[base64.StdEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(ip))] = ip
+	}
+}
+
+func fallbackFor(observedFn func(...string) map[string]interface{}, errs ...error) func(...string) fallBackObserverFn {
+	return func(fields ...string) fallBackObserverFn {
+		return func(genericListers configobserver.Listers, recorder events.Recorder, currentConfig map[string]interface{}, storageConfigURLsPath []string) (map[string]interface{}, []error) {
+			return observedFn(fields...), errs
+		}
+	}
+}
+
+func endpointsOld(configs ...func(endpoints *v1.Endpoints)) *v1.Endpoints {
+	endpoints := &v1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "host-etcd-2",
+			Namespace: "openshift-etcd",
+			Annotations: map[string]string{
+				"alpha.installer.openshift.io/dns-suffix": "foo.bar",
+			},
+		},
+		Subsets: []v1.EndpointSubset{{Addresses: []v1.EndpointAddress{}}},
+	}
+	for _, config := range configs {
+		config(endpoints)
+	}
+	return endpoints
+}
+
+func withAddressOld(hostname, ip string) func(*v1.Endpoints) {
+	return func(endpoints *v1.Endpoints) {
+		endpoints.Subsets[0].Addresses = append(endpoints.Subsets[0].Addresses, v1.EndpointAddress{
+			Hostname: hostname,
+			IP:       ip,
+		})
+	}
+}


### PR DESCRIPTION
this PR moves existing observer to the shared library as it will be used by CAO and OAS-O.

I slightly changed the code so that it supports passing a custom path under which the configuration will be saved.