### PR TITLE
installer: log connection errors on retry

### DIFF
--- a/pkg/operator/resource/retry/retry.go
+++ b/pkg/operator/resource/retry/retry.go
@@ -6,6 +6,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
 )
 
 // ignoreConnectionErrors is a wrapper for condition function that will cause to retry on all errors like
@@ -23,6 +24,7 @@ func ignoreConnectionErrors(lastError *error, fn ConditionWithContextFunc) Condi
 			return false, err
 		default:
 			*lastError = err
+			klog.V(4).Infof("Retrying connection error %v ...", err)
 			return false, nil
 		}
 	}


### PR DESCRIPTION
Log retries on connection errors with the connection errors so we know the installer actually retry them.