### PR TITLE
Check errors if we can't annotate a secret

### DIFF
--- a/pkg/operator/encryption/controllers/migration_controller.go
+++ b/pkg/operator/encryption/controllers/migration_controller.go
@@ -246,6 +246,9 @@ func (c *migrationController) migrateKeysIfNeededAndRevisionStable(syncContext f
 			}
 
 			changed, err := setResourceMigrated(gr, s)
+			if err != nil {
+				return err
+			}
 			if !changed {
 				return nil
 			}


### PR DESCRIPTION
Now we ignore errors from setResourceMigrated function, which can lead to unpredictable behavior in runtime. To prevent this we add the standard error checking in the function.