### PR TITLE
add harcoded authorizer type for well-known rules

### DIFF
--- a/pkg/authorization/hardcodedauthorizer/evaluation_helpers.go
+++ b/pkg/authorization/hardcodedauthorizer/evaluation_helpers.go
@@ -1,0 +1,165 @@
+package hardcodedauthorizer
+
+import (
+	"fmt"
+	"strings"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// lifted from k/k. same filename
+
+func RoleRefGroupKind(roleRef rbacv1.RoleRef) schema.GroupKind {
+	return schema.GroupKind{Group: roleRef.APIGroup, Kind: roleRef.Kind}
+}
+
+func verbMatches(rule *rbacv1.PolicyRule, requestedVerb string) bool {
+	for _, ruleVerb := range rule.Verbs {
+		if ruleVerb == rbacv1.VerbAll {
+			return true
+		}
+		if ruleVerb == requestedVerb {
+			return true
+		}
+	}
+
+	return false
+}
+
+func apiGroupMatches(rule *rbacv1.PolicyRule, requestedGroup string) bool {
+	for _, ruleGroup := range rule.APIGroups {
+		if ruleGroup == rbacv1.APIGroupAll {
+			return true
+		}
+		if ruleGroup == requestedGroup {
+			return true
+		}
+	}
+
+	return false
+}
+
+func resourceMatches(rule *rbacv1.PolicyRule, combinedRequestedResource, requestedSubresource string) bool {
+	for _, ruleResource := range rule.Resources {
+		// if everything is allowed, we match
+		if ruleResource == rbacv1.ResourceAll {
+			return true
+		}
+		// if we have an exact match, we match
+		if ruleResource == combinedRequestedResource {
+			return true
+		}
+
+		// We can also match a */subresource.
+		// if there isn't a subresource, then continue
+		if len(requestedSubresource) == 0 {
+			continue
+		}
+		// if the rule isn't in the format */subresource, then we don't match, continue
+		if len(ruleResource) == len(requestedSubresource)+2 &&
+			strings.HasPrefix(ruleResource, "*/") &&
+			strings.HasSuffix(ruleResource, requestedSubresource) {
+			return true
+
+		}
+	}
+
+	return false
+}
+
+func resourceNameMatches(rule *rbacv1.PolicyRule, requestedName string) bool {
+	if len(rule.ResourceNames) == 0 {
+		return true
+	}
+
+	for _, ruleName := range rule.ResourceNames {
+		if ruleName == requestedName {
+			return true
+		}
+	}
+
+	return false
+}
+
+func nonResourceURLMatches(rule *rbacv1.PolicyRule, requestedURL string) bool {
+	for _, ruleURL := range rule.NonResourceURLs {
+		if ruleURL == rbacv1.NonResourceAll {
+			return true
+		}
+		if ruleURL == requestedURL {
+			return true
+		}
+		if strings.HasSuffix(ruleURL, "*") && strings.HasPrefix(requestedURL, strings.TrimRight(ruleURL, "*")) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// subjectsStrings returns users, groups, serviceaccounts, unknown for display purposes.
+func SubjectsStrings(subjects []rbacv1.Subject) ([]string, []string, []string, []string) {
+	users := []string{}
+	groups := []string{}
+	sas := []string{}
+	others := []string{}
+
+	for _, subject := range subjects {
+		switch subject.Kind {
+		case rbacv1.ServiceAccountKind:
+			sas = append(sas, fmt.Sprintf("%s/%s", subject.Namespace, subject.Name))
+
+		case rbacv1.UserKind:
+			users = append(users, subject.Name)
+
+		case rbacv1.GroupKind:
+			groups = append(groups, subject.Name)
+
+		default:
+			others = append(others, fmt.Sprintf("%s/%s/%s", subject.Kind, subject.Namespace, subject.Name))
+		}
+	}
+
+	return users, groups, sas, others
+}
+
+func String(r rbacv1.PolicyRule) string {
+	return "PolicyRule" + CompactString(r)
+}
+
+// CompactString exposes a compact string representation for use in escalation error messages
+func CompactString(r rbacv1.PolicyRule) string {
+	formatStringParts := []string{}
+	formatArgs := []interface{}{}
+	if len(r.APIGroups) > 0 {
+		formatStringParts = append(formatStringParts, "APIGroups:%q")
+		formatArgs = append(formatArgs, r.APIGroups)
+	}
+	if len(r.Resources) > 0 {
+		formatStringParts = append(formatStringParts, "Resources:%q")
+		formatArgs = append(formatArgs, r.Resources)
+	}
+	if len(r.NonResourceURLs) > 0 {
+		formatStringParts = append(formatStringParts, "NonResourceURLs:%q")
+		formatArgs = append(formatArgs, r.NonResourceURLs)
+	}
+	if len(r.ResourceNames) > 0 {
+		formatStringParts = append(formatStringParts, "ResourceNames:%q")
+		formatArgs = append(formatArgs, r.ResourceNames)
+	}
+	if len(r.Verbs) > 0 {
+		formatStringParts = append(formatStringParts, "Verbs:%q")
+		formatArgs = append(formatArgs, r.Verbs)
+	}
+	formatString := "{" + strings.Join(formatStringParts, ", ") + "}"
+	return fmt.Sprintf(formatString, formatArgs...)
+}
+
+type SortableRuleSlice []rbacv1.PolicyRule
+
+func (s SortableRuleSlice) Len() int      { return len(s) }
+func (s SortableRuleSlice) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s SortableRuleSlice) Less(i, j int) bool {
+	return strings.Compare(s[i].String(), s[j].String()) < 0
+}

--- a/pkg/authorization/hardcodedauthorizer/hardcoded_authorizer.go
+++ b/pkg/authorization/hardcodedauthorizer/hardcoded_authorizer.go
@@ -1,0 +1,82 @@
+package hardcodedauthorizer
+
+import (
+	"context"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+)
+
+type hardcodedAuthorizer struct {
+	usernames sets.String
+	rules     []rbacv1.PolicyRule
+}
+
+func (h hardcodedAuthorizer) Authorize(ctx context.Context, a authorizer.Attributes) (authorized authorizer.Decision, reason string, err error) {
+	if !h.usernames.Has(a.GetUser().GetName()) {
+		return authorizer.DecisionNoOpinion, "", nil
+	}
+
+	for i := range h.rules {
+		if ruleAllows(a, &h.rules[i]) {
+			return authorizer.DecisionAllow, "hardcoded rules allow", nil
+		}
+	}
+
+	return authorizer.DecisionNoOpinion, "", nil
+}
+
+// lifted directly from k/k authorizer/rbac/rbac.go
+func ruleAllows(requestAttributes authorizer.Attributes, rule *rbacv1.PolicyRule) bool {
+	if requestAttributes.IsResourceRequest() {
+		combinedResource := requestAttributes.GetResource()
+		if len(requestAttributes.GetSubresource()) > 0 {
+			combinedResource = requestAttributes.GetResource() + "/" + requestAttributes.GetSubresource()
+		}
+
+		return verbMatches(rule, requestAttributes.GetVerb()) &&
+			apiGroupMatches(rule, requestAttributes.GetAPIGroup()) &&
+			resourceMatches(rule, combinedResource, requestAttributes.GetSubresource()) &&
+			resourceNameMatches(rule, requestAttributes.GetName())
+	}
+
+	return verbMatches(rule, requestAttributes.GetVerb()) &&
+		nonResourceURLMatches(rule, requestAttributes.GetPath())
+}
+
+func containsString(haystack []string, needle string) bool {
+	for _, val := range haystack {
+		if needle == val {
+			return true
+		}
+	}
+	return false
+}
+
+// NewHardcodedAuthorizer allows a set of named users access to the rules.
+// You cannot restrict by namespaces (there's just no field)
+func NewHardcodedAuthorizer(rules []rbacv1.PolicyRule, usernames ...string) (authorizer.Authorizer, error) {
+	return &hardcodedAuthorizer{
+		usernames: sets.NewString(usernames...),
+		rules:     rules,
+	}, nil
+}
+
+func NewHardcodedAuthorizerOrDie(rules []rbacv1.PolicyRule, usernames ...string) authorizer.Authorizer {
+	ret, err := NewHardcodedAuthorizer(rules, usernames...)
+	if err != nil {
+		panic(err)
+	}
+	return ret
+}
+
+// NewHardcodedMetricsScaperAuthorizer provides an authorizer that allows metrics scraping without contacting the
+// kube-apiserver for an authorization check on a rule we always have in place.
+func NewHardcodedMetricsScaperAuthorizer() authorizer.Authorizer {
+	return NewHardcodedAuthorizerOrDie(
+		[]rbacv1.PolicyRule{
+			NewRule("get").URLs("/metrics").RuleOrDie(),
+		},
+		"system:serviceaccount:openshift-monitoring:prometheus-k8s")
+}

--- a/pkg/authorization/hardcodedauthorizer/hardcoded_authorizer_test.go
+++ b/pkg/authorization/hardcodedauthorizer/hardcoded_authorizer_test.go
@@ -1,0 +1,309 @@
+package hardcodedauthorizer
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+)
+
+func newRule(verbs, apiGroups, resources, nonResourceURLs string) rbacv1.PolicyRule {
+	return rbacv1.PolicyRule{
+		Verbs:           strings.Split(verbs, ","),
+		APIGroups:       strings.Split(apiGroups, ","),
+		Resources:       strings.Split(resources, ","),
+		NonResourceURLs: strings.Split(nonResourceURLs, ","),
+	}
+}
+
+type defaultAttributes struct {
+	user        string
+	groups      string
+	verb        string
+	resource    string
+	subresource string
+	namespace   string
+	apiGroup    string
+}
+
+func (d *defaultAttributes) String() string {
+	return fmt.Sprintf("user=(%s), groups=(%s), verb=(%s), resource=(%s), namespace=(%s), apiGroup=(%s)",
+		d.user, strings.Split(d.groups, ","), d.verb, d.resource, d.namespace, d.apiGroup)
+}
+
+func (d *defaultAttributes) GetUser() user.Info {
+	return &user.DefaultInfo{Name: d.user, Groups: strings.Split(d.groups, ",")}
+}
+func (d *defaultAttributes) GetVerb() string         { return d.verb }
+func (d *defaultAttributes) IsReadOnly() bool        { return d.verb == "get" || d.verb == "watch" }
+func (d *defaultAttributes) GetNamespace() string    { return d.namespace }
+func (d *defaultAttributes) GetResource() string     { return d.resource }
+func (d *defaultAttributes) GetSubresource() string  { return d.subresource }
+func (d *defaultAttributes) GetName() string         { return "" }
+func (d *defaultAttributes) GetAPIGroup() string     { return d.apiGroup }
+func (d *defaultAttributes) GetAPIVersion() string   { return "" }
+func (d *defaultAttributes) IsResourceRequest() bool { return true }
+func (d *defaultAttributes) GetPath() string         { return "" }
+
+func TestAuthorizer(t *testing.T) {
+	tests := []struct {
+		name       string
+		authorizer authorizer.Authorizer
+
+		shouldPass []authorizer.Attributes
+		shouldFail []authorizer.Attributes
+	}{
+		{
+			name: "Non-resource-url tests",
+			authorizer: NewHardcodedAuthorizerOrDie(
+				[]rbacv1.PolicyRule{
+					newRule("get", "", "", "/apis"),
+				},
+				"non-resource-url-getter"),
+			shouldPass: []authorizer.Attributes{
+				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "non-resource-url-getter"}, Verb: "get", Path: "/apis"},
+			},
+			shouldFail: []authorizer.Attributes{
+				// wrong user
+				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "other"}, Verb: "get", Path: "/apis"},
+				// wrong verb
+				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "non-resource-url-getter"}, Verb: "update", Path: "/apis"},
+
+				// wrong path
+				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "non-resource-url-getter"}, Verb: "get", Path: "/apis/foo"},
+				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "non-resource-url-getter"}, Verb: "get", Path: "/api"},
+				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "non-resource-url-getter"}, Verb: "get", Path: "/apismore"},
+			},
+		},
+		{
+			name: "Non-resource-url tests with star verb",
+			authorizer: NewHardcodedAuthorizerOrDie(
+				[]rbacv1.PolicyRule{
+					newRule("*", "", "", "/apis"),
+				},
+				"non-resource-url"),
+			shouldPass: []authorizer.Attributes{
+				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "non-resource-url"}, Verb: "get", Path: "/apis"},
+				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "non-resource-url"}, Verb: "watch", Path: "/apis"},
+				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "non-resource-url"}, Verb: "update", Path: "/apis"},
+			},
+			shouldFail: []authorizer.Attributes{},
+		},
+		{
+			name: "Non-resource-url tests with star pattern",
+			authorizer: NewHardcodedAuthorizerOrDie(
+				[]rbacv1.PolicyRule{
+					newRule("*", "", "", "/apis/*"),
+				},
+				"non-resource-prefix"),
+			shouldPass: []authorizer.Attributes{
+				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "non-resource-prefix"}, Verb: "get", Path: "/apis/v1"},
+				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "non-resource-prefix"}, Verb: "get", Path: "/apis/v1/foobar"},
+			},
+			shouldFail: []authorizer.Attributes{
+				// wrong path
+				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "non-resource-prefix"}, Verb: "get", Path: "/api/v1"},
+				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "non-resource-prefix"}, Verb: "get", Path: "/metrics"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, attr := range tt.shouldPass {
+				if decision, _, _ := tt.authorizer.Authorize(context.Background(), attr); decision != authorizer.DecisionAllow {
+					t.Errorf("incorrectly restricted %s", attr)
+				}
+			}
+
+			for _, attr := range tt.shouldFail {
+				if decision, _, _ := tt.authorizer.Authorize(context.Background(), attr); decision == authorizer.DecisionAllow {
+					t.Errorf("incorrectly passed %s", attr)
+				}
+			}
+		})
+	}
+}
+
+func TestRuleMatches(t *testing.T) {
+	tests := []struct {
+		name string
+		rule rbacv1.PolicyRule
+
+		requestsToExpected map[authorizer.AttributesRecord]bool
+	}{
+		{
+			name: "star verb, exact match other",
+			rule: NewRule("*").Groups("group1").Resources("resource1").RuleOrDie(),
+			requestsToExpected: map[authorizer.AttributesRecord]bool{
+				resourceRequest("verb1").Group("group1").Resource("resource1").New(): true,
+				resourceRequest("verb1").Group("group2").Resource("resource1").New(): false,
+				resourceRequest("verb1").Group("group1").Resource("resource2").New(): false,
+				resourceRequest("verb1").Group("group2").Resource("resource2").New(): false,
+				resourceRequest("verb2").Group("group1").Resource("resource1").New(): true,
+				resourceRequest("verb2").Group("group2").Resource("resource1").New(): false,
+				resourceRequest("verb2").Group("group1").Resource("resource2").New(): false,
+				resourceRequest("verb2").Group("group2").Resource("resource2").New(): false,
+			},
+		},
+		{
+			name: "star group, exact match other",
+			rule: NewRule("verb1").Groups("*").Resources("resource1").RuleOrDie(),
+			requestsToExpected: map[authorizer.AttributesRecord]bool{
+				resourceRequest("verb1").Group("group1").Resource("resource1").New(): true,
+				resourceRequest("verb1").Group("group2").Resource("resource1").New(): true,
+				resourceRequest("verb1").Group("group1").Resource("resource2").New(): false,
+				resourceRequest("verb1").Group("group2").Resource("resource2").New(): false,
+				resourceRequest("verb2").Group("group1").Resource("resource1").New(): false,
+				resourceRequest("verb2").Group("group2").Resource("resource1").New(): false,
+				resourceRequest("verb2").Group("group1").Resource("resource2").New(): false,
+				resourceRequest("verb2").Group("group2").Resource("resource2").New(): false,
+			},
+		},
+		{
+			name: "star resource, exact match other",
+			rule: NewRule("verb1").Groups("group1").Resources("*").RuleOrDie(),
+			requestsToExpected: map[authorizer.AttributesRecord]bool{
+				resourceRequest("verb1").Group("group1").Resource("resource1").New(): true,
+				resourceRequest("verb1").Group("group2").Resource("resource1").New(): false,
+				resourceRequest("verb1").Group("group1").Resource("resource2").New(): true,
+				resourceRequest("verb1").Group("group2").Resource("resource2").New(): false,
+				resourceRequest("verb2").Group("group1").Resource("resource1").New(): false,
+				resourceRequest("verb2").Group("group2").Resource("resource1").New(): false,
+				resourceRequest("verb2").Group("group1").Resource("resource2").New(): false,
+				resourceRequest("verb2").Group("group2").Resource("resource2").New(): false,
+			},
+		},
+		{
+			name: "tuple expansion",
+			rule: NewRule("verb1", "verb2").Groups("group1", "group2").Resources("resource1", "resource2").RuleOrDie(),
+			requestsToExpected: map[authorizer.AttributesRecord]bool{
+				resourceRequest("verb1").Group("group1").Resource("resource1").New(): true,
+				resourceRequest("verb1").Group("group2").Resource("resource1").New(): true,
+				resourceRequest("verb1").Group("group1").Resource("resource2").New(): true,
+				resourceRequest("verb1").Group("group2").Resource("resource2").New(): true,
+				resourceRequest("verb2").Group("group1").Resource("resource1").New(): true,
+				resourceRequest("verb2").Group("group2").Resource("resource1").New(): true,
+				resourceRequest("verb2").Group("group1").Resource("resource2").New(): true,
+				resourceRequest("verb2").Group("group2").Resource("resource2").New(): true,
+			},
+		},
+		{
+			name: "subresource expansion",
+			rule: NewRule("*").Groups("*").Resources("resource1/subresource1").RuleOrDie(),
+			requestsToExpected: map[authorizer.AttributesRecord]bool{
+				resourceRequest("verb1").Group("group1").Resource("resource1").Subresource("subresource1").New(): true,
+				resourceRequest("verb1").Group("group2").Resource("resource1").Subresource("subresource2").New(): false,
+				resourceRequest("verb1").Group("group1").Resource("resource2").Subresource("subresource1").New(): false,
+				resourceRequest("verb1").Group("group2").Resource("resource2").Subresource("subresource1").New(): false,
+				resourceRequest("verb2").Group("group1").Resource("resource1").Subresource("subresource1").New(): true,
+				resourceRequest("verb2").Group("group2").Resource("resource1").Subresource("subresource2").New(): false,
+				resourceRequest("verb2").Group("group1").Resource("resource2").Subresource("subresource1").New(): false,
+				resourceRequest("verb2").Group("group2").Resource("resource2").Subresource("subresource1").New(): false,
+			},
+		},
+		{
+			name: "star nonresource, exact match other",
+			rule: NewRule("verb1").URLs("*").RuleOrDie(),
+			requestsToExpected: map[authorizer.AttributesRecord]bool{
+				nonresourceRequest("verb1").URL("/foo").New():         true,
+				nonresourceRequest("verb1").URL("/foo/bar").New():     true,
+				nonresourceRequest("verb1").URL("/foo/baz").New():     true,
+				nonresourceRequest("verb1").URL("/foo/bar/one").New(): true,
+				nonresourceRequest("verb1").URL("/foo/baz/one").New(): true,
+				nonresourceRequest("verb2").URL("/foo").New():         false,
+				nonresourceRequest("verb2").URL("/foo/bar").New():     false,
+				nonresourceRequest("verb2").URL("/foo/baz").New():     false,
+				nonresourceRequest("verb2").URL("/foo/bar/one").New(): false,
+				nonresourceRequest("verb2").URL("/foo/baz/one").New(): false,
+			},
+		},
+		{
+			name: "star nonresource subpath",
+			rule: NewRule("verb1").URLs("/foo/*").RuleOrDie(),
+			requestsToExpected: map[authorizer.AttributesRecord]bool{
+				nonresourceRequest("verb1").URL("/foo").New():            false,
+				nonresourceRequest("verb1").URL("/foo/bar").New():        true,
+				nonresourceRequest("verb1").URL("/foo/baz").New():        true,
+				nonresourceRequest("verb1").URL("/foo/bar/one").New():    true,
+				nonresourceRequest("verb1").URL("/foo/baz/one").New():    true,
+				nonresourceRequest("verb1").URL("/notfoo").New():         false,
+				nonresourceRequest("verb1").URL("/notfoo/bar").New():     false,
+				nonresourceRequest("verb1").URL("/notfoo/baz").New():     false,
+				nonresourceRequest("verb1").URL("/notfoo/bar/one").New(): false,
+				nonresourceRequest("verb1").URL("/notfoo/baz/one").New(): false,
+			},
+		},
+		{
+			name: "star verb, exact nonresource",
+			rule: NewRule("*").URLs("/foo", "/foo/bar/one").RuleOrDie(),
+			requestsToExpected: map[authorizer.AttributesRecord]bool{
+				nonresourceRequest("verb1").URL("/foo").New():         true,
+				nonresourceRequest("verb1").URL("/foo/bar").New():     false,
+				nonresourceRequest("verb1").URL("/foo/baz").New():     false,
+				nonresourceRequest("verb1").URL("/foo/bar/one").New(): true,
+				nonresourceRequest("verb1").URL("/foo/baz/one").New(): false,
+				nonresourceRequest("verb2").URL("/foo").New():         true,
+				nonresourceRequest("verb2").URL("/foo/bar").New():     false,
+				nonresourceRequest("verb2").URL("/foo/baz").New():     false,
+				nonresourceRequest("verb2").URL("/foo/bar/one").New(): true,
+				nonresourceRequest("verb2").URL("/foo/baz/one").New(): false,
+			},
+		},
+	}
+	for _, tc := range tests {
+		for request, expected := range tc.requestsToExpected {
+			if e, a := expected, ruleAllows(request, &tc.rule); e != a {
+				t.Errorf("%q: expected %v, got %v for %v", tc.name, e, a, request)
+			}
+		}
+	}
+}
+
+type requestAttributeBuilder struct {
+	request authorizer.AttributesRecord
+}
+
+func resourceRequest(verb string) *requestAttributeBuilder {
+	return &requestAttributeBuilder{
+		request: authorizer.AttributesRecord{ResourceRequest: true, Verb: verb},
+	}
+}
+
+func nonresourceRequest(verb string) *requestAttributeBuilder {
+	return &requestAttributeBuilder{
+		request: authorizer.AttributesRecord{ResourceRequest: false, Verb: verb},
+	}
+}
+
+func (r *requestAttributeBuilder) Group(group string) *requestAttributeBuilder {
+	r.request.APIGroup = group
+	return r
+}
+
+func (r *requestAttributeBuilder) Resource(resource string) *requestAttributeBuilder {
+	r.request.Resource = resource
+	return r
+}
+
+func (r *requestAttributeBuilder) Subresource(subresource string) *requestAttributeBuilder {
+	r.request.Subresource = subresource
+	return r
+}
+
+func (r *requestAttributeBuilder) Name(name string) *requestAttributeBuilder {
+	r.request.Name = name
+	return r
+}
+
+func (r *requestAttributeBuilder) URL(url string) *requestAttributeBuilder {
+	r.request.Path = url
+	return r
+}
+
+func (r *requestAttributeBuilder) New() authorizer.AttributesRecord {
+	return r.request
+}

--- a/pkg/authorization/hardcodedauthorizer/rule_builder.go
+++ b/pkg/authorization/hardcodedauthorizer/rule_builder.go
@@ -1,0 +1,81 @@
+package hardcodedauthorizer
+
+import (
+	"fmt"
+	"sort"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+// copied from k/k
+
+// PolicyRuleBuilder let's us attach methods.  A no-no for API types.
+// We use it to construct rules in code.  It's more compact than trying to write them
+// out in a literal and allows us to perform some basic checking during construction
+type PolicyRuleBuilder struct {
+	PolicyRule rbacv1.PolicyRule
+}
+
+func NewRule(verbs ...string) *PolicyRuleBuilder {
+	return &PolicyRuleBuilder{
+		PolicyRule: rbacv1.PolicyRule{Verbs: verbs},
+	}
+}
+
+func (r *PolicyRuleBuilder) Groups(groups ...string) *PolicyRuleBuilder {
+	r.PolicyRule.APIGroups = append(r.PolicyRule.APIGroups, groups...)
+	return r
+}
+
+func (r *PolicyRuleBuilder) Resources(resources ...string) *PolicyRuleBuilder {
+	r.PolicyRule.Resources = append(r.PolicyRule.Resources, resources...)
+	return r
+}
+
+func (r *PolicyRuleBuilder) Names(names ...string) *PolicyRuleBuilder {
+	r.PolicyRule.ResourceNames = append(r.PolicyRule.ResourceNames, names...)
+	return r
+}
+
+func (r *PolicyRuleBuilder) URLs(urls ...string) *PolicyRuleBuilder {
+	r.PolicyRule.NonResourceURLs = append(r.PolicyRule.NonResourceURLs, urls...)
+	return r
+}
+
+func (r *PolicyRuleBuilder) RuleOrDie() rbacv1.PolicyRule {
+	ret, err := r.Rule()
+	if err != nil {
+		panic(err)
+	}
+	return ret
+}
+
+func (r *PolicyRuleBuilder) Rule() (rbacv1.PolicyRule, error) {
+	if len(r.PolicyRule.Verbs) == 0 {
+		return rbacv1.PolicyRule{}, fmt.Errorf("verbs are required: %#v", r.PolicyRule)
+	}
+
+	switch {
+	case len(r.PolicyRule.NonResourceURLs) > 0:
+		if len(r.PolicyRule.APIGroups) != 0 || len(r.PolicyRule.Resources) != 0 || len(r.PolicyRule.ResourceNames) != 0 {
+			return rbacv1.PolicyRule{}, fmt.Errorf("non-resource rule may not have apiGroups, resources, or resourceNames: %#v", r.PolicyRule)
+		}
+	case len(r.PolicyRule.Resources) > 0:
+		if len(r.PolicyRule.NonResourceURLs) != 0 {
+			return rbacv1.PolicyRule{}, fmt.Errorf("resource rule may not have nonResourceURLs: %#v", r.PolicyRule)
+		}
+		if len(r.PolicyRule.APIGroups) == 0 {
+			// this a common bug
+			return rbacv1.PolicyRule{}, fmt.Errorf("resource rule must have apiGroups: %#v", r.PolicyRule)
+		}
+	default:
+		return rbacv1.PolicyRule{}, fmt.Errorf("a rule must have either nonResourceURLs or resources: %#v", r.PolicyRule)
+	}
+
+	sort.Strings(r.PolicyRule.Resources)
+	sort.Strings(r.PolicyRule.ResourceNames)
+	sort.Strings(r.PolicyRule.APIGroups)
+	sort.Strings(r.PolicyRule.NonResourceURLs)
+	sort.Strings(r.PolicyRule.Verbs)
+	return r.PolicyRule, nil
+}


### PR DESCRIPTION
Notably, we want to allow the metrics scraper since that rule is always present in openshift clusters