### PR TITLE
factory: use the cron schedule to run periodic resyncs

### DIFF
--- a/pkg/controller/factory/controller_context.go
+++ b/pkg/controller/factory/controller_context.go
@@ -85,7 +85,7 @@ func (c syncContext) eventHandler(queueKeyFunc ObjectQueueKeyFunc, filter EventF
 	}
 }
 
-// namespaceChecker returns a function which returns true if an inpuut obj
+// namespaceChecker returns a function which returns true if an input obj
 // (or its tombstone) is a namespace  and it matches a name of any namespaces
 // that we are interested in
 func namespaceChecker(interestingNamespaces []string) func(obj interface{}) bool {

--- a/pkg/controller/factory/factory_test.go
+++ b/pkg/controller/factory/factory_test.go
@@ -97,7 +97,7 @@ func makeFakeSecret() *v1.Secret {
 
 func TestResyncController(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
-	factory := New().ResyncEvery(100 * time.Millisecond)
+	factory := New().ResyncSchedule("@every 100ms")
 
 	controllerSynced := make(chan struct{})
 	syncCallCount := 0
@@ -253,7 +253,7 @@ func TestControllerScheduled(t *testing.T) {
 
 func TestControllerSyncAfterStart(t *testing.T) {
 	syncCalled := make(chan struct{})
-	controller := New().ResyncEvery(10*time.Second).WithSync(func(ctx context.Context, controllerContext SyncContext) error {
+	controller := New().ResyncSchedule("@every 10s").WithSync(func(ctx context.Context, controllerContext SyncContext) error {
 		close(syncCalled)
 		return nil
 	}).ToController("test", events.NewInMemoryRecorder("fake-controller"))


### PR DESCRIPTION
This removes the "special" case "ResyncEvery()" and use the cron scheduler to execute periodic resyncs.
It also fixes a case when initial periodic jobs were not run and instead we waited the scheduled period to trigger initial sync (imagine you set "schedule ever 1h", then operator start and the first resync is done after 1h...)
