### PR TITLE
config/clusteroperator: add etcd revision resource

### DIFF
--- a/pkg/config/clusteroperator/revisionresource/etcd/etcd.go
+++ b/pkg/config/clusteroperator/revisionresource/etcd/etcd.go
@@ -1,0 +1,41 @@
+package etcd
+
+import (
+	"github.com/openshift/library-go/pkg/operator/staticpod/controller/revision"
+)
+
+// RevisionConfigMaps is a list of configmaps that are directly copied for the current values.  A different actor/controller modifies these.
+// the first element should be the configmap that contains the static pod manifest
+var RevisionConfigMaps = []revision.RevisionResource{
+	{Name: "etcd-pod"},
+
+	{Name: "config"},
+	{Name: "etcd-serving-ca"},
+	{Name: "etcd-peer-client-ca"},
+	{Name: "etcd-metrics-proxy-serving-ca"},
+	{Name: "etcd-metrics-proxy-client-ca"},
+}
+
+// RevisionSecrets is a list of secrets that are directly copied for the current values.  A different actor/controller modifies these.
+var RevisionSecrets = []revision.RevisionResource{
+	{Name: "etcd-all-peer"},
+	{Name: "etcd-all-serving"},
+	{Name: "etcd-all-serving-metrics"},
+}
+
+var CertConfigMaps = []revision.RevisionResource{
+	{Name: "restore-etcd-pod"},
+	{Name: "etcd-scripts"},
+	{Name: "etcd-serving-ca"},
+	{Name: "etcd-peer-client-ca"},
+	{Name: "etcd-metrics-proxy-serving-ca"},
+	{Name: "etcd-metrics-proxy-client-ca"},
+}
+
+var CertSecrets = []revision.RevisionResource{
+	// these are also copied to certs to have a constant file location so we can refer to them in various recovery scripts
+	// and in the PDB
+	{Name: "etcd-all-peer"},
+	{Name: "etcd-all-serving"},
+	{Name: "etcd-all-serving-metrics"},
+}


### PR DESCRIPTION
usecase: for disaster recovery and in general it is important to have an expected list of resources that should be found in each revision for each static pod operator. By moving these definitions to library-go we can import without needing to add operators as dependencies directly.