### PR TITLE
installer: add reason with blame

### DIFF
--- a/pkg/operator/staticpod/controller/installer/blame.go
+++ b/pkg/operator/staticpod/controller/installer/blame.go
@@ -1,0 +1,17 @@
+package installer
+
+import (
+	"fmt"
+	"strings"
+)
+
+// reasonWithBlame inspects the reason given by the installer pod, which usually include the last log line from the installer pod
+// and try to point a finger on component that likely caused its failure to provide better operator message.
+func reasonWithBlame(originalReason string) string {
+	switch {
+	case strings.Contains(originalReason, "no route to host"):
+		return fmt.Sprintf("%s (most likely node networking is misbehaving)", originalReason)
+	default:
+		return originalReason
+	}
+}

--- a/pkg/operator/staticpod/controller/installer/installer_controller.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller.go
@@ -328,7 +328,7 @@ func (c *InstallerController) manageInstallationPods(ctx context.Context, operat
 				}
 				return false, nil
 			} else {
-				klog.V(2).Infof("%q is in transition to %d, but has not made progress because %s", currNodeState.NodeName, currNodeState.TargetRevision, reason)
+				klog.V(2).Infof("%q is in transition to %d, but has not made progress because %s", currNodeState.NodeName, currNodeState.TargetRevision, reasonWithBlame(reason))
 			}
 
 			// We want to retry the installer pod by deleting and then rekicking. Also we don't set LastFailedRevision.


### PR DESCRIPTION
Provide blame given the reason message. When the installer pod fails because of networking is not working, suggest admins to look into networking-operator for possible reason.