### PR TITLE
ObserveStorageURLs: allows for setting reserved IPs as specified in RFC 5735, 5737

### DIFF
--- a/pkg/operator/configobserver/etcd/observe_etcd_endpoints.go
+++ b/pkg/operator/configobserver/etcd/observe_etcd_endpoints.go
@@ -104,11 +104,6 @@ func innerObserveStorageURLs(fallbackObserver fallBackObserverFn, alwaysAppendLo
 			errs = append(errs, ipErr)
 			continue
 		}
-		// skip placeholder ip addresses used in previous versions where the hostname was used instead
-		if strings.HasPrefix(ip.String(), "192.0.2.") || strings.HasPrefix(ip.String(), "2001:db8:") {
-			// not considered an error
-			continue
-		}
 		// use the canonical representation of the ip address (not original input) when constructing the url
 		if ip.To4() != nil {
 			etcdURLs = append(etcdURLs, fmt.Sprintf("https://%s:2379", ip))

--- a/pkg/operator/configobserver/etcd/observe_etcd_endpoints_test.go
+++ b/pkg/operator/configobserver/etcd/observe_etcd_endpoints_test.go
@@ -107,8 +107,8 @@ func TestInnerObserveStorageURLs(t *testing.T) {
 		{
 			name:              "ValidIPv4",
 			currentConfigFor:  observedConfigFor(withStorageURLFor("https://previous.url:2379")),
-			endpoint:          endpoints(withAddress("10.0.0.1")),
-			expectedConfigFor: observedConfigFor(withStorageURLFor("https://10.0.0.1:2379")),
+			endpoint:          endpoints(withAddress("10.0.0.1"), withAddress("192.0.2.1")),
+			expectedConfigFor: observedConfigFor(withStorageURLFor("https://10.0.0.1:2379"), withStorageURLFor("https://192.0.2.1:2379")),
 		},
 		{
 			name:             "InvalidIPv4",
@@ -123,8 +123,8 @@ func TestInnerObserveStorageURLs(t *testing.T) {
 		{
 			name:              "ValidIPv6",
 			currentConfigFor:  observedConfigFor(withStorageURLFor("https://previous.url:2379")),
-			endpoint:          endpoints(withAddress("FE80:CD00:0000:0CDE:1257:0000:211E:729C")),
-			expectedConfigFor: observedConfigFor(withStorageURLFor("https://[fe80:cd00:0:cde:1257:0:211e:729c]:2379")),
+			endpoint:          endpoints(withAddress("FE80:CD00:0000:0CDE:1257:0000:211E:729C"), withAddress("2001:0DB8:0000:0CDE:1257:0000:211E:729C")),
+			expectedConfigFor: observedConfigFor(withStorageURLFor("https://[2001:db8:0:cde:1257:0:211e:729c]:2379"), withStorageURLFor("https://[fe80:cd00:0:cde:1257:0:211e:729c]:2379")),
 		},
 		{
 			name:             "InvalidIPv6",
@@ -137,37 +137,19 @@ func TestInnerObserveStorageURLs(t *testing.T) {
 			expectErrors:      true,
 		},
 		{
-			name:             "FakeIPv4",
-			currentConfigFor: observedConfigFor(withStorageURLFor("https://previous.url:2379")),
-			endpoint: endpoints(
-				withAddress("10.0.0.1"),
-				withAddress("192.0.2.1"),
-			),
-			expectedConfigFor: observedConfigFor(withStorageURLFor("https://10.0.0.1:2379")),
-		},
-		{
-			name:             "FakeIPv6",
-			currentConfigFor: observedConfigFor(withStorageURLFor("https://previous.url:2379")),
-			endpoint: endpoints(
-				withAddress("FE80:CD00:0000:0CDE:1257:0000:211E:729C"),
-				withAddress("2001:0DB8:0000:0CDE:1257:0000:211E:729C"),
-			),
-			expectedConfigFor: observedConfigFor(withStorageURLFor("https://[fe80:cd00:0:cde:1257:0:211e:729c]:2379")),
-		},
-		{
 			name:              "ValidIPv4AsIPv6Literal",
 			currentConfigFor:  observedConfigFor(withStorageURLFor("https://previous.url:2379")),
 			endpoint:          endpoints(withAddress("::ffff:a00:1")),
 			expectedConfigFor: observedConfigFor(withStorageURLFor("https://10.0.0.1:2379")),
 		},
 		{
-			name:             "FakeIPv4AsIPv6Literal",
+			name:             "IPv4AsIPv6Literal",
 			currentConfigFor: observedConfigFor(withStorageURLFor("https://previous.url:2379")),
 			endpoint: endpoints(
 				withAddress("FE80:CD00:0000:0CDE:1257:0000:211E:729C"),
 				withAddress("::ffff:c000:201"),
 			),
-			expectedConfigFor: observedConfigFor(withStorageURLFor("https://[fe80:cd00:0:cde:1257:0:211e:729c]:2379")),
+			expectedConfigFor: observedConfigFor(withStorageURLFor("https://192.0.2.1:2379"), withStorageURLFor("https://[fe80:cd00:0:cde:1257:0:211e:729c]:2379")),
 		},
 		{
 			name:              "NoAddressesFound",
@@ -177,11 +159,11 @@ func TestInnerObserveStorageURLs(t *testing.T) {
 			expectErrors:      true,
 		},
 		{
-			name:             "OnlyFakeAddressesFound",
+			name:             "OnlyInvalidAddressesFound",
 			currentConfigFor: observedConfigFor(withStorageURLFor("https://previous.url:2379")),
 			endpoint: endpoints(
-				withAddress("192.0.2.1"),
-				withAddress("::ffff:c000:201"),
+				withAddress("0.192.0.2.1"),
+				withAddress("::ffff:c000:201:invalid"),
 			),
 			expectedConfigFor: observedConfigFor(withStorageURLFor("https://previous.url:2379")),
 			expectErrors:      true,


### PR DESCRIPTION
changes `ObserveStorageURLs` so that it allows for setting previously reserved addresses. That is addresses with `192.0.2.` prefix for v4 and `2001:db8:` for v6.

these addresses should be accepted sine we don't implement RFC 5735, 5737.