### PR TITLE
[OCPCLOUD-1109] External cloud volume plugin observer for KCM

### DIFF
--- a/pkg/operator/configobserver/cloudprovider/observe_cloud_volume_plugin.go
+++ b/pkg/operator/configobserver/cloudprovider/observe_cloud_volume_plugin.go
@@ -1,0 +1,60 @@
+package cloudprovider
+
+import (
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/library-go/pkg/cloudprovider"
+	"github.com/openshift/library-go/pkg/operator/configobserver"
+	"github.com/openshift/library-go/pkg/operator/events"
+)
+
+// ObserveCloudVolumePlugin fills in the cluster-name extended argument for the controller-manager with the cluster's infra ID
+func ObserveCloudVolumePlugin(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (map[string]interface{}, []error) {
+	listers := genericListers.(InfrastructureLister)
+	errs := []error{}
+	volumePluginPath := []string{"extendedArguments", "external-cloud-volume-plugin"}
+	previouslyObservedConfig := map[string]interface{}{}
+
+	if currentVolumePlugin, _, _ := unstructured.NestedStringSlice(existingConfig, volumePluginPath...); len(currentVolumePlugin) > 0 {
+		if err := unstructured.SetNestedStringSlice(previouslyObservedConfig, currentVolumePlugin, volumePluginPath...); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	infrastructure, err := listers.InfrastructureLister().Get("cluster")
+	if err != nil {
+		if errors.IsNotFound(err) {
+			recorder.Warningf("ObserveCloudVolumePlugin", "Required infrastructures.%s/cluster not found", configv1.GroupName)
+		}
+		return previouslyObservedConfig, errs
+	}
+
+	featureGate, err := listers.FeatureGateLister().Get("cluster")
+	if errors.IsNotFound(err) {
+		recorder.Eventf("ObserveCloudVolumePlugin", "Optional featuregate.%s/cluster not found", configv1.GroupName)
+	} else if err != nil {
+		return previouslyObservedConfig, append(errs, err)
+	}
+
+	external, err := cloudprovider.IsCloudProviderExternal(infrastructure.Status.Platform, featureGate)
+	if err != nil {
+		recorder.Eventf("ObserveCloudVolumePlugin", "Invalid featuregate.%s/cluster format: %v", err)
+	} else if !external {
+		// Running in-tree volumes - no configuration needed. Skip
+		return previouslyObservedConfig, errs
+	}
+
+	observedConfig := map[string]interface{}{}
+
+	// Set --external-cloud-volume-plugin=<cloudProvider> for external
+	cloudProvider := getPlatformName(infrastructure.Status.Platform, recorder)
+	if len(cloudProvider) > 0 {
+		if err := unstructured.SetNestedStringSlice(observedConfig, []string{cloudProvider}, volumePluginPath...); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return observedConfig, errs
+}

--- a/pkg/operator/configobserver/cloudprovider/observe_cloud_volume_plugin_test.go
+++ b/pkg/operator/configobserver/cloudprovider/observe_cloud_volume_plugin_test.go
@@ -8,23 +8,31 @@ import (
 	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
 	"github.com/openshift/library-go/pkg/cloudprovider"
 	"github.com/openshift/library-go/pkg/operator/events"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	corelisterv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 )
 
 func TestObserveCloudVolumePlugin(t *testing.T) {
+	defaultCloudConfig := &corev1.ConfigMap{}
+	defaultCloudConfig.SetName(machineSpecifiedConfig)
+	defaultCloudConfig.SetNamespace(machineSpecifiedConfigNamespace)
+
 	type Test struct {
-		name        string
-		platform    configv1.PlatformType
-		fgSelection configv1.FeatureGateSelection
-		expected    string
+		name           string
+		platform       configv1.PlatformType
+		fgSelection    configv1.FeatureGateSelection
+		expected       string
+		expectedConfig string
 	}
 
 	tests := []Test{{
-		name:     "AWS external-cloud-volume-plugin should be set",
-		platform: configv1.AWSPlatformType,
-		expected: "aws",
+		name:           "AWS external-cloud-volume-plugin should be set",
+		platform:       configv1.AWSPlatformType,
+		expected:       "aws",
+		expectedConfig: "/etc/kubernetes/static-pod-resources/configmaps/cloud-config/cloud.conf",
 		fgSelection: configv1.FeatureGateSelection{
 			FeatureSet: configv1.CustomNoUpgrade,
 			CustomNoUpgrade: &configv1.CustomFeatureGates{
@@ -35,9 +43,10 @@ func TestObserveCloudVolumePlugin(t *testing.T) {
 		name:     "FeatureGate should be set for platform to become external",
 		platform: configv1.AWSPlatformType,
 	}, {
-		name:     "OpenStack external-cloud-volume-plugin should be set",
-		platform: configv1.OpenStackPlatformType,
-		expected: "openstack",
+		name:           "OpenStack external-cloud-volume-plugin should be set",
+		platform:       configv1.OpenStackPlatformType,
+		expected:       "openstack",
+		expectedConfig: "/etc/kubernetes/static-pod-resources/configmaps/cloud-config/cloud.conf",
 		fgSelection: configv1.FeatureGateSelection{
 			FeatureSet: configv1.CustomNoUpgrade,
 			CustomNoUpgrade: &configv1.CustomFeatureGates{
@@ -89,6 +98,9 @@ func TestObserveCloudVolumePlugin(t *testing.T) {
 			if err := indexer.Add(&configv1.Infrastructure{ObjectMeta: v1.ObjectMeta{Name: "cluster"}, Status: configv1.InfrastructureStatus{Platform: c.platform}}); err != nil {
 				t.Fatal(err.Error())
 			}
+			if err := indexer.Add(defaultCloudConfig); err != nil {
+				t.Fatal(err.Error())
+			}
 			if err := fgIndexer.Add(&configv1.FeatureGate{
 				ObjectMeta: v1.ObjectMeta{Name: "cluster"},
 				Spec: configv1.FeatureGateSpec{
@@ -99,20 +111,32 @@ func TestObserveCloudVolumePlugin(t *testing.T) {
 			listers := FakeInfrastructureLister{
 				InfrastructureLister_: configlistersv1.NewInfrastructureLister(indexer),
 				ResourceSync:          &FakeResourceSyncer{},
-				ConfigMapLister_:      &FakeConfigMapLister{},
+				ConfigMapLister_:      corelisterv1.NewConfigMapLister(indexer),
 				FeatureGateLister_:    configlistersv1.NewFeatureGateLister(fgIndexer),
 			}
-			result, errs := ObserveCloudVolumePlugin(listers, events.NewInMemoryRecorder("cloud-volume"), map[string]interface{}{})
+			cloudVolumePluginPath := []string{"extendedArguments", "external-cloud-volume-plugin"}
+			cloudProviderConfPath := []string{"extendedArguments", "cloud-config"}
+			observe := NewCloudVolumePluginObserver("kube-controller-manager", cloudVolumePluginPath, cloudProviderConfPath)
+			result, errs := observe(listers, events.NewInMemoryRecorder("cloud-volume"), map[string]interface{}{})
 			if len(errs) > 0 {
 				t.Fatal(errs)
 			}
-			cloudVolumePlugin, _, err := unstructured.NestedStringSlice(result, "extendedArguments", "external-cloud-volume-plugin")
+			cloudVolumePlugin, _, err := unstructured.NestedStringSlice(result, cloudVolumePluginPath...)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			cloudProviderConfig, _, err := unstructured.NestedStringSlice(result, cloudProviderConfPath...)
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			if strings.Join(cloudVolumePlugin, "") != c.expected {
 				t.Errorf("expected --external-cloud-volume-plugin=%s, got %s", c.expected, cloudVolumePlugin)
+			}
+
+			if strings.Join(cloudProviderConfig, "") != c.expectedConfig {
+				t.Errorf("expected --cloud-config=%s, got %s", c.expectedConfig, cloudProviderConfig)
 			}
 		})
 	}

--- a/pkg/operator/configobserver/cloudprovider/observe_cloud_volume_plugin_test.go
+++ b/pkg/operator/configobserver/cloudprovider/observe_cloud_volume_plugin_test.go
@@ -1,0 +1,119 @@
+package cloudprovider
+
+import (
+	"strings"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+	"github.com/openshift/library-go/pkg/cloudprovider"
+	"github.com/openshift/library-go/pkg/operator/events"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestObserveCloudVolumePlugin(t *testing.T) {
+	type Test struct {
+		name        string
+		platform    configv1.PlatformType
+		fgSelection configv1.FeatureGateSelection
+		expected    string
+	}
+
+	tests := []Test{{
+		name:     "AWS external-cloud-volume-plugin should be set",
+		platform: configv1.AWSPlatformType,
+		expected: "aws",
+		fgSelection: configv1.FeatureGateSelection{
+			FeatureSet: configv1.CustomNoUpgrade,
+			CustomNoUpgrade: &configv1.CustomFeatureGates{
+				Enabled: []string{cloudprovider.ExternalCloudProviderFeature},
+			},
+		},
+	}, {
+		name:     "FeatureGate should be set for platform to become external",
+		platform: configv1.AWSPlatformType,
+	}, {
+		name:     "OpenStack external-cloud-volume-plugin should be set",
+		platform: configv1.OpenStackPlatformType,
+		expected: "openstack",
+		fgSelection: configv1.FeatureGateSelection{
+			FeatureSet: configv1.CustomNoUpgrade,
+			CustomNoUpgrade: &configv1.CustomFeatureGates{
+				Enabled: []string{cloudprovider.ExternalCloudProviderFeature},
+			},
+		},
+	}, {
+		name:     "no external-cloud-volume-plugin for no cloud",
+		platform: configv1.NonePlatformType,
+		fgSelection: configv1.FeatureGateSelection{
+			FeatureSet: configv1.CustomNoUpgrade,
+			CustomNoUpgrade: &configv1.CustomFeatureGates{
+				Enabled: []string{cloudprovider.ExternalCloudProviderFeature},
+			},
+		},
+	}, {
+		name:     "no external-cloud-volume-plugin for Azure",
+		platform: configv1.AzurePlatformType,
+		fgSelection: configv1.FeatureGateSelection{
+			FeatureSet: configv1.CustomNoUpgrade,
+			CustomNoUpgrade: &configv1.CustomFeatureGates{
+				Enabled: []string{cloudprovider.ExternalCloudProviderFeature},
+			},
+		},
+	}, {
+		name:     "no external-cloud-volume-plugin for GCP",
+		platform: configv1.GCPPlatformType,
+		fgSelection: configv1.FeatureGateSelection{
+			FeatureSet: configv1.CustomNoUpgrade,
+			CustomNoUpgrade: &configv1.CustomFeatureGates{
+				Enabled: []string{cloudprovider.ExternalCloudProviderFeature},
+			},
+		},
+	}, {
+		name:     "no external-cloud-volume-plugin for VSphere",
+		platform: configv1.VSpherePlatformType,
+		fgSelection: configv1.FeatureGateSelection{
+			FeatureSet: configv1.CustomNoUpgrade,
+			CustomNoUpgrade: &configv1.CustomFeatureGates{
+				Enabled: []string{cloudprovider.ExternalCloudProviderFeature},
+			},
+		},
+	},
+	}
+	for _, c := range tests {
+		t.Run(string(c.platform), func(t *testing.T) {
+			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			fgIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			if err := indexer.Add(&configv1.Infrastructure{ObjectMeta: v1.ObjectMeta{Name: "cluster"}, Status: configv1.InfrastructureStatus{Platform: c.platform}}); err != nil {
+				t.Fatal(err.Error())
+			}
+			if err := fgIndexer.Add(&configv1.FeatureGate{
+				ObjectMeta: v1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.FeatureGateSpec{
+					FeatureGateSelection: c.fgSelection,
+				}}); err != nil {
+				t.Fatal(err.Error())
+			}
+			listers := FakeInfrastructureLister{
+				InfrastructureLister_: configlistersv1.NewInfrastructureLister(indexer),
+				ResourceSync:          &FakeResourceSyncer{},
+				ConfigMapLister_:      &FakeConfigMapLister{},
+				FeatureGateLister_:    configlistersv1.NewFeatureGateLister(fgIndexer),
+			}
+			result, errs := ObserveCloudVolumePlugin(listers, events.NewInMemoryRecorder("cloud-volume"), map[string]interface{}{})
+			if len(errs) > 0 {
+				t.Fatal(errs)
+			}
+			cloudVolumePlugin, _, err := unstructured.NestedStringSlice(result, "extendedArguments", "external-cloud-volume-plugin")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if strings.Join(cloudVolumePlugin, "") != c.expected {
+				t.Errorf("expected --external-cloud-volume-plugin=%s, got %s", c.expected, cloudVolumePlugin)
+			}
+		})
+	}
+}

--- a/pkg/operator/configobserver/cloudprovider/observe_cloudprovider.go
+++ b/pkg/operator/configobserver/cloudprovider/observe_cloudprovider.go
@@ -26,6 +26,7 @@ const (
 // InfrastructureLister lists infrastrucre information and allows resources to be synced
 type InfrastructureLister interface {
 	InfrastructureLister() configlistersv1.InfrastructureLister
+	FeatureGateLister() configlistersv1.FeatureGateLister
 	ResourceSyncer() resourcesynccontroller.ResourceSyncer
 	ConfigMapLister() corelisterv1.ConfigMapLister
 }

--- a/pkg/operator/configobserver/cloudprovider/observe_cloudprovider_test.go
+++ b/pkg/operator/configobserver/cloudprovider/observe_cloudprovider_test.go
@@ -48,6 +48,7 @@ type FakeInfrastructureLister struct {
 	ResourceSync          resourcesynccontroller.ResourceSyncer
 	PreRunCachesSynced    []cache.InformerSynced
 	ConfigMapLister_      corelisterv1.ConfigMapLister
+	FeatureGateLister_    configlistersv1.FeatureGateLister
 }
 
 func (l FakeInfrastructureLister) ResourceSyncer() resourcesynccontroller.ResourceSyncer {
@@ -64,6 +65,10 @@ func (l FakeInfrastructureLister) PreRunHasSynced() []cache.InformerSynced {
 
 func (l FakeInfrastructureLister) ConfigMapLister() corelisterv1.ConfigMapLister {
 	return l.ConfigMapLister_
+}
+
+func (l FakeInfrastructureLister) FeatureGateLister() configlistersv1.FeatureGateLister {
+	return l.FeatureGateLister_
 }
 
 func TestObserveCloudProviderNames(t *testing.T) {


### PR DESCRIPTION
This implementation allows to preserve in-tree storage related cloud interaction code for external cloud providers. Will be used in https://github.com/openshift/cluster-kube-controller-manager-operator/pull/450

More details in https://github.com/openshift/enhancements/pull/463/files#diff-3e0e2c48e70215076dfe36c13768a823ab7080d929d80292f37db2ef5a2121e8R191-R197