### PR TITLE
WIP: Support removable operators

### DIFF
--- a/pkg/controller/controllercmd/builder.go
+++ b/pkg/controller/controllercmd/builder.go
@@ -52,6 +52,9 @@ type ControllerContext struct {
 
 	// Server is the GenericAPIServer serving healthz checks and debug info
 	Server *genericapiserver.GenericAPIServer
+
+	// Namespace where the operator runs. Either specified on the command line or autodetected.
+	OperatorNamespace string
 }
 
 // defaultObserverInterval specifies the default interval that file observer will do rehash the files it watches and react to any changes
@@ -274,11 +277,12 @@ func (b *ControllerBuilder) Run(ctx context.Context, config *unstructured.Unstru
 	protoConfig.ContentType = "application/vnd.kubernetes.protobuf"
 
 	controllerContext := &ControllerContext{
-		ComponentConfig: config,
-		KubeConfig:      clientConfig,
-		ProtoKubeConfig: protoConfig,
-		EventRecorder:   eventRecorder,
-		Server:          server,
+		ComponentConfig:   config,
+		KubeConfig:        clientConfig,
+		ProtoKubeConfig:   protoConfig,
+		EventRecorder:     eventRecorder,
+		Server:            server,
+		OperatorNamespace: namespace,
 	}
 
 	if b.leaderElection == nil {

--- a/pkg/operator/csi/csicontrollerset/csi_controller_set.go
+++ b/pkg/operator/csi/csicontrollerset/csi_controller_set.go
@@ -38,7 +38,7 @@ type CSIControllerSet struct {
 	csiDriverNodeServiceController       factory.Controller
 
 	preRunCachesSynced []cache.InformerSynced
-	operatorClient     v1helpers.OperatorClient
+	operatorClient     v1helpers.OperatorClientWithFinalizers
 	eventRecorder      events.Recorder
 }
 
@@ -84,7 +84,7 @@ func (c *CSIControllerSet) WithLogLevelController() *CSIControllerSet {
 // WithManagementStateController returns a *ControllerSet with a management state controller initialized.
 func (c *CSIControllerSet) WithManagementStateController(operandName string, supportsOperandRemoval bool) *CSIControllerSet {
 	c.managementStateController = management.NewOperatorManagementStateController(operandName, c.operatorClient, c.eventRecorder)
-	if supportsOperandRemoval {
+	if !supportsOperandRemoval {
 		management.SetOperatorNotRemovable()
 	}
 	return c
@@ -196,7 +196,7 @@ func (c *CSIControllerSet) WithExtraInformers(informers ...cache.SharedIndexInfo
 }
 
 // New returns a basic *ControllerSet without any controller.
-func NewCSIControllerSet(operatorClient v1helpers.OperatorClient, eventRecorder events.Recorder) *CSIControllerSet {
+func NewCSIControllerSet(operatorClient v1helpers.OperatorClientWithFinalizers, eventRecorder events.Recorder) *CSIControllerSet {
 	return &CSIControllerSet{
 		operatorClient: operatorClient,
 		eventRecorder:  eventRecorder,

--- a/pkg/operator/csi/csidrivernodeservicecontroller/csi_driver_node_service_controller.go
+++ b/pkg/operator/csi/csidrivernodeservicecontroller/csi_driver_node_service_controller.go
@@ -137,7 +137,7 @@ func (c *CSIDriverNodeServiceController) sync(ctx context.Context, syncContext f
 }
 
 func (c *CSIDriverNodeServiceController) syncManaged(opSpec *opv1.OperatorSpec, opStatus *opv1.OperatorStatus, ctx context.Context, syncContext factory.SyncContext) error {
-	if !management.IsOperatorNotRemovable() {
+	if management.IsOperatorRemovable() {
 		err := c.operatorClient.EnsureFinalizer(c.name)
 		if err != nil {
 			return err

--- a/pkg/operator/genericoperatorclient/dynamic_operator_client.go
+++ b/pkg/operator/genericoperatorclient/dynamic_operator_client.go
@@ -9,6 +9,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
@@ -40,7 +41,7 @@ func newClusterScopedOperatorClient(config *rest.Config, gvr schema.GroupVersion
 	}, informers, nil
 }
 
-func NewClusterScopedOperatorClient(config *rest.Config, gvr schema.GroupVersionResource) (v1helpers.OperatorClient, dynamicinformer.DynamicSharedInformerFactory, error) {
+func NewClusterScopedOperatorClient(config *rest.Config, gvr schema.GroupVersionResource) (v1helpers.OperatorClientWithFinalizers, dynamicinformer.DynamicSharedInformerFactory, error) {
 	d, informers, err := newClusterScopedOperatorClient(config, gvr)
 	if err != nil {
 		return nil, nil, err
@@ -52,7 +53,7 @@ func NewClusterScopedOperatorClient(config *rest.Config, gvr schema.GroupVersion
 
 type OperatorClientOption func(*dynamicOperatorClient)
 
-func NewClusterScopedOperatorClientWithConfigName(config *rest.Config, gvr schema.GroupVersionResource, configName string, options ...OperatorClientOption) (v1helpers.OperatorClient, dynamicinformer.DynamicSharedInformerFactory, error) {
+func NewClusterScopedOperatorClientWithConfigName(config *rest.Config, gvr schema.GroupVersionResource, configName string, options ...OperatorClientOption) (v1helpers.OperatorClientWithFinalizers, dynamicinformer.DynamicSharedInformerFactory, error) {
 	if len(configName) < 1 {
 		return nil, nil, fmt.Errorf("config name cannot be empty")
 	}
@@ -186,6 +187,76 @@ func (c dynamicOperatorClient) UpdateOperatorStatus(resourceVersion string, stat
 	}
 
 	return retStatus, nil
+}
+
+func (c dynamicOperatorClient) EnsureFinalizer(finalizer string) error {
+	uncastInstance, err := c.informer.Lister().Get(c.configName)
+	if err != nil {
+		if errors.IsNotFound(err) && c.fakeMissingInstance {
+			return nil
+		}
+		return err
+
+	}
+
+	instance := uncastInstance.(*unstructured.Unstructured)
+	finalizers := instance.GetFinalizers()
+	for _, f := range finalizers {
+		if f == finalizer {
+			return nil
+		}
+	}
+
+	// Change is needed
+	klog.V(4).Infof("Adding finalizer %q", finalizer)
+	newFinalizers := append(finalizers, finalizer)
+	err = c.saveFinalizers(instance, newFinalizers)
+	if err != nil {
+		return err
+	}
+	klog.V(2).Infof("Added finalizer %q", finalizer)
+	return err
+}
+
+func (c dynamicOperatorClient) RemoveFinalizer(finalizer string) error {
+	uncastInstance, err := c.informer.Lister().Get(c.configName)
+	if err != nil {
+		if errors.IsNotFound(err) && c.fakeMissingInstance {
+			return nil
+		}
+		return err
+
+	}
+
+	instance := uncastInstance.(*unstructured.Unstructured)
+	finalizers := instance.GetFinalizers()
+	found := false
+	newFinalizers := make([]string, 0, len(finalizers))
+	for _, f := range finalizers {
+		if f == finalizer {
+			found = true
+			continue
+		}
+		newFinalizers = append(newFinalizers, f)
+	}
+	if !found {
+		return nil
+	}
+
+	klog.V(42).Infof("Removing finalizer %q: %v", finalizer, newFinalizers)
+	err = c.saveFinalizers(instance, newFinalizers)
+	if err != nil {
+		return err
+	}
+	klog.V(2).Infof("Removed finalizer %q", finalizer)
+	return nil
+}
+
+func (c dynamicOperatorClient) saveFinalizers(instance *unstructured.Unstructured, finalizers []string) error {
+	clone := instance.DeepCopy()
+	clone.SetFinalizers(finalizers)
+	_, err := c.client.Update(context.TODO(), clone, metav1.UpdateOptions{})
+	return err
 }
 
 func getObjectMetaFromUnstructured(obj map[string]interface{}) (*metav1.ObjectMeta, error) {

--- a/pkg/operator/management/management_state.go
+++ b/pkg/operator/management/management_state.go
@@ -40,9 +40,14 @@ func IsOperatorAlwaysManaged() bool {
 	return !getAllowedOperatorUnmanaged()
 }
 
-// IsOperatorNotRemovable means the operator can't bet set to removed state.
+// IsOperatorNotRemovable means the operator can't be set to removed state.
 func IsOperatorNotRemovable() bool {
 	return !getAllowedOperatorRemovedState()
+}
+
+// IsOperatorRemovable means the operator can be set to removed state.
+func IsOperatorRemovable() bool {
+	return getAllowedOperatorRemovedState()
 }
 
 func IsOperatorUnknownState(state v1.ManagementState) bool {

--- a/pkg/operator/resource/resourceread/storage.go
+++ b/pkg/operator/resource/resourceread/storage.go
@@ -33,3 +33,11 @@ func ReadCSIDriverV1Beta1OrDie(objBytes []byte) *storagev1beta1.CSIDriver {
 	}
 	return requiredObj.(*storagev1beta1.CSIDriver)
 }
+
+func ReadCSIDriverV1OrDie(objBytes []byte) *storagev1.CSIDriver {
+	requiredObj, err := runtime.Decode(storageCodecs.UniversalDecoder(storagev1.SchemeGroupVersion), objBytes)
+	if err != nil {
+		panic(err)
+	}
+	return requiredObj.(*storagev1.CSIDriver)
+}

--- a/pkg/operator/v1helpers/interfaces.go
+++ b/pkg/operator/v1helpers/interfaces.go
@@ -31,3 +31,11 @@ type StaticPodOperatorClient interface {
 	// UpdateStaticPodOperatorSpec updates the spec, assuming the given resource  version.
 	UpdateStaticPodOperatorSpec(resourceVersion string, in *operatorv1.StaticPodOperatorSpec) (out *operatorv1.StaticPodOperatorSpec, newResourceVersion string, err error)
 }
+
+type OperatorClientWithFinalizers interface {
+	OperatorClient
+	// EnsureFinalizer adds a new finalizer to the operator CR, if it does not exists. No-op otherwise.
+	EnsureFinalizer(finalizer string) error
+	// RemoveFinalizer removes a finalizer to the operator CR, if it is there. No-op otherwise.
+	RemoveFinalizer(finalizer string) error
+}


### PR DESCRIPTION
**Goal:** Add support for removable operators managed by OLM, namely CSI drivers. Operands (a CSI driver) should be installed when user creates a CR and removed when user deletes it.

Includes https://github.com/openshift/library-go/pull/1012 and https://github.com/openshift/library-go/pull/1017 to test with AWS EFS CSI driver operator (which is in progress)

* Most library-go controllers log error / warning messages when operator CR is missing. I updated `dynamicOperatorClient` to optionally (!) return a fake `OperatorSpec`/`OperatorStatus` when the CR is deleted / not yet created. The fake CR has `ManagementState: Unmanaged` to tell controllers to do nothing when CR is missing. [ Faking `ManagementState: Removed` would work too. ]

* Reusing `ManagementState: Removed` and  `management.SetOperatorNotRemovable()` to tell controllers to start removing the operands.

  * Most controllers ignore `ManagementState: Removed`  and most operators don't call `SetOperatorNotRemovable`, even though they don't support removal. I touched only `ManagementStateController` and CSI controllers in this PR. More controllers may come in future with removal support.
 
*  Extended `ManagementStateController` to force set `ManagementState: Removed` when the operator CR meets **all these conditions**:

      * Has a finalizer.
      * Has deletion timestamp.
      * The operator itself is removable (`SetOperatorNotRemovable` was not called)
  
    This way, other controllers need to react only to `ManagementState: Removed` and they don't need to check DeletionTimestamp or finalizers. Existing operators don't use finalizers on their CRs, therefore they won't be affected by this logic, even though they may not set themselves as `NotRemovable`.

    Similarly, users may set `ManagementState: Removed` to un-install the operands and `Managed` to install it back. This is just a side-effect, users should create / delete CRs to install/remove the operands.

  * Added helper `GetSyncAction` to further simplify controllers that may support Removed state.

* Removable operators may need to add/remove finalizers in the operator CR. I added a new interface `OperatorClientWithFinalizers` that can add/remove finalizers as the controller manage the operands / finished their removal. I avoided `OperatorClient` changes, because it's implemented on too many places.

* See the last commit how it all fits together, where CSI Node controller creates / deletes DaemonSet + adds/removes finalizers accordingly when its CR is created / gets DeletionTimestamp.

WIP:
* Fix/add unit tests
* Add all CSI Driver controllers (namely, the control plane Deployment one)
* Maybe update StaticResourceController to remove the objects it creates, however, this must be explicit opt-in, as many operators use it and I doubt they set `NotRemovable` correctly.