### PR TITLE
pkg/verify: Delegate to update-approvers

### DIFF
--- a/pkg/verify/OWNERS
+++ b/pkg/verify/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - update-approvers


### PR DESCRIPTION
This package will be created by the updates (OTA) team and will be used by
the cluster-version operator and 'oc adm release mirror' command both of
which are maintained by the updates team. I'm seeding the alias with the
content from 1 (and adding Lala, who's the team lead). I've left
the 'component' property (added to the root OWNERS in e83f2ac, Add
BZ component name to OWNERS, 2020-04-03, #367) off for now, because
the tooling around that only consumes entries at the repo level.

This PR depends on commit 35b150a, which defines the update-approvers
alias, being merged first.