### PR TITLE
optimize library-go to eliminate unnecessary SARs

### DIFF
--- a/pkg/config/serving/server.go
+++ b/pkg/config/serving/server.go
@@ -58,7 +58,10 @@ func ToServerConfig(ctx context.Context, servingInfo configv1.HTTPServingInfo, a
 	}
 
 	if !authorizationConfig.Disabled {
-		authorizationOptions := genericapiserveroptions.NewDelegatingAuthorizationOptions()
+		authorizationOptions := genericapiserveroptions.NewDelegatingAuthorizationOptions().
+			WithAlwaysAllowPaths("/healthz", "/readyz", "/livez"). // this allows the kubelet to always get health and readiness without causing an access check
+			WithAlwaysAllowGroups("system:masters")                // in a kube cluster, system:masters can take any action, so there is no need to ask for an authz check
+
 		authorizationOptions.RemoteKubeConfigFile = kubeConfigFile
 		// the platform generally uses 30s for /metrics scraping, avoid API request for every other /metrics request to the component
 		authorizationOptions.AllowCacheTTL = 35 * time.Second


### PR DESCRIPTION
healthz and readyz have to accessible to unauthenticated so the kubelet can health check. Because of this, there is no reason to run an authz check on them.

system:masters has full power, so the authorization check is unnecessary and just uses an extra call.