### PR TITLE
introduces a few convenient functions for querying netlink subsystem

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/docker/go-metrics v0.0.1 // indirect
 	github.com/docker/libnetwork v0.0.0-20190731215715-7f13a5c99f4b // indirect
 	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect
+	github.com/elastic/gosigar v0.13.0
 	github.com/evanphx/json-patch v4.9.0+incompatible
 	github.com/fsouza/go-dockerclient v0.0.0-20171004212419-da3951ba2e9e
 	github.com/getsentry/raven-go v0.0.0-20190513200303-c977f96e1095

--- a/go.sum
+++ b/go.sum
@@ -143,6 +143,8 @@ github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/elastic/gosigar v0.13.0 h1:EIeuQcLPKia759s6mlVztlxUyKiKYHo6y6kOODOLO7A=
+github.com/elastic/gosigar v0.13.0/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
@@ -703,6 +705,7 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20180810173357-98c5dad5d1a0/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/pkg/network/networkutils/netlink.go
+++ b/pkg/network/networkutils/netlink.go
@@ -1,0 +1,167 @@
+// +build linux
+
+package networkutils
+
+import (
+	"fmt"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	nl "github.com/elastic/gosigar/sys/linux"
+)
+
+// SocketDiagMsg struct that holds data returned from netlink and filtered for our purposes
+//
+// full description can be found at https://man7.org/linux/man-pages/man7/sock_diag.7.html
+// the original struct name is inet_diag_msg
+type SocketDiagMsg struct {
+	// state holds a human-readable value of the socket state, like ESTABLISHED or LISTEN
+	state string
+
+	// recvQ - from https://man7.org/linux/man-pages/man7/sock_diag.7.html:
+	//  for listening sockets: the number of pending connections.
+	//  for other sockets: the amount of data in the incoming queue.
+	//
+	// in practice it tells you the number of bytes of data that have been received by the kernel but haven't been copied by the process
+	recvQ int
+
+	// sendQ - from https://man7.org/linux/man-pages/man7/sock_diag.7.html:
+	//  for listening sockets: the backlog length.
+	//  for other sockets: the amount of memory available for sending.
+	//
+	// in practice it tells you the number of bytes data that have been sent but hasn't been acknowledged
+	sendQ int
+
+	// localAddress holds an IP address and the port of the local process
+	localAddress string
+
+	// remoteAddress holds an IP address and the port of the remote process
+	remoteAddress string
+
+	// timer - see timerFieldToHumanReadable for possible values
+	timer string
+
+	// retransmissions - for timer values 1, 2, and 4, this field contains
+	// the number of retransmits. For other timer values, this field is set to 0.
+	retransmissions int
+
+	// timerExpiry - for TCP sockets that have an active timer, this field
+	// describes its expiration time in milliseconds.  For other sockets, this field is set to 0.
+	//
+	// note: it will hold the current value at the probe time
+	timerExpiry int
+}
+
+// for TCP sockets, this field describes the type of timer
+// that is currently active for the socket.  It is set to one of the following constants:
+//
+// 0 - no timer is active
+// 1 - a retransmit timer
+// 2 - a keep-alive timer
+// 3 - a TIME_WAIT timer
+// 4 - a zero window probe timer
+func timerFieldToHumanReadable(timer uint8) string {
+	switch timer {
+	case 0:
+		return "no-timer"
+	case 1:
+		return "retransmit"
+	case 2:
+		return "keep-alive"
+	case 3:
+		return "time-wait"
+	case 4:
+		return "probe"
+	default:
+		return "unknown"
+	}
+}
+
+// GetNetworkSocketsDiagnosticMsg returns an array of SocketDiagMsg both for IPv4 and IPv6 sockets.
+// Check SocketDiagMsg struct to see what data it holds.
+//
+// This method uses netlink subsystem for obtaining information
+// about sockets of various address families from the linux kernel.
+//
+// in the future we could:
+//  use InetDiagReqV2 to specify an address family (IPv4 or IPv6) and a protocol (TCP, UDP)
+//  ask the kernel to only return sockets for specific port or address (filtering)
+//
+// Note:
+//  depending on the platform this function is run on, it might require setting custom permissions.
+func GetNetworkSocketsDiagnosticMsg() ([]*SocketDiagMsg, error) {
+	rawInetDiagRsp, err := nl.NetlinkInetDiagWithBuf(nl.NewInetDiagReq(), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := make([]*SocketDiagMsg, 0, len(rawInetDiagRsp))
+	for _, rawDiagMsg := range rawInetDiagRsp {
+		ret = append(ret, &SocketDiagMsg{
+			state:           nl.TCPState(rawDiagMsg.State).String(),
+			recvQ:           int(rawDiagMsg.RQueue),
+			sendQ:           int(rawDiagMsg.WQueue),
+			localAddress:    fmt.Sprintf("%v:%v", rawDiagMsg.SrcIP().String(), rawDiagMsg.SrcPort()),
+			remoteAddress:   fmt.Sprintf("%v:%v", rawDiagMsg.DstIP().String(), rawDiagMsg.DstPort()),
+			timer:           timerFieldToHumanReadable(rawDiagMsg.Timer),
+			retransmissions: int(rawDiagMsg.Retrans),
+			timerExpiry:     int(rawDiagMsg.Expires / 1000),
+		})
+	}
+
+	return ret, nil
+}
+
+// GetSocketStateChanges returns a list of SocketDiagMsg that has changed according the current state and data returned from GetNetworkSocketsDiagnosticMsg method
+func GetSocketStateChanges(socketsDiag []*SocketDiagMsg, state map[string]*SocketDiagMsg) []*SocketDiagMsg {
+	ret := []*SocketDiagMsg{}
+	visitedSocketKeys := sets.String{}
+	changedSocketsKeys := sets.String{}
+	for _, currentSocketDiag := range socketsDiag {
+		socketKey := currentSocketDiag.localAddress
+		if changed := detectSocketChangesAndUpdate(socketKey, currentSocketDiag, state); changed {
+			changedSocketsKeys.Insert(socketKey)
+			ret = append(ret, currentSocketDiag)
+		}
+		visitedSocketKeys.Insert(socketKey)
+	}
+
+	// detect closed sockets
+	allSocketKeys := sets.String{}
+	for socketKey := range state {
+		allSocketKeys.Insert(socketKey)
+	}
+	closedSocketKeys := allSocketKeys.Difference(visitedSocketKeys).List()
+	for _, closedSocketKey := range closedSocketKeys {
+		prevSocketDiag, _ := state[closedSocketKey]
+		prevSocketDiag.state = "CLOSED"
+		ret = append(ret, prevSocketDiag)
+		delete(state, closedSocketKey)
+	}
+	return ret
+}
+
+// detectSocketChangesAndUpdate detect changes to the currentSocketDiag and updates the state.
+// It notifies the caller whether the currentSocketDiag has changed so that further processing can be done.
+func detectSocketChangesAndUpdate(socketKey string, currentSocketDiag *SocketDiagMsg, state map[string]*SocketDiagMsg) bool {
+	// store the copy
+	currentSocketDiagCpy := *currentSocketDiag
+
+	// clear fields that are not stable and we don't want to track
+	currentSocketDiagCpy.timerExpiry = 0
+
+	// new socket that hasn't been seen
+	prevSocketDiag, exists := state[socketKey]
+	if !exists {
+		state[socketKey] = &currentSocketDiagCpy
+		return true
+	}
+
+	// SocketDiagMsg holds simple types thus dereferencing and comparing works
+	if *prevSocketDiag == currentSocketDiagCpy {
+		return false
+	}
+
+	// something has changed
+	state[socketKey] = &currentSocketDiagCpy
+	return true
+}

--- a/vendor/github.com/elastic/gosigar/LICENSE
+++ b/vendor/github.com/elastic/gosigar/LICENSE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/vendor/github.com/elastic/gosigar/NOTICE
+++ b/vendor/github.com/elastic/gosigar/NOTICE
@@ -1,0 +1,9 @@
+Copyright (c) [2009-2011] VMware, Inc. All Rights Reserved. 
+
+This product is licensed to you under the Apache License, Version 2.0 (the "License").  
+You may not use this product except in compliance with the License.  
+
+This product includes a number of subcomponents with
+separate copyright notices and license terms. Your use of these
+subcomponents is subject to the terms and conditions of the 
+subcomponent's license, as noted in the LICENSE file.

--- a/vendor/github.com/elastic/gosigar/sys/endian.go
+++ b/vendor/github.com/elastic/gosigar/sys/endian.go
@@ -1,0 +1,16 @@
+package sys
+
+import (
+	"encoding/binary"
+	"unsafe"
+)
+
+func GetEndian() binary.ByteOrder {
+	var i int32 = 0x1
+	v := (*[4]byte)(unsafe.Pointer(&i))
+	if v[0] == 0 {
+		return binary.BigEndian
+	} else {
+		return binary.LittleEndian
+	}
+}

--- a/vendor/github.com/elastic/gosigar/sys/linux/inetdiag.go
+++ b/vendor/github.com/elastic/gosigar/sys/linux/inetdiag.go
@@ -1,0 +1,381 @@
+// +build linux
+
+package linux
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"hash/fnv"
+	"io"
+	"net"
+	"os"
+	"syscall"
+	"unsafe"
+
+	"github.com/elastic/gosigar/sys"
+	"github.com/pkg/errors"
+)
+
+// Enums / Constants
+
+const (
+	// AllTCPStates is a flag to request all sockets in any TCP state.
+	AllTCPStates = ^uint32(0)
+
+	// TCPDIAG_GETSOCK is the netlink message type for requesting TCP diag data.
+	// https://github.com/torvalds/linux/blob/v4.0/include/uapi/linux/inet_diag.h#L7
+	TCPDIAG_GETSOCK = 18
+
+	// SOCK_DIAG_BY_FAMILY is the netlink message type for requestion socket
+	// diag data by family. This is newer and can be used with inet_diag_req_v2.
+	// https://github.com/torvalds/linux/blob/v4.0/include/uapi/linux/sock_diag.h#L6
+	SOCK_DIAG_BY_FAMILY = 20
+)
+
+// AddressFamily is the address family of the socket.
+type AddressFamily uint8
+
+// https://github.com/torvalds/linux/blob/5924bbecd0267d87c24110cbe2041b5075173a25/include/linux/socket.h#L159
+const (
+	AF_INET  AddressFamily = 2
+	AF_INET6               = 10
+)
+
+var addressFamilyNames = map[AddressFamily]string{
+	AF_INET:  "ipv4",
+	AF_INET6: "ipv6",
+}
+
+func (af AddressFamily) String() string {
+	if fam, found := addressFamilyNames[af]; found {
+		return fam
+	}
+	return fmt.Sprintf("UNKNOWN (%d)", af)
+}
+
+// TCPState represents the state of a TCP connection.
+type TCPState uint8
+
+// https://github.com/torvalds/linux/blob/5924bbecd0267d87c24110cbe2041b5075173a25/include/net/tcp_states.h#L16
+const (
+	TCP_ESTABLISHED TCPState = iota + 1
+	TCP_SYN_SENT
+	TCP_SYN_RECV
+	TCP_FIN_WAIT1
+	TCP_FIN_WAIT2
+	TCP_TIME_WAIT
+	TCP_CLOSE
+	TCP_CLOSE_WAIT
+	TCP_LAST_ACK
+	TCP_LISTEN
+	TCP_CLOSING /* Now a valid state */
+)
+
+var tcpStateNames = map[TCPState]string{
+	TCP_ESTABLISHED: "ESTAB",
+	TCP_SYN_SENT:    "SYN-SENT",
+	TCP_SYN_RECV:    "SYN-RECV",
+	TCP_FIN_WAIT1:   "FIN-WAIT-1",
+	TCP_FIN_WAIT2:   "FIN-WAIT-2",
+	TCP_TIME_WAIT:   "TIME-WAIT",
+	TCP_CLOSE:       "UNCONN",
+	TCP_CLOSE_WAIT:  "CLOSE-WAIT",
+	TCP_LAST_ACK:    "LAST-ACK",
+	TCP_LISTEN:      "LISTEN",
+	TCP_CLOSING:     "CLOSING",
+}
+
+func (s TCPState) String() string {
+	if state, found := tcpStateNames[s]; found {
+		return state
+	}
+	return "UNKNOWN"
+}
+
+// Extensions that can be used in the InetDiagReqV2 request to ask for
+// additional data.
+// https://github.com/torvalds/linux/blob/v4.0/include/uapi/linux/inet_diag.h#L103
+const (
+	INET_DIAG_NONE    = 0
+	INET_DIAG_MEMINFO = 1 << iota
+	INET_DIAG_INFO
+	INET_DIAG_VEGASINFO
+	INET_DIAG_CONG
+	INET_DIAG_TOS
+	INET_DIAG_TCLASS
+	INET_DIAG_SKMEMINFO
+	INET_DIAG_SHUTDOWN
+	INET_DIAG_DCTCPINFO
+	INET_DIAG_PROTOCOL /* response attribute only */
+	INET_DIAG_SKV6ONLY
+	INET_DIAG_LOCALS
+	INET_DIAG_PEERS
+	INET_DIAG_PAD
+	INET_DIAG_MARK
+)
+
+var (
+	byteOrder = sys.GetEndian()
+)
+
+// NetlinkInetDiag sends the given netlink request parses the responses with the
+// assumption that they are inet_diag_msgs. This will allocate a temporary
+// buffer for reading from the socket whose size will be the length of a page
+// (usually 32k). Use NetlinkInetDiagWithBuf if you want to provide your own
+// buffer.
+func NetlinkInetDiag(request syscall.NetlinkMessage) ([]*InetDiagMsg, error) {
+	return NetlinkInetDiagWithBuf(request, nil, nil)
+}
+
+// NetlinkInetDiagWithBuf sends the given netlink request parses the responses
+// with the assumption that they are inet_diag_msgs. readBuf will be used to
+// hold the raw data read from the socket. If the length is not large enough to
+// hold the socket contents the data will be truncated. If readBuf is nil then a
+// temporary buffer will be allocated for each invocation. The resp writer, if
+// non-nil, will receive a copy of all bytes read (this is useful for
+// debugging).
+func NetlinkInetDiagWithBuf(request syscall.NetlinkMessage, readBuf []byte, resp io.Writer) ([]*InetDiagMsg, error) {
+	s, err := syscall.Socket(syscall.AF_NETLINK, syscall.SOCK_RAW, syscall.NETLINK_INET_DIAG)
+	if err != nil {
+		return nil, err
+	}
+	defer syscall.Close(s)
+
+	lsa := &syscall.SockaddrNetlink{Family: syscall.AF_NETLINK}
+	if err := syscall.Sendto(s, serialize(request), 0, lsa); err != nil {
+		return nil, err
+	}
+
+	if len(readBuf) == 0 {
+		// Default size used in libnl.
+		readBuf = make([]byte, os.Getpagesize())
+	}
+
+	var inetDiagMsgs []*InetDiagMsg
+done:
+	for {
+		buf := readBuf
+		nr, _, err := syscall.Recvfrom(s, buf, 0)
+		if err != nil {
+			return nil, err
+		}
+		if nr < syscall.NLMSG_HDRLEN {
+			return nil, syscall.EINVAL
+		}
+
+		buf = buf[:nr]
+
+		// Dump raw data for inspection purposes.
+		if resp != nil {
+			if _, err := resp.Write(buf); err != nil {
+				return nil, err
+			}
+		}
+
+		msgs, err := syscall.ParseNetlinkMessage(buf)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, m := range msgs {
+			if m.Header.Type == syscall.NLMSG_DONE {
+				break done
+			}
+			if m.Header.Type == syscall.NLMSG_ERROR {
+				return nil, ParseNetlinkError(m.Data)
+			}
+
+			inetDiagMsg, err := ParseInetDiagMsg(m.Data)
+			if err != nil {
+				return nil, err
+			}
+			inetDiagMsgs = append(inetDiagMsgs, inetDiagMsg)
+		}
+	}
+	return inetDiagMsgs, nil
+}
+
+func serialize(msg syscall.NetlinkMessage) []byte {
+	msg.Header.Len = uint32(syscall.SizeofNlMsghdr + len(msg.Data))
+	b := make([]byte, msg.Header.Len)
+	byteOrder.PutUint32(b[0:4], msg.Header.Len)
+	byteOrder.PutUint16(b[4:6], msg.Header.Type)
+	byteOrder.PutUint16(b[6:8], msg.Header.Flags)
+	byteOrder.PutUint32(b[8:12], msg.Header.Seq)
+	byteOrder.PutUint32(b[12:16], msg.Header.Pid)
+	copy(b[16:], msg.Data)
+	return b
+}
+
+// Request messages.
+
+var sizeofInetDiagReq = int(unsafe.Sizeof(InetDiagReq{}))
+
+// InetDiagReq (inet_diag_req) is used to request diagnostic data from older
+// kernels.
+// https://github.com/torvalds/linux/blob/v4.0/include/uapi/linux/inet_diag.h#L25
+type InetDiagReq struct {
+	Family uint8
+	SrcLen uint8
+	DstLen uint8
+	Ext    uint8
+	ID     InetDiagSockID
+	States uint32 // States to dump.
+	DBs    uint32 // Tables to dump.
+}
+
+func (r InetDiagReq) toWireFormat() []byte {
+	buf := bytes.NewBuffer(make([]byte, sizeofInetDiagReq))
+	buf.Reset()
+	if err := binary.Write(buf, byteOrder, r); err != nil {
+		// This never returns an error.
+		panic(err)
+	}
+	return buf.Bytes()
+}
+
+// NewInetDiagReq returns a new NetlinkMessage whose payload is an InetDiagReq.
+// Callers should set their own sequence number in the returned message header.
+func NewInetDiagReq() syscall.NetlinkMessage {
+	hdr := syscall.NlMsghdr{
+		Type:  uint16(TCPDIAG_GETSOCK),
+		Flags: uint16(syscall.NLM_F_DUMP | syscall.NLM_F_REQUEST),
+		Pid:   uint32(0),
+	}
+	req := InetDiagReq{
+		Family: uint8(AF_INET), // This returns both ipv4 and ipv6.
+		States: AllTCPStates,
+	}
+
+	return syscall.NetlinkMessage{Header: hdr, Data: req.toWireFormat()}
+}
+
+// V2 Request
+
+var sizeofInetDiagReqV2 = int(unsafe.Sizeof(InetDiagReqV2{}))
+
+// InetDiagReqV2 (inet_diag_req_v2) is used to request diagnostic data.
+// https://github.com/torvalds/linux/blob/v4.0/include/uapi/linux/inet_diag.h#L37
+type InetDiagReqV2 struct {
+	Family   uint8
+	Protocol uint8
+	Ext      uint8
+	Pad      uint8
+	States   uint32
+	ID       InetDiagSockID
+}
+
+func (r InetDiagReqV2) toWireFormat() []byte {
+	buf := bytes.NewBuffer(make([]byte, sizeofInetDiagReqV2))
+	buf.Reset()
+	if err := binary.Write(buf, byteOrder, r); err != nil {
+		// This never returns an error.
+		panic(err)
+	}
+	return buf.Bytes()
+}
+
+// NewInetDiagReqV2 returns a new NetlinkMessage whose payload is an
+// InetDiagReqV2. Callers should set their own sequence number in the returned
+// message header.
+func NewInetDiagReqV2(af AddressFamily) syscall.NetlinkMessage {
+	hdr := syscall.NlMsghdr{
+		Type:  uint16(SOCK_DIAG_BY_FAMILY),
+		Flags: uint16(syscall.NLM_F_DUMP | syscall.NLM_F_REQUEST),
+		Pid:   uint32(0),
+	}
+	req := InetDiagReqV2{
+		Family:   uint8(af),
+		Protocol: syscall.IPPROTO_TCP,
+		States:   AllTCPStates,
+	}
+
+	return syscall.NetlinkMessage{Header: hdr, Data: req.toWireFormat()}
+}
+
+// Response messages.
+
+// InetDiagMsg (inet_diag_msg) is the base info structure. It contains socket
+// identity (addrs/ports/cookie) and the information shown by netstat.
+// https://github.com/torvalds/linux/blob/v4.0/include/uapi/linux/inet_diag.h#L86
+type InetDiagMsg struct {
+	Family  uint8 // Address family.
+	State   uint8 // TCP State
+	Timer   uint8
+	Retrans uint8
+
+	ID InetDiagSockID
+
+	Expires uint32
+	RQueue  uint32 // Recv-Q
+	WQueue  uint32 // Send-Q
+	UID     uint32 // UID
+	Inode   uint32 // Inode of socket.
+}
+
+// ParseInetDiagMsg parse an InetDiagMsg from a byte slice. It assumes the
+// InetDiagMsg starts at the beginning of b. Invoke this method to parse the
+// payload of a netlink response.
+func ParseInetDiagMsg(b []byte) (*InetDiagMsg, error) {
+	r := bytes.NewReader(b)
+	inetDiagMsg := &InetDiagMsg{}
+	err := binary.Read(r, byteOrder, inetDiagMsg)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal inet_diag_msg")
+	}
+	return inetDiagMsg, nil
+}
+
+// SrcPort returns the source (local) port.
+func (m InetDiagMsg) SrcPort() int { return int(binary.BigEndian.Uint16(m.ID.SPort[:])) }
+
+// DstPort returns the destination (remote) port.
+func (m InetDiagMsg) DstPort() int { return int(binary.BigEndian.Uint16(m.ID.DPort[:])) }
+
+// SrcIP returns the source (local) IP.
+func (m InetDiagMsg) SrcIP() net.IP { return ip(m.ID.Src, AddressFamily(m.Family)) }
+
+// DstIP returns the destination (remote) IP.
+func (m InetDiagMsg) DstIP() net.IP { return ip(m.ID.Dst, AddressFamily(m.Family)) }
+
+func (m InetDiagMsg) srcIPBytes() []byte { return ipBytes(m.ID.Src, AddressFamily(m.Family)) }
+func (m InetDiagMsg) dstIPBytes() []byte { return ipBytes(m.ID.Dst, AddressFamily(m.Family)) }
+
+func ip(data [16]byte, af AddressFamily) net.IP {
+	if af == AF_INET {
+		return net.IPv4(data[0], data[1], data[2], data[3])
+	}
+	return net.IP(data[:])
+}
+
+func ipBytes(data [16]byte, af AddressFamily) []byte {
+	if af == AF_INET {
+		return data[:4]
+	}
+
+	return data[:]
+}
+
+// FastHash returns a hash calculated using FNV-1 of the source and destination
+// addresses.
+func (m *InetDiagMsg) FastHash() uint64 {
+	// Hash using FNV-1 algorithm.
+	h := fnv.New64()
+	h.Write(m.srcIPBytes()) // Must trim non-zero garbage from ipv4 buffers.
+	h.Write(m.dstIPBytes())
+	h.Write(m.ID.SPort[:])
+	h.Write(m.ID.DPort[:])
+	return h.Sum64()
+}
+
+// InetDiagSockID (inet_diag_sockid) contains the socket identity.
+// https://github.com/torvalds/linux/blob/v4.0/include/uapi/linux/inet_diag.h#L13
+type InetDiagSockID struct {
+	SPort  [2]byte  // Source port (big-endian).
+	DPort  [2]byte  // Destination port (big-endian).
+	Src    [16]byte // Source IP
+	Dst    [16]byte // Destination IP
+	If     uint32
+	Cookie [2]uint32
+}

--- a/vendor/github.com/elastic/gosigar/sys/linux/netlink.go
+++ b/vendor/github.com/elastic/gosigar/sys/linux/netlink.go
@@ -1,0 +1,112 @@
+// +build linux
+
+package linux
+
+import (
+	"errors"
+
+	"github.com/elastic/gosigar/sys"
+)
+
+// Netlink Error Code Handling
+
+// ParseNetlinkError parses the errno from the data section of a
+// syscall.NetlinkMessage. If netlinkData is less than 4 bytes an error
+// describing the problem will be returned.
+func ParseNetlinkError(netlinkData []byte) error {
+	if len(netlinkData) >= 4 {
+		errno := -sys.GetEndian().Uint32(netlinkData[:4])
+		return NetlinkErrno(errno)
+	}
+	return errors.New("received netlink error (data too short to read errno)")
+}
+
+// NetlinkErrno represent the error code contained in a netlink message of
+// type NLMSG_ERROR.
+type NetlinkErrno uint32
+
+// Netlink error codes.
+const (
+	NLE_SUCCESS NetlinkErrno = iota
+	NLE_FAILURE
+	NLE_INTR
+	NLE_BAD_SOCK
+	NLE_AGAIN
+	NLE_NOMEM
+	NLE_EXIST
+	NLE_INVAL
+	NLE_RANGE
+	NLE_MSGSIZE
+	NLE_OPNOTSUPP
+	NLE_AF_NOSUPPORT
+	NLE_OBJ_NOTFOUND
+	NLE_NOATTR
+	NLE_MISSING_ATTR
+	NLE_AF_MISMATCH
+	NLE_SEQ_MISMATCH
+	NLE_MSG_OVERFLOW
+	NLE_MSG_TRUNC
+	NLE_NOADDR
+	NLE_SRCRT_NOSUPPORT
+	NLE_MSG_TOOSHORT
+	NLE_MSGTYPE_NOSUPPORT
+	NLE_OBJ_MISMATCH
+	NLE_NOCACHE
+	NLE_BUSY
+	NLE_PROTO_MISMATCH
+	NLE_NOACCESS
+	NLE_PERM
+	NLE_PKTLOC_FILE
+	NLE_PARSE_ERR
+	NLE_NODEV
+	NLE_IMMUTABLE
+	NLE_DUMP_INTR
+	NLE_ATTRSIZE
+)
+
+// https://github.com/thom311/libnl/blob/libnl3_2_28/lib/error.c
+var netlinkErrorMsgs = map[NetlinkErrno]string{
+	NLE_SUCCESS:           "Success",
+	NLE_FAILURE:           "Unspecific failure",
+	NLE_INTR:              "Interrupted system call",
+	NLE_BAD_SOCK:          "Bad socket",
+	NLE_AGAIN:             "Try again",
+	NLE_NOMEM:             "Out of memory",
+	NLE_EXIST:             "Object exists",
+	NLE_INVAL:             "Invalid input data or parameter",
+	NLE_RANGE:             "Input data out of range",
+	NLE_MSGSIZE:           "Message size not sufficient",
+	NLE_OPNOTSUPP:         "Operation not supported",
+	NLE_AF_NOSUPPORT:      "Address family not supported",
+	NLE_OBJ_NOTFOUND:      "Object not found",
+	NLE_NOATTR:            "Attribute not available",
+	NLE_MISSING_ATTR:      "Missing attribute",
+	NLE_AF_MISMATCH:       "Address family mismatch",
+	NLE_SEQ_MISMATCH:      "Message sequence number mismatch",
+	NLE_MSG_OVERFLOW:      "Kernel reported message overflow",
+	NLE_MSG_TRUNC:         "Kernel reported truncated message",
+	NLE_NOADDR:            "Invalid address for specified address family",
+	NLE_SRCRT_NOSUPPORT:   "Source based routing not supported",
+	NLE_MSG_TOOSHORT:      "Netlink message is too short",
+	NLE_MSGTYPE_NOSUPPORT: "Netlink message type is not supported",
+	NLE_OBJ_MISMATCH:      "Object type does not match cache",
+	NLE_NOCACHE:           "Unknown or invalid cache type",
+	NLE_BUSY:              "Object busy",
+	NLE_PROTO_MISMATCH:    "Protocol mismatch",
+	NLE_NOACCESS:          "No Access",
+	NLE_PERM:              "Operation not permitted",
+	NLE_PKTLOC_FILE:       "Unable to open packet location file",
+	NLE_PARSE_ERR:         "Unable to parse object",
+	NLE_NODEV:             "No such device",
+	NLE_IMMUTABLE:         "Immutable attribute",
+	NLE_DUMP_INTR:         "Dump inconsistency detected, interrupted",
+	NLE_ATTRSIZE:          "Attribute max length exceeded",
+}
+
+func (e NetlinkErrno) Error() string {
+	if msg, found := netlinkErrorMsgs[e]; found {
+		return msg
+	}
+
+	return netlinkErrorMsgs[NLE_FAILURE]
+}

--- a/vendor/github.com/elastic/gosigar/sys/linux/sysconf_cgo.go
+++ b/vendor/github.com/elastic/gosigar/sys/linux/sysconf_cgo.go
@@ -1,0 +1,13 @@
+// +build linux,cgo
+
+package linux
+
+/*
+#include <unistd.h>
+*/
+import "C"
+
+// GetClockTicks returns the number of click ticks in one jiffie.
+func GetClockTicks() int {
+	return int(C.sysconf(C._SC_CLK_TCK))
+}

--- a/vendor/github.com/elastic/gosigar/sys/linux/sysconf_nocgo.go
+++ b/vendor/github.com/elastic/gosigar/sys/linux/sysconf_nocgo.go
@@ -1,0 +1,8 @@
+// +build !cgo !linux
+
+package linux
+
+// GetClockTicks returns the number of click ticks in one jiffie.
+func GetClockTicks() int {
+	return 100
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -84,6 +84,9 @@ github.com/docker/go-units
 github.com/docker/libnetwork/ipamutils
 # github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7
 github.com/docker/libtrust
+# github.com/elastic/gosigar v0.13.0
+github.com/elastic/gosigar/sys
+github.com/elastic/gosigar/sys/linux
 # github.com/emicklei/go-restful v2.9.5+incompatible
 github.com/emicklei/go-restful
 github.com/emicklei/go-restful/log


### PR DESCRIPTION
`netlink` can be used for obtaining information about network sockets of various address families from the Linux kernel.

more information can be found at https://man7.org/linux/man-pages/man7/sock_diag.7.html