### PR TITLE
Fix reading of CRD v1

### DIFF
--- a/pkg/operator/resource/resourceread/apiextensions.go
+++ b/pkg/operator/resource/resourceread/apiextensions.go
@@ -27,7 +27,7 @@ func ReadCustomResourceDefinitionV1Beta1OrDie(objBytes []byte) *apiextensionsv1b
 }
 
 func ReadCustomResourceDefinitionV1OrDie(objBytes []byte) *apiextensionsv1.CustomResourceDefinition {
-	requiredObj, err := runtime.Decode(apiExtensionsCodecs.UniversalDecoder(apiextensionsv1beta1.SchemeGroupVersion), objBytes)
+	requiredObj, err := runtime.Decode(apiExtensionsCodecs.UniversalDecoder(apiextensionsv1.SchemeGroupVersion), objBytes)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Use the right SchemeGroupVersion. Reading v1 CRD manifest panics with:
```
panic: converting (v1.CustomResourceDefinition) to (v1beta1.CustomResourceDefinition): unknown conversion [recovered]
```

/assign @sttts @deads2k 