### PR TITLE
add a check for an unhandled error in ApplyServiceMonitor

### DIFF
--- a/pkg/operator/resource/resourceapply/monitoring.go
+++ b/pkg/operator/resource/resourceapply/monitoring.go
@@ -76,6 +76,9 @@ func ApplyServiceMonitor(client dynamic.Interface, recorder events.Recorder, ser
 		recorder.Eventf("ServiceMonitorCreated", "Created ServiceMonitor.monitoring.coreos.com/v1 because it was missing")
 		return true, nil
 	}
+	if err != nil {
+		return false, err
+	}
 
 	existingCopy := existing.DeepCopy()
 


### PR DESCRIPTION
If ApplyServiceMonitor fails to Get() an existing resource because it
is not there, it correctly handles the error and creates the
resource. However, if Get() fails for some other reason the error was
left unhandled, causing a panic later when a pointer is
uninitialized. This change handles the error to avoid the panic.

See the machine-api-operator logs in https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_machine-api-operator/671/pull-ci-openshift-machine-api-operator-master-e2e-metal-ipi/1318544074000568320 for an example of the panic. I suspect it's caused by not having RBAC set up for ServiceMonitor.