### PR TITLE
introduces health check monitor

### DIFF
--- a/pkg/healthmonitor/health_monitor.go
+++ b/pkg/healthmonitor/health_monitor.go
@@ -1,0 +1,338 @@
+package healthmonitor
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/transport"
+	"k8s.io/klog/v2"
+)
+
+type HealthMonitor struct {
+	// targetProvider provides a list of targets to monitor
+	// it also can schedule refreshing the list by simply calling Enqueue method
+	targetProvider TargetProvider
+
+	// client is an HTTP client that is used to probe health checks for targets
+	client *http.Client
+
+	// probeResponseTimeout specifies a time limit for requests made by the HTTP client for the health check
+	probeResponseTimeout time.Duration
+
+	// probeInterval specifies a time interval at which health checks are send
+	probeInterval time.Duration
+
+	// unhealthyProbesThreshold specifies consecutive failed health checks after which a target is considered unhealthy
+	unhealthyProbesThreshold int
+
+	// healthyProbesThreshold  specifies consecutive successful health checks after which a target is considered healthy
+	healthyProbesThreshold int
+
+	healthyTargets   []string
+	unhealthyTargets []string
+	targetsToMonitor []string
+
+	consecutiveSuccessfulProbes map[string]int
+	consecutiveFailedProbes     map[string][]error
+
+	refreshTargetsLock sync.Mutex
+	refreshTargets     bool
+
+	// exportedHealthyTargets holds a copy of healthyTargets
+	exportedHealthyTargets atomic.Value
+
+	// exportedUnhealthyTargets holds a copy of unhealthyTargets
+	exportedUnhealthyTargets atomic.Value
+
+	// listeners holds a list of interested parties to be notified when the list of healthy targets changes
+	listeners []Listener
+}
+
+var _ Listener = &HealthMonitor{}
+var _ Notifier = &HealthMonitor{}
+
+// New creates a health monitor that periodically sends requests to the provided targets to check their health.
+// This method also allows you to configure behaviour of the monitor upfront.
+//
+//   unhealthyProbesThreshold - that specifies consecutive failed health checks after which a target is considered unhealthy
+//   healthyProbesThreshold   - that specifies consecutive successful health checks after which a target is considered healthy
+//   probeResponseTimeout     - that specifies a time limit for requests made by the HTTP client for the health check
+//   probeInterval            - that specifies a time interval at which health checks are send
+//
+//
+// Additionally the monitor implements Listener and Notifier interfaces.
+//
+// The health monitor automatically registers for notification if the target provided also implements the Notifier interface.
+// It is implicit so that the provider can provide a static or a dynamic list of targets.
+//
+// Interested parties can register a listener for notifications about healthy/unhealthy targets changes via AddListener.
+// TODO: instead of restConfig we could accept transport so that it is reused instead of creating a new connection to targets
+//       reusing the transport has the advantage of using the same connection as other clients
+func New(targetProvider TargetProvider, restConfig *rest.Config, unhealthyProbesThreshold int, healthyProbesThreshold int, probeResponseTimeout, probeInterval time.Duration) (*HealthMonitor, error) {
+	client, err := createHealthCheckHTTPClient(probeResponseTimeout, restConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	hm := &HealthMonitor{
+		client:                   client,
+		targetProvider:           targetProvider,
+		targetsToMonitor:         targetProvider.CurrentTargetsList(),
+		probeResponseTimeout:     probeResponseTimeout,
+		probeInterval:            probeInterval,
+		unhealthyProbesThreshold: unhealthyProbesThreshold,
+		healthyProbesThreshold:   healthyProbesThreshold,
+
+		consecutiveSuccessfulProbes: map[string]int{},
+		consecutiveFailedProbes:     map[string][]error{},
+	}
+	hm.exportedHealthyTargets.Store([]string{})
+	hm.exportedUnhealthyTargets.Store([]string{})
+
+	if notifier, ok := targetProvider.(Notifier); ok {
+		notifier.AddListener(hm)
+	}
+
+	return hm, nil
+}
+
+// Run starts monitoring the provided targets until stop channel is closed
+// This method is blocking and it is meant to be launched in a separate goroutine
+func (sm *HealthMonitor) Run(stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+
+	klog.Infof("Starting the health monitor with Interval = %v, Timeout = %v, HealthyThreshold = %v, UnhealthyThreshold = %v ", sm.probeInterval, sm.probeResponseTimeout, sm.healthyProbesThreshold, sm.unhealthyProbesThreshold)
+	defer klog.Info("Shutting down the health monitor")
+
+	wait.Until(sm.healthCheckRegisteredTargets, sm.probeInterval, stopCh)
+}
+
+// Enqueue schedules refreshing the target list on the next probeInterval
+// This method is used by the TargetProvider to notify that the list has changed
+func (sm *HealthMonitor) Enqueue() {
+	sm.refreshTargetsLock.Lock()
+	defer sm.refreshTargetsLock.Unlock()
+	sm.refreshTargets = true
+}
+
+// Targets returns a list of healthy and unhealthy targets
+func (sm *HealthMonitor) Targets() ([]string, []string) {
+	return sm.exportedHealthyTargets.Load().([]string), sm.exportedUnhealthyTargets.Load().([]string)
+}
+
+// AddListener adds a listener to be notified when the list of healthy targets changes
+//
+// Note:
+// this method is not thread safe and mustn't be called after calling StartMonitoring() method
+func (sm *HealthMonitor) AddListener(listener Listener) {
+	sm.listeners = append(sm.listeners, listener)
+}
+
+type targetErrTuple struct {
+	target string
+	err    error
+}
+
+// refreshTargetsLocked updates the internal targets list to monitor if it was requested (via the Enqueue method)
+func (sm *HealthMonitor) refreshTargetsLocked() {
+	sm.refreshTargetsLock.Lock()
+	defer sm.refreshTargetsLock.Unlock()
+	if !sm.refreshTargets {
+		return
+	}
+
+	sm.refreshTargets = false
+	freshTargets := sm.targetProvider.CurrentTargetsList()
+	freshTargetSet := sets.NewString(freshTargets...)
+
+	currentTargetsSet := sets.NewString(sm.targetsToMonitor...)
+	newTargetsToMonitorSet := freshTargetSet.Difference(currentTargetsSet)
+	if newTargetsToMonitorSet.Len() > 0 {
+		klog.V(2).Infof("health monitor observed new targets = %v", newTargetsToMonitorSet.List())
+	}
+
+	removedTargetsToMonitorSet := currentTargetsSet.Difference(freshTargetSet)
+	if removedTargetsToMonitorSet.Len() > 0 {
+		klog.V(2).Infof("health monitor will stop checking the following targets targets = %v", removedTargetsToMonitorSet.List())
+		for targetToRemove := range removedTargetsToMonitorSet {
+			delete(sm.consecutiveSuccessfulProbes, targetToRemove)
+			delete(sm.consecutiveFailedProbes, targetToRemove)
+		}
+
+		healthyTargetsSet := sets.NewString(sm.healthyTargets...)
+		healthyTargetsSet.Delete(removedTargetsToMonitorSet.List()...)
+		sm.healthyTargets = healthyTargetsSet.List()
+
+		unhealthyTargetsSet := sets.NewString(sm.unhealthyTargets...)
+		unhealthyTargetsSet.Delete(removedTargetsToMonitorSet.List()...)
+		sm.unhealthyTargets = unhealthyTargetsSet.List()
+	}
+
+	sm.targetsToMonitor = freshTargets
+}
+
+func (sm *HealthMonitor) healthCheckRegisteredTargets() {
+	sm.refreshTargetsLocked()
+	var wg sync.WaitGroup
+	resTargetErrTupleCh := make(chan targetErrTuple, len(sm.targetsToMonitor))
+
+	for i := 0; i < len(sm.targetsToMonitor); i++ {
+		wg.Add(1)
+		go func(target string) {
+			defer wg.Done()
+			err := sm.healthCheckSingleTarget(target)
+			resTargetErrTupleCh <- targetErrTuple{target, err}
+		}(sm.targetsToMonitor[i])
+	}
+	wg.Wait()
+	close(resTargetErrTupleCh)
+
+	currentHealthCheckProbes := make([]targetErrTuple, 0, len(sm.targetsToMonitor))
+	for svrErrTuple := range resTargetErrTupleCh {
+		currentHealthCheckProbes = append(currentHealthCheckProbes, svrErrTuple)
+	}
+
+	sm.updateHealthChecksFor(currentHealthCheckProbes)
+}
+
+// TODO: add metrics
+// updateHealthChecksFor examines the health of targets based on the provided probes and the current configuration.
+// It also notifies interested parties about changes in the health condition.
+// Interested parties can be registered by calling AddListener method.
+func (sm *HealthMonitor) updateHealthChecksFor(currentHealthCheckProbes []targetErrTuple) {
+	newUnhealthyTargets := []string{}
+	newHealthyTargets := []string{}
+
+	for _, svrErrTuple := range currentHealthCheckProbes {
+		if svrErrTuple.err != nil {
+			delete(sm.consecutiveSuccessfulProbes, svrErrTuple.target)
+
+			unhealthyProbesSlice := sm.consecutiveFailedProbes[svrErrTuple.target]
+			if len(unhealthyProbesSlice) < sm.unhealthyProbesThreshold {
+				unhealthyProbesSlice = append(unhealthyProbesSlice, svrErrTuple.err)
+				sm.consecutiveFailedProbes[svrErrTuple.target] = unhealthyProbesSlice
+				if len(unhealthyProbesSlice) == sm.unhealthyProbesThreshold {
+					newUnhealthyTargets = append(newUnhealthyTargets, svrErrTuple.target)
+				}
+			}
+			continue
+		}
+
+		delete(sm.consecutiveFailedProbes, svrErrTuple.target)
+
+		healthyProbesCounter := sm.consecutiveSuccessfulProbes[svrErrTuple.target]
+		if healthyProbesCounter < sm.healthyProbesThreshold {
+			healthyProbesCounter++
+			sm.consecutiveSuccessfulProbes[svrErrTuple.target] = healthyProbesCounter
+			if healthyProbesCounter == sm.healthyProbesThreshold {
+				newHealthyTargets = append(newHealthyTargets, svrErrTuple.target)
+			}
+		}
+	}
+
+	newUnhealthyTargetsSet := sets.NewString(newUnhealthyTargets...)
+	newHealthyTargetsSet := sets.NewString(newHealthyTargets...)
+	notifyListeners := false
+
+	// detect unhealthy targets
+	previouslyUnhealthyTargetsSet := sets.NewString(sm.unhealthyTargets...)
+	currentlyUnhealthyTargetsSet := previouslyUnhealthyTargetsSet.Union(newUnhealthyTargetsSet)
+	currentlyUnhealthyTargetsSet.Delete(newHealthyTargetsSet.List()...)
+	if !currentlyUnhealthyTargetsSet.Equal(previouslyUnhealthyTargetsSet) {
+		sm.unhealthyTargets = currentlyUnhealthyTargetsSet.List()
+		klog.V(2).Infof("observed the following unhealthy targets %v", sm.unhealthyTargets)
+		logUnhealthyTargets(sm.unhealthyTargets, currentHealthCheckProbes)
+
+		exportedUnhealthyTargets := make([]string, len(sm.unhealthyTargets))
+		for index, unhealthyTarget := range sm.unhealthyTargets {
+			exportedUnhealthyTargets[index] = unhealthyTarget
+		}
+		sm.exportedUnhealthyTargets.Store(exportedUnhealthyTargets)
+		notifyListeners = true
+	}
+
+	// detect healthy targets
+	previouslyHealthyTargetsSet := sets.NewString(sm.healthyTargets...)
+	currentlyHealthyTargetsSet := previouslyHealthyTargetsSet.Union(newHealthyTargetsSet)
+	currentlyHealthyTargetsSet.Delete(newUnhealthyTargetsSet.List()...)
+	if !currentlyHealthyTargetsSet.Equal(previouslyHealthyTargetsSet) {
+		sm.healthyTargets = currentlyHealthyTargetsSet.List()
+		klog.V(2).Infof("observed the following healthy targets %v", sm.healthyTargets)
+
+		exportedHealthyTargets := make([]string, len(sm.healthyTargets))
+		for index, healthyTarget := range sm.healthyTargets {
+			exportedHealthyTargets[index] = healthyTarget
+		}
+		sm.exportedHealthyTargets.Store(exportedHealthyTargets)
+		notifyListeners = true
+	}
+
+	if notifyListeners {
+		// notify listeners about the new healthy/unhealthy targets
+		for _, listener := range sm.listeners {
+			listener.Enqueue()
+		}
+	}
+}
+
+func (sm *HealthMonitor) healthCheckSingleTarget(target string) error {
+	// TODO: make the protocol, port and the path configurable
+	url := fmt.Sprintf("https://%s/%s", target, "readyz")
+	newReq, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := sm.client.Do(newReq)
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("bad status from %v: %v, expected HTTP 200", url, resp.StatusCode)
+	}
+
+	return err
+}
+
+func createHealthCheckHTTPClient(responseTimeout time.Duration, restConfig *rest.Config) (*http.Client, error) {
+	transportConfig, err := restConfig.TransportConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	tlsConfig, err := transport.TLSConfigFor(transportConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	client := &http.Client{
+		Transport: utilnet.SetTransportDefaults(&http.Transport{
+			TLSClientConfig: tlsConfig,
+		}),
+		Timeout: responseTimeout,
+	}
+
+	return client, nil
+}
+
+func logUnhealthyTargets(unhealthyTargets []string, currentHealthCheckProbes []targetErrTuple) {
+	for _, unhealthyTarget := range unhealthyTargets {
+		errorsForUnhealthyTarget := []error{}
+		for _, svrErrTuple := range currentHealthCheckProbes {
+			if svrErrTuple.target == unhealthyTarget {
+				errorsForUnhealthyTarget = append(errorsForUnhealthyTarget, svrErrTuple.err)
+			}
+		}
+		klog.V(2).Infof("the following target %v became unhealthy due to %v", unhealthyTarget, utilerrors.NewAggregate(errorsForUnhealthyTarget).Error())
+	}
+}

--- a/pkg/healthmonitor/health_monitor.go
+++ b/pkg/healthmonitor/health_monitor.go
@@ -115,6 +115,7 @@ func New(targetProvider TargetProvider, restConfig *rest.Config) (*HealthMonitor
 
 		metrics: &Metrics{
 			HealthyTargetsTotal:   noopMetrics{}.TargetsTotal,
+			CurrentHealthyTargets: noopMetrics{}.TargetsGauge,
 			UnHealthyTargetsTotal: noopMetrics{}.TargetsTotal,
 		},
 	}
@@ -301,6 +302,9 @@ func (sm *HealthMonitor) updateHealthChecksFor(currentHealthCheckProbes []target
 	}
 
 	if notifyListeners {
+		// something has changed update the currently healthy targets metric
+		sm.metrics.CurrentHealthyTargets(float64(len(sm.healthyTargets)))
+
 		// notify listeners about the new healthy/unhealthy targets
 		for _, listener := range sm.listeners {
 			listener.Enqueue()

--- a/pkg/healthmonitor/health_monitor.go
+++ b/pkg/healthmonitor/health_monitor.go
@@ -1,6 +1,7 @@
 package healthmonitor
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -134,13 +135,13 @@ func New(targetProvider TargetProvider, restConfig *rest.Config) (*HealthMonitor
 
 // Run starts monitoring the provided targets until stop channel is closed
 // This method is blocking and it is meant to be launched in a separate goroutine
-func (sm *HealthMonitor) Run(stopCh <-chan struct{}) {
+func (sm *HealthMonitor) Run(ctx context.Context) {
 	defer utilruntime.HandleCrash()
 
 	klog.Infof("Starting the health monitor with Interval = %v, Timeout = %v, HealthyThreshold = %v, UnhealthyThreshold = %v ", sm.probeInterval, sm.client.Timeout, sm.healthyProbesThreshold, sm.unhealthyProbesThreshold)
 	defer klog.Info("Shutting down the health monitor")
 
-	wait.Until(sm.healthCheckRegisteredTargets, sm.probeInterval, stopCh)
+	wait.Until(sm.healthCheckRegisteredTargets, sm.probeInterval, ctx.Done())
 }
 
 // Enqueue schedules refreshing the target list on the next probeInterval

--- a/pkg/healthmonitor/health_monitor_test.go
+++ b/pkg/healthmonitor/health_monitor_test.go
@@ -1,0 +1,431 @@
+package healthmonitor
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+type fakeTargetProvider []string
+
+func (sp fakeTargetProvider) CurrentTargetsList() []string {
+	return sp
+}
+
+type fakeHealthyTargetListener struct {
+	called bool
+}
+
+func (f *fakeHealthyTargetListener) Enqueue() {
+	f.called = true
+}
+
+func (f *fakeHealthyTargetListener) reset() {
+	f.called = false
+}
+
+func TestNeverHealthyTargets(t *testing.T) {
+	fakeListener := &fakeHealthyTargetListener{}
+
+	target := newHealthMonitor()
+	target.AddListener(fakeListener)
+	target.unhealthyProbesThreshold = 1
+	target.healthyProbesThreshold = 1
+	target.targetsToMonitor = []string{"master-0"}
+
+	scenarios := []struct {
+		name                string
+		currentHealthProbes []targetErrTuple
+
+		expectedHealthyTargets   []string
+		expectedUnhealthyTargets []string
+		listenerNotified         bool
+	}{
+		{
+			name:                     "round 1: master-0 failed probe",
+			currentHealthProbes:      []targetErrTuple{createUnHealthyProbe("master-0")},
+			expectedUnhealthyTargets: []string{"master-0"},
+			listenerNotified:         true,
+		},
+
+		{
+			name:                     "round 2: master-0 failed probe again",
+			currentHealthProbes:      []targetErrTuple{createUnHealthyProbe("master-0")},
+			expectedUnhealthyTargets: []string{"master-0"},
+			listenerNotified:         false,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			// act
+			fakeListener.reset()
+			target.updateHealthChecksFor(scenario.currentHealthProbes)
+			actualHealthyTargets, actualUnhealthyTargets := target.Targets()
+
+			// validate
+			if !cmp.Equal(actualHealthyTargets, scenario.expectedHealthyTargets, cmpopts.EquateEmpty()) {
+				t.Errorf("unexpected list of healthy targets = %v, expected = %v", actualHealthyTargets, scenario.expectedHealthyTargets)
+			}
+			if !cmp.Equal(actualUnhealthyTargets, scenario.expectedUnhealthyTargets, cmpopts.EquateEmpty()) {
+				t.Errorf("unexpected list of unhealthy targets = %v, expected = %v", actualUnhealthyTargets, scenario.expectedUnhealthyTargets)
+			}
+			if fakeListener.called != scenario.listenerNotified {
+				t.Errorf("unexpected state of the registered listener, notified = %v, expected notified = %v", fakeListener.called, scenario.listenerNotified)
+			}
+		})
+	}
+}
+
+func TestHealthyTargets(t *testing.T) {
+	fakeListener := &fakeHealthyTargetListener{}
+
+	target := newHealthMonitor()
+	target.AddListener(fakeListener)
+	target.unhealthyProbesThreshold = 1
+	target.healthyProbesThreshold = 1
+	target.targetsToMonitor = []string{"master-0", "master-1", "master-2"}
+
+	scenarios := []struct {
+		name                string
+		currentHealthProbes []targetErrTuple
+
+		expectedHealthyTargets   []string
+		expectedUnhealthyTargets []string
+		listenerNotified         bool
+	}{
+		{
+			name: "round 0: works with empty list",
+		},
+
+		{
+			name:                   "round 1: all servers passed probe, registered listener notified about healthy targets",
+			currentHealthProbes:    []targetErrTuple{createHealthyProbe("master-0"), createHealthyProbe("master-1"), createHealthyProbe("master-2")},
+			expectedHealthyTargets: []string{"master-0", "master-1", "master-2"},
+			listenerNotified:       true,
+		},
+
+		{
+			name:                     "round 2: master-1 becomes unhealthy, registered listener notified",
+			currentHealthProbes:      []targetErrTuple{createHealthyProbe("master-0"), createUnHealthyProbe("master-1"), createHealthyProbe("master-2")},
+			expectedHealthyTargets:   []string{"master-0", "master-2"},
+			expectedUnhealthyTargets: []string{"master-1"},
+			listenerNotified:         true,
+		},
+
+		{
+			name:                     "round 3: nothing changes, the listener is not notified",
+			currentHealthProbes:      []targetErrTuple{createHealthyProbe("master-0"), createUnHealthyProbe("master-1"), createHealthyProbe("master-2")},
+			expectedHealthyTargets:   []string{"master-0", "master-2"},
+			expectedUnhealthyTargets: []string{"master-1"},
+			listenerNotified:         false,
+		},
+
+		{
+			name:                     "round 4: master-2 becomes unhealthy, registered listener notified",
+			currentHealthProbes:      []targetErrTuple{createHealthyProbe("master-0"), createUnHealthyProbe("master-1"), createUnHealthyProbe("master-2")},
+			expectedHealthyTargets:   []string{"master-0"},
+			expectedUnhealthyTargets: []string{"master-1", "master-2"},
+			listenerNotified:         true,
+		},
+
+		{
+			name:                   "round 5: master-1 and master-2 becomes healthy, registered listener notified",
+			currentHealthProbes:    []targetErrTuple{createHealthyProbe("master-0"), createHealthyProbe("master-1"), createHealthyProbe("master-2")},
+			expectedHealthyTargets: []string{"master-0", "master-1", "master-2"},
+			listenerNotified:       true,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			// act
+			fakeListener.reset()
+			target.updateHealthChecksFor(scenario.currentHealthProbes)
+			actualHealthyTargets, actualUnhealthyTargets := target.Targets()
+
+			// validate
+			if !cmp.Equal(actualHealthyTargets, scenario.expectedHealthyTargets, cmpopts.EquateEmpty()) {
+				t.Errorf("unexpected list of healthy targets = %v, expected = %v", actualHealthyTargets, scenario.expectedHealthyTargets)
+			}
+			if !cmp.Equal(actualUnhealthyTargets, scenario.expectedUnhealthyTargets, cmpopts.EquateEmpty()) {
+				t.Errorf("unexpected list of unhealthy targets = %v, expected = %v", actualUnhealthyTargets, scenario.expectedUnhealthyTargets)
+			}
+			if fakeListener.called != scenario.listenerNotified {
+				t.Errorf("unexpected state of the registered listener, notified = %v, expected notified = %v", fakeListener.called, scenario.listenerNotified)
+			}
+		})
+	}
+}
+
+func TestInternalStateAfterRefreshingTargets(t *testing.T) {
+	monitor := newHealthMonitor()
+
+	scenarios := []struct {
+		name                 string
+		shouldRefreshTargets bool
+		provider             fakeTargetProvider
+		currentTargetList    []string
+
+		currentHealthyTargets    []string
+		expectedHealthyTargets   []string
+		currentUnhealthyTargets  []string
+		expectedUnhealthyTargets []string
+
+		currentConsecutiveSuccessfulProbes  map[string]int
+		expectedConsecutiveSuccessfulProbes map[string]int
+		currentConsecutiveFailedProbes      map[string][]error
+		expectedConsecutiveFailedProbes     map[string][]error
+	}{
+		{
+			name:                   "a new target is not immediately added to the list of healthy targets",
+			shouldRefreshTargets:   true,
+			provider:               fakeTargetProvider{"master-0", "master-1", "master-2", "master-3"},
+			currentTargetList:      []string{"master-0", "master-1", "master-2"},
+			currentHealthyTargets:  []string{"master-0", "master-1", "master-2"},
+			expectedHealthyTargets: []string{"master-0", "master-1", "master-2"},
+		},
+
+		{
+			name:                                "an old target is immediately removed from the list of healthy targets",
+			shouldRefreshTargets:                true,
+			provider:                            fakeTargetProvider{"master-0", "master-1", "master-2"},
+			currentTargetList:                   []string{"master-0", "master-1", "master-2", "master-3"},
+			currentHealthyTargets:               []string{"master-0", "master-1", "master-2", "master-3"},
+			expectedHealthyTargets:              []string{"master-0", "master-1", "master-2"},
+			currentConsecutiveSuccessfulProbes:  map[string]int{"master-0": 3, "master-1": 3, "master-2": 3, "master-3": 3},
+			expectedConsecutiveSuccessfulProbes: map[string]int{"master-0": 3, "master-1": 3, "master-2": 3},
+		},
+
+		{
+			name:                                "an old target is immediately removed from the list of unhealthy targets",
+			shouldRefreshTargets:                true,
+			provider:                            fakeTargetProvider{"master-0", "master-1", "master-2"},
+			currentTargetList:                   []string{"master-0", "master-1", "master-2", "master-3"},
+			currentHealthyTargets:               []string{"master-0", "master-1", "master-2"},
+			expectedHealthyTargets:              []string{"master-0", "master-1", "master-2"},
+			currentUnhealthyTargets:             []string{"master-3"},
+			expectedUnhealthyTargets:            []string{},
+			currentConsecutiveFailedProbes:      map[string][]error{"master-3": {errors.New("abc")}},
+			expectedConsecutiveFailedProbes:     map[string][]error{},
+			currentConsecutiveSuccessfulProbes:  map[string]int{"master-0": 3, "master-1": 3, "master-2": 3},
+			expectedConsecutiveSuccessfulProbes: map[string]int{"master-0": 3, "master-1": 3, "master-2": 3},
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			monitor.refreshTargets = scenario.shouldRefreshTargets
+			monitor.targetProvider = scenario.provider
+			monitor.targetsToMonitor = scenario.currentTargetList
+			monitor.healthyTargets = scenario.currentHealthyTargets
+			monitor.unhealthyTargets = scenario.currentUnhealthyTargets
+			monitor.consecutiveSuccessfulProbes = scenario.currentConsecutiveSuccessfulProbes
+			monitor.consecutiveFailedProbes = scenario.currentConsecutiveFailedProbes
+
+			// act
+			monitor.refreshTargetsLocked()
+
+			// validate
+			if !cmp.Equal(monitor.healthyTargets, scenario.expectedHealthyTargets, cmpopts.EquateEmpty()) {
+				t.Errorf("unexpected list of healthy targets = %v, expected = %v", monitor.healthyTargets, scenario.expectedHealthyTargets)
+			}
+			if !cmp.Equal(monitor.unhealthyTargets, scenario.expectedUnhealthyTargets, cmpopts.EquateEmpty()) {
+				t.Errorf("unexpected list of unhealthy targets = %v, expected = %v", monitor.unhealthyTargets, scenario.expectedUnhealthyTargets)
+			}
+
+			if !cmp.Equal(monitor.consecutiveSuccessfulProbes, scenario.expectedConsecutiveSuccessfulProbes, cmpopts.EquateEmpty()) {
+				t.Errorf("unexpected state of consecutiveSuccessfulProbes = %v, expected = %v", monitor.consecutiveSuccessfulProbes, scenario.expectedConsecutiveSuccessfulProbes)
+			}
+			if !cmp.Equal(monitor.consecutiveFailedProbes, scenario.expectedConsecutiveFailedProbes, cmpopts.EquateEmpty()) {
+				t.Errorf("unexpected state of consecutiveFailedProbes = %v, expected = %v", monitor.consecutiveFailedProbes, scenario.expectedConsecutiveFailedProbes)
+			}
+		})
+	}
+}
+
+func TestRefreshTargets(t *testing.T) {
+	monitor := newHealthMonitor()
+
+	scenarios := []struct {
+		name                 string
+		shouldRefreshTargets bool
+		provider             fakeTargetProvider
+		currentTargetList    []string
+		expectedTargetList   []string
+	}{
+		{
+			name:               "shouldn't refresh, nothing changes",
+			currentTargetList:  []string{"master-0", "master-1", "master-2"},
+			expectedTargetList: []string{"master-0", "master-1", "master-2"},
+		},
+
+		{
+			name:               "new list available but hasn't been scheduled, nothing changes",
+			provider:           fakeTargetProvider{"master-0", "master-1", "master-2", "master-3"},
+			currentTargetList:  []string{"master-0", "master-1", "master-2"},
+			expectedTargetList: []string{"master-0", "master-1", "master-2"},
+		},
+
+		{
+			name:                 "new list available and scheduled, new target observed",
+			shouldRefreshTargets: true,
+			provider:             fakeTargetProvider{"master-0", "master-1", "master-2", "master-3"},
+			currentTargetList:    []string{"master-0", "master-1", "master-2"},
+			expectedTargetList:   []string{"master-0", "master-1", "master-2", "master-3"},
+		},
+
+		{
+			name:                 "new list available and scheduled, old target removed",
+			shouldRefreshTargets: true,
+			provider:             fakeTargetProvider{"master-0", "master-1", "master-2"},
+			currentTargetList:    []string{"master-0", "master-1", "master-2", "master-3"},
+			expectedTargetList:   []string{"master-0", "master-1", "master-2"},
+		},
+
+		{
+			name:                 "new list available and scheduled, old target removed and new one observed",
+			shouldRefreshTargets: true,
+			provider:             fakeTargetProvider{"master-0", "master-1", "master-2", "master-4"},
+			currentTargetList:    []string{"master-0", "master-1", "master-2", "master-3"},
+			expectedTargetList:   []string{"master-0", "master-1", "master-2", "master-4"},
+		},
+
+		{
+			name:                 "new list available and scheduled, all targets observed",
+			shouldRefreshTargets: true,
+			provider:             fakeTargetProvider{"master-0", "master-1", "master-2", "master-4"},
+			expectedTargetList:   []string{"master-0", "master-1", "master-2", "master-4"},
+		},
+
+		{
+			name:                 "new list available and scheduled, all targets removed",
+			shouldRefreshTargets: true,
+			provider:             fakeTargetProvider{},
+			currentTargetList:    []string{"master-0", "master-1", "master-2", "master-4"},
+			expectedTargetList:   []string{},
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			monitor.refreshTargets = scenario.shouldRefreshTargets
+			monitor.targetProvider = scenario.provider
+			monitor.targetsToMonitor = scenario.currentTargetList
+
+			// act
+			monitor.refreshTargetsLocked()
+
+			// validate
+			if !cmp.Equal(monitor.targetsToMonitor, scenario.expectedTargetList, cmpopts.EquateEmpty()) {
+				t.Errorf("unexpected list of targets = %v, expected = %v", monitor.targetsToMonitor, scenario.expectedTargetList)
+			}
+		})
+	}
+}
+
+func TestHealthProbes(t *testing.T) {
+	target := newHealthMonitor()
+	target.targetsToMonitor = []string{"master-0", "master-1", "master-2"}
+
+	scenarios := []struct {
+		name                     string
+		currentHealthProbes      []targetErrTuple
+		expectedHealthyServers   []string
+		expectedUnhealthyServers []string
+	}{
+		{
+			name:                "round 1: all servers passed probe",
+			currentHealthProbes: []targetErrTuple{createHealthyProbe("master-0"), createHealthyProbe("master-1"), createHealthyProbe("master-2")},
+		},
+
+		{
+			name:                "round 2: all servers passed probe",
+			currentHealthProbes: []targetErrTuple{createHealthyProbe("master-0"), createHealthyProbe("master-1"), createHealthyProbe("master-2")},
+		},
+
+		{
+			name:                   "round 3: all servers became healthy",
+			currentHealthProbes:    []targetErrTuple{createHealthyProbe("master-0"), createHealthyProbe("master-1"), createHealthyProbe("master-2")},
+			expectedHealthyServers: []string{"master-0", "master-1", "master-2"},
+		},
+
+		{
+			name:                   "round 4: all servers passed probe, nothing has changed",
+			currentHealthProbes:    []targetErrTuple{createHealthyProbe("master-0"), createHealthyProbe("master-1"), createHealthyProbe("master-2")},
+			expectedHealthyServers: []string{"master-0", "master-1", "master-2"},
+		},
+
+		{
+			name:                   "round 5: master-1 failed probe",
+			currentHealthProbes:    []targetErrTuple{createHealthyProbe("master-0"), createUnHealthyProbe("master-1"), createHealthyProbe("master-2")},
+			expectedHealthyServers: []string{"master-0", "master-1", "master-2"},
+		},
+
+		{
+			name:                     "round 6: master-1 became unhealthy",
+			currentHealthProbes:      []targetErrTuple{createHealthyProbe("master-0"), createUnHealthyProbe("master-1"), createHealthyProbe("master-2")},
+			expectedHealthyServers:   []string{"master-0", "master-2"},
+			expectedUnhealthyServers: []string{"master-1"},
+		},
+
+		{
+			name:                     "round 7: master-1 passed probe",
+			currentHealthProbes:      []targetErrTuple{createHealthyProbe("master-0"), createHealthyProbe("master-1"), createHealthyProbe("master-2")},
+			expectedHealthyServers:   []string{"master-0", "master-2"},
+			expectedUnhealthyServers: []string{"master-1"},
+		},
+
+		{
+			name:                     "round 8: master-1 passed probe",
+			currentHealthProbes:      []targetErrTuple{createHealthyProbe("master-0"), createHealthyProbe("master-1"), createHealthyProbe("master-2")},
+			expectedHealthyServers:   []string{"master-0", "master-2"},
+			expectedUnhealthyServers: []string{"master-1"},
+		},
+
+		{
+			name:                   "round 9: master-1 became healthy",
+			currentHealthProbes:    []targetErrTuple{createHealthyProbe("master-0"), createHealthyProbe("master-1"), createHealthyProbe("master-2")},
+			expectedHealthyServers: []string{"master-0", "master-1", "master-2"},
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			// act
+			target.updateHealthChecksFor(scenario.currentHealthProbes)
+
+			// validate
+			if !cmp.Equal(target.healthyTargets, scenario.expectedHealthyServers, cmpopts.EquateEmpty()) {
+				t.Errorf("unexpected list of healthy servers = %v, expected = %v", target.healthyTargets, scenario.expectedHealthyServers)
+			}
+			if !cmp.Equal(target.unhealthyTargets, scenario.expectedUnhealthyServers, cmpopts.EquateEmpty()) {
+				t.Errorf("unexpected list of unhealthy servers = %v, expected = %v", target.unhealthyTargets, scenario.expectedUnhealthyServers)
+			}
+		})
+	}
+}
+
+func newHealthMonitor() *HealthMonitor {
+	hm := &HealthMonitor{
+		unhealthyProbesThreshold: 2,
+		healthyProbesThreshold:   3,
+
+		consecutiveSuccessfulProbes: map[string]int{},
+		consecutiveFailedProbes:     map[string][]error{},
+	}
+	hm.exportedHealthyTargets.Store([]string{})
+	hm.exportedUnhealthyTargets.Store([]string{})
+
+	return hm
+}
+
+func createHealthyProbe(server string) targetErrTuple {
+	return targetErrTuple{server, nil}
+}
+
+func createUnHealthyProbe(server string) targetErrTuple {
+	return targetErrTuple{server, errors.New("random error")}
+}

