### PR TITLE
Pass operator namespace to the controller

### DIFF
--- a/pkg/controller/controllercmd/builder.go
+++ b/pkg/controller/controllercmd/builder.go
@@ -52,6 +52,9 @@ type ControllerContext struct {
 
 	// Server is the GenericAPIServer serving healthz checks and debug info
 	Server *genericapiserver.GenericAPIServer
+
+	// Namespace where the operator runs. Either specified on the command line or autodetected.
+	OperatorNamespace string
 }
 
 // defaultObserverInterval specifies the default interval that file observer will do rehash the files it watches and react to any changes
@@ -274,11 +277,12 @@ func (b *ControllerBuilder) Run(ctx context.Context, config *unstructured.Unstru
 	protoConfig.ContentType = "application/vnd.kubernetes.protobuf"
 
 	controllerContext := &ControllerContext{
-		ComponentConfig: config,
-		KubeConfig:      clientConfig,
-		ProtoKubeConfig: protoConfig,
-		EventRecorder:   eventRecorder,
-		Server:          server,
+		ComponentConfig:   config,
+		KubeConfig:        clientConfig,
+		ProtoKubeConfig:   protoConfig,
+		EventRecorder:     eventRecorder,
+		Server:            server,
+		OperatorNamespace: namespace,
 	}
 
 	if b.leaderElection == nil {


### PR DESCRIPTION
`ControllerCommandConfig` knows the namespace where the operator runs, either from cmdline (`--namespace`) or autodetected from `/var/run/secrets`. Pass this namespace to the operator controller's `StarterFunc`, so the operator knows the namespace too (if it's interested).

This will help library-go based operators to create operands in the same namespace as the operator without passing the namespace as an env. variable.