### PR TITLE
image/reference: support parsing partial repo names

### DIFF
--- a/pkg/image/reference/reference_test.go
+++ b/pkg/image/reference/reference_test.go
@@ -163,6 +163,30 @@ func TestParse(t *testing.T) {
 			Tag:      "tag",
 		},
 		{
+			From:     "quay.io",
+			Registry: "quay.io",
+			Name:     "",
+			Tag:      "",
+		},
+		{
+			From:     "quay.io/org",
+			Registry: "quay.io",
+			Name:     "org",
+			Tag:      "",
+		},
+		{
+			From:     "localhost:5000",
+			Registry: "localhost:5000",
+			Name:     "",
+			Tag:      "",
+		},
+		{
+			From:     "localhost:5000/org",
+			Registry: "localhost:5000",
+			Name:     "org",
+			Tag:      "",
+		},
+		{
 			// registry/namespace/name > 255 chars
 			From: fmt.Sprintf("bar:5000/%s/%s:tag", strings.Repeat("a", 63), strings.Repeat("b", 183)),
 			Err:  true,


### PR DESCRIPTION
This is useful in mirroring contexts, where a set of images may be mirrored into the same registry, or into the same namespace of a target.

For example, `oc adm catalog mirror` allows you to mirror a catalog into a specific registry or location, so the destination for a mirror can be `localhost:5000` or `quay.io` or `quay.io/my-namespace` or `docker.io/my/nested/org` etc.

Unlike `oc image mirror`, the source is a large list of images instead of only one. Adding support for parsing partial repository names makes it easier to use `TypedImageReferences` in `oc adm catalog mirror`