### PR TITLE
Bug 1896977: add library function for host name validation

### DIFF
--- a/pkg/route/OWNERS
+++ b/pkg/route/OWNERS
@@ -4,6 +4,7 @@ approvers:
   - Miciah
   - sgreene570
   - smarterclayton
+  - candita
 reviewers:
   - danehans
   - frobware
@@ -11,4 +12,5 @@ reviewers:
   - Miciah
   - sgreene570
   - smarterclayton
+  - candita
 component: Routing


### PR DESCRIPTION
Router host name validation does not match between the apiserver validation and the route admission validation. Add the function to the library so it can be shared between the two processes.

Use a k8s apimachinery host name validation that reports the issue properly, as well as enforcing host name must have at least two labels (new), with each label less than 63 chars, and total length less than 253 chars. Trailing dots are allowed (new). The old behavior may be retained for customers who need it, by using a route annotation set to "true".