### PR TITLE
Bug 1878007: Validate operatorSpec.logLevel

### DIFF
--- a/pkg/operator/loglevel/logging_controller.go
+++ b/pkg/operator/loglevel/logging_controller.go
@@ -7,6 +7,8 @@ import (
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
 	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
+
+	"k8s.io/klog"
 )
 
 type LogLevelController struct {
@@ -41,6 +43,11 @@ func (c LogLevelController) sync(ctx context.Context, syncCtx factory.SyncContex
 	// if operator operatorSpec OperatorLogLevel is empty, default to "Normal"
 	// TODO: This should be probably done by defaulting the CR field?
 	if len(desiredLogLevel) == 0 {
+		desiredLogLevel = operatorv1.Normal
+	}
+
+	if !ValidLogLevel(desiredLogLevel) {
+		klog.Warningf("OperatorLogLevelInvalid: Invalid logLevel %q, falling back to %q", desiredLogLevel, operatorv1.Normal)
 		desiredLogLevel = operatorv1.Normal
 	}
 

--- a/pkg/operator/loglevel/logging_controller_test.go
+++ b/pkg/operator/loglevel/logging_controller_test.go
@@ -85,6 +85,15 @@ func TestClusterOperatorLoggingController(t *testing.T) {
 			},
 			startingVerbosity: 4,
 			expectedVerbosity: 2,
+			evalEvents: func(events []*corev1.Event, t *testing.T) {
+				if len(events) != 1 {
+					t.Errorf("expected exactly one event, got %d", len(events))
+					return
+				}
+				if !strings.Contains(events[0].Message, `Operator log level changed from "Debug" to "Normal"`) {
+					t.Errorf("expected message to be %q, got %q", `Operator log level changed from "Debug" to "Normal"`, events[0].Message)
+				}
+			},
 		},
 		{
 			name: "when OperatorLogLevel is set to Normal operator must set V(2) once",

--- a/pkg/operator/loglevel/util.go
+++ b/pkg/operator/loglevel/util.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
@@ -23,6 +24,18 @@ func LogLevelToVerbosity(logLevel operatorv1.LogLevel) int {
 	default:
 		return 2
 	}
+}
+
+var validLogLevels = sets.NewString(
+	string(operatorv1.Normal),
+	string(operatorv1.Debug),
+	string(operatorv1.Trace),
+	string(operatorv1.TraceAll),
+	"", // Tolerate empty value, it gets defaulted.
+)
+
+func ValidLogLevel(logLevel operatorv1.LogLevel) bool {
+	return validLogLevels.Has(string(logLevel))
 }
 
 // verbosityFn is exported so it can be unit tested


### PR DESCRIPTION
Report event (and log it) on failures and fall back to the default log level
(Normal in most cases).

We can't do hard validation to prevent from breaking working clusters with
potentially bad logLevels.

(cherry picked from commit 29b87426f36212e3a2873a707fa03869507a9082)