### PR TITLE
installer: do not log stacktrace when installer pod fail

### DIFF
--- a/pkg/operator/staticpod/installerpod/cmd.go
+++ b/pkg/operator/staticpod/installerpod/cmd.go
@@ -78,16 +78,16 @@ func NewInstaller() *cobra.Command {
 			klog.V(1).Info(spew.Sdump(o))
 
 			if err := o.Complete(); err != nil {
-				klog.Fatal(err)
+				klog.Exit(err)
 			}
 			if err := o.Validate(); err != nil {
-				klog.Fatal(err)
+				klog.Exit(err)
 			}
 
 			ctx, cancel := context.WithTimeout(context.TODO(), o.Timeout)
 			defer cancel()
 			if err := o.Run(ctx); err != nil {
-				klog.Fatal(err)
+				klog.Exit(err)
 			}
 		},
 	}


### PR DESCRIPTION
With `Fatalf` the klog will dump a not really useful stacktrace into log which is then reported in operators as a reason the installer pod fails (hiding the original reason). `Exit()` should still exit 1 but omit the stacktrace.