### PR TITLE
Add IsCloudProviderExternal helper for operators

### DIFF
--- a/pkg/cloudprovider/external.go
+++ b/pkg/cloudprovider/external.go
@@ -38,14 +38,16 @@ func isExternalFeatureGateEnabled(featureGate *configv1.FeatureGate) (bool, erro
 	}
 	featureSet, ok := configv1.FeatureSets[featureGate.Spec.FeatureSet]
 	if !ok {
-		return false, fmt.Errorf("enabled FeatureSet %v does not have a corresponding config", featureGate.Spec.FeatureSet)
+		return false, fmt.Errorf(".spec.featureSet %q not found", featureGate.Spec.FeatureSet)
 	}
 
 	enabledFeatureGates := sets.NewString(featureSet.Enabled...)
+	disabledFeatureGates := sets.NewString(featureSet.Disabled...)
 	// CustomNoUpgrade will override the deafult enabled feature gates.
 	if featureGate.Spec.FeatureSet == configv1.CustomNoUpgrade && featureGate.Spec.CustomNoUpgrade != nil {
 		enabledFeatureGates = sets.NewString(featureGate.Spec.CustomNoUpgrade.Enabled...)
+		disabledFeatureGates = sets.NewString(featureGate.Spec.CustomNoUpgrade.Disabled...)
 	}
 
-	return enabledFeatureGates.Has(ExternalCloudProviderFeature), nil
+	return !disabledFeatureGates.Has(ExternalCloudProviderFeature) && enabledFeatureGates.Has(ExternalCloudProviderFeature), nil
 }

--- a/pkg/cloudprovider/external.go
+++ b/pkg/cloudprovider/external.go
@@ -1,0 +1,51 @@
+package cloudprovider
+
+import (
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+const (
+	// ExternalCloudProviderFeature is the name of the external cloud provider feature gate.
+	// This is used to flag to operators that the cluster should be using the external cloud-controller-manager
+	// rather than the in-tree cloud controller loops.
+	ExternalCloudProviderFeature = "ExternalCloudProvider"
+)
+
+// IsCloudProviderExternal is used to check whether external cloud provider settings should be used in a component.
+// It checks whether the ExternalCloudProvider feature gate is enabled and whether the ExternalCloudProvider feature
+// has been implemented for the platform.
+func IsCloudProviderExternal(platformType configv1.PlatformType, featureGate *configv1.FeatureGate) (bool, error) {
+	switch platformType {
+	case configv1.AWSPlatformType,
+		configv1.OpenStackPlatformType:
+		// Platforms that are external based on feature gate presence
+		return isExternalFeatureGateEnabled(featureGate)
+	default:
+		// Platforms that do not have external cloud providers implemented
+		return false, nil
+	}
+}
+
+// isExternalFeatureGateEnabled determines whether the ExternalCloudProvider feature gate is present in the current
+// feature set.
+func isExternalFeatureGateEnabled(featureGate *configv1.FeatureGate) (bool, error) {
+	if featureGate == nil {
+		// If no featureGate is present, then the user hasn't opted in to the external cloud controllers
+		return false, nil
+	}
+	featureSet, ok := configv1.FeatureSets[featureGate.Spec.FeatureSet]
+	if !ok {
+		return false, fmt.Errorf("enabled FeatureSet %v does not have a corresponding config", featureGate.Spec.FeatureSet)
+	}
+
+	enabledFeatureGates := sets.NewString(featureSet.Enabled...)
+	// CustomNoUpgrade will override the deafult enabled feature gates.
+	if featureGate.Spec.FeatureSet == configv1.CustomNoUpgrade && featureGate.Spec.CustomNoUpgrade != nil {
+		enabledFeatureGates = sets.NewString(featureGate.Spec.CustomNoUpgrade.Enabled...)
+	}
+
+	return enabledFeatureGates.Has(ExternalCloudProviderFeature), nil
+}

--- a/pkg/cloudprovider/external_test.go
+++ b/pkg/cloudprovider/external_test.go
@@ -31,7 +31,7 @@ func TestIsCloudProviderExternal(t *testing.T) {
 			},
 		},
 		expected:    false,
-		expectedErr: fmt.Errorf("enabled FeatureSet Unknown does not have a corresponding config"),
+		expectedErr: fmt.Errorf(".spec.featureSet \"Unknown\" not found"),
 	}, {
 		name:     "FeatureSet: TechPreviewNoUpgrade, Platform: OpenStack",
 		platform: configv1.OpenStackPlatformType,
@@ -80,7 +80,7 @@ func TestIsCloudProviderExternal(t *testing.T) {
 		},
 		expected: false,
 	}, {
-		name:     "FeatureSet: CustomNoUpgrade (With External Feature Gate), Platform: OpenStack",
+		name:     "FeatureSet: CustomNoUpgrade (With External Feature Gate Enabled), Platform: OpenStack",
 		platform: configv1.OpenStackPlatformType,
 		featureGate: &configv1.FeatureGate{
 			Spec: configv1.FeatureGateSpec{
@@ -93,6 +93,35 @@ func TestIsCloudProviderExternal(t *testing.T) {
 			},
 		},
 		expected: true,
+	}, {
+		name:     "FeatureSet: CustomNoUpgrade (With External Feature Gate Enabled & Disabled), Platform: OpenStack",
+		platform: configv1.OpenStackPlatformType,
+		featureGate: &configv1.FeatureGate{
+			Spec: configv1.FeatureGateSpec{
+				FeatureGateSelection: configv1.FeatureGateSelection{
+					FeatureSet: configv1.CustomNoUpgrade,
+					CustomNoUpgrade: &configv1.CustomFeatureGates{
+						Enabled:  []string{ExternalCloudProviderFeature},
+						Disabled: []string{ExternalCloudProviderFeature},
+					},
+				},
+			},
+		},
+		expected: false,
+	}, {
+		name:     "FeatureSet: CustomNoUpgrade (With External Feature Gate Disabled), Platform: OpenStack",
+		platform: configv1.OpenStackPlatformType,
+		featureGate: &configv1.FeatureGate{
+			Spec: configv1.FeatureGateSpec{
+				FeatureGateSelection: configv1.FeatureGateSelection{
+					FeatureSet: configv1.CustomNoUpgrade,
+					CustomNoUpgrade: &configv1.CustomFeatureGates{
+						Disabled: []string{ExternalCloudProviderFeature},
+					},
+				},
+			},
+		},
+		expected: false,
 	}, {
 		name:     "FeatureSet: CustomNoUpgrade (With External Feature Gate), Platform: AWS",
 		platform: configv1.AWSPlatformType,

--- a/pkg/cloudprovider/external_test.go
+++ b/pkg/cloudprovider/external_test.go
@@ -1,0 +1,196 @@
+package cloudprovider
+
+import (
+	"fmt"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+func TestIsCloudProviderExternal(t *testing.T) {
+	cases := []struct {
+		name        string
+		platform    configv1.PlatformType
+		featureGate *configv1.FeatureGate
+		expected    bool
+		expectedErr error
+	}{{
+		name:        "No FeatureGate, Platform: OpenStack",
+		platform:    configv1.OpenStackPlatformType,
+		featureGate: nil,
+		expected:    false,
+		expectedErr: nil,
+	}, {
+		name:     "FeatureSet: Unknown, Platform: OpenStack",
+		platform: configv1.OpenStackPlatformType,
+		featureGate: &configv1.FeatureGate{
+			Spec: configv1.FeatureGateSpec{
+				FeatureGateSelection: configv1.FeatureGateSelection{
+					FeatureSet: configv1.FeatureSet("Unknown"),
+				},
+			},
+		},
+		expected:    false,
+		expectedErr: fmt.Errorf("enabled FeatureSet Unknown does not have a corresponding config"),
+	}, {
+		name:     "FeatureSet: TechPreviewNoUpgrade, Platform: OpenStack",
+		platform: configv1.OpenStackPlatformType,
+		featureGate: &configv1.FeatureGate{
+			Spec: configv1.FeatureGateSpec{
+				FeatureGateSelection: configv1.FeatureGateSelection{
+					FeatureSet: configv1.TechPreviewNoUpgrade,
+				},
+			},
+		},
+		expected: false,
+	}, {
+		name:     "FeatureSet: LatencySensitive, Platform: OpenStack",
+		platform: configv1.OpenStackPlatformType,
+		featureGate: &configv1.FeatureGate{
+			Spec: configv1.FeatureGateSpec{
+				FeatureGateSelection: configv1.FeatureGateSelection{
+					FeatureSet: configv1.LatencySensitive,
+				},
+			},
+		},
+		expected: false,
+	}, {
+		name:     "FeatureSet: IPv6DualStackNoUpgrade, Platform: OpenStack",
+		platform: configv1.OpenStackPlatformType,
+		featureGate: &configv1.FeatureGate{
+			Spec: configv1.FeatureGateSpec{
+				FeatureGateSelection: configv1.FeatureGateSelection{
+					FeatureSet: configv1.IPv6DualStackNoUpgrade,
+				},
+			},
+		},
+		expected: false,
+	}, {
+		name:     "FeatureSet: CustomNoUpgrade (No External Feature Gate), Platform: OpenStack",
+		platform: configv1.OpenStackPlatformType,
+		featureGate: &configv1.FeatureGate{
+			Spec: configv1.FeatureGateSpec{
+				FeatureGateSelection: configv1.FeatureGateSelection{
+					FeatureSet: configv1.CustomNoUpgrade,
+					CustomNoUpgrade: &configv1.CustomFeatureGates{
+						Enabled: []string{},
+					},
+				},
+			},
+		},
+		expected: false,
+	}, {
+		name:     "FeatureSet: CustomNoUpgrade (With External Feature Gate), Platform: OpenStack",
+		platform: configv1.OpenStackPlatformType,
+		featureGate: &configv1.FeatureGate{
+			Spec: configv1.FeatureGateSpec{
+				FeatureGateSelection: configv1.FeatureGateSelection{
+					FeatureSet: configv1.CustomNoUpgrade,
+					CustomNoUpgrade: &configv1.CustomFeatureGates{
+						Enabled: []string{ExternalCloudProviderFeature},
+					},
+				},
+			},
+		},
+		expected: true,
+	}, {
+		name:     "FeatureSet: CustomNoUpgrade (With External Feature Gate), Platform: AWS",
+		platform: configv1.AWSPlatformType,
+		featureGate: &configv1.FeatureGate{
+			Spec: configv1.FeatureGateSpec{
+				FeatureGateSelection: configv1.FeatureGateSelection{
+					FeatureSet: configv1.CustomNoUpgrade,
+					CustomNoUpgrade: &configv1.CustomFeatureGates{
+						Enabled: []string{ExternalCloudProviderFeature},
+					},
+				},
+			},
+		},
+		expected: true,
+	}, {
+		name:     "FeatureSet: CustomNoUpgrade (With External Feature Gate), Platform: Azure",
+		platform: configv1.AzurePlatformType,
+		featureGate: &configv1.FeatureGate{
+			Spec: configv1.FeatureGateSpec{
+				FeatureGateSelection: configv1.FeatureGateSelection{
+					FeatureSet: configv1.CustomNoUpgrade,
+					CustomNoUpgrade: &configv1.CustomFeatureGates{
+						Enabled: []string{ExternalCloudProviderFeature},
+					},
+				},
+			},
+		},
+		expected: false,
+	}, {
+		name:     "FeatureSet: CustomNoUpgrade (With External Feature Gate), Platform: BareMetal",
+		platform: configv1.BareMetalPlatformType,
+		featureGate: &configv1.FeatureGate{
+			Spec: configv1.FeatureGateSpec{
+				FeatureGateSelection: configv1.FeatureGateSelection{
+					FeatureSet: configv1.CustomNoUpgrade,
+					CustomNoUpgrade: &configv1.CustomFeatureGates{
+						Enabled: []string{ExternalCloudProviderFeature},
+					},
+				},
+			},
+		},
+		expected: false,
+	}, {
+		name:     "FeatureSet: CustomNoUpgrade (With External Feature Gate), Platform: Libvirt",
+		platform: configv1.LibvirtPlatformType,
+		featureGate: &configv1.FeatureGate{
+			Spec: configv1.FeatureGateSpec{
+				FeatureGateSelection: configv1.FeatureGateSelection{
+					FeatureSet: configv1.CustomNoUpgrade,
+					CustomNoUpgrade: &configv1.CustomFeatureGates{
+						Enabled: []string{ExternalCloudProviderFeature},
+					},
+				},
+			},
+		},
+		expected: false,
+	}, {
+		name:     "FeatureSet: CustomNoUpgrade (With External Feature Gate), Platform: GCP",
+		platform: configv1.GCPPlatformType,
+		featureGate: &configv1.FeatureGate{
+			Spec: configv1.FeatureGateSpec{
+				FeatureGateSelection: configv1.FeatureGateSelection{
+					FeatureSet: configv1.CustomNoUpgrade,
+					CustomNoUpgrade: &configv1.CustomFeatureGates{
+						Enabled: []string{ExternalCloudProviderFeature},
+					},
+				},
+			},
+		},
+		expected: false,
+	}, {
+		name:     "FeatureSet: CustomNoUpgrade (With External Feature Gate), Platform: None",
+		platform: configv1.NonePlatformType,
+		featureGate: &configv1.FeatureGate{
+			Spec: configv1.FeatureGateSpec{
+				FeatureGateSelection: configv1.FeatureGateSelection{
+					FeatureSet: configv1.CustomNoUpgrade,
+					CustomNoUpgrade: &configv1.CustomFeatureGates{
+						Enabled: []string{ExternalCloudProviderFeature},
+					},
+				},
+			},
+		},
+		expected: false,
+	}}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := IsCloudProviderExternal(c.platform, c.featureGate)
+			if c.expectedErr != nil {
+				if err == nil {
+					t.Errorf("expected error: %v, but got no error", c.expectedErr)
+				} else if c.expectedErr.Error() != err.Error() {
+					t.Errorf("expected error: %v, got error: %v", c.expectedErr, err)
+				}
+			}
+			if got != c.expected {
+				t.Errorf("expect external: %v, got external: %v", c.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This will allow operators to determine whether or not they should be using internal or external cloud providers.

We want to be able to have this logic centrally so that we can restrict the feature gate usage only to platforms that have external provider support, without duplicating this logic in multiple locations.

Initially, only the openstack provider will be allowed to use this feature gate as for 4.8 that is the only planned external provider.