### PR TITLE
Fixing function name case

### DIFF
--- a/pkg/operator/loglevel/logging_controller.go
+++ b/pkg/operator/loglevel/logging_controller.go
@@ -29,7 +29,7 @@ func NewClusterOperatorLoggingController(operatorClient operatorv1helpers.Operat
 func NewClusterOperatorLoggingControllerWithLogLevel(operatorClient operatorv1helpers.OperatorClient, defaultLogLevel operatorv1.LogLevel, recorder events.Recorder) factory.Controller {
 	c := &LogLevelController{
 		operatorClient:  operatorClient,
-		setLogLevelFn:   SetLogLEvel,
+		setLogLevelFn:   SetLogLevel,
 		getLogLevelFn:   GetLogLevel,
 		defaultLogLevel: defaultLogLevel,
 	}

--- a/pkg/operator/loglevel/util.go
+++ b/pkg/operator/loglevel/util.go
@@ -60,9 +60,9 @@ func GetLogLevel() (operatorv1.LogLevel, bool) {
 	}
 }
 
-// SetLogLEvel is a nasty hack and attempt to manipulate the global flags as klog does not expose
+// SetLogLevel is a nasty hack and attempt to manipulate the global flags as klog does not expose
 // a way to dynamically change the loglevel in runtime.
-func SetLogLEvel(targetLevel operatorv1.LogLevel) error {
+func SetLogLevel(targetLevel operatorv1.LogLevel) error {
 	var level *klog.Level
 
 	// Convert operator loglevel to klog numeric string


### PR DESCRIPTION
Using lower case is the way to go.