### PR TITLE
Bug 1879475: Update status reasons to be more explicit

### DIFF
--- a/pkg/operator/csi/csidrivercontrollerservicecontroller/csi_driver_controller_service_controller.go
+++ b/pkg/operator/csi/csidrivercontrollerservicecontroller/csi_driver_controller_service_controller.go
@@ -142,7 +142,7 @@ func (c *CSIDriverControllerServiceController) sync(ctx context.Context, syncCon
 	} else {
 		availableCondition.Status = opv1.ConditionFalse
 		availableCondition.Message = "Waiting for Deployment to deploy the CSI Controller Service"
-		availableCondition.Reason = "AsExpected"
+		availableCondition.Reason = "Deploying"
 	}
 
 	progressingCondition := opv1.OperatorCondition{
@@ -153,7 +153,7 @@ func (c *CSIDriverControllerServiceController) sync(ctx context.Context, syncCon
 	if ok, msg := isProgressing(opStatus, deployment); ok {
 		progressingCondition.Status = opv1.ConditionTrue
 		progressingCondition.Message = msg
-		progressingCondition.Reason = "AsExpected"
+		progressingCondition.Reason = "Deploying"
 	}
 
 	updateStatusFn := func(newStatus *opv1.OperatorStatus) error {

--- a/pkg/operator/csi/csidrivernodeservicecontroller/csi_driver_node_service_controller.go
+++ b/pkg/operator/csi/csidrivernodeservicecontroller/csi_driver_node_service_controller.go
@@ -136,7 +136,7 @@ func (c *CSIDriverNodeServiceController) sync(ctx context.Context, syncContext f
 	} else {
 		availableCondition.Status = opv1.ConditionFalse
 		availableCondition.Message = "Waiting for the DaemonSet to deploy the CSI Node Service"
-		availableCondition.Reason = "AsExpected"
+		availableCondition.Reason = "Deploying"
 	}
 
 	progressingCondition := opv1.OperatorCondition{
@@ -147,7 +147,7 @@ func (c *CSIDriverNodeServiceController) sync(ctx context.Context, syncContext f
 	if ok, msg := isProgressing(opStatus, daemonSet); ok {
 		progressingCondition.Status = opv1.ConditionTrue
 		progressingCondition.Message = msg
-		progressingCondition.Reason = "AsExpected"
+		progressingCondition.Reason = "Deploying"
 	}
 
 	updateStatusFn := func(newStatus *opv1.OperatorStatus) error {


### PR DESCRIPTION
This PR updates the status reasons in progressing scenarios to be a bit more explicit. This should reduce the number of "AsExpected" reasons that we see.