--- a/pkg/healthmonitor/health_monitor_test.go
+++ b/pkg/healthmonitor/health_monitor_test.go
@@ -415,6 +415,11 @@ func newHealthMonitor() *HealthMonitor {
 
 		consecutiveSuccessfulProbes: map[string]int{},
 		consecutiveFailedProbes:     map[string][]error{},
+
+		metrics: &Metrics{
+			HealthyTargetsTotal:   noopMetrics{}.TargetsTotal,
+			UnHealthyTargetsTotal: noopMetrics{}.TargetsTotal,
+		},
 	}
 	hm.exportedHealthyTargets.Store([]string{})
 	hm.exportedUnhealthyTargets.Store([]string{})

--- a/pkg/healthmonitor/health_monitor_test.go
+++ b/pkg/healthmonitor/health_monitor_test.go
@@ -423,6 +423,8 @@ func newHealthMonitor() *HealthMonitor {
 	}
 	hm.exportedHealthyTargets.Store([]string{})
 	hm.exportedUnhealthyTargets.Store([]string{})
+	fakeMetrics := &fakeMetrics{}
+	hm.metrics = &Metrics{HealthyTargetsTotal: fakeMetrics.HealthyTargetsTotal, UnHealthyTargetsTotal: fakeMetrics.UnHealthyTargetsTotal, CurrentHealthyTargets: fakeMetrics.CurrentHealthyTargets}
 
 	return hm
 }

