### PR TITLE
Add OWNERS to connectivitycheckcontroller and rcarrillocruz as approver

### DIFF
--- a/pkg/operator/connectivitycheckcontroller/OWNERS
+++ b/pkg/operator/connectivitycheckcontroller/OWNERS
@@ -1,0 +1,12 @@
+reviewers:
+  - mfojtik
+  - deads2k
+  - sttts
+  - sanchezl
+  - rcarrillocruz
+approvers:
+  - mfojtik
+  - deads2k
+  - sttts
+  - sanchezl
+  - rcarrillocruz


### PR DESCRIPTION
This is to handoff ownership to Network team of this controller piece.