### PR TITLE
WIP Enable static pods to be written as human-readable yaml

### DIFF
--- a/pkg/operator/resource/resourcehelper/resource_helpers.go
+++ b/pkg/operator/resource/resourcehelper/resource_helpers.go
@@ -1,10 +1,13 @@
 package resourcehelper
 
 import (
+	"encoding/json"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/yaml"
 
 	"github.com/openshift/api"
 )
@@ -73,4 +76,13 @@ func GuessObjectGroupVersionKind(object runtime.Object) schema.GroupVersionKind 
 		return kinds[0]
 	}
 	return schema.GroupVersionKind{Kind: "<unknown>"}
+}
+
+// InterfaceToYAML converts an interface to pretty printed YAML.
+func InterfaceToYAML(v interface{}) ([]byte, error) {
+	jsonBytes, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return yaml.JSONToYAML(jsonBytes)
 }

--- a/pkg/operator/resource/resourcemerge/generic_config_merger.go
+++ b/pkg/operator/resource/resourcemerge/generic_config_merger.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/yaml"
 
+	"github.com/openshift/library-go/pkg/operator/resource/resourcehelper"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -129,7 +130,8 @@ func MergePrunedProcessConfig(schema runtime.Object, specialCases map[string]Mer
 	if err := json.Unmarshal(inputBytes, &inputJSON); err != nil {
 		return nil, err
 	}
-	return json.Marshal(intersectJSON(inputJSON, untypedJSON))
+	intersectedJSON := intersectJSON(inputJSON, untypedJSON)
+	return resourcehelper.InterfaceToYAML(intersectedJSON)
 }
 
 type MergeFunc func(dst, src interface{}, currentPath string) (interface{}, error)

--- a/pkg/operator/resource/resourcemerge/generic_config_merger_test.go
+++ b/pkg/operator/resource/resourcemerge/generic_config_merger_test.go
@@ -232,7 +232,10 @@ alpha: first
 			additional: `
 consolePublicURL: http://foo/bar
 `,
-			expected: `{"apiVersion":"foo","consolePublicURL":"http://foo/bar","kind":"the-kind"}`,
+			expected: `apiVersion: foo
+consolePublicURL: http://foo/bar
+kind: the-kind
+`,
 		},
 		{
 			name: "prune unknown values with array",
@@ -245,7 +248,12 @@ corsAllowedOrigins:
 			additional: `
 consolePublicURL: http://foo/bar
 `,
-			expected: `{"apiVersion":"foo","consolePublicURL":"http://foo/bar","corsAllowedOrigins":["(?i)//openshift(:|\\z)"],"kind":"the-kind"}`,
+			expected: `apiVersion: foo
+consolePublicURL: http://foo/bar
+corsAllowedOrigins:
+- (?i)//openshift(:|\z)
+kind: the-kind
+`,
 		},
 	}
 


### PR DESCRIPTION
Previously static pod content was written as minified json which was hard to read when troubleshooting.

Canary: https://github.com/openshift/cluster-kube-apiserver-operator/pull/1059