### PR TITLE
factory: allow to describe controller

### DIFF
--- a/pkg/controller/factory/base_controller.go
+++ b/pkg/controller/factory/base_controller.go
@@ -29,6 +29,7 @@ var defaultCacheSyncTimeout = 10 * time.Minute
 // baseController represents generic Kubernetes controller boiler-plate
 type baseController struct {
 	name               string
+	description        string
 	cachesToSync       []cache.InformerSynced
 	sync               func(ctx context.Context, controllerContext SyncContext) error
 	syncContext        SyncContext

--- a/pkg/controller/factory/factory.go
+++ b/pkg/controller/factory/factory.go
@@ -33,6 +33,7 @@ type Factory struct {
 	namespaceInformers    []*namespaceInformer
 	cachesToSync          []cache.InformerSynced
 	interestingNamespaces sets.String
+	description           string
 }
 
 // Informer represents any structure that allow to register event handlers and informs if caches are synced.
@@ -122,6 +123,13 @@ func (f *Factory) WithInformersQueueKeyFunc(queueKeyFn ObjectQueueKeyFunc, infor
 		informers:  informers,
 		queueKeyFn: queueKeyFn,
 	})
+	return f
+}
+
+// WithDescription allow to describe intent of the controller the factory is producing.
+// This in general can help understand bugs and errors better if used properly.
+func (f *Factory) WithDescription(description string) *Factory {
+	f.description = description
 	return f
 }
 
@@ -226,6 +234,7 @@ func (f *Factory) ToController(name string, eventRecorder events.Recorder) Contr
 
 	c := &baseController{
 		name:               name,
+		description:        f.description,
 		syncDegradedClient: f.syncDegradedClient,
 		sync:               f.sync,
 		resyncEvery:        f.resyncInterval,


### PR DESCRIPTION
This allow to use `.WithDescription("<description>")` when constructing the controller. Developers can describe the purpose of this controller better which might help understand the errors better (if the intent/purpose of the controller failing or giving error is known).

