### PR TITLE
Set TCP_USER_TIMEOUT socket option

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381
+	golang.org/x/sys v0.0.0-20200622214017-ed371f2e16b4
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 	gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d // indirect
 	gopkg.in/ldap.v2 v2.5.1

--- a/pkg/config/client/client_config.go
+++ b/pkg/config/client/client_config.go
@@ -2,14 +2,12 @@ package client
 
 import (
 	"io/ioutil"
-	"net"
-	"net/http"
-	"time"
-
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"net/http"
 
 	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/library-go/pkg/network"
 )
 
 // GetKubeConfigOrInClusterConfig loads in-cluster config if kubeConfigFile is empty or the file if not,
@@ -101,10 +99,8 @@ func (c ClientTransportOverrides) DefaultClientTransport(rt http.RoundTripper) h
 		return rt
 	}
 
-	transport.DialContext = (&net.Dialer{
-		Timeout:   30 * time.Second,
-		KeepAlive: 30 * time.Second,
-	}).DialContext
+	dialer := network.DefaultClientDialer()
+	transport.DialContext = dialer.DialContext
 
 	// Hold open more internal idle connections
 	transport.MaxIdleConnsPerHost = 100

--- a/pkg/config/client/client_config.go
+++ b/pkg/config/client/client_config.go
@@ -99,8 +99,7 @@ func (c ClientTransportOverrides) DefaultClientTransport(rt http.RoundTripper) h
 		return rt
 	}
 
-	dialer := network.DefaultClientDialer()
-	transport.DialContext = dialer.DialContext
+	transport.DialContext = network.DefaultClientDialContext()
 
 	// Hold open more internal idle connections
 	transport.MaxIdleConnsPerHost = 100

--- a/pkg/network/dialer.go
+++ b/pkg/network/dialer.go
@@ -1,10 +1,13 @@
 package network
 
 import (
+	"context"
 	"net"
 )
 
-// DefaultClientDialer returns a network dialer with default options sets.
-func DefaultClientDialer() *net.Dialer {
+type DialContext func(ctx context.Context, network, address string) (net.Conn, error)
+
+// DefaultDialContext returns a DialContext function from a network dialer with default options sets.
+func DefaultClientDialContext() DialContext {
 	return dialerWithDefaultOptions()
 }

--- a/pkg/network/dialer.go
+++ b/pkg/network/dialer.go
@@ -1,0 +1,10 @@
+package network
+
+import (
+	"net"
+)
+
+// DefaultClientDialer returns a network dialer with default options sets.
+func DefaultClientDialer() *net.Dialer {
+	return dialerWithDefaultOptions()
+}

--- a/pkg/network/dialer_linux.go
+++ b/pkg/network/dialer_linux.go
@@ -1,0 +1,76 @@
+// +build linux
+
+package network
+
+import (
+	"net"
+	"os"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func dialerWithDefaultOptions() *net.Dialer {
+	return &net.Dialer{
+		// TCP_USER_TIMEOUT does affect the behaviour of connect() which is controlled by this field so we set it to the same value
+		Timeout: 25 * time.Second,
+		Control: func(network, address string, con syscall.RawConn) error {
+			var err error
+			err = con.Control(func(fd uintptr) {
+				err = setDefaultSocketOptions(int(fd))
+			})
+			return err
+		},
+	}
+}
+
+// setDefaultSocketOptions sets custom socket options so that we can detect connections to an unhealthy (dead) peer quickly.
+// In particular we set TCP_USER_TIMEOUT that specifies the maximum amount of time that transmitted data may remain
+// unacknowledged before TCP will forcibly close the connection.
+//
+// Note
+// TCP_USER_TIMEOUT can't be too low because a single dropped packet might drop the entire connection.
+// Ideally it should be set to: TCP_KEEPIDLE + TCP_KEEPINTVL * TCP_KEEPCNT
+func setDefaultSocketOptions(fd int) error {
+	// specifies the maximum amount of time in milliseconds that transmitted data may remain
+	// unacknowledged before TCP will forcibly close the corresponding connection and return ETIMEDOUT to the application
+	tcpUserTimeoutInMilliSeconds := int(25 * time.Second / time.Millisecond)
+
+	// specifies the interval at which probes are sent in seconds
+	tcpKeepIntvl := int(roundDuration(5*time.Second, time.Second))
+
+	// specifies the threshold for sending the first KEEP ALIVE probe in seconds
+	tcpKeepIdle := int(roundDuration(2*time.Second, time.Second))
+
+	if err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, unix.TCP_USER_TIMEOUT, tcpUserTimeoutInMilliSeconds); err != nil {
+		return wrapSyscallError("setsockopt", err)
+	}
+
+	if err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, syscall.TCP_KEEPINTVL, tcpKeepIntvl); err != nil {
+		return wrapSyscallError("setsockopt", err)
+	}
+
+	if err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, syscall.TCP_KEEPIDLE, tcpKeepIdle); err != nil {
+		return wrapSyscallError("setsockopt", err)
+	}
+	return nil
+}
+
+// roundDurationUp rounds d to the next multiple of to.
+//
+// note that it was copied from the std library
+func roundDuration(d time.Duration, to time.Duration) time.Duration {
+	return (d + to - 1) / to
+}
+
+// wrapSyscallError takes an error and a syscall name. If the error is
+// a syscall.Errno, it wraps it in a os.SyscallError using the syscall name.
+//
+// note that it was copied from the std library
+func wrapSyscallError(name string, err error) error {
+	if _, ok := err.(syscall.Errno); ok {
+		err = os.NewSyscallError(name, err)
+	}
+	return err
+}

--- a/pkg/network/dialer_others.go
+++ b/pkg/network/dialer_others.go
@@ -1,0 +1,18 @@
+// +build !linux
+
+package network
+
+import (
+	"net"
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+func dialerWithDefaultOptions() *net.Dialer {
+	klog.V(2).Info("Creating the default network Dialer (unsupported platform). It may take up to 15 minutes to detect broken connections and establish a new one")
+	return &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}
+}

--- a/pkg/network/dialer_others.go
+++ b/pkg/network/dialer_others.go
@@ -9,10 +9,11 @@ import (
 	"k8s.io/klog/v2"
 )
 
-func dialerWithDefaultOptions() *net.Dialer {
+func dialerWithDefaultOptions() DialContext {
 	klog.V(2).Info("Creating the default network Dialer (unsupported platform). It may take up to 15 minutes to detect broken connections and establish a new one")
-	return &net.Dialer{
+	nd := &net.Dialer{
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,
 	}
+	return nd.DialContext
 }


### PR DESCRIPTION
This PR sets the `TCP_USER_TIMEOUT` (https://man7.org/linux/man-pages/man7/tcp.7.html) socket option which controls for how long transmitted data may be unacknowledged before the connection is forcefully closed.

Without that option, we rely on the TCP stack to detect broken network connection. This can take up to 15 minutes. During that time our platform might be unavailable. 

There are already reported cases in which aggregated APIs (i.e. `openshift-apiserver`) were unable to establish a new connection to the Kube API for 15 minutes after "ungraceful termination" (https://bugzilla.redhat.com/show_bug.cgi?id=1881878 and https://bugzilla.redhat.com/show_bug.cgi?id=1879232#c39)

It looks like detecting broken connections on the application level is getting more traction and is preferable. Unfortunately, it is on the slow track and will require backporting to golang's std library. Until that time we would like to take advantage of `TCP_USER_TIMEOUT`

[1] https://go-review.googlesource.com/c/net/+/198040
[2] https://go-review.googlesource.com/c/net/+/236498#message-7bd657ac6960f0dc7acbbe28cbe3d80ac4f3a34b

