### PR TITLE
static pod operator should not update versions until the image is new

### DIFF
--- a/pkg/operator/status/version.go
+++ b/pkg/operator/status/version.go
@@ -19,6 +19,7 @@ type versionGetter struct {
 }
 
 const (
+	operandImageEnvVarName         = "IMAGE"
 	operandImageVersionEnvVarName  = "OPERAND_IMAGE_VERSION"
 	operatorImageVersionEnvVarName = "OPERATOR_IMAGE_VERSION"
 )
@@ -62,6 +63,10 @@ func (v *versionGetter) VersionChangedChannel() <-chan struct{} {
 	channel := make(chan struct{}, 50)
 	v.notificationChannels = append(v.notificationChannels, channel)
 	return channel
+}
+
+func ImageForOperandFromEnv() string {
+	return os.Getenv(operandImageEnvVarName)
 }
 
 func VersionForOperandFromEnv() string {


### PR DESCRIPTION
This fixes a bug, but I don't know which one.

Proof PRs are needed for the big static pod operator.  Will link shortly.
- [ ] https://github.com/openshift/cluster-kube-apiserver-operator/pull/932
- [ ] https://github.com/openshift/cluster-etcd-operator/pull/422
- [ ] https://github.com/openshift/cluster-kube-controller-manager-operator/pull/434
- [ ] https://github.com/openshift/cluster-kube-scheduler-operator/pull/272