### PR TITLE
[release-4.4] Bug 1876484: static-pod-installer: recreate installers that disappeared

### DIFF
--- a/pkg/operator/staticpod/controller/installer/installer_controller.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller.go
@@ -515,18 +515,18 @@ func setAvailableProgressingNodeInstallerFailingConditions(newStatus *operatorv1
 // newNodeStateForInstallInProgress returns the new NodeState, whether it was killed by OOM or an error
 func (c *InstallerController) newNodeStateForInstallInProgress(currNodeState *operatorv1.NodeStatus, latestRevisionAvailable int32) (status *operatorv1.NodeStatus, installerPodFailed bool, reason string, err error) {
 	ret := currNodeState.DeepCopy()
-	installerPod, err := c.podsGetter.Pods(c.targetNamespace).Get(getInstallerPodName(currNodeState.TargetRevision, currNodeState.NodeName), metav1.GetOptions{})
+	installerPodName := getInstallerPodName(currNodeState.TargetRevision, currNodeState.NodeName)
+	installerPod, err := c.podsGetter.Pods(c.targetNamespace).Get(installerPodName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		ret.LastFailedRevision = currNodeState.TargetRevision
-		ret.TargetRevision = currNodeState.CurrentRevision
-		ret.LastFailedRevisionErrors = []string{err.Error()}
-		return ret, false, "installer pod was not found", nil
+		// installer pod has disappeared before we saw it's termination state. Retry like if it had failed.
+		c.eventRecorder.Warning("InstallerPodDisappeared", err.Error())
+		return currNodeState, true, err.Error(), nil
 	}
 	if err != nil {
 		return nil, false, "", err
 	}
 
-	failed := false
+	operandFailed := false
 	errors := []string{}
 	reason = ""
 
@@ -563,7 +563,7 @@ func (c *InstallerController) newNodeStateForInstallInProgress(currNodeState *op
 
 		switch state {
 		case staticPodStateFailed:
-			failed = true
+			operandFailed = true
 			reason = staticPodReason
 			errors = failedErrors
 
@@ -580,7 +580,7 @@ func (c *InstallerController) newNodeStateForInstallInProgress(currNodeState *op
 		}
 
 	case corev1.PodFailed:
-		failed = true
+		operandFailed = true
 		reason = "installer pod failed"
 		for _, containerStatus := range installerPod.Status.ContainerStatuses {
 			if containerStatus.State.Terminated != nil && len(containerStatus.State.Terminated.Message) > 0 {
@@ -592,7 +592,7 @@ func (c *InstallerController) newNodeStateForInstallInProgress(currNodeState *op
 		}
 	}
 
-	if failed {
+	if operandFailed {
 		ret.LastFailedRevision = currNodeState.TargetRevision
 		ret.TargetRevision = 0
 		if len(errors) == 0 {


### PR DESCRIPTION
The line

```
ret.TargetRevision = currNodeState.CurrentRevision
```

led to a dead-lock because the installer controller only does anything if either

- all `TargetRevision`s are zero
- or the `TargetRevision` value is larger than `CurrentRevision`.

We went into the second case and the controller dead-locked.

/assign @sttts 