### PR TITLE
Change GetServiceCIDR() to GetServiceCIDRs() for dual-stack support

### DIFF
--- a/pkg/operator/configobserver/network/observe_network.go
+++ b/pkg/operator/configobserver/network/observe_network.go
@@ -40,24 +40,24 @@ func GetClusterCIDRs(lister configlistersv1.NetworkLister, recorder events.Recor
 	return clusterCIDRs, nil
 }
 
-// GetServiceCIDR reads the service IP range from the global network configuration resource. Emits events if CIDRs are not found.
-func GetServiceCIDR(lister configlistersv1.NetworkLister, recorder events.Recorder) (string, error) {
+// GetServiceCIDRs reads the service IP ranges from the global network configuration resource. Emits events if CIDRs are not found.
+func GetServiceCIDRs(lister configlistersv1.NetworkLister, recorder events.Recorder) ([]string, error) {
 	network, err := lister.Get("cluster")
 	if errors.IsNotFound(err) {
 		recorder.Warningf("GetServiceCIDRFailed", "Required networks.%s/cluster not found", configv1.GroupName)
-		return "", nil
+		return nil, nil
 	}
 	if err != nil {
 		recorder.Warningf("GetServiceCIDRFailed", "error getting networks.%s/cluster: %v", configv1.GroupName, err)
-		return "", err
+		return nil, err
 	}
 
 	if len(network.Status.ServiceNetwork) == 0 || len(network.Status.ServiceNetwork[0]) == 0 {
 		recorder.Warningf("GetServiceCIDRFailed", "Required status.serviceNetwork field is not set in networks.%s/cluster", configv1.GroupName)
-		return "", fmt.Errorf("networks.%s/cluster: status.serviceNetwork not found", configv1.GroupName)
+		return nil, fmt.Errorf("networks.%s/cluster: status.serviceNetwork not found", configv1.GroupName)
 	}
 
-	return network.Status.ServiceNetwork[0], nil
+	return network.Status.ServiceNetwork, nil
 }
 
 // GetExternalIPPolicy retrieves the ExternalIPPolicy for the cluster.

--- a/pkg/operator/configobserver/network/observe_networking_test.go
+++ b/pkg/operator/configobserver/network/observe_networking_test.go
@@ -82,18 +82,18 @@ func TestObserveServiceClusterIPRanges(t *testing.T) {
 	if err := indexer.Add(&configv1.Network{
 		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
 		Status: configv1.NetworkStatus{
-			ServiceNetwork: []string{"serviceCIDR"},
+			ServiceNetwork: []string{"serviceCIDRv4", "serviceCIDRv6"},
 		},
 	},
 	); err != nil {
 		t.Fatal(err.Error())
 	}
-	result, err := GetServiceCIDR(configlistersv1.NewNetworkLister(indexer), events.NewInMemoryRecorder("network"))
+	result, err := GetServiceCIDRs(configlistersv1.NewNetworkLister(indexer), events.NewInMemoryRecorder("network"))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if expected := "serviceCIDR"; !reflect.DeepEqual(expected, result) {
+	if expected := []string{"serviceCIDRv4", "serviceCIDRv6"}; !reflect.DeepEqual(expected, result) {
 		t.Errorf("\n===== observed config expected:\n%v\n===== observed config actual:\n%v", toYAML(expected), toYAML(result))
 	}
 }


### PR DESCRIPTION
This has been the subject of FIXMEs for a while...

AFAIK this is used by cluster-kube-apiserver-operator and cluster-kube-controller-manager-operator, and both of their operands have been updated to be able to deal with multiple values.
