### PR TITLE
resourcesync: add provided by to sync error message

### DIFF
--- a/pkg/operator/resourcesynccontroller/interfaces.go
+++ b/pkg/operator/resourcesynccontroller/interfaces.go
@@ -4,6 +4,10 @@ package resourcesynccontroller
 type ResourceLocation struct {
 	Namespace string `json:"namespace"`
 	Name      string `json:"name"`
+
+	// Provider if set for the source location enhance the error message to point to the component which
+	// provide this resource.
+	Provider string `json:"provider,omitempty"`
 }
 
 var emptyResourceLocation = ResourceLocation{}


### PR DESCRIPTION
If the `Provider` field is set for the sync source and the sync will fail with error, the error message will include the `... (provided by FOO)` string that helps identify the resource provider.
Practically, when an ingress operator is not running and we fail to sync a config map provided by this operator, the auth operator will error out with "config map foo not found", but it does not say what provides that config map (or it does not mention where to start looking). 