### PR TITLE
CSI: Accept custom instance name

### DIFF
--- a/pkg/operator/csi/csicontrollerset/csi_controller_set.go
+++ b/pkg/operator/csi/csicontrollerset/csi_controller_set.go
@@ -134,6 +134,7 @@ func (c *CSIControllerSet) WithCredentialsRequestController(
 // WithCSIDriverController returns a *ControllerSet with a CSI Driver controller initialized.
 func (c *CSIControllerSet) WithCSIDriverController(
 	name string,
+	configName string,
 	csiDriverName string,
 	csiDriverNamespace string,
 	assetFunc func(string) []byte,
@@ -145,6 +146,7 @@ func (c *CSIControllerSet) WithCSIDriverController(
 		name,
 		csiDriverName,
 		csiDriverNamespace,
+		configName,
 		c.operatorClient,
 		assetFunc,
 		kubeClient,

--- a/pkg/operator/csi/csidrivercontroller/csi_driver_controller.go
+++ b/pkg/operator/csi/csidrivercontroller/csi_driver_controller.go
@@ -32,8 +32,6 @@ const (
 	nodeDriverRegistrarImageEnvName = "NODE_DRIVER_REGISTRAR_IMAGE"
 	livenessProbeImageEnvName       = "LIVENESS_PROBE_IMAGE"
 
-	globalConfigName = "cluster"
-
 	maxRetries = 15
 )
 
@@ -95,6 +93,7 @@ type CSIDriverController struct {
 
 	// Resources
 	kubeClient     kubernetes.Interface
+	configName     string
 	operatorClient v1helpers.OperatorClient
 }
 
@@ -115,6 +114,7 @@ func NewCSIDriverController(
 	name string,
 	csiDriverName string,
 	csiDriverNamespace string,
+	instanceName string,
 	operatorClient v1helpers.OperatorClient,
 	assetFunc func(string) []byte,
 	kubeClient kubernetes.Interface,
@@ -125,6 +125,7 @@ func NewCSIDriverController(
 		csiDriverName:      csiDriverName,
 		csiDriverNamespace: csiDriverNamespace,
 		kubeClient:         kubeClient,
+		configName:         instanceName,
 		operatorClient:     operatorClient,
 		assetFunc:          assetFunc,
 		images:             imagesFromEnv(),
@@ -303,7 +304,7 @@ func (c *CSIDriverController) handleSync(
 }
 
 func (c *CSIDriverController) enqueue(obj interface{}) {
-	c.queue.Add(globalConfigName)
+	c.queue.Add(c.configName)
 }
 
 func (c *CSIDriverController) eventHandler(kind string) cache.ResourceEventHandler {

--- a/pkg/operator/csi/csidrivercontroller/csi_driver_controller_test.go
+++ b/pkg/operator/csi/csidrivercontroller/csi_driver_controller_test.go
@@ -124,6 +124,7 @@ func newOperator(test testCase, t *testing.T) *testContext {
 		controllerName,
 		operandName,
 		operandNamespace,
+		"cluster",
 		fakeOperatorClient,
 		makeFakeManifest,
 		coreClient,
@@ -714,7 +715,7 @@ func TestSync(t *testing.T) {
 			if test.expectedObjects.driver != nil {
 				_, actualStatus, _, err := ctx.operatorClient.GetOperatorState()
 				if err != nil {
-					t.Errorf("Failed to get Driver %s: %v", globalConfigName, err)
+					t.Errorf("Failed to get Driver %s: %v", ctx.controller.configName, err)
 				}
 				sanitizeInstanceStatus(actualStatus)
 				sanitizeInstanceStatus(&test.expectedObjects.driver.Status)

--- a/pkg/operator/genericoperatorclient/dynamic_operator_client.go
+++ b/pkg/operator/genericoperatorclient/dynamic_operator_client.go
@@ -2,6 +2,7 @@ package genericoperatorclient
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"strings"
 	"time"
@@ -20,9 +21,9 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-const globalConfigName = "cluster"
+const defaultConfigName = "cluster"
 
-func NewClusterScopedOperatorClient(config *rest.Config, gvr schema.GroupVersionResource) (v1helpers.OperatorClient, dynamicinformer.DynamicSharedInformerFactory, error) {
+func newClusterScopedOperatorClient(config *rest.Config, gvr schema.GroupVersionResource) (*dynamicOperatorClient, dynamicinformer.DynamicSharedInformerFactory, error) {
 	dynamicClient, err := dynamic.NewForConfig(config)
 	if err != nil {
 		return nil, nil, err
@@ -38,9 +39,33 @@ func NewClusterScopedOperatorClient(config *rest.Config, gvr schema.GroupVersion
 	}, informers, nil
 }
 
+func NewClusterScopedOperatorClient(config *rest.Config, gvr schema.GroupVersionResource) (v1helpers.OperatorClient, dynamicinformer.DynamicSharedInformerFactory, error) {
+	d, informers, err := newClusterScopedOperatorClient(config, gvr)
+	if err != nil {
+		return nil, nil, err
+	}
+	d.configName = defaultConfigName
+	return d, informers, nil
+
+}
+
+func NewClusterScopedOperatorClientWithConfigName(config *rest.Config, gvr schema.GroupVersionResource, configName string) (v1helpers.OperatorClient, dynamicinformer.DynamicSharedInformerFactory, error) {
+	if len(configName) < 1 {
+		return nil, nil, fmt.Errorf("config name cannot be empty")
+	}
+	d, informers, err := newClusterScopedOperatorClient(config, gvr)
+	if err != nil {
+		return nil, nil, err
+	}
+	d.configName = configName
+	return d, informers, nil
+
+}
+
 type dynamicOperatorClient struct {
-	informer informers.GenericInformer
-	client   dynamic.ResourceInterface
+	configName string
+	informer   informers.GenericInformer
+	client     dynamic.ResourceInterface
 }
 
 func (c dynamicOperatorClient) Informer() cache.SharedIndexInformer {
@@ -48,7 +73,7 @@ func (c dynamicOperatorClient) Informer() cache.SharedIndexInformer {
 }
 
 func (c dynamicOperatorClient) GetObjectMeta() (*metav1.ObjectMeta, error) {
-	uncastInstance, err := c.informer.Lister().Get(globalConfigName)
+	uncastInstance, err := c.informer.Lister().Get(c.configName)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +82,7 @@ func (c dynamicOperatorClient) GetObjectMeta() (*metav1.ObjectMeta, error) {
 }
 
 func (c dynamicOperatorClient) GetOperatorState() (*operatorv1.OperatorSpec, *operatorv1.OperatorStatus, string, error) {
-	uncastInstance, err := c.informer.Lister().Get(globalConfigName)
+	uncastInstance, err := c.informer.Lister().Get(c.configName)
 	if err != nil {
 		return nil, nil, "", err
 	}
@@ -79,7 +104,7 @@ func (c dynamicOperatorClient) GetOperatorState() (*operatorv1.OperatorSpec, *op
 // in operatorv1.OperatorSpec while preserving pre-existing spec fields that have
 // no correspondence in operatorv1.OperatorSpec.
 func (c dynamicOperatorClient) UpdateOperatorSpec(resourceVersion string, spec *operatorv1.OperatorSpec) (*operatorv1.OperatorSpec, string, error) {
-	uncastOriginal, err := c.informer.Lister().Get(globalConfigName)
+	uncastOriginal, err := c.informer.Lister().Get(c.configName)
 	if err != nil {
 		return nil, "", err
 	}
@@ -107,7 +132,7 @@ func (c dynamicOperatorClient) UpdateOperatorSpec(resourceVersion string, spec *
 // in operatorv1.OperatorStatus while preserving pre-existing status fields that have
 // no correspondence in operatorv1.OperatorStatus.
 func (c dynamicOperatorClient) UpdateOperatorStatus(resourceVersion string, status *operatorv1.OperatorStatus) (*operatorv1.OperatorStatus, error) {
-	uncastOriginal, err := c.informer.Lister().Get(globalConfigName)
+	uncastOriginal, err := c.informer.Lister().Get(c.configName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
PR https://github.com/oVirt/csi-driver-operator/pull/12/files landed, so the CSI Driver controller needs to react to a different resource: `clustercsidrivers`. In addition to that, the controller should only react if the CR has a certain name.

CC @openshift/storage 