### PR TITLE
workload: switch to use pod lister instead of passing full informer factory

### DIFF
--- a/pkg/operator/apiserver/controller/workload/workload.go
+++ b/pkg/operator/apiserver/controller/workload/workload.go
@@ -16,7 +16,6 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -83,7 +82,7 @@ type Controller struct {
 func NewController(name, operatorNamespace, targetNamespace, targetOperandVersion, operandNamePrefix, conditionsPrefix string,
 	operatorClient v1helpers.OperatorClient,
 	kubeClient kubernetes.Interface,
-	kubeInformersForTargetNamespace informers.SharedInformerFactory,
+	podLister corev1listers.PodLister,
 	delegate Delegate,
 	openshiftClusterConfigClient openshiftconfigclientv1.ClusterOperatorInterface,
 	eventRecorder events.Recorder,
@@ -97,7 +96,7 @@ func NewController(name, operatorNamespace, targetNamespace, targetOperandVersio
 		conditionsPrefix:             conditionsPrefix,
 		operatorClient:               operatorClient,
 		kubeClient:                   kubeClient,
-		podsLister:                   kubeInformersForTargetNamespace.Core().V1().Pods().Lister(),
+		podsLister:                   podLister,
 		delegate:                     delegate,
 		openshiftClusterConfigClient: openshiftClusterConfigClient,
 		eventRecorder:                eventRecorder.WithComponentSuffix("workload-controller"),

--- a/pkg/operator/apiserver/controllerset/apiservercontrollerset.go
+++ b/pkg/operator/apiserver/controllerset/apiservercontrollerset.go
@@ -216,7 +216,6 @@ func (cs *APIServerControllerSet) WithWorkloadController(
 	openshiftClusterConfigClient openshiftconfigclientv1.ClusterOperatorInterface,
 	versionRecorder status.VersionGetter,
 	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
-	kubeInformersForTargetNamespace kubeinformers.SharedInformerFactory,
 	informers ...cache.SharedIndexInformer) *APIServerControllerSet {
 
 	workloadController := workload.NewController(
@@ -228,7 +227,7 @@ func (cs *APIServerControllerSet) WithWorkloadController(
 		conditionsPrefix,
 		cs.operatorClient,
 		kubeClient,
-		kubeInformersForTargetNamespace,
+		kubeInformersForNamespaces.PodLister(),
 		delegate,
 		openshiftClusterConfigClient,
 		cs.eventRecorder,
@@ -236,6 +235,7 @@ func (cs *APIServerControllerSet) WithWorkloadController(
 
 	workloadController.AddInformer(kubeInformersForNamespaces.InformersFor(targetNamespace).Core().V1().ConfigMaps().Informer())
 	workloadController.AddInformer(kubeInformersForNamespaces.InformersFor(targetNamespace).Core().V1().Secrets().Informer())
+	workloadController.AddInformer(kubeInformersForNamespaces.InformersFor(targetNamespace).Core().V1().Pods().Informer())
 	workloadController.AddInformer(kubeInformersForNamespaces.InformersFor(targetNamespace).Apps().V1().Deployments().Informer())
 	workloadController.AddInformer(kubeInformersForNamespaces.InformersFor(metav1.NamespaceSystem).Core().V1().Nodes().Informer())
 


### PR DESCRIPTION
We don't need to pass full informer factory to this controller, pass only things we really need (pod lister).