### PR TITLE
resourcemerge: set LastGeneration to 1 when no previous instances exist

### DIFF
--- a/pkg/operator/resource/resourcemerge/apps.go
+++ b/pkg/operator/resource/resourcemerge/apps.go
@@ -29,6 +29,7 @@ func SetGeneration(generations *[]operatorsv1.GenerationStatus, newGeneration op
 
 	existingGeneration := GenerationFor(*generations, schema.GroupResource{Group: newGeneration.Group, Resource: newGeneration.Resource}, newGeneration.Namespace, newGeneration.Name)
 	if existingGeneration == nil {
+		newGeneration.LastGeneration = 1
 		*generations = append(*generations, newGeneration)
 		return
 	}


### PR DESCRIPTION
The ObjecMeta.generation field is set to 1 when a resource is first
created, if no previous generation of the same resource exists
it's better to init LastGeneration to 1 otherwise the resource might get patched needlessly
right after creation.

Signed-off-by: Antonio Cardace <acardace@redhat.com>