### PR TITLE
add Default Audit Policy getter function

### DIFF
--- a/pkg/operator/apiserver/audit/audit_policies.go
+++ b/pkg/operator/apiserver/audit/audit_policies.go
@@ -22,6 +22,21 @@ const (
 	auditPolicyAsset = "pkg/operator/apiserver/audit/manifests/audit-policies-cm.yaml"
 )
 
+// DefaultPolicy brings back the default.yaml audit policy to init the api
+func DefaultPolicy() ([]byte, error) {
+	// none is used on target name and namespace as it's not a key in the default.yaml
+	cm, err := GetAuditPolicies("none", "none")
+	if err != nil {
+		return nil, fmt.Errorf("failed to retreive audit policies - %w", err)
+	}
+
+	cmData := []byte(cm.Data["default.yaml"])
+	if len(cmData) == 0 {
+		return nil, errors.New("failed to locate the default policy from configmap")
+	}
+	return cmData, nil
+}
+
 // WithAuditPolicies is meant to wrap a standard Asset function usually provided by an operator.
 // It delegates to GetAuditPolicies when the filename matches the predicate for retrieving a audit policy config map for target namespace and name.
 func WithAuditPolicies(targetName string, targetNamespace string, assetDelegateFunc resourceapply.AssetFunc) resourceapply.AssetFunc {

--- a/pkg/operator/apiserver/audit/audit_policies_test.go
+++ b/pkg/operator/apiserver/audit/audit_policies_test.go
@@ -155,6 +155,29 @@ func TestNewAuditPolicyPathGetter(t *testing.T) {
 	}
 }
 
+func TestDefaultPolicy(t *testing.T) {
+	scenarios := []struct {
+		name string
+	}{
+		{
+			name: "Get default audit policy for the kube-apiserver",
+		},
+	}
+	for _, test := range scenarios {
+		t.Run(test.name, func(t *testing.T) {
+			// act
+			data, err := DefaultPolicy()
+			// assert
+			if err != nil {
+				t.Errorf("expected no error, but got: %v", err)
+			}
+			if len(data) == 0 {
+				t.Error("expected a non empty default policy")
+			}
+		})
+	}
+}
+
 func readBytesFromFile(t *testing.T, filename string) []byte {
 	file, err := os.Open(filename)
 	if err != nil {


### PR DESCRIPTION
Currently our cluster-kube-apiserver-operator does not use library go audit pkg and uses internal static files.
This is the addition of missing functions to library-go so that the package of library-go audit pkg will work.
Essentially, this fixes build errors.