### PR TITLE
tweaks audit policies

### DIFF
--- a/pkg/operator/apiserver/audit/audit_policies.go
+++ b/pkg/operator/apiserver/audit/audit_policies.go
@@ -23,7 +23,7 @@ const (
 )
 
 // WithAuditPolicies is meant to wrap a standard Asset function usually provided by an operator.
-// It delegates to GetAuditPolicies when the filename matches the predicate for retrieving a audit policy config map for target namespace.
+// It delegates to GetAuditPolicies when the filename matches the predicate for retrieving a audit policy config map for target namespace and name.
 func WithAuditPolicies(targetName string, targetNamespace string, assetDelegateFunc resourceapply.AssetFunc) resourceapply.AssetFunc {
 	return func(file string) ([]byte, error) {
 		if file == AuditPoliciesConfigMapFileName {
@@ -33,7 +33,17 @@ func WithAuditPolicies(targetName string, targetNamespace string, assetDelegateF
 	}
 }
 
-// getRawAuditPolicies returns a raw config map that holds the audit policies for the target namespaces
+// GetAuditPolicies returns a config map that holds the audit policies for the target namespaces and name
+func GetAuditPolicies(targetName, targetNamespace string) (*corev1.ConfigMap, error) {
+	rawAuditPolicies, err := getRawAuditPolicies(targetName, targetNamespace)
+	if err != nil {
+		return nil, err
+	}
+
+	return resourceread.ReadConfigMapV1OrDie(rawAuditPolicies), nil
+}
+
+// getRawAuditPolicies returns a raw config map that holds the audit policies for the target namespaces and name
 func getRawAuditPolicies(targetName, targetNamespace string) ([]byte, error) {
 	if len(targetNamespace) == 0 {
 		return nil, errors.New("please specify the target namespace")

--- a/pkg/operator/apiserver/audit/audit_policies.go
+++ b/pkg/operator/apiserver/audit/audit_policies.go
@@ -57,13 +57,12 @@ func getRawAuditPolicies(targetName, targetNamespace string) ([]byte, error) {
 	return auditPoliciesForTargetNs, nil
 }
 
-// NewAuditPolicyPathGetter returns a path getter for audit policy file mounted into
-// the '/var/run/configmaps/audit' directory of a Pod.
+// NewAuditPolicyPathGetter returns a path getter for audit policy file mounted into the given path of a Pod as a directory.
 //
 // openshift-apiserver and oauth-apiserver mounts the audit policy ConfigMap into
 // the above path inside the Pod.
-func NewAuditPolicyPathGetter() (libgoapiserver.AuditPolicyPathGetterFunc, error) {
-	return newAuditPolicyPathGetter("/var/run/configmaps/audit")
+func NewAuditPolicyPathGetter(path string) (libgoapiserver.AuditPolicyPathGetterFunc, error) {
+	return newAuditPolicyPathGetter(path)
 }
 
 func newAuditPolicyPathGetter(path string) (libgoapiserver.AuditPolicyPathGetterFunc, error) {

--- a/pkg/operator/apiserver/audit/audit_policies_test.go
+++ b/pkg/operator/apiserver/audit/audit_policies_test.go
@@ -17,18 +17,21 @@ func TestWithAuditPolicies(t *testing.T) {
 		name            string
 		delegate        *fakeAsset
 		targetNamespace string
+		targetName      string
 		targetFilename  string
 		goldenFile      string
 	}{
 		{
 			name:            "happy path: the audit policies file for target namespace is created when the target file name matches",
 			targetNamespace: "ScenarioOne",
+			targetName:      "audit",
 			targetFilename:  "audit-policies-cm.yaml",
 			goldenFile:      "./testdata/audit-policies-cm-scenario-1.yaml",
 		},
 		{
 			name:            "the delegate is called when the target file name doesn't match",
 			targetNamespace: "ScenarioTwo",
+			targetName:      "audit",
 			targetFilename:  "trusted_ca_cm.yaml",
 			delegate:        &fakeAsset{"", "trusted_ca_cm.yaml"},
 		},
@@ -39,7 +42,7 @@ func TestWithAuditPolicies(t *testing.T) {
 			if scenario.delegate == nil {
 				scenario.delegate = &fakeAsset{}
 			}
-			target := WithAuditPolicies(scenario.targetNamespace, scenario.delegate.AssetFunc)
+			target := WithAuditPolicies(scenario.targetName, scenario.targetNamespace, scenario.delegate.AssetFunc)
 			actualAuditPoliciesData, err := target(scenario.targetFilename)
 			if err != nil {
 				t.Fatal(err)
@@ -65,18 +68,20 @@ func TestGetAuditPolicies(t *testing.T) {
 	scenarios := []struct {
 		name            string
 		targetNamespace string
+		targetName      string
 		goldenFile      string
 	}{
 		{
 			name:            "happy path: the audit policies file for target namespace is created",
 			targetNamespace: "ScenarioOne",
+			targetName:      "audit",
 			goldenFile:      "./testdata/audit-policies-cm-scenario-1.yaml",
 		},
 	}
 	for _, scenario := range scenarios {
 		t.Run(scenario.name, func(t *testing.T) {
 			// act
-			actualAuditPoliciesData, err := getAuditPolicies(scenario.targetNamespace)
+			actualAuditPoliciesData, err := getRawAuditPolicies(scenario.targetName, scenario.targetNamespace)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/operator/apiserver/audit/audit_policies_test.go
+++ b/pkg/operator/apiserver/audit/audit_policies_test.go
@@ -128,7 +128,7 @@ func TestNewAuditPolicyPathGetter(t *testing.T) {
 		},
 	}
 
-	pathGetter, err := NewAuditPolicyPathGetter()
+	pathGetter, err := NewAuditPolicyPathGetter("/var/run/configmaps/audit")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/operator/apiserver/audit/bindata/bindata.go
+++ b/pkg/operator/apiserver/audit/bindata/bindata.go
@@ -57,7 +57,7 @@ func (fi bindataFileInfo) Sys() interface{} {
 var _pkgOperatorApiserverAuditManifestsAuditPoliciesCmYaml = []byte(`apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: audit
+  name: ${TARGET_NAME}
   namespace: ${TARGET_NAMESPACE}
 data:
   default.yaml: |

--- a/pkg/operator/apiserver/audit/manifests/audit-policies-cm.yaml
+++ b/pkg/operator/apiserver/audit/manifests/audit-policies-cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: audit
+  name: ${TARGET_NAME}
   namespace: ${TARGET_NAMESPACE}
 data:
   default.yaml: |


### PR DESCRIPTION
makes it more generic so that it can be used by the API servers.