### PR TITLE
tweak EnsureAtMostOnePodPerNode method

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,6 @@ require (
 	github.com/gonum/lapack v0.0.0-20181123203213-e4cdc5a0bff9 // indirect
 	github.com/gonum/matrix v0.0.0-20181209220409-c518dec07be9 // indirect
 	github.com/google/go-cmp v0.4.0
-	github.com/google/uuid v1.1.1
 	github.com/googleapis/gnostic v0.4.1
 	github.com/gorilla/mux v0.0.0-20191024121256-f395758b854c // indirect
 	github.com/imdario/mergo v0.3.7


### PR DESCRIPTION
the `EnsureAtMostOnePodPerNode` will assign a stable anit-affinity value to unblock usage of `ApplyDeployment` method.

It turned out that assigning a random value is not necessary and the deployment controller will roll out a new version even if the value is static.