### PR TITLE
factory: produce nicer message when reconcile fail

### DIFF
--- a/pkg/controller/factory/base_controller.go
+++ b/pkg/controller/factory/base_controller.go
@@ -247,7 +247,11 @@ func (c *baseController) processNextWorkItem(queueCtx context.Context) {
 			// logging this helps detecting wedged controllers with missing pre-requirements
 			klog.V(5).Infof("%q controller requested synthetic requeue with key %q", c.name, key)
 		} else {
-			utilruntime.HandleError(fmt.Errorf("%q controller failed to sync %q, err: %w", c.name, key, err))
+			if klog.V(4).Enabled() || key != "key" {
+				utilruntime.HandleError(fmt.Errorf("%q controller failed to sync %q, err: %w", c.name, key, err))
+			} else {
+				utilruntime.HandleError(fmt.Errorf("%s reconciliation failed: %w", c.name, err))
+			}
 		}
 		c.syncContext.Queue().AddRateLimited(key)
 		return


### PR DESCRIPTION
Instead of 

`"OAuthRouteCheckEndpointAccessibleController" controller failed to sync "key", err: Get "https://oauth-openshift.apps.prod..com/healthz": EOF` 

produce error like:

`OAuthRouteCheckEndpointAccessibleController reconciliation failed: Get "https://oauth-openshift.apps.prod..com/healthz": EOF`

95% of all controller using factory just use string `"key"` as queue key and the controller word is always included in the controller name. This makes the message shorter and nicer to users (this message usually show up in logs and in some cases in degraded reason).