### PR TITLE
add installer args to revision-status

### DIFF
--- a/pkg/operator/revisioncontroller/revision_controller.go
+++ b/pkg/operator/revisioncontroller/revision_controller.go
@@ -199,8 +199,9 @@ func (c RevisionController) createNewRevision(recorder events.Recorder, revision
 			Name:      nameFor("revision-status", revision),
 		},
 		Data: map[string]string{
-			"status":   prune.StatusInProgress,
-			"revision": fmt.Sprintf("%d", revision),
+			"status":        prune.StatusInProgress,
+			"revision":      fmt.Sprintf("%d", revision),
+			"installerArgs": prune.StatusInProgress,
 		},
 	}
 	statusConfigMap, _, err := resourceapply.ApplyConfigMap(c.configMapGetter, recorder, statusConfigMap)


### PR DESCRIPTION
When a new static pod revision is created, the args artifacts which are passed to the installer essentially allow for the revision to be recreated.

Currently in DR we backup the static pod resources persisted to disk. While this is effective it requires a hostMount and adds some complexity understanding which revision is the latest and if it was a success. By having access to the args that were passed to the revision we can use the installer to replay the revision in a container.

This work is part of BackupConfigController design.

ref: https://github.com/openshift/enhancements/pull/415

proof: https://github.com/openshift/cluster-etcd-operator/pull/408