### PR TITLE
NewNestedConfigObserver controller

### DIFF
--- a/pkg/operator/configobserver/config_observer_controller.go
+++ b/pkg/operator/configobserver/config_observer_controller.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/imdario/mergo"
@@ -13,6 +14,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/tools/cache"
@@ -45,8 +47,11 @@ type ConfigObserver struct {
 	observers []ObserveConfigFunc
 
 	operatorClient v1helpers.OperatorClient
+
 	// listers are used by config observers to retrieve necessary resources
 	listers Listers
+
+	nestedConfigPath []string
 }
 
 func NewConfigObserver(
@@ -56,10 +61,48 @@ func NewConfigObserver(
 	informers []factory.Informer,
 	observers ...ObserveConfigFunc,
 ) factory.Controller {
+	return NewNestedConfigObserver(
+		operatorClient,
+		eventRecorder,
+		listers,
+		informers,
+		nil,
+		observers...,
+	)
+}
+
+// NewNestedConfigObserver creates a config observer that watches changes to a nested field (nestedConfigPath) in the config.
+// Useful when the config is shared across multiple controllers in the same process.
+//
+// Example:
+//
+// Given the following configuration, you could run two separate controllers and point each to its own section.
+// The first controller would be responsible for "oauthAPIServer" and the second for "oauthServer" section.
+//
+// "observedConfig": {
+//   "oauthAPIServer": {
+//     "apiServerArguments": {"tls-min-version": "VersionTLS12"}
+//   },
+//   "oauthServer": {
+//     "corsAllowedOrigins": [ "//127\\.0\\.0\\.1(:|$)","//localhost(:|$)"]
+//   }
+// }
+//
+// oauthAPIController    := NewNestedConfigObserver(..., []string{"oauthAPIServer"}
+// oauthServerController := NewNestedConfigObserver(..., []string{"oauthServer"}
+func NewNestedConfigObserver(
+	operatorClient v1helpers.OperatorClient,
+	eventRecorder events.Recorder,
+	listers Listers,
+	informers []factory.Informer,
+	nestedConfigPath []string,
+	observers ...ObserveConfigFunc,
+) factory.Controller {
 	c := &ConfigObserver{
-		operatorClient: operatorClient,
-		observers:      observers,
-		listers:        listers,
+		operatorClient:   operatorClient,
+		observers:        observers,
+		listers:          listers,
+		nestedConfigPath: nestedConfigPath,
 	}
 
 	return factory.New().ResyncEvery(time.Second).WithSync(c.sync).WithInformers(append(informers, listersToInformer(listers)...)...).ToController("ConfigObserver", eventRecorder.WithComponentSuffix("config-observer"))
@@ -107,14 +150,8 @@ func (c ConfigObserver) sync(ctx context.Context, syncCtx factory.SyncContext) e
 		errs = append(errs, errors.New("non-deterministic config observation detected"))
 	}
 
-	if !equality.Semantic.DeepEqual(existingConfig, mergedObservedConfig) {
-		syncCtx.Recorder().Eventf("ObservedConfigChanged", "Writing updated observed config: %v", diff.ObjectDiff(existingConfig, mergedObservedConfig))
-		if _, _, err := v1helpers.UpdateSpec(c.operatorClient, v1helpers.UpdateObservedConfigFn(mergedObservedConfig)); err != nil {
-			// At this point we failed to write the updated config. If we are permanently broken, do not pile the errors from observers
-			// but instead reset the errors and only report single error condition.
-			errs = []error{fmt.Errorf("error writing updated observed config: %v", err)}
-			syncCtx.Recorder().Warningf("ObservedConfigWriteError", "Failed to write observed config: %v", err)
-		}
+	if err := c.updateObservedConfig(syncCtx, existingConfig, mergedObservedConfig); err != nil {
+		errs = []error{err}
 	}
 	configError := v1helpers.NewMultiLineAggregate(errs)
 
@@ -133,6 +170,57 @@ func (c ConfigObserver) sync(ctx context.Context, syncCtx factory.SyncContext) e
 	}
 
 	return configError
+}
+
+func (c ConfigObserver) updateObservedConfig(syncCtx factory.SyncContext, existingConfig map[string]interface{}, mergedObservedConfig map[string]interface{}) error {
+	if len(c.nestedConfigPath) == 0 {
+		if !equality.Semantic.DeepEqual(existingConfig, mergedObservedConfig) {
+			syncCtx.Recorder().Eventf("ObservedConfigChanged", "Writing updated observed config: %v", diff.ObjectDiff(existingConfig, mergedObservedConfig))
+			return c.updateConfig(syncCtx, mergedObservedConfig, v1helpers.UpdateObservedConfigFn)
+		}
+		return nil
+	}
+
+	existingConfigNested, _, err := unstructured.NestedMap(existingConfig, c.nestedConfigPath...)
+	if err != nil {
+		return fmt.Errorf("unable to extract the config under %v key, err %v", c.nestedConfigPath, err)
+	}
+	mergedObservedConfigNested, _, err := unstructured.NestedMap(mergedObservedConfig, c.nestedConfigPath...)
+	if err != nil {
+		return fmt.Errorf("unable to extract the merged config under %v, err %v", c.nestedConfigPath, err)
+	}
+	if !equality.Semantic.DeepEqual(existingConfigNested, mergedObservedConfigNested) {
+		syncCtx.Recorder().Eventf("ObservedConfigChanged", "Writing updated section (%q) of observed config: %q", strings.Join(c.nestedConfigPath, "/"), diff.ObjectDiff(existingConfigNested, mergedObservedConfigNested))
+		return c.updateConfig(syncCtx, mergedObservedConfigNested, c.updateNestedConfigHelper)
+	}
+	return nil
+}
+
+type updateObservedConfigFn func(config map[string]interface{}) v1helpers.UpdateOperatorSpecFunc
+
+func (c ConfigObserver) updateConfig(syncCtx factory.SyncContext, updatedMaybeNestedConfig map[string]interface{}, updateConfigHelper updateObservedConfigFn) error {
+	if _, _, err := v1helpers.UpdateSpec(c.operatorClient, updateConfigHelper(updatedMaybeNestedConfig)); err != nil {
+		// At this point we failed to write the updated config. If we are permanently broken, do not pile the errors from observers
+		// but instead reset the errors and only report single error condition.
+		syncCtx.Recorder().Warningf("ObservedConfigWriteError", "Failed to write observed config: %v", err)
+		return fmt.Errorf("error writing updated observed config: %v", err)
+	}
+	return nil
+}
+
+// updateNestedConfigHelper returns a helper function for updating the nested config.
+func (c ConfigObserver) updateNestedConfigHelper(updatedNestedConfig map[string]interface{}) v1helpers.UpdateOperatorSpecFunc {
+	return func(currentSpec *operatorv1.OperatorSpec) error {
+		existingConfig := map[string]interface{}{}
+		if err := json.NewDecoder(bytes.NewBuffer(currentSpec.ObservedConfig.Raw)).Decode(&existingConfig); err != nil {
+			klog.V(4).Infof("decode of existing config failed with error: %v", err)
+		}
+		if err := unstructured.SetNestedField(existingConfig, updatedNestedConfig, c.nestedConfigPath...); err != nil {
+			return fmt.Errorf("unable to set the nested (%q) observed config: %v", strings.Join(c.nestedConfigPath, "/"), err)
+		}
+		currentSpec.ObservedConfig = runtime.RawExtension{Object: &unstructured.Unstructured{Object: existingConfig}}
+		return nil
+	}
 }
 
 // listersToInformer converts the Listers interface to informer with empty AddEventHandler as we only care about synced caches in the Run.
@@ -156,8 +244,7 @@ func (l *listerInformer) HasSynced() bool {
 	return l.cacheSynced()
 }
 
-// WithPrefix adds a prefix to the path the input observer would otherwise
-// observe into
+// WithPrefix adds a prefix to the path the input observer would otherwise observe into
 func WithPrefix(observer ObserveConfigFunc, prefix ...string) ObserveConfigFunc {
 	if len(prefix) == 0 {
 		return observer


### PR DESCRIPTION
This PR adds `NewNestedConfigObserver` controller that creates a config observer that watches changes to a nested field (nestedConfigPath) in the config.

The new function is useful when the config is shared across multiple controllers in the same process.


For example, passing `operandOne` in the `nestedConfigPath` argument will create a controller that watches only values stored under that path.

```
"operandOne": {
 "foo": "one",
 "bar": "two",
 "baz": "three"
 },
 "operandTwo": {
  "foo1": "one",
  "bar1": "two",
  "baz1": "three"
 }
}`
``