### PR TITLE
unsupported encryption config

### DIFF
--- a/pkg/operator/encryption/controllers.go
+++ b/pkg/operator/encryption/controllers.go
@@ -25,6 +25,7 @@ type runner interface {
 
 func NewControllers(
 	component string,
+	unsupportedConfigPrefix []string,
 	provider controllers.Provider,
 	deployer statemachine.Deployer,
 	migrator migrators.Migrator,
@@ -45,6 +46,7 @@ func NewControllers(
 		controllers: []runner{
 			controllers.NewKeyController(
 				component,
+				unsupportedConfigPrefix,
 				provider,
 				deployer,
 				operatorClient,


### PR DESCRIPTION
allows for specifying an optional prefix for retrieving unsupported config for the encryption controllers 