### PR TITLE
encryption key controller: cleans up reading unsupportedEncryptionConfig

### DIFF
--- a/pkg/operator/encryption/controllers/key_controller_test.go
+++ b/pkg/operator/encryption/controllers/key_controller_test.go
@@ -437,6 +437,17 @@ func TestGetCurrentModeAndExternalReason(t *testing.T) {
 			apiServerObjects:      []runtime.Object{&configv1.APIServer{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}}},
 			expectedReasonFromCfg: "oauth-api-reason",
 		},
+
+		{
+			name:             "with prefix reading empty config works",
+			prefix:           []string{"oauthAPIServer"},
+			apiServerObjects: []runtime.Object{&configv1.APIServer{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}}},
+		},
+
+		{
+			name:             "reading empty config works",
+			apiServerObjects: []runtime.Object{&configv1.APIServer{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}}},
+		},
 	}
 
 	for _, scenario := range scenarios {


### PR DESCRIPTION
there's no need to convert `UnsupportedConfigOverrides.Raw` from `yaml` to `json` as it always comes as `json`. 
I suspect that this code was added because passing no data to `Unmarshal` has unexpected behaviour and could be avoided by examining the lenght of the input.

See for more details:
https://play.golang.org/p/dsWkiPrzZoL