### PR TITLE
Validate operatorSpec.logLevel

### DIFF
--- a/pkg/operator/loglevel/logging_controller.go
+++ b/pkg/operator/loglevel/logging_controller.go
@@ -51,6 +51,11 @@ func (c LogLevelController) sync(ctx context.Context, syncCtx factory.SyncContex
 		desiredLogLevel = c.defaultLogLevel
 	}
 
+	if !ValidLogLevel(desiredLogLevel) {
+		syncCtx.Recorder().Warningf("OperatorLogLevelInvalid", "Invalid logLevel %q, falling back to %q", desiredLogLevel, c.defaultLogLevel)
+		desiredLogLevel = c.defaultLogLevel
+	}
+
 	// correct log level is set and it matches the expected log level from operator operatorSpec, do nothing.
 	if !isUnknown && currentLogLevel == desiredLogLevel {
 		return nil

--- a/pkg/operator/loglevel/logging_controller_test.go
+++ b/pkg/operator/loglevel/logging_controller_test.go
@@ -88,6 +88,16 @@ func TestClusterOperatorLoggingController(t *testing.T) {
 			},
 			startingVerbosity: 4,
 			expectedVerbosity: 2,
+			defaultLoglevel:   &operatorv1.Normal,
+			evalEvents: func(events []*corev1.Event, t *testing.T) {
+				if len(events) != 1 {
+					t.Errorf("expected exactly one event, got %d", len(events))
+					return
+				}
+				if !strings.Contains(events[0].Message, `Invalid logLevel "Unknown", falling back to "Normal"`) {
+					t.Errorf("expected message to be %q, got %q", `Invalid logLevel "Unknown", falling back to "Normal"`, events[0].Message)
+				}
+			},
 		},
 		{
 			name: "when OperatorLogLevel is set to Normal operator must set V(2) once",

--- a/pkg/operator/loglevel/util.go
+++ b/pkg/operator/loglevel/util.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
@@ -23,6 +24,18 @@ func LogLevelToVerbosity(logLevel operatorv1.LogLevel) int {
 	default:
 		return 2
 	}
+}
+
+var validLogLevels = sets.NewString(
+	string(operatorv1.Normal),
+	string(operatorv1.Debug),
+	string(operatorv1.Trace),
+	string(operatorv1.TraceAll),
+	"", // Tolerate empty value, it gets defaulted.
+)
+
+func ValidLogLevel(logLevel operatorv1.LogLevel) bool {
+	return validLogLevels.Has(string(logLevel))
 }
 
 // verbosityFn is exported so it can be unit tested


### PR DESCRIPTION
Only report an event (and log it) on failures and fall back to the default log level (`Normal` in most cases).

We can't do hard validation to prevent from breaking working clusters with potentially bad `logLevels`.