### PR TITLE
[WIP]Add user-request to audit policy and profile

### DIFF
--- a/pkg/operator/apiserver/audit/audit_policies_test.go
+++ b/pkg/operator/apiserver/audit/audit_policies_test.go
@@ -124,7 +124,7 @@ func TestNewAuditPolicyPathGetter(t *testing.T) {
 		{
 			name:         "UserRequests audit policy",
 			profile:      "UserRequests",
-			expectedPath: "/var/run/configmaps/audit/userrequests.yaml",
+			expectedPath: "/var/run/configmaps/audit/userrequestbodies.yaml",
 		},
 		{
 			name:        "audit policy does not exist",

--- a/pkg/operator/apiserver/audit/audit_policies_test.go
+++ b/pkg/operator/apiserver/audit/audit_policies_test.go
@@ -122,6 +122,11 @@ func TestNewAuditPolicyPathGetter(t *testing.T) {
 			expectedPath: "/var/run/configmaps/audit/allrequestbodies.yaml",
 		},
 		{
+			name:         "UserRequests audit policy",
+			profile:      "UserRequests",
+			expectedPath: "/var/run/configmaps/audit/userrequests.yaml",
+		},
+		{
 			name:        "audit policy does not exist",
 			profile:     "Foo",
 			errExpected: true,

--- a/pkg/operator/apiserver/audit/bindata/bindata.go
+++ b/pkg/operator/apiserver/audit/bindata/bindata.go
@@ -354,7 +354,7 @@ data:
       - create
       - delete
     # Logs at Metadata level for these users and groups.
-    - level: Metadata
+    - level: RequestResponse
       userGroups: ["system:authenticated:oauth"]
     - level: Metadata
       users: ["kube:admin"]

--- a/pkg/operator/apiserver/audit/bindata/bindata.go
+++ b/pkg/operator/apiserver/audit/bindata/bindata.go
@@ -313,7 +313,7 @@ data:
     # catch-all rule to log all other requests with request and response payloads
     - level: RequestResponse
 
-  userrequests.yaml: |
+  userrequestbodies.yaml: |
     apiVersion: audit.k8s.io/v1beta1
     kind: Policy
     metadata:
@@ -336,7 +336,7 @@ data:
     - level: Metadata
       users: ["kube:admin"]
 
-  secure-oauth-storage-userrequests.yaml: |
+  secure-oauth-storage-userrequestbodies.yaml: |
     apiVersion: audit.k8s.io/v1beta1
     kind: Policy
     metadata:

--- a/pkg/operator/apiserver/audit/bindata/bindata.go
+++ b/pkg/operator/apiserver/audit/bindata/bindata.go
@@ -311,7 +311,54 @@ data:
       - group: "oauth.openshift.io"
         resources: ["oauthclients"]
     # catch-all rule to log all other requests with request and response payloads
-    - level: RequestResponse`)
+    - level: RequestResponse
+
+  userrequests.yaml: |
+    apiVersion: audit.k8s.io/v1beta1
+    kind: Policy
+    metadata:
+      name: UserRequests
+    # Don't generate audit events for all requests in RequestReceived stage.
+    omitStages:
+    - "RequestReceived"
+    rules:
+    # Logs request and response for oauthaccess tokens.
+    - level: RequestResponse
+      resources:
+      - group: "oauth.openshift.io"
+        resources: ["oauthaccesstokens"]
+      verbs:
+      - create
+      - delete
+    # Logs at Metadata level for these users and groups.
+    - level: Metadata
+      userGroups: ["system:authenticated:oauth"]
+    - level: Metadata
+      users: ["kube:admin"]
+
+  secure-oauth-storage-userrequests.yaml: |
+    apiVersion: audit.k8s.io/v1beta1
+    kind: Policy
+    metadata:
+      name: UserRequests
+    # Don't generate audit events for all requests in RequestReceived stage.
+    omitStages:
+    - "RequestReceived"
+    rules:
+    # Logs request and response for oauthaccess tokens.
+    - level: RequestResponse
+      resources:
+      - group: "oauth.openshift.io"
+        resources: ["oauthaccesstokens"]
+      verbs:
+      - create
+      - delete
+    # Logs at Metadata level for these users and groups.
+    - level: Metadata
+      userGroups: ["system:authenticated:oauth"]
+    - level: Metadata
+      users: ["kube:admin"]
+`)
 
 func pkgOperatorApiserverAuditManifestsAuditPoliciesCmYamlBytes() ([]byte, error) {
 	return _pkgOperatorApiserverAuditManifestsAuditPoliciesCmYaml, nil

--- a/pkg/operator/apiserver/audit/bindata/bindata.go
+++ b/pkg/operator/apiserver/audit/bindata/bindata.go
@@ -322,8 +322,8 @@ data:
     omitStages:
     - "RequestReceived"
     rules:
-    # Logs request and response for oauthaccess tokens.
-    - level: RequestResponse
+    # Don't log for oauth tokens.
+    - level: None
       resources:
       - group: "oauth.openshift.io"
         resources: ["oauthaccesstokens"]
@@ -345,8 +345,8 @@ data:
     omitStages:
     - "RequestReceived"
     rules:
-    # Logs request and response for oauthaccess tokens.
-    - level: RequestResponse
+    # Log at Request level for oauth tokens
+    - level: Request
       resources:
       - group: "oauth.openshift.io"
         resources: ["oauthaccesstokens"]

--- a/pkg/operator/apiserver/audit/manifests/audit-policies-cm.yaml
+++ b/pkg/operator/apiserver/audit/manifests/audit-policies-cm.yaml
@@ -266,8 +266,8 @@ data:
     omitStages:
     - "RequestReceived"
     rules:
-    # Logs request and response for oauthaccess tokens.
-    - level: RequestResponse
+    # Don't log for oauth tokens.
+    - level: None
       resources:
       - group: "oauth.openshift.io"
         resources: ["oauthaccesstokens"]
@@ -289,8 +289,8 @@ data:
     omitStages:
     - "RequestReceived"
     rules:
-    # Logs request and response for oauthaccess tokens.
-    - level: RequestResponse
+    # Log at Request level for oauth tokens
+    - level: Request
       resources:
       - group: "oauth.openshift.io"
         resources: ["oauthaccesstokens"]

--- a/pkg/operator/apiserver/audit/manifests/audit-policies-cm.yaml
+++ b/pkg/operator/apiserver/audit/manifests/audit-policies-cm.yaml
@@ -256,3 +256,49 @@ data:
         resources: ["oauthclients"]
     # catch-all rule to log all other requests with request and response payloads
     - level: RequestResponse
+
+  userrequests.yaml: |
+    apiVersion: audit.k8s.io/v1beta1
+    kind: Policy
+    metadata:
+      name: UserRequests
+    # Don't generate audit events for all requests in RequestReceived stage.
+    omitStages:
+    - "RequestReceived"
+    rules:
+    # Logs request and response for oauthaccess tokens.
+    - level: RequestResponse
+      resources:
+      - group: "oauth.openshift.io"
+        resources: ["oauthaccesstokens"]
+      verbs:
+      - create
+      - delete
+    # Logs at Metadata level for these users and groups.
+    - level: Metadata
+      userGroups: ["system:authenticated:oauth"]
+    - level: Metadata
+      users: ["kube:admin"]
+
+  secure-oauth-storage-userrequests.yaml: |
+    apiVersion: audit.k8s.io/v1beta1
+    kind: Policy
+    metadata:
+      name: UserRequests
+    # Don't generate audit events for all requests in RequestReceived stage.
+    omitStages:
+    - "RequestReceived"
+    rules:
+    # Logs request and response for oauthaccess tokens.
+    - level: RequestResponse
+      resources:
+      - group: "oauth.openshift.io"
+        resources: ["oauthaccesstokens"]
+      verbs:
+      - create
+      - delete
+    # Logs at Metadata level for these users and groups.
+    - level: Metadata
+      userGroups: ["system:authenticated:oauth"]
+    - level: Metadata
+      users: ["kube:admin"]

--- a/pkg/operator/apiserver/audit/manifests/audit-policies-cm.yaml
+++ b/pkg/operator/apiserver/audit/manifests/audit-policies-cm.yaml
@@ -257,7 +257,7 @@ data:
     # catch-all rule to log all other requests with request and response payloads
     - level: RequestResponse
 
-  userrequests.yaml: |
+  userrequestbodies.yaml: |
     apiVersion: audit.k8s.io/v1beta1
     kind: Policy
     metadata:
@@ -280,7 +280,7 @@ data:
     - level: Metadata
       users: ["kube:admin"]
 
-  secure-oauth-storage-userrequests.yaml: |
+  secure-oauth-storage-userrequestbodies.yaml: |
     apiVersion: audit.k8s.io/v1beta1
     kind: Policy
     metadata:

--- a/pkg/operator/apiserver/audit/manifests/audit-policies-cm.yaml
+++ b/pkg/operator/apiserver/audit/manifests/audit-policies-cm.yaml
@@ -298,7 +298,7 @@ data:
       - create
       - delete
     # Logs at Metadata level for these users and groups.
-    - level: Metadata
+    - level: RequestResponse
       userGroups: ["system:authenticated:oauth"]
     - level: Metadata
       users: ["kube:admin"]

--- a/pkg/operator/apiserver/audit/testdata/audit-policies-cm-scenario-1.yaml
+++ b/pkg/operator/apiserver/audit/testdata/audit-policies-cm-scenario-1.yaml
@@ -256,3 +256,49 @@ data:
         resources: ["oauthclients"]
     # catch-all rule to log all other requests with request and response payloads
     - level: RequestResponse
+
+  userrequests.yaml: |
+    apiVersion: audit.k8s.io/v1beta1
+    kind: Policy
+    metadata:
+      name: UserRequests
+    # Don't generate audit events for all requests in RequestReceived stage.
+    omitStages:
+    - "RequestReceived"
+    rules:
+    # Logs request and response for oauthaccess tokens.
+    - level: RequestResponse
+      resources:
+      - group: "oauth.openshift.io"
+        resources: ["oauthaccesstokens"]
+      verbs:
+      - create
+      - delete
+    # Logs at Metadata level for these users and groups.
+    - level: Metadata
+      userGroups: ["system:authenticated:oauth"]
+    - level: Metadata
+      users: ["kube:admin"]
+
+  secure-oauth-storage-userrequests.yaml: |
+    apiVersion: audit.k8s.io/v1beta1
+    kind: Policy
+    metadata:
+      name: UserRequests
+    # Don't generate audit events for all requests in RequestReceived stage.
+    omitStages:
+    - "RequestReceived"
+    rules:
+    # Logs request and response for oauthaccess tokens.
+    - level: RequestResponse
+      resources:
+      - group: "oauth.openshift.io"
+        resources: ["oauthaccesstokens"]
+      verbs:
+      - create
+      - delete
+    # Logs at Metadata level for these users and groups.
+    - level: Metadata
+      userGroups: ["system:authenticated:oauth"]
+    - level: Metadata
+      users: ["kube:admin"]

--- a/pkg/operator/apiserver/audit/testdata/audit-policies-cm-scenario-1.yaml
+++ b/pkg/operator/apiserver/audit/testdata/audit-policies-cm-scenario-1.yaml
@@ -257,7 +257,7 @@ data:
     # catch-all rule to log all other requests with request and response payloads
     - level: RequestResponse
 
-  userrequests.yaml: |
+  userrequestbodies.yaml: |
     apiVersion: audit.k8s.io/v1beta1
     kind: Policy
     metadata:
@@ -280,7 +280,7 @@ data:
     - level: Metadata
       users: ["kube:admin"]
 
-  secure-oauth-storage-userrequests.yaml: |
+  secure-oauth-storage-userrequestbodies.yaml: |
     apiVersion: audit.k8s.io/v1beta1
     kind: Policy
     metadata:


### PR DESCRIPTION
This PR adds the userrequest profile and policy and associated unit tests. This policy adds the ability to filter audit logs on the resource requests of system:authenticated:oauth users.