### PR TITLE
factory: do not panic on cache sync when we shutdown

### DIFF
--- a/pkg/controller/factory/factory.go
+++ b/pkg/controller/factory/factory.go
@@ -198,6 +198,7 @@ func (f *Factory) ToController(name string, eventRecorder events.Recorder) Contr
 		cachesToSync:       append([]cache.InformerSynced{}, f.cachesToSync...),
 		syncContext:        ctx,
 		postStartHooks:     f.postStartHooks,
+		cacheSyncTimeout:   defaultCacheSyncTimeout,
 	}
 
 	for i := range f.informerQueueKeys {


### PR DESCRIPTION
This change fix a case when the operator is shutting down **before** the caches are synced. In that case, the main context is cancelled and the WaitForCacheSync() receives stop which result in panic. While these panics are harmless, they look ugly and they might trigger some post-processing filters in CI that look for panics.