--- a/pkg/healthmonitor/metrics.go
+++ b/pkg/healthmonitor/metrics.go
@@ -1,0 +1,64 @@
+package healthmonitor
+
+import (
+	compbasemetrics "k8s.io/component-base/metrics"
+)
+
+type registerables []compbasemetrics.Registerable
+
+var (
+	healthyTargetsTotal = compbasemetrics.NewCounterVec(
+		&compbasemetrics.CounterOpts{
+			Name:           "health_monitor_healthy_target_total",
+			Help:           "Number of healthy instances registered with the health monitor. Partitioned by targets",
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"target"},
+	)
+
+	unHealthyTargetsTotal = compbasemetrics.NewCounterVec(
+		&compbasemetrics.CounterOpts{
+			Name:           "health_monitor_unhealthy_target_total",
+			Help:           "Number of unhealthy instances registered with the health monitor. Partitioned by targets",
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"target"},
+	)
+
+	metrics = registerables{
+		healthyTargetsTotal,
+		unHealthyTargetsTotal,
+	}
+)
+
+// HealthyTargetsTotal increments the total number of healthy instances observed by the health monitor
+func HealthyTargetsTotal(target string) {
+	healthyTargetsTotal.WithLabelValues(target).Add(1)
+}
+
+// UnHealthyTargetsTotal increments the total number of unhealthy instances observed by the health monitor
+func UnHealthyTargetsTotal(target string) {
+	unHealthyTargetsTotal.WithLabelValues(target).Add(1)
+}
+
+// Metrics specifies a set of methods that are used to register various metrics
+type Metrics struct {
+	// HealthyTargetsTotal increments the total number of healthy instances observed by the health monitor
+	HealthyTargetsTotal func(target string)
+
+	// UnHealthyTargetsTotal increments the total number of unhealthy instances observed by the health monitor
+	UnHealthyTargetsTotal func(target string)
+}
+
+// Register is a way to register the health monitor related metrics in the provided store
+func Register(registerFn func(...compbasemetrics.Registerable)) *Metrics {
+	registerFn(metrics...)
+	return &Metrics{
+		HealthyTargetsTotal:   HealthyTargetsTotal,
+		UnHealthyTargetsTotal: UnHealthyTargetsTotal,
+	}
+}
+
+type noopMetrics struct{}
+
+func (noopMetrics) TargetsTotal(string) {}

--- a/pkg/healthmonitor/metrics.go
+++ b/pkg/healthmonitor/metrics.go
@@ -10,7 +10,7 @@ var (
 	healthyTargetsTotal = compbasemetrics.NewCounterVec(
 		&compbasemetrics.CounterOpts{
 			Name:           "health_monitor_healthy_target_total",
-			Help:           "Number of healthy instances registered with the health monitor. Partitioned by targets",
+			Help:           "Number of healthy instances registered with the health monitor. Partitioned by targets.",
 			StabilityLevel: compbasemetrics.ALPHA,
 		},
 		[]string{"target"},
@@ -27,16 +27,26 @@ var (
 	unHealthyTargetsTotal = compbasemetrics.NewCounterVec(
 		&compbasemetrics.CounterOpts{
 			Name:           "health_monitor_unhealthy_target_total",
-			Help:           "Number of unhealthy instances registered with the health monitor. Partitioned by targets",
+			Help:           "Number of unhealthy instances registered with the health monitor. Partitioned by targets.",
 			StabilityLevel: compbasemetrics.ALPHA,
 		},
 		[]string{"target"},
+	)
+
+	readyzViolationRequestTotal = compbasemetrics.NewCounterVec(
+		&compbasemetrics.CounterOpts{
+			Name:           "health_monitor_readyz_violation_request_total",
+			Help:           "Number of HTTP requests partitioned by status code and target that violate the readyz protocol.",
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"code", "target"},
 	)
 
 	metrics = registerables{
 		healthyTargetsTotal,
 		currentHealthyTargets,
 		unHealthyTargetsTotal,
+		readyzViolationRequestTotal,
 	}
 )
 
@@ -55,6 +65,15 @@ func UnHealthyTargetsTotal(target string) {
 	unHealthyTargetsTotal.WithLabelValues(target).Add(1)
 }
 
+// ReadyzProtocolRequestTotal increments the total number of requests issues by the health monitor that violate the "readyz" protocol
+//
+// the "readyz" protocol defines the following HTTP status code:
+//   HTTP 200 - when the server operates normally
+//   HTTP 500 - when the server is not ready, for example, is undergoing a shutdown
+func ReadyzProtocolRequestTotal(code, target string) {
+	readyzViolationRequestTotal.WithLabelValues(code, target).Add(1)
+}
+
 // Metrics specifies a set of methods that are used to register various metrics
 type Metrics struct {
 	// HealthyTargetsTotal increments the total number of healthy instances observed by the health monitor
@@ -65,19 +84,28 @@ type Metrics struct {
 
 	// UnHealthyTargetsTotal increments the total number of unhealthy instances observed by the health monitor
 	UnHealthyTargetsTotal func(target string)
+
+	// ReadyzProtocolRequestTotal increments the total number of requests issues by the health monitor that violate the "readyz" protocol
+	//
+	// the "readyz" protocol defines the following HTTP status code:
+	//   HTTP 200 - when the server operates normally
+	//   HTTP 500 - when the server is not ready, for example, is undergoing a shutdown
+	ReadyzProtocolRequestTotal func(code, target string)
 }
 
 // Register is a way to register the health monitor related metrics in the provided store
 func Register(registerFn func(...compbasemetrics.Registerable)) *Metrics {
 	registerFn(metrics...)
 	return &Metrics{
-		HealthyTargetsTotal:   HealthyTargetsTotal,
-		CurrentHealthyTargets: CurrentHealthyTargets,
-		UnHealthyTargetsTotal: UnHealthyTargetsTotal,
+		HealthyTargetsTotal:        HealthyTargetsTotal,
+		CurrentHealthyTargets:      CurrentHealthyTargets,
+		UnHealthyTargetsTotal:      UnHealthyTargetsTotal,
+		ReadyzProtocolRequestTotal: ReadyzProtocolRequestTotal,
 	}
 }
 
 type noopMetrics struct{}
 
-func (noopMetrics) TargetsTotal(string)  {}
-func (noopMetrics) TargetsGauge(float64) {}
+func (noopMetrics) TargetsTotal(string)                 {}
+func (noopMetrics) TargetsGauge(float64)                {}
+func (noopMetrics) TargetsWithCodeTotal(string, string) {}

--- a/pkg/healthmonitor/metrics_test.go
+++ b/pkg/healthmonitor/metrics_test.go
@@ -1,0 +1,73 @@
+package healthmonitor
+
+import (
+	"testing"
+)
+
+func TestMetrics(t *testing.T) {
+	target := newHealthMonitor()
+	target.unhealthyProbesThreshold = 1
+	target.healthyProbesThreshold = 1
+	target.targetsToMonitor = []string{"master-0"}
+
+	scenarios := []struct {
+		name                string
+		currentHealthProbes []targetErrTuple
+
+		expectedRegisteredHealthyTarget   string
+		expectedRegisteredUnhealthyTarget string
+		listenerNotified                  bool
+	}{
+		{
+			name:                              "round 1: master-0 failed probe",
+			currentHealthProbes:               []targetErrTuple{createUnHealthyProbe("master-0")},
+			expectedRegisteredUnhealthyTarget: "master-0",
+		},
+
+		{
+			name:                "round 2: master-0 failed probe again",
+			currentHealthProbes: []targetErrTuple{createUnHealthyProbe("master-0")},
+		},
+
+		{
+			name:                            "round 3: master-0 passed probe",
+			currentHealthProbes:             []targetErrTuple{createHealthyProbe("master-0")},
+			expectedRegisteredHealthyTarget: "master-0",
+		},
+
+		{
+			name:                "round 4: master-0 passed probe again",
+			currentHealthProbes: []targetErrTuple{createHealthyProbe("master-0")},
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			// act
+			fakeMetrics := &fakeMetrics{}
+			target.metrics = &Metrics{HealthyTargetsTotal: fakeMetrics.HealthyTargetsTotal, UnHealthyTargetsTotal: fakeMetrics.UnHealthyTargetsTotal}
+			target.updateHealthChecksFor(scenario.currentHealthProbes)
+
+			// validate
+			if fakeMetrics.totalHealthyTargets != scenario.expectedRegisteredHealthyTarget {
+				t.Errorf("incorrect target recorded for HealthyTargetsTotal method, expected = %v, got %v", scenario.expectedRegisteredHealthyTarget, fakeMetrics.totalHealthyTargets)
+			}
+			if fakeMetrics.totalUnHealthyTargets != scenario.expectedRegisteredUnhealthyTarget {
+				t.Errorf("incorrect target recorded for UnHealthyTargetsTotal method, expected = %v, got %v", scenario.expectedRegisteredUnhealthyTarget, fakeMetrics.totalUnHealthyTargets)
+			}
+		})
+	}
+}
+
+type fakeMetrics struct {
+	totalHealthyTargets   string
+	totalUnHealthyTargets string
+}
+
+func (f *fakeMetrics) HealthyTargetsTotal(target string) {
+	f.totalHealthyTargets = target
+}
+
+func (f *fakeMetrics) UnHealthyTargetsTotal(target string) {
+	f.totalUnHealthyTargets = target
+}

--- a/pkg/healthmonitor/options.go
+++ b/pkg/healthmonitor/options.go
@@ -1,0 +1,33 @@
+package healthmonitor
+
+import "time"
+
+// WithUnHealthyProbesThreshold specifies consecutive failed health checks after which a target is considered unhealthy
+func (sm *HealthMonitor) WithUnHealthyProbesThreshold(unhealthyProbesThreshold int) *HealthMonitor {
+	sm.unhealthyProbesThreshold = unhealthyProbesThreshold
+	return sm
+}
+
+// WithHealthyProbesThreshold  specifies consecutive successful health checks after which a target is considered healthy
+func (sm *HealthMonitor) WithHealthyProbesThreshold(healthyProbesThreshold int) *HealthMonitor {
+	sm.healthyProbesThreshold = healthyProbesThreshold
+	return sm
+}
+
+// WithProbeResponseTimeout specifies a time limit for requests made by the HTTP client for the health check
+func (sm *HealthMonitor) WithProbeResponseTimeout(probeResponseTimeout time.Duration) *HealthMonitor {
+	sm.client.Timeout = probeResponseTimeout
+	return sm
+}
+
+// WithProbeInterval specifies a time interval at which health checks are send
+func (sm *HealthMonitor) WithProbeInterval(probeInterval time.Duration) *HealthMonitor {
+	sm.probeInterval = probeInterval
+	return sm
+}
+
+// WithMetrics specifies a set of methods that are used to register various metrics
+func (sm *HealthMonitor) WithMetrics(metrics *Metrics) *HealthMonitor {
+	sm.metrics = metrics
+	return sm
+}

--- a/pkg/healthmonitor/target_resolver.go
+++ b/pkg/healthmonitor/target_resolver.go
@@ -1,0 +1,28 @@
+package healthmonitor
+
+// Listener is an interface to use to notify interested parties of a change.
+type Listener interface {
+	// Enqueue should be called when an input may have changed
+	Enqueue()
+}
+
+// Notifier is a way to add listeners
+type Notifier interface {
+	// AddListener is adds a listener to be notified of potential input changes
+	AddListener(listener Listener)
+}
+
+// TargetProviders is an interface to use to get a list of targets to monitor
+type TargetProvider interface {
+	// CurrentTargetsList returns a precomputed list of targets
+	CurrentTargetsList() []string
+}
+
+// StaticTargetProvider implements TargetProvider and provides a static list of targets
+type StaticTargetProvider []string
+
+var _ TargetProvider = StaticTargetProvider{}
+
+func (sp StaticTargetProvider) CurrentTargetsList() []string {
+	return sp
+}

--- a/vendor/github.com/google/go-cmp/cmp/cmpopts/equate.go
+++ b/vendor/github.com/google/go-cmp/cmp/cmpopts/equate.go
@@ -1,0 +1,156 @@
+// Copyright 2017, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+// Package cmpopts provides common options for the cmp package.
+package cmpopts
+
+import (
+	"math"
+	"reflect"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"golang.org/x/xerrors"
+)
+
+func equateAlways(_, _ interface{}) bool { return true }
+
+// EquateEmpty returns a Comparer option that determines all maps and slices
+// with a length of zero to be equal, regardless of whether they are nil.
+//
+// EquateEmpty can be used in conjunction with SortSlices and SortMaps.
+func EquateEmpty() cmp.Option {
+	return cmp.FilterValues(isEmpty, cmp.Comparer(equateAlways))
+}
+
+func isEmpty(x, y interface{}) bool {
+	vx, vy := reflect.ValueOf(x), reflect.ValueOf(y)
+	return (x != nil && y != nil && vx.Type() == vy.Type()) &&
+		(vx.Kind() == reflect.Slice || vx.Kind() == reflect.Map) &&
+		(vx.Len() == 0 && vy.Len() == 0)
+}
+
+// EquateApprox returns a Comparer option that determines float32 or float64
+// values to be equal if they are within a relative fraction or absolute margin.
+// This option is not used when either x or y is NaN or infinite.
+//
+// The fraction determines that the difference of two values must be within the
+// smaller fraction of the two values, while the margin determines that the two
+// values must be within some absolute margin.
+// To express only a fraction or only a margin, use 0 for the other parameter.
+// The fraction and margin must be non-negative.
+//
+// The mathematical expression used is equivalent to:
+//	|x-y| ≤ max(fraction*min(|x|, |y|), margin)
+//
+// EquateApprox can be used in conjunction with EquateNaNs.
+func EquateApprox(fraction, margin float64) cmp.Option {
+	if margin < 0 || fraction < 0 || math.IsNaN(margin) || math.IsNaN(fraction) {
+		panic("margin or fraction must be a non-negative number")
+	}
+	a := approximator{fraction, margin}
+	return cmp.Options{
+		cmp.FilterValues(areRealF64s, cmp.Comparer(a.compareF64)),
+		cmp.FilterValues(areRealF32s, cmp.Comparer(a.compareF32)),
+	}
+}
+
+type approximator struct{ frac, marg float64 }
+
+func areRealF64s(x, y float64) bool {
+	return !math.IsNaN(x) && !math.IsNaN(y) && !math.IsInf(x, 0) && !math.IsInf(y, 0)
+}
+func areRealF32s(x, y float32) bool {
+	return areRealF64s(float64(x), float64(y))
+}
+func (a approximator) compareF64(x, y float64) bool {
+	relMarg := a.frac * math.Min(math.Abs(x), math.Abs(y))
+	return math.Abs(x-y) <= math.Max(a.marg, relMarg)
+}
+func (a approximator) compareF32(x, y float32) bool {
+	return a.compareF64(float64(x), float64(y))
+}
+
+// EquateNaNs returns a Comparer option that determines float32 and float64
+// NaN values to be equal.
+//
+// EquateNaNs can be used in conjunction with EquateApprox.
+func EquateNaNs() cmp.Option {
+	return cmp.Options{
+		cmp.FilterValues(areNaNsF64s, cmp.Comparer(equateAlways)),
+		cmp.FilterValues(areNaNsF32s, cmp.Comparer(equateAlways)),
+	}
+}
+
+func areNaNsF64s(x, y float64) bool {
+	return math.IsNaN(x) && math.IsNaN(y)
+}
+func areNaNsF32s(x, y float32) bool {
+	return areNaNsF64s(float64(x), float64(y))
+}
+
+// EquateApproxTime returns a Comparer option that determines two non-zero
+// time.Time values to be equal if they are within some margin of one another.
+// If both times have a monotonic clock reading, then the monotonic time
+// difference will be used. The margin must be non-negative.
+func EquateApproxTime(margin time.Duration) cmp.Option {
+	if margin < 0 {
+		panic("margin must be a non-negative number")
+	}
+	a := timeApproximator{margin}
+	return cmp.FilterValues(areNonZeroTimes, cmp.Comparer(a.compare))
+}
+
+func areNonZeroTimes(x, y time.Time) bool {
+	return !x.IsZero() && !y.IsZero()
+}
+
+type timeApproximator struct {
+	margin time.Duration
+}
+
+func (a timeApproximator) compare(x, y time.Time) bool {
+	// Avoid subtracting times to avoid overflow when the
+	// difference is larger than the largest representible duration.
+	if x.After(y) {
+		// Ensure x is always before y
+		x, y = y, x
+	}
+	// We're within the margin if x+margin >= y.
+	// Note: time.Time doesn't have AfterOrEqual method hence the negation.
+	return !x.Add(a.margin).Before(y)
+}
+
+// AnyError is an error that matches any non-nil error.
+var AnyError anyError
+
+type anyError struct{}
+
+func (anyError) Error() string     { return "any error" }
+func (anyError) Is(err error) bool { return err != nil }
+
+// EquateErrors returns a Comparer option that determines errors to be equal
+// if errors.Is reports them to match. The AnyError error can be used to
+// match any non-nil error.
+func EquateErrors() cmp.Option {
+	return cmp.FilterValues(areConcreteErrors, cmp.Comparer(compareErrors))
+}
+
+// areConcreteErrors reports whether x and y are types that implement error.
+// The input types are deliberately of the interface{} type rather than the
+// error type so that we can handle situations where the current type is an
+// interface{}, but the underlying concrete types both happen to implement
+// the error interface.
+func areConcreteErrors(x, y interface{}) bool {
+	_, ok1 := x.(error)
+	_, ok2 := y.(error)
+	return ok1 && ok2
+}
+
+func compareErrors(x, y interface{}) bool {
+	xe := x.(error)
+	ye := y.(error)
+	// TODO(≥go1.13): Use standard definition of errors.Is.
+	return xerrors.Is(xe, ye) || xerrors.Is(ye, xe)
+}

--- a/vendor/github.com/google/go-cmp/cmp/cmpopts/ignore.go
+++ b/vendor/github.com/google/go-cmp/cmp/cmpopts/ignore.go
@@ -1,0 +1,206 @@
+// Copyright 2017, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+package cmpopts
+
+import (
+	"fmt"
+	"reflect"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/internal/function"
+)
+
+// IgnoreFields returns an Option that ignores fields of the
+// given names on a single struct type. It respects the names of exported fields
+// that are forwarded due to struct embedding.
+// The struct type is specified by passing in a value of that type.
+//
+// The name may be a dot-delimited string (e.g., "Foo.Bar") to ignore a
+// specific sub-field that is embedded or nested within the parent struct.
+func IgnoreFields(typ interface{}, names ...string) cmp.Option {
+	sf := newStructFilter(typ, names...)
+	return cmp.FilterPath(sf.filter, cmp.Ignore())
+}
+
+// IgnoreTypes returns an Option that ignores all values assignable to
+// certain types, which are specified by passing in a value of each type.
+func IgnoreTypes(typs ...interface{}) cmp.Option {
+	tf := newTypeFilter(typs...)
+	return cmp.FilterPath(tf.filter, cmp.Ignore())
+}
+
+type typeFilter []reflect.Type
+
+func newTypeFilter(typs ...interface{}) (tf typeFilter) {
+	for _, typ := range typs {
+		t := reflect.TypeOf(typ)
+		if t == nil {
+			// This occurs if someone tries to pass in sync.Locker(nil)
+			panic("cannot determine type; consider using IgnoreInterfaces")
+		}
+		tf = append(tf, t)
+	}
+	return tf
+}
+func (tf typeFilter) filter(p cmp.Path) bool {
+	if len(p) < 1 {
+		return false
+	}
+	t := p.Last().Type()
+	for _, ti := range tf {
+		if t.AssignableTo(ti) {
+			return true
+		}
+	}
+	return false
+}
+
+// IgnoreInterfaces returns an Option that ignores all values or references of
+// values assignable to certain interface types. These interfaces are specified
+// by passing in an anonymous struct with the interface types embedded in it.
+// For example, to ignore sync.Locker, pass in struct{sync.Locker}{}.
+func IgnoreInterfaces(ifaces interface{}) cmp.Option {
+	tf := newIfaceFilter(ifaces)
+	return cmp.FilterPath(tf.filter, cmp.Ignore())
+}
+
+type ifaceFilter []reflect.Type
+
+func newIfaceFilter(ifaces interface{}) (tf ifaceFilter) {
+	t := reflect.TypeOf(ifaces)
+	if ifaces == nil || t.Name() != "" || t.Kind() != reflect.Struct {
+		panic("input must be an anonymous struct")
+	}
+	for i := 0; i < t.NumField(); i++ {
+		fi := t.Field(i)
+		switch {
+		case !fi.Anonymous:
+			panic("struct cannot have named fields")
+		case fi.Type.Kind() != reflect.Interface:
+			panic("embedded field must be an interface type")
+		case fi.Type.NumMethod() == 0:
+			// This matches everything; why would you ever want this?
+			panic("cannot ignore empty interface")
+		default:
+			tf = append(tf, fi.Type)
+		}
+	}
+	return tf
+}
+func (tf ifaceFilter) filter(p cmp.Path) bool {
+	if len(p) < 1 {
+		return false
+	}
+	t := p.Last().Type()
+	for _, ti := range tf {
+		if t.AssignableTo(ti) {
+			return true
+		}
+		if t.Kind() != reflect.Ptr && reflect.PtrTo(t).AssignableTo(ti) {
+			return true
+		}
+	}
+	return false
+}
+
+// IgnoreUnexported returns an Option that only ignores the immediate unexported
+// fields of a struct, including anonymous fields of unexported types.
+// In particular, unexported fields within the struct's exported fields
+// of struct types, including anonymous fields, will not be ignored unless the
+// type of the field itself is also passed to IgnoreUnexported.
+//
+// Avoid ignoring unexported fields of a type which you do not control (i.e. a
+// type from another repository), as changes to the implementation of such types
+// may change how the comparison behaves. Prefer a custom Comparer instead.
+func IgnoreUnexported(typs ...interface{}) cmp.Option {
+	ux := newUnexportedFilter(typs...)
+	return cmp.FilterPath(ux.filter, cmp.Ignore())
+}
+
+type unexportedFilter struct{ m map[reflect.Type]bool }
+
+func newUnexportedFilter(typs ...interface{}) unexportedFilter {
+	ux := unexportedFilter{m: make(map[reflect.Type]bool)}
+	for _, typ := range typs {
+		t := reflect.TypeOf(typ)
+		if t == nil || t.Kind() != reflect.Struct {
+			panic(fmt.Sprintf("%T must be a non-pointer struct", typ))
+		}
+		ux.m[t] = true
+	}
+	return ux
+}
+func (xf unexportedFilter) filter(p cmp.Path) bool {
+	sf, ok := p.Index(-1).(cmp.StructField)
+	if !ok {
+		return false
+	}
+	return xf.m[p.Index(-2).Type()] && !isExported(sf.Name())
+}
+
+// isExported reports whether the identifier is exported.
+func isExported(id string) bool {
+	r, _ := utf8.DecodeRuneInString(id)
+	return unicode.IsUpper(r)
+}
+
+// IgnoreSliceElements returns an Option that ignores elements of []V.
+// The discard function must be of the form "func(T) bool" which is used to
+// ignore slice elements of type V, where V is assignable to T.
+// Elements are ignored if the function reports true.
+func IgnoreSliceElements(discardFunc interface{}) cmp.Option {
+	vf := reflect.ValueOf(discardFunc)
+	if !function.IsType(vf.Type(), function.ValuePredicate) || vf.IsNil() {
+		panic(fmt.Sprintf("invalid discard function: %T", discardFunc))
+	}
+	return cmp.FilterPath(func(p cmp.Path) bool {
+		si, ok := p.Index(-1).(cmp.SliceIndex)
+		if !ok {
+			return false
+		}
+		if !si.Type().AssignableTo(vf.Type().In(0)) {
+			return false
+		}
+		vx, vy := si.Values()
+		if vx.IsValid() && vf.Call([]reflect.Value{vx})[0].Bool() {
+			return true
+		}
+		if vy.IsValid() && vf.Call([]reflect.Value{vy})[0].Bool() {
+			return true
+		}
+		return false
+	}, cmp.Ignore())
+}
+
+// IgnoreMapEntries returns an Option that ignores entries of map[K]V.
+// The discard function must be of the form "func(T, R) bool" which is used to
+// ignore map entries of type K and V, where K and V are assignable to T and R.
+// Entries are ignored if the function reports true.
+func IgnoreMapEntries(discardFunc interface{}) cmp.Option {
+	vf := reflect.ValueOf(discardFunc)
+	if !function.IsType(vf.Type(), function.KeyValuePredicate) || vf.IsNil() {
+		panic(fmt.Sprintf("invalid discard function: %T", discardFunc))
+	}
+	return cmp.FilterPath(func(p cmp.Path) bool {
+		mi, ok := p.Index(-1).(cmp.MapIndex)
+		if !ok {
+			return false
+		}
+		if !mi.Key().Type().AssignableTo(vf.Type().In(0)) || !mi.Type().AssignableTo(vf.Type().In(1)) {
+			return false
+		}
+		k := mi.Key()
+		vx, vy := mi.Values()
+		if vx.IsValid() && vf.Call([]reflect.Value{k, vx})[0].Bool() {
+			return true
+		}
+		if vy.IsValid() && vf.Call([]reflect.Value{k, vy})[0].Bool() {
+			return true
+		}
+		return false
+	}, cmp.Ignore())
+}

--- a/vendor/github.com/google/go-cmp/cmp/cmpopts/sort.go
+++ b/vendor/github.com/google/go-cmp/cmp/cmpopts/sort.go
@@ -1,0 +1,147 @@
+// Copyright 2017, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+package cmpopts
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/internal/function"
+)
+
+// SortSlices returns a Transformer option that sorts all []V.
+// The less function must be of the form "func(T, T) bool" which is used to
+// sort any slice with element type V that is assignable to T.
+//
+// The less function must be:
+//	• Deterministic: less(x, y) == less(x, y)
+//	• Irreflexive: !less(x, x)
+//	• Transitive: if !less(x, y) and !less(y, z), then !less(x, z)
+//
+// The less function does not have to be "total". That is, if !less(x, y) and
+// !less(y, x) for two elements x and y, their relative order is maintained.
+//
+// SortSlices can be used in conjunction with EquateEmpty.
+func SortSlices(lessFunc interface{}) cmp.Option {
+	vf := reflect.ValueOf(lessFunc)
+	if !function.IsType(vf.Type(), function.Less) || vf.IsNil() {
+		panic(fmt.Sprintf("invalid less function: %T", lessFunc))
+	}
+	ss := sliceSorter{vf.Type().In(0), vf}
+	return cmp.FilterValues(ss.filter, cmp.Transformer("cmpopts.SortSlices", ss.sort))
+}
+
+type sliceSorter struct {
+	in  reflect.Type  // T
+	fnc reflect.Value // func(T, T) bool
+}
+
+func (ss sliceSorter) filter(x, y interface{}) bool {
+	vx, vy := reflect.ValueOf(x), reflect.ValueOf(y)
+	if !(x != nil && y != nil && vx.Type() == vy.Type()) ||
+		!(vx.Kind() == reflect.Slice && vx.Type().Elem().AssignableTo(ss.in)) ||
+		(vx.Len() <= 1 && vy.Len() <= 1) {
+		return false
+	}
+	// Check whether the slices are already sorted to avoid an infinite
+	// recursion cycle applying the same transform to itself.
+	ok1 := sort.SliceIsSorted(x, func(i, j int) bool { return ss.less(vx, i, j) })
+	ok2 := sort.SliceIsSorted(y, func(i, j int) bool { return ss.less(vy, i, j) })
+	return !ok1 || !ok2
+}
+func (ss sliceSorter) sort(x interface{}) interface{} {
+	src := reflect.ValueOf(x)
+	dst := reflect.MakeSlice(src.Type(), src.Len(), src.Len())
+	for i := 0; i < src.Len(); i++ {
+		dst.Index(i).Set(src.Index(i))
+	}
+	sort.SliceStable(dst.Interface(), func(i, j int) bool { return ss.less(dst, i, j) })
+	ss.checkSort(dst)
+	return dst.Interface()
+}
+func (ss sliceSorter) checkSort(v reflect.Value) {
+	start := -1 // Start of a sequence of equal elements.
+	for i := 1; i < v.Len(); i++ {
+		if ss.less(v, i-1, i) {
+			// Check that first and last elements in v[start:i] are equal.
+			if start >= 0 && (ss.less(v, start, i-1) || ss.less(v, i-1, start)) {
+				panic(fmt.Sprintf("incomparable values detected: want equal elements: %v", v.Slice(start, i)))
+			}
+			start = -1
+		} else if start == -1 {
+			start = i
+		}
+	}
+}
+func (ss sliceSorter) less(v reflect.Value, i, j int) bool {
+	vx, vy := v.Index(i), v.Index(j)
+	return ss.fnc.Call([]reflect.Value{vx, vy})[0].Bool()
+}
+
+// SortMaps returns a Transformer option that flattens map[K]V types to be a
+// sorted []struct{K, V}. The less function must be of the form
+// "func(T, T) bool" which is used to sort any map with key K that is
+// assignable to T.
+//
+// Flattening the map into a slice has the property that cmp.Equal is able to
+// use Comparers on K or the K.Equal method if it exists.
+//
+// The less function must be:
+//	• Deterministic: less(x, y) == less(x, y)
+//	• Irreflexive: !less(x, x)
+//	• Transitive: if !less(x, y) and !less(y, z), then !less(x, z)
+//	• Total: if x != y, then either less(x, y) or less(y, x)
+//
+// SortMaps can be used in conjunction with EquateEmpty.
+func SortMaps(lessFunc interface{}) cmp.Option {
+	vf := reflect.ValueOf(lessFunc)
+	if !function.IsType(vf.Type(), function.Less) || vf.IsNil() {
+		panic(fmt.Sprintf("invalid less function: %T", lessFunc))
+	}
+	ms := mapSorter{vf.Type().In(0), vf}
+	return cmp.FilterValues(ms.filter, cmp.Transformer("cmpopts.SortMaps", ms.sort))
+}
+
+type mapSorter struct {
+	in  reflect.Type  // T
+	fnc reflect.Value // func(T, T) bool
+}
+
+func (ms mapSorter) filter(x, y interface{}) bool {
+	vx, vy := reflect.ValueOf(x), reflect.ValueOf(y)
+	return (x != nil && y != nil && vx.Type() == vy.Type()) &&
+		(vx.Kind() == reflect.Map && vx.Type().Key().AssignableTo(ms.in)) &&
+		(vx.Len() != 0 || vy.Len() != 0)
+}
+func (ms mapSorter) sort(x interface{}) interface{} {
+	src := reflect.ValueOf(x)
+	outType := reflect.StructOf([]reflect.StructField{
+		{Name: "K", Type: src.Type().Key()},
+		{Name: "V", Type: src.Type().Elem()},
+	})
+	dst := reflect.MakeSlice(reflect.SliceOf(outType), src.Len(), src.Len())
+	for i, k := range src.MapKeys() {
+		v := reflect.New(outType).Elem()
+		v.Field(0).Set(k)
+		v.Field(1).Set(src.MapIndex(k))
+		dst.Index(i).Set(v)
+	}
+	sort.Slice(dst.Interface(), func(i, j int) bool { return ms.less(dst, i, j) })
+	ms.checkSort(dst)
+	return dst.Interface()
+}
+func (ms mapSorter) checkSort(v reflect.Value) {
+	for i := 1; i < v.Len(); i++ {
+		if !ms.less(v, i-1, i) {
+			panic(fmt.Sprintf("partial order detected: want %v < %v", v.Index(i-1), v.Index(i)))
+		}
+	}
+}
+func (ms mapSorter) less(v reflect.Value, i, j int) bool {
+	vx, vy := v.Index(i).Field(0), v.Index(j).Field(0)
+	return ms.fnc.Call([]reflect.Value{vx, vy})[0].Bool()
+}

--- a/vendor/github.com/google/go-cmp/cmp/cmpopts/struct_filter.go
+++ b/vendor/github.com/google/go-cmp/cmp/cmpopts/struct_filter.go
@@ -1,0 +1,187 @@
+// Copyright 2017, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+package cmpopts
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// filterField returns a new Option where opt is only evaluated on paths that
+// include a specific exported field on a single struct type.
+// The struct type is specified by passing in a value of that type.
+//
+// The name may be a dot-delimited string (e.g., "Foo.Bar") to select a
+// specific sub-field that is embedded or nested within the parent struct.
+func filterField(typ interface{}, name string, opt cmp.Option) cmp.Option {
+	// TODO: This is currently unexported over concerns of how helper filters
+	// can be composed together easily.
+	// TODO: Add tests for FilterField.
+
+	sf := newStructFilter(typ, name)
+	return cmp.FilterPath(sf.filter, opt)
+}
+
+type structFilter struct {
+	t  reflect.Type // The root struct type to match on
+	ft fieldTree    // Tree of fields to match on
+}
+
+func newStructFilter(typ interface{}, names ...string) structFilter {
+	// TODO: Perhaps allow * as a special identifier to allow ignoring any
+	// number of path steps until the next field match?
+	// This could be useful when a concrete struct gets transformed into
+	// an anonymous struct where it is not possible to specify that by type,
+	// but the transformer happens to provide guarantees about the names of
+	// the transformed fields.
+
+	t := reflect.TypeOf(typ)
+	if t == nil || t.Kind() != reflect.Struct {
+		panic(fmt.Sprintf("%T must be a non-pointer struct", typ))
+	}
+	var ft fieldTree
+	for _, name := range names {
+		cname, err := canonicalName(t, name)
+		if err != nil {
+			panic(fmt.Sprintf("%s: %v", strings.Join(cname, "."), err))
+		}
+		ft.insert(cname)
+	}
+	return structFilter{t, ft}
+}
+
+func (sf structFilter) filter(p cmp.Path) bool {
+	for i, ps := range p {
+		if ps.Type().AssignableTo(sf.t) && sf.ft.matchPrefix(p[i+1:]) {
+			return true
+		}
+	}
+	return false
+}
+
+// fieldTree represents a set of dot-separated identifiers.
+//
+// For example, inserting the following selectors:
+//	Foo
+//	Foo.Bar.Baz
+//	Foo.Buzz
+//	Nuka.Cola.Quantum
+//
+// Results in a tree of the form:
+//	{sub: {
+//		"Foo": {ok: true, sub: {
+//			"Bar": {sub: {
+//				"Baz": {ok: true},
+//			}},
+//			"Buzz": {ok: true},
+//		}},
+//		"Nuka": {sub: {
+//			"Cola": {sub: {
+//				"Quantum": {ok: true},
+//			}},
+//		}},
+//	}}
+type fieldTree struct {
+	ok  bool                 // Whether this is a specified node
+	sub map[string]fieldTree // The sub-tree of fields under this node
+}
+
+// insert inserts a sequence of field accesses into the tree.
+func (ft *fieldTree) insert(cname []string) {
+	if ft.sub == nil {
+		ft.sub = make(map[string]fieldTree)
+	}
+	if len(cname) == 0 {
+		ft.ok = true
+		return
+	}
+	sub := ft.sub[cname[0]]
+	sub.insert(cname[1:])
+	ft.sub[cname[0]] = sub
+}
+
+// matchPrefix reports whether any selector in the fieldTree matches
+// the start of path p.
+func (ft fieldTree) matchPrefix(p cmp.Path) bool {
+	for _, ps := range p {
+		switch ps := ps.(type) {
+		case cmp.StructField:
+			ft = ft.sub[ps.Name()]
+			if ft.ok {
+				return true
+			}
+			if len(ft.sub) == 0 {
+				return false
+			}
+		case cmp.Indirect:
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+// canonicalName returns a list of identifiers where any struct field access
+// through an embedded field is expanded to include the names of the embedded
+// types themselves.
+//
+// For example, suppose field "Foo" is not directly in the parent struct,
+// but actually from an embedded struct of type "Bar". Then, the canonical name
+// of "Foo" is actually "Bar.Foo".
+//
+// Suppose field "Foo" is not directly in the parent struct, but actually
+// a field in two different embedded structs of types "Bar" and "Baz".
+// Then the selector "Foo" causes a panic since it is ambiguous which one it
+// refers to. The user must specify either "Bar.Foo" or "Baz.Foo".
+func canonicalName(t reflect.Type, sel string) ([]string, error) {
+	var name string
+	sel = strings.TrimPrefix(sel, ".")
+	if sel == "" {
+		return nil, fmt.Errorf("name must not be empty")
+	}
+	if i := strings.IndexByte(sel, '.'); i < 0 {
+		name, sel = sel, ""
+	} else {
+		name, sel = sel[:i], sel[i:]
+	}
+
+	// Type must be a struct or pointer to struct.
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("%v must be a struct", t)
+	}
+
+	// Find the canonical name for this current field name.
+	// If the field exists in an embedded struct, then it will be expanded.
+	sf, _ := t.FieldByName(name)
+	if !isExported(name) {
+		// Avoid using reflect.Type.FieldByName for unexported fields due to
+		// buggy behavior with regard to embeddeding and unexported fields.
+		// See https://golang.org/issue/4876 for details.
+		sf = reflect.StructField{}
+		for i := 0; i < t.NumField() && sf.Name == ""; i++ {
+			if t.Field(i).Name == name {
+				sf = t.Field(i)
+			}
+		}
+	}
+	if sf.Name == "" {
+		return []string{name}, fmt.Errorf("does not exist")
+	}
+	var ss []string
+	for i := range sf.Index {
+		ss = append(ss, t.FieldByIndex(sf.Index[:i+1]).Name)
+	}
+	if sel == "" {
+		return ss, nil
+	}
+	ssPost, err := canonicalName(sf.Type, sel)
+	return append(ss, ssPost...), err
+}

--- a/vendor/github.com/google/go-cmp/cmp/cmpopts/xform.go
+++ b/vendor/github.com/google/go-cmp/cmp/cmpopts/xform.go
@@ -1,0 +1,35 @@
+// Copyright 2018, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+package cmpopts
+
+import (
+	"github.com/google/go-cmp/cmp"
+)
+
+type xformFilter struct{ xform cmp.Option }
+
+func (xf xformFilter) filter(p cmp.Path) bool {
+	for _, ps := range p {
+		if t, ok := ps.(cmp.Transform); ok && t.Option() == xf.xform {
+			return false
+		}
+	}
+	return true
+}
+
+// AcyclicTransformer returns a Transformer with a filter applied that ensures
+// that the transformer cannot be recursively applied upon its own output.
+//
+// An example use case is a transformer that splits a string by lines:
+//	AcyclicTransformer("SplitLines", func(s string) []string{
+//		return strings.Split(s, "\n")
+//	})
+//
+// Had this been an unfiltered Transformer instead, this would result in an
+// infinite cycle converting a string to []string to [][]string and so on.
+func AcyclicTransformer(name string, xformFunc interface{}) cmp.Option {
+	xf := xformFilter{cmp.Transformer(name, xformFunc)}
+	return cmp.FilterPath(xf.filter, xf.xform)
+}

--- a/vendor/golang.org/x/xerrors/LICENSE
+++ b/vendor/golang.org/x/xerrors/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2019 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/golang.org/x/xerrors/PATENTS
+++ b/vendor/golang.org/x/xerrors/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/vendor/golang.org/x/xerrors/README
+++ b/vendor/golang.org/x/xerrors/README
@@ -1,0 +1,2 @@
+This repository holds the transition packages for the new Go 1.13 error values.
+See golang.org/design/29934-error-values.

--- a/vendor/golang.org/x/xerrors/adaptor.go
+++ b/vendor/golang.org/x/xerrors/adaptor.go
@@ -1,0 +1,193 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package xerrors
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"reflect"
+	"strconv"
+)
+
+// FormatError calls the FormatError method of f with an errors.Printer
+// configured according to s and verb, and writes the result to s.
+func FormatError(f Formatter, s fmt.State, verb rune) {
+	// Assuming this function is only called from the Format method, and given
+	// that FormatError takes precedence over Format, it cannot be called from
+	// any package that supports errors.Formatter. It is therefore safe to
+	// disregard that State may be a specific printer implementation and use one
+	// of our choice instead.
+
+	// limitations: does not support printing error as Go struct.
+
+	var (
+		sep    = " " // separator before next error
+		p      = &state{State: s}
+		direct = true
+	)
+
+	var err error = f
+
+	switch verb {
+	// Note that this switch must match the preference order
+	// for ordinary string printing (%#v before %+v, and so on).
+
+	case 'v':
+		if s.Flag('#') {
+			if stringer, ok := err.(fmt.GoStringer); ok {
+				io.WriteString(&p.buf, stringer.GoString())
+				goto exit
+			}
+			// proceed as if it were %v
+		} else if s.Flag('+') {
+			p.printDetail = true
+			sep = "\n  - "
+		}
+	case 's':
+	case 'q', 'x', 'X':
+		// Use an intermediate buffer in the rare cases that precision,
+		// truncation, or one of the alternative verbs (q, x, and X) are
+		// specified.
+		direct = false
+
+	default:
+		p.buf.WriteString("%!")
+		p.buf.WriteRune(verb)
+		p.buf.WriteByte('(')
+		switch {
+		case err != nil:
+			p.buf.WriteString(reflect.TypeOf(f).String())
+		default:
+			p.buf.WriteString("<nil>")
+		}
+		p.buf.WriteByte(')')
+		io.Copy(s, &p.buf)
+		return
+	}
+
+loop:
+	for {
+		switch v := err.(type) {
+		case Formatter:
+			err = v.FormatError((*printer)(p))
+		case fmt.Formatter:
+			v.Format(p, 'v')
+			break loop
+		default:
+			io.WriteString(&p.buf, v.Error())
+			break loop
+		}
+		if err == nil {
+			break
+		}
+		if p.needColon || !p.printDetail {
+			p.buf.WriteByte(':')
+			p.needColon = false
+		}
+		p.buf.WriteString(sep)
+		p.inDetail = false
+		p.needNewline = false
+	}
+
+exit:
+	width, okW := s.Width()
+	prec, okP := s.Precision()
+
+	if !direct || (okW && width > 0) || okP {
+		// Construct format string from State s.
+		format := []byte{'%'}
+		if s.Flag('-') {
+			format = append(format, '-')
+		}
+		if s.Flag('+') {
+			format = append(format, '+')
+		}
+		if s.Flag(' ') {
+			format = append(format, ' ')
+		}
+		if okW {
+			format = strconv.AppendInt(format, int64(width), 10)
+		}
+		if okP {
+			format = append(format, '.')
+			format = strconv.AppendInt(format, int64(prec), 10)
+		}
+		format = append(format, string(verb)...)
+		fmt.Fprintf(s, string(format), p.buf.String())
+	} else {
+		io.Copy(s, &p.buf)
+	}
+}
+
+var detailSep = []byte("\n    ")
+
+// state tracks error printing state. It implements fmt.State.
+type state struct {
+	fmt.State
+	buf bytes.Buffer
+
+	printDetail bool
+	inDetail    bool
+	needColon   bool
+	needNewline bool
+}
+
+func (s *state) Write(b []byte) (n int, err error) {
+	if s.printDetail {
+		if len(b) == 0 {
+			return 0, nil
+		}
+		if s.inDetail && s.needColon {
+			s.needNewline = true
+			if b[0] == '\n' {
+				b = b[1:]
+			}
+		}
+		k := 0
+		for i, c := range b {
+			if s.needNewline {
+				if s.inDetail && s.needColon {
+					s.buf.WriteByte(':')
+					s.needColon = false
+				}
+				s.buf.Write(detailSep)
+				s.needNewline = false
+			}
+			if c == '\n' {
+				s.buf.Write(b[k:i])
+				k = i + 1
+				s.needNewline = true
+			}
+		}
+		s.buf.Write(b[k:])
+		if !s.inDetail {
+			s.needColon = true
+		}
+	} else if !s.inDetail {
+		s.buf.Write(b)
+	}
+	return len(b), nil
+}
+
+// printer wraps a state to implement an xerrors.Printer.
+type printer state
+
+func (s *printer) Print(args ...interface{}) {
+	if !s.inDetail || s.printDetail {
+		fmt.Fprint((*state)(s), args...)
+	}
+}
+
+func (s *printer) Printf(format string, args ...interface{}) {
+	if !s.inDetail || s.printDetail {
+		fmt.Fprintf((*state)(s), format, args...)
+	}
+}
+
+func (s *printer) Detail() bool {
+	s.inDetail = true
+	return s.printDetail
+}

--- a/vendor/golang.org/x/xerrors/codereview.cfg
+++ b/vendor/golang.org/x/xerrors/codereview.cfg
@@ -1,0 +1,1 @@
+issuerepo: golang/go

--- a/vendor/golang.org/x/xerrors/doc.go
+++ b/vendor/golang.org/x/xerrors/doc.go
@@ -1,0 +1,22 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package xerrors implements functions to manipulate errors.
+//
+// This package is based on the Go 2 proposal for error values:
+//   https://golang.org/design/29934-error-values
+//
+// These functions were incorporated into the standard library's errors package
+// in Go 1.13:
+// - Is
+// - As
+// - Unwrap
+//
+// Also, Errorf's %w verb was incorporated into fmt.Errorf.
+//
+// Use this package to get equivalent behavior in all supported Go versions.
+//
+// No other features of this package were included in Go 1.13, and at present
+// there are no plans to include any of them.
+package xerrors // import "golang.org/x/xerrors"

--- a/vendor/golang.org/x/xerrors/errors.go
+++ b/vendor/golang.org/x/xerrors/errors.go
@@ -1,0 +1,33 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package xerrors
+
+import "fmt"
+
+// errorString is a trivial implementation of error.
+type errorString struct {
+	s     string
+	frame Frame
+}
+
+// New returns an error that formats as the given text.
+//
+// The returned error contains a Frame set to the caller's location and
+// implements Formatter to show this information when printed with details.
+func New(text string) error {
+	return &errorString{text, Caller(1)}
+}
+
+func (e *errorString) Error() string {
+	return e.s
+}
+
+func (e *errorString) Format(s fmt.State, v rune) { FormatError(e, s, v) }
+
+func (e *errorString) FormatError(p Printer) (next error) {
+	p.Print(e.s)
+	e.frame.Format(p)
+	return nil
+}

--- a/vendor/golang.org/x/xerrors/fmt.go
+++ b/vendor/golang.org/x/xerrors/fmt.go
@@ -1,0 +1,187 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package xerrors
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"golang.org/x/xerrors/internal"
+)
+
+const percentBangString = "%!"
+
+// Errorf formats according to a format specifier and returns the string as a
+// value that satisfies error.
+//
+// The returned error includes the file and line number of the caller when
+// formatted with additional detail enabled. If the last argument is an error
+// the returned error's Format method will return it if the format string ends
+// with ": %s", ": %v", or ": %w". If the last argument is an error and the
+// format string ends with ": %w", the returned error implements an Unwrap
+// method returning it.
+//
+// If the format specifier includes a %w verb with an error operand in a
+// position other than at the end, the returned error will still implement an
+// Unwrap method returning the operand, but the error's Format method will not
+// return the wrapped error.
+//
+// It is invalid to include more than one %w verb or to supply it with an
+// operand that does not implement the error interface. The %w verb is otherwise
+// a synonym for %v.
+func Errorf(format string, a ...interface{}) error {
+	format = formatPlusW(format)
+	// Support a ": %[wsv]" suffix, which works well with xerrors.Formatter.
+	wrap := strings.HasSuffix(format, ": %w")
+	idx, format2, ok := parsePercentW(format)
+	percentWElsewhere := !wrap && idx >= 0
+	if !percentWElsewhere && (wrap || strings.HasSuffix(format, ": %s") || strings.HasSuffix(format, ": %v")) {
+		err := errorAt(a, len(a)-1)
+		if err == nil {
+			return &noWrapError{fmt.Sprintf(format, a...), nil, Caller(1)}
+		}
+		// TODO: this is not entirely correct. The error value could be
+		// printed elsewhere in format if it mixes numbered with unnumbered
+		// substitutions. With relatively small changes to doPrintf we can
+		// have it optionally ignore extra arguments and pass the argument
+		// list in its entirety.
+		msg := fmt.Sprintf(format[:len(format)-len(": %s")], a[:len(a)-1]...)
+		frame := Frame{}
+		if internal.EnableTrace {
+			frame = Caller(1)
+		}
+		if wrap {
+			return &wrapError{msg, err, frame}
+		}
+		return &noWrapError{msg, err, frame}
+	}
+	// Support %w anywhere.
+	// TODO: don't repeat the wrapped error's message when %w occurs in the middle.
+	msg := fmt.Sprintf(format2, a...)
+	if idx < 0 {
+		return &noWrapError{msg, nil, Caller(1)}
+	}
+	err := errorAt(a, idx)
+	if !ok || err == nil {
+		// Too many %ws or argument of %w is not an error. Approximate the Go
+		// 1.13 fmt.Errorf message.
+		return &noWrapError{fmt.Sprintf("%sw(%s)", percentBangString, msg), nil, Caller(1)}
+	}
+	frame := Frame{}
+	if internal.EnableTrace {
+		frame = Caller(1)
+	}
+	return &wrapError{msg, err, frame}
+}
+
+func errorAt(args []interface{}, i int) error {
+	if i < 0 || i >= len(args) {
+		return nil
+	}
+	err, ok := args[i].(error)
+	if !ok {
+		return nil
+	}
+	return err
+}
+
+// formatPlusW is used to avoid the vet check that will barf at %w.
+func formatPlusW(s string) string {
+	return s
+}
+
+// Return the index of the only %w in format, or -1 if none.
+// Also return a rewritten format string with %w replaced by %v, and
+// false if there is more than one %w.
+// TODO: handle "%[N]w".
+func parsePercentW(format string) (idx int, newFormat string, ok bool) {
+	// Loosely copied from golang.org/x/tools/go/analysis/passes/printf/printf.go.
+	idx = -1
+	ok = true
+	n := 0
+	sz := 0
+	var isW bool
+	for i := 0; i < len(format); i += sz {
+		if format[i] != '%' {
+			sz = 1
+			continue
+		}
+		// "%%" is not a format directive.
+		if i+1 < len(format) && format[i+1] == '%' {
+			sz = 2
+			continue
+		}
+		sz, isW = parsePrintfVerb(format[i:])
+		if isW {
+			if idx >= 0 {
+				ok = false
+			} else {
+				idx = n
+			}
+			// "Replace" the last character, the 'w', with a 'v'.
+			p := i + sz - 1
+			format = format[:p] + "v" + format[p+1:]
+		}
+		n++
+	}
+	return idx, format, ok
+}
+
+// Parse the printf verb starting with a % at s[0].
+// Return how many bytes it occupies and whether the verb is 'w'.
+func parsePrintfVerb(s string) (int, bool) {
+	// Assume only that the directive is a sequence of non-letters followed by a single letter.
+	sz := 0
+	var r rune
+	for i := 1; i < len(s); i += sz {
+		r, sz = utf8.DecodeRuneInString(s[i:])
+		if unicode.IsLetter(r) {
+			return i + sz, r == 'w'
+		}
+	}
+	return len(s), false
+}
+
+type noWrapError struct {
+	msg   string
+	err   error
+	frame Frame
+}
+
+func (e *noWrapError) Error() string {
+	return fmt.Sprint(e)
+}
+
+func (e *noWrapError) Format(s fmt.State, v rune) { FormatError(e, s, v) }
+
+func (e *noWrapError) FormatError(p Printer) (next error) {
+	p.Print(e.msg)
+	e.frame.Format(p)
+	return e.err
+}
+
+type wrapError struct {
+	msg   string
+	err   error
+	frame Frame
+}
+
+func (e *wrapError) Error() string {
+	return fmt.Sprint(e)
+}
+
+func (e *wrapError) Format(s fmt.State, v rune) { FormatError(e, s, v) }
+
+func (e *wrapError) FormatError(p Printer) (next error) {
+	p.Print(e.msg)
+	e.frame.Format(p)
+	return e.err
+}
+
+func (e *wrapError) Unwrap() error {
+	return e.err
+}

--- a/vendor/golang.org/x/xerrors/format.go
+++ b/vendor/golang.org/x/xerrors/format.go
@@ -1,0 +1,34 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package xerrors
+
+// A Formatter formats error messages.
+type Formatter interface {
+	error
+
+	// FormatError prints the receiver's first error and returns the next error in
+	// the error chain, if any.
+	FormatError(p Printer) (next error)
+}
+
+// A Printer formats error messages.
+//
+// The most common implementation of Printer is the one provided by package fmt
+// during Printf (as of Go 1.13). Localization packages such as golang.org/x/text/message
+// typically provide their own implementations.
+type Printer interface {
+	// Print appends args to the message output.
+	Print(args ...interface{})
+
+	// Printf writes a formatted string.
+	Printf(format string, args ...interface{})
+
+	// Detail reports whether error detail is requested.
+	// After the first call to Detail, all text written to the Printer
+	// is formatted as additional detail, or ignored when
+	// detail has not been requested.
+	// If Detail returns false, the caller can avoid printing the detail at all.
+	Detail() bool
+}

--- a/vendor/golang.org/x/xerrors/frame.go
+++ b/vendor/golang.org/x/xerrors/frame.go
@@ -1,0 +1,56 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package xerrors
+
+import (
+	"runtime"
+)
+
+// A Frame contains part of a call stack.
+type Frame struct {
+	// Make room for three PCs: the one we were asked for, what it called,
+	// and possibly a PC for skipPleaseUseCallersFrames. See:
+	// https://go.googlesource.com/go/+/032678e0fb/src/runtime/extern.go#169
+	frames [3]uintptr
+}
+
+// Caller returns a Frame that describes a frame on the caller's stack.
+// The argument skip is the number of frames to skip over.
+// Caller(0) returns the frame for the caller of Caller.
+func Caller(skip int) Frame {
+	var s Frame
+	runtime.Callers(skip+1, s.frames[:])
+	return s
+}
+
+// location reports the file, line, and function of a frame.
+//
+// The returned function may be "" even if file and line are not.
+func (f Frame) location() (function, file string, line int) {
+	frames := runtime.CallersFrames(f.frames[:])
+	if _, ok := frames.Next(); !ok {
+		return "", "", 0
+	}
+	fr, ok := frames.Next()
+	if !ok {
+		return "", "", 0
+	}
+	return fr.Function, fr.File, fr.Line
+}
+
+// Format prints the stack as error detail.
+// It should be called from an error's Format implementation
+// after printing any other error detail.
+func (f Frame) Format(p Printer) {
+	if p.Detail() {
+		function, file, line := f.location()
+		if function != "" {
+			p.Printf("%s\n    ", function)
+		}
+		if file != "" {
+			p.Printf("%s:%d\n", file, line)
+		}
+	}
+}

--- a/vendor/golang.org/x/xerrors/go.mod
+++ b/vendor/golang.org/x/xerrors/go.mod
@@ -1,0 +1,3 @@
+module golang.org/x/xerrors
+
+go 1.11

--- a/vendor/golang.org/x/xerrors/internal/internal.go
+++ b/vendor/golang.org/x/xerrors/internal/internal.go
@@ -1,0 +1,8 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package internal
+
+// EnableTrace indicates whether stack information should be recorded in errors.
+var EnableTrace = true

--- a/vendor/golang.org/x/xerrors/wrap.go
+++ b/vendor/golang.org/x/xerrors/wrap.go
@@ -1,0 +1,106 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package xerrors
+
+import (
+	"reflect"
+)
+
+// A Wrapper provides context around another error.
+type Wrapper interface {
+	// Unwrap returns the next error in the error chain.
+	// If there is no next error, Unwrap returns nil.
+	Unwrap() error
+}
+
+// Opaque returns an error with the same error formatting as err
+// but that does not match err and cannot be unwrapped.
+func Opaque(err error) error {
+	return noWrapper{err}
+}
+
+type noWrapper struct {
+	error
+}
+
+func (e noWrapper) FormatError(p Printer) (next error) {
+	if f, ok := e.error.(Formatter); ok {
+		return f.FormatError(p)
+	}
+	p.Print(e.error)
+	return nil
+}
+
+// Unwrap returns the result of calling the Unwrap method on err, if err implements
+// Unwrap. Otherwise, Unwrap returns nil.
+func Unwrap(err error) error {
+	u, ok := err.(Wrapper)
+	if !ok {
+		return nil
+	}
+	return u.Unwrap()
+}
+
+// Is reports whether any error in err's chain matches target.
+//
+// An error is considered to match a target if it is equal to that target or if
+// it implements a method Is(error) bool such that Is(target) returns true.
+func Is(err, target error) bool {
+	if target == nil {
+		return err == target
+	}
+
+	isComparable := reflect.TypeOf(target).Comparable()
+	for {
+		if isComparable && err == target {
+			return true
+		}
+		if x, ok := err.(interface{ Is(error) bool }); ok && x.Is(target) {
+			return true
+		}
+		// TODO: consider supporing target.Is(err). This would allow
+		// user-definable predicates, but also may allow for coping with sloppy
+		// APIs, thereby making it easier to get away with them.
+		if err = Unwrap(err); err == nil {
+			return false
+		}
+	}
+}
+
+// As finds the first error in err's chain that matches the type to which target
+// points, and if so, sets the target to its value and returns true. An error
+// matches a type if it is assignable to the target type, or if it has a method
+// As(interface{}) bool such that As(target) returns true. As will panic if target
+// is not a non-nil pointer to a type which implements error or is of interface type.
+//
+// The As method should set the target to its value and return true if err
+// matches the type to which target points.
+func As(err error, target interface{}) bool {
+	if target == nil {
+		panic("errors: target cannot be nil")
+	}
+	val := reflect.ValueOf(target)
+	typ := val.Type()
+	if typ.Kind() != reflect.Ptr || val.IsNil() {
+		panic("errors: target must be a non-nil pointer")
+	}
+	if e := typ.Elem(); e.Kind() != reflect.Interface && !e.Implements(errorType) {
+		panic("errors: *target must be interface or implement error")
+	}
+	targetType := typ.Elem()
+	for err != nil {
+		if reflect.TypeOf(err).AssignableTo(targetType) {
+			val.Elem().Set(reflect.ValueOf(err))
+			return true
+		}
+		if x, ok := err.(interface{ As(interface{}) bool }); ok && x.As(target) {
+			return true
+		}
+		err = Unwrap(err)
+	}
+	return false
+}
+
+var errorType = reflect.TypeOf((*error)(nil)).Elem()

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -152,6 +152,7 @@ github.com/gonum/matrix
 github.com/gonum/matrix/mat64
 # github.com/google/go-cmp v0.5.2
 github.com/google/go-cmp/cmp
+github.com/google/go-cmp/cmp/cmpopts
 github.com/google/go-cmp/cmp/internal/diff
 github.com/google/go-cmp/cmp/internal/flags
 github.com/google/go-cmp/cmp/internal/function
@@ -410,6 +411,9 @@ golang.org/x/text/width
 golang.org/x/time/rate
 # golang.org/x/tools v0.0.0-20200616133436-c1934b75d054
 golang.org/x/tools/container/intsets
+# golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+golang.org/x/xerrors
+golang.org/x/xerrors/internal
 # google.golang.org/appengine v1.6.5
 google.golang.org/appengine/internal
 google.golang.org/appengine/internal/base


### PR DESCRIPTION
This PR adds a health check monitor that periodically sends requests to the provided targets to check their health status.
Users can configure:

 - `unhealthyProbesThreshold`: specifies consecutive failed health checks after which a target is considered unhealthy
 - `healthyProbesThreshold`: specifies consecutive successful health checks after which a target is considered healthy
 - `probeResponseTimeout`: specifies a time limit for requests made by the HTTP client for the health check
 - `probeInterval`: specifies a time interval at which health checks are send


The HM also implements `Listener` and `Notifier` interfaces.

It automatically registers for notification if the target provided also implements the `Notifier` interface.
It is implicit so that the provider can provide a static or a dynamic list of targets.

Interested parties can register a listener for notifications about healthy/unhealthy targets changes via AddListener.


This PR also defines the following metrics:

1. `health_monitor_healthy_target_total` - for tracking the number of healthy instances registered partitioned by targets.
2. `health_monitor_unhealthy_target_total` - for tracking the number of unhealthy instances registered partitioned by targets.
3. `health_monitor_current_healthy_targets` - for tracking the number of current healthy targets observed by the health monitor.