### PR TITLE
fix image reference parsing when tag includes a `.`

### DIFF
--- a/pkg/image/reference/reference.go
+++ b/pkg/image/reference/reference.go
@@ -41,7 +41,7 @@ func Parse(spec string) (DockerImageReference, error) {
 	i := strings.IndexRune(name, '/')
 
 	// if there are no path components, and it looks like a url (contains a .) or localhost, it's a registry
-	isRegistryOnly := i == -1 && (strings.ContainsAny(spec, ".") || strings.HasPrefix(spec, "localhost"))
+	isRegistryOnly := i == -1 && (strings.ContainsAny(name, ".") || strings.HasPrefix(name, "localhost"))
 
 	// if there are no path components, and it's not a registry, it's a name
 	isNameOnly := i == -1 && !isRegistryOnly

--- a/pkg/image/reference/reference_test.go
+++ b/pkg/image/reference/reference_test.go
@@ -187,6 +187,12 @@ func TestParse(t *testing.T) {
 			Tag:      "",
 		},
 		{
+			From:     "wildfly:15.0",
+			Registry: "",
+			Name:     "wildfly",
+			Tag:      "15.0",
+		},
+		{
 			// registry/namespace/name > 255 chars
 			From: fmt.Sprintf("bar:5000/%s/%s:tag", strings.Repeat("a", 63), strings.Repeat("b", 183)),
 			Err:  true,


### PR DESCRIPTION
this was incorrectly detecting images without a registry, but with a
tag that included a '.' as a registry-only image reference, instead
of a name+tag image reference.

The corrects an issue introduced in 670e819