### PR TITLE
Fixed PostStartHook execution

### DIFF
--- a/pkg/controller/factory/factory.go
+++ b/pkg/controller/factory/factory.go
@@ -197,6 +197,7 @@ func (f *Factory) ToController(name string, eventRecorder events.Recorder) Contr
 		resyncSchedules:    cronSchedules,
 		cachesToSync:       append([]cache.InformerSynced{}, f.cachesToSync...),
 		syncContext:        ctx,
+		postStartHooks:     f.postStartHooks,
 	}
 
 	for i := range f.informerQueueKeys {


### PR DESCRIPTION
I noticed `factory.New().WithPostStartHooks(foo)` does not do anything useful.

The hooks must be copied to newly created Controller, so the Controller can actually find them when their time comes.