### PR TITLE
resourceapply: fix reporting modified on EnsureMeta

### DIFF
--- a/pkg/operator/resource/resourceapply/core_test.go
+++ b/pkg/operator/resource/resourceapply/core_test.go
@@ -600,6 +600,28 @@ func TestApplyNamespace(t *testing.T) {
 			},
 		},
 		{
+			name: "don't report modified if the removed annotation is already not present",
+			existing: []runtime.Object{
+				&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{Name: "foo", Labels: map[string]string{"some-label": "labelval"}},
+				},
+			},
+			input: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo", Labels: map[string]string{"run-level-": ""}},
+			},
+
+			expectedModified: false,
+			verifyActions: func(actions []clienttesting.Action, t *testing.T) {
+				if len(actions) != 1 {
+					t.Fatal(spew.Sdump(actions))
+				}
+
+				if !actions[0].Matches("get", "namespaces") || actions[0].(clienttesting.GetAction).GetName() != "foo" {
+					t.Error(spew.Sdump(actions))
+				}
+			},
+		},
+		{
 			name: "add run-level if requested",
 			existing: []runtime.Object{
 				&corev1.Namespace{

--- a/pkg/operator/resource/resourcemerge/object_merger.go
+++ b/pkg/operator/resource/resourcemerge/object_merger.go
@@ -140,15 +140,27 @@ func MergeMap(modified *bool, existing *map[string]string, required map[string]s
 		*existing = map[string]string{}
 	}
 	for k, v := range required {
-		if existingV, ok := (*existing)[k]; !ok || v != existingV {
-			*modified = true
-			// if "required" map contains a key with "-" as suffix, remove that
-			// key from the existing map instead of replacing the value
-			if strings.HasSuffix(k, "-") {
-				delete(*existing, strings.TrimRight(k, "-"))
-			} else {
-				(*existing)[k] = v
+		actualKey := k
+		removeKey := false
+
+		// if "required" map contains a key with "-" as suffix, remove that
+		// key from the existing map instead of replacing the value
+		if strings.HasSuffix(k, "-") {
+			removeKey = true
+			actualKey = strings.TrimRight(k, "-")
+		}
+
+		if existingV, ok := (*existing)[actualKey]; removeKey {
+			if !ok {
+				continue
 			}
+			// value found -> it should be removed
+			delete(*existing, actualKey)
+			*modified = true
+
+		} else if !ok || v != existingV {
+			*modified = true
+			(*existing)[actualKey] = v
 		}
 	}
 }


### PR DESCRIPTION
EnsureMeta would report modified=true even if the annotation marked
for removal was already not present in the existing object

should be proven to work by https://github.com/openshift/service-ca-operator/pull/109