### PR TITLE
Bug 1887392: allow configuring authn/z caches TTLs

### DIFF
--- a/pkg/config/serving/server.go
+++ b/pkg/config/serving/server.go
@@ -39,6 +39,8 @@ func ToServerConfig(ctx context.Context, servingInfo configv1.HTTPServingInfo, a
 	if !authenticationConfig.Disabled {
 		authenticationOptions := genericapiserveroptions.NewDelegatingAuthenticationOptions()
 		authenticationOptions.RemoteKubeConfigFile = kubeConfigFile
+		// the platform generally uses 30s for /metrics scraping, avoid API request for every other /metrics request to the component
+		authenticationOptions.CacheTTL = 35 * time.Second
 
 		// In some cases the API server can return connection refused when getting the "extension-apiserver-authentication"
 		// config map.
@@ -58,6 +60,8 @@ func ToServerConfig(ctx context.Context, servingInfo configv1.HTTPServingInfo, a
 	if !authorizationConfig.Disabled {
 		authorizationOptions := genericapiserveroptions.NewDelegatingAuthorizationOptions()
 		authorizationOptions.RemoteKubeConfigFile = kubeConfigFile
+		// the platform generally uses 30s for /metrics scraping, avoid API request for every other /metrics request to the component
+		authorizationOptions.AllowCacheTTL = 35 * time.Second
 
 		// In some cases the API server can return connection refused when getting the "extension-apiserver-authentication"
 		// config map.


### PR DESCRIPTION
This should contribute to reducing traffic inside a cluster since not every metrics request to our operators (once every 30s per operator) will need to pass an authn/z check (tokenreview/SAR).

/assign @sttts 

/hold
contains fake bump