### PR TITLE
fix bug failed to apply CRD v1

### DIFF
--- a/pkg/operator/resource/resourceapply/generic.go
+++ b/pkg/operator/resource/resourceapply/generic.go
@@ -30,6 +30,7 @@ var (
 func init() {
 	utilruntime.Must(api.InstallKube(genericScheme))
 	utilruntime.Must(apiextensionsv1beta1.AddToScheme(genericScheme))
+	utilruntime.Must(apiextensionsv1.AddToScheme(genericScheme))
 }
 
 type AssetFunc func(name string) ([]byte, error)


### PR DESCRIPTION
Signed-off-by: Zhiwei Yin <zyin@redhat.com>

issue:
I met an issue when  I use `resourceapply.ApplyDirectly` to apply CRD `v1` resources
```
E0111 08:29:45.220260    ....: no kind "CustomResourceDefinition" is registered for version "apiextensions.k8s.io/v1" in scheme "pkg/runtime/scheme.go:101"
```
solution:
add `utilruntime.Must(apiextensionsv1.AddToScheme(genericScheme))` into `init` since `ApplyDirectly` has implemented to apply CRD `v1beta1` and `v1`.