### PR TITLE
Add support for removable csi drivers

### DIFF
--- a/pkg/operator/csi/credentialsrequestcontroller/credentials_request_controller.go
+++ b/pkg/operator/csi/credentialsrequestcontroller/credentials_request_controller.go
@@ -28,7 +28,7 @@ import (
 // <name>Degraded: produced when the sync() method returns an error.
 type CredentialsRequestController struct {
 	name            string
-	operatorClient  v1helpers.OperatorClient
+	operatorClient  v1helpers.OperatorClientWithFinalizers
 	targetNamespace string
 	manifest        []byte
 	dynamicClient   dynamic.Interface
@@ -40,7 +40,7 @@ func NewCredentialsRequestController(
 	targetNamespace string,
 	manifest []byte,
 	dynamicClient dynamic.Interface,
-	operatorClient v1helpers.OperatorClient,
+	operatorClient v1helpers.OperatorClientWithFinalizers,
 	recorder events.Recorder,
 ) factory.Controller {
 	c := &CredentialsRequestController{

--- a/pkg/operator/csi/csicontrollerset/csi_controller_set.go
+++ b/pkg/operator/csi/csicontrollerset/csi_controller_set.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/loglevel"
 	"github.com/openshift/library-go/pkg/operator/management"
+	"github.com/openshift/library-go/pkg/operator/managementstatecontroller"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/openshift/library-go/pkg/operator/staticresourcecontroller"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
@@ -38,7 +39,7 @@ type CSIControllerSet struct {
 	csiDriverNodeServiceController       factory.Controller
 	serviceMonitorController             factory.Controller
 
-	operatorClient v1helpers.OperatorClient
+	operatorClient v1helpers.OperatorClientWithFinalizers
 	eventRecorder  events.Recorder
 }
 
@@ -72,8 +73,8 @@ func (c *CSIControllerSet) WithLogLevelController() *CSIControllerSet {
 
 // WithManagementStateController returns a *ControllerSet with a management state controller initialized.
 func (c *CSIControllerSet) WithManagementStateController(operandName string, supportsOperandRemoval bool) *CSIControllerSet {
-	c.managementStateController = management.NewOperatorManagementStateController(operandName, c.operatorClient, c.eventRecorder)
-	if supportsOperandRemoval {
+	c.managementStateController = managementstatecontroller.NewOperatorManagementStateController(operandName, c.operatorClient, c.eventRecorder)
+	if !supportsOperandRemoval {
 		management.SetOperatorNotRemovable()
 	}
 	return c
@@ -210,7 +211,7 @@ func (c *CSIControllerSet) WithServiceMonitorController(
 }
 
 // New returns a basic *ControllerSet without any controller.
-func NewCSIControllerSet(operatorClient v1helpers.OperatorClient, eventRecorder events.Recorder) *CSIControllerSet {
+func NewCSIControllerSet(operatorClient v1helpers.OperatorClientWithFinalizers, eventRecorder events.Recorder) *CSIControllerSet {
 	return &CSIControllerSet{
 		operatorClient: operatorClient,
 		eventRecorder:  eventRecorder,

--- a/pkg/operator/csi/csidrivercontrollerservicecontroller/csi_driver_controller_service_controller.go
+++ b/pkg/operator/csi/csidrivercontrollerservicecontroller/csi_driver_controller_service_controller.go
@@ -5,11 +5,9 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	configinformers "github.com/openshift/client-go/config/informers/externalversions"
-
 	"github.com/openshift/library-go/pkg/controller/factory"
 	dc "github.com/openshift/library-go/pkg/operator/deploymentcontroller"
 	"github.com/openshift/library-go/pkg/operator/events"
-
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
 
@@ -46,6 +44,8 @@ import (
 // The placeholder ${CLUSTER_ID} specified in the static file is replaced with the cluster ID (sometimes referred as infra ID).
 // This is mostly used by CSI drivers to tag volumes and snapshots so that those resources can be cleaned up on cluster deletion.
 //
+// This controller supports removable operands, as configured in pkg/operator/management.
+//
 // This controller produces the following conditions:
 //
 // <name>Available: indicates that the CSI Controller Service was successfully deployed and at least one Deployment replica is available.
@@ -56,7 +56,7 @@ func NewCSIDriverControllerServiceController(
 	name string,
 	manifest []byte,
 	recorder events.Recorder,
-	operatorClient v1helpers.OperatorClient,
+	operatorClient v1helpers.OperatorClientWithFinalizers,
 	kubeClient kubernetes.Interface,
 	deployInformer appsinformersv1.DeploymentInformer,
 	configInformer configinformers.SharedInformerFactory,
@@ -67,5 +67,4 @@ func NewCSIDriverControllerServiceController(
 	var optionalManifestHooks []dc.ManifestHookFunc
 	optionalManifestHooks = append(optionalManifestHooks, WithPlaceholdersHook(configInformer))
 	return dc.NewDeploymentController(name, manifest, recorder, operatorClient, kubeClient, deployInformer, optionalInformers, optionalManifestHooks, optionalDeploymentHooks...)
-
 }

--- a/pkg/operator/csi/csidrivernodeservicecontroller/csi_driver_node_service_controller.go
+++ b/pkg/operator/csi/csidrivernodeservicecontroller/csi_driver_node_service_controller.go
@@ -142,8 +142,7 @@ func (c *CSIDriverNodeServiceController) sync(ctx context.Context, syncContext f
 func (c *CSIDriverNodeServiceController) syncManaged(ctx context.Context, opSpec *opv1.OperatorSpec, opStatus *opv1.OperatorStatus, syncContext factory.SyncContext) error {
 	klog.V(4).Infof("syncManaged")
 	if management.IsOperatorRemovable() {
-		err := c.operatorClient.EnsureFinalizer(c.name)
-		if err != nil {
+		if err := v1helpers.EnsureFinalizer(c.operatorClient, c.name); err != nil {
 			return err
 		}
 	}
@@ -274,9 +273,5 @@ func (c *CSIDriverNodeServiceController) syncDeleting(ctx context.Context, opSpe
 	}
 
 	// All removed, remove the finalizer as the last step
-	err = c.operatorClient.RemoveFinalizer(c.name)
-	if err != nil {
-		return err
-	}
-	return nil
+	return v1helpers.RemoveFinalizer(c.operatorClient, c.name)
 }

--- a/pkg/operator/csi/csidrivernodeservicecontroller/csi_driver_node_service_controller.go
+++ b/pkg/operator/csi/csidrivernodeservicecontroller/csi_driver_node_service_controller.go
@@ -8,19 +8,21 @@ import (
 	"strings"
 	"time"
 
-	appsv1 "k8s.io/api/apps/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	appsinformersv1 "k8s.io/client-go/informers/apps/v1"
-	"k8s.io/client-go/kubernetes"
-
 	opv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/loglevel"
+	"github.com/openshift/library-go/pkg/operator/management"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	appsinformersv1 "k8s.io/client-go/informers/apps/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -57,6 +59,8 @@ type DaemonSetHookFunc func(*opv1.OperatorSpec, *appsv1.DaemonSet) error
 // In order to do that, the placeholder ${LOG_LEVEL} from the manifest file is replaced with the value specified
 // in the OperatorClient resource (Spec.LogLevel).
 //
+// This controller supports removable operands, as configured in pkg/operator/management.
+//
 // This controller produces the following conditions:
 //
 // <name>Available: indicates that the CSI Node Service was successfully deployed.
@@ -65,7 +69,7 @@ type DaemonSetHookFunc func(*opv1.OperatorSpec, *appsv1.DaemonSet) error
 type CSIDriverNodeServiceController struct {
 	name           string
 	manifest       []byte
-	operatorClient v1helpers.OperatorClient
+	operatorClient v1helpers.OperatorClientWithFinalizers
 	kubeClient     kubernetes.Interface
 	dsInformer     appsinformersv1.DaemonSetInformer
 	// Optional hook functions to modify the DaemonSet.
@@ -79,7 +83,7 @@ func NewCSIDriverNodeServiceController(
 	name string,
 	manifest []byte,
 	recorder events.Recorder,
-	operatorClient v1helpers.OperatorClient,
+	operatorClient v1helpers.OperatorClientWithFinalizers,
 	kubeClient kubernetes.Interface,
 	dsInformer appsinformersv1.DaemonSetInformer,
 	optionalInformers []factory.Informer,
@@ -114,10 +118,10 @@ func (c *CSIDriverNodeServiceController) Name() string {
 
 func (c *CSIDriverNodeServiceController) sync(ctx context.Context, syncContext factory.SyncContext) error {
 	opSpec, opStatus, _, err := c.operatorClient.GetOperatorState()
+	if errors.IsNotFound(err) && management.IsOperatorRemovable() {
+		return nil
+	}
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil
-		}
 		return err
 	}
 
@@ -125,14 +129,28 @@ func (c *CSIDriverNodeServiceController) sync(ctx context.Context, syncContext f
 		return nil
 	}
 
-	manifest := replacePlaceholders(c.manifest, opSpec)
-	required := resourceread.ReadDaemonSetV1OrDie(manifest)
+	meta, err := c.operatorClient.GetObjectMeta()
+	if err != nil {
+		return err
+	}
+	if management.IsOperatorRemovable() && meta.DeletionTimestamp != nil {
+		return c.syncDeleting(ctx, opSpec, opStatus, syncContext)
+	}
+	return c.syncManaged(ctx, opSpec, opStatus, syncContext)
+}
 
-	for i := range c.optionalDaemonSetHooks {
-		err := c.optionalDaemonSetHooks[i](opSpec, required)
+func (c *CSIDriverNodeServiceController) syncManaged(ctx context.Context, opSpec *opv1.OperatorSpec, opStatus *opv1.OperatorStatus, syncContext factory.SyncContext) error {
+	klog.V(4).Infof("syncManaged")
+	if management.IsOperatorRemovable() {
+		err := c.operatorClient.EnsureFinalizer(c.name)
 		if err != nil {
-			return fmt.Errorf("error running hook function (index=%d): %w", i, err)
+			return err
 		}
+	}
+
+	required, err := c.getDaemonSet(opSpec)
+	if err != nil {
+		return err
 	}
 
 	daemonSet, _, err := resourceapply.ApplyDaemonSet(
@@ -185,6 +203,19 @@ func (c *CSIDriverNodeServiceController) sync(ctx context.Context, syncContext f
 	return err
 }
 
+func (c *CSIDriverNodeServiceController) getDaemonSet(opSpec *opv1.OperatorSpec) (*appsv1.DaemonSet, error) {
+	manifest := replacePlaceholders(c.manifest, opSpec)
+	required := resourceread.ReadDaemonSetV1OrDie(manifest)
+
+	for i := range c.optionalDaemonSetHooks {
+		err := c.optionalDaemonSetHooks[i](opSpec, required)
+		if err != nil {
+			return nil, fmt.Errorf("error running hook function (index=%d): %w", i, err)
+		}
+	}
+	return required, nil
+}
+
 func isProgressing(status *opv1.OperatorStatus, daemonSet *appsv1.DaemonSet) (bool, string) {
 	switch {
 	case daemonSet.Generation != daemonSet.Status.ObservedGeneration:
@@ -226,4 +257,26 @@ func replacePlaceholders(manifest []byte, spec *opv1.OperatorSpec) []byte {
 
 	replaced := strings.NewReplacer(pairs...).Replace(string(manifest))
 	return []byte(replaced)
+}
+
+func (c *CSIDriverNodeServiceController) syncDeleting(ctx context.Context, opSpec *opv1.OperatorSpec, opStatus *opv1.OperatorStatus, syncContext factory.SyncContext) error {
+	klog.V(4).Infof("syncDeleting")
+	required, err := c.getDaemonSet(opSpec)
+	if err != nil {
+		return err
+	}
+
+	err = c.kubeClient.AppsV1().DaemonSets(required.Namespace).Delete(ctx, required.Name, metav1.DeleteOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	} else {
+		klog.V(2).Infof("Deleted DaemonSet %s/%s", required.Namespace, required.Name)
+	}
+
+	// All removed, remove the finalizer as the last step
+	err = c.operatorClient.RemoveFinalizer(c.name)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/operator/csi/csidrivernodeservicecontroller/csi_driver_node_service_controller_test.go
+++ b/pkg/operator/csi/csidrivernodeservicecontroller/csi_driver_node_service_controller_test.go
@@ -46,7 +46,7 @@ const (
 	hookDaemonSetAnnKey = "operator.openshift.io/foo"
 	hookDaemonSetAnnVal = "bar"
 
-	finalizerName = controllerName
+	finalizerName = "test.operator.openshift.io/" + controllerName
 )
 
 var (
@@ -118,11 +118,11 @@ func newTestContext(test testCase, t *testing.T) *testContext {
 	)
 
 	// Pretend env vars are set
+	os.Setenv("OPERATOR_NAME", "test")
 	// TODO: inject these in New() instead
 	os.Setenv(driverImageEnvName, test.images.csiDriver)
 	os.Setenv(nodeDriverRegistrarImageEnvName, test.images.nodeDriverRegistrar)
 	os.Setenv(livenessProbeImageEnvName, test.images.livenessProbe)
-
 	return &testContext{
 		controller:     controller,
 		operatorClient: fakeOperatorClient,

--- a/pkg/operator/deploymentcontroller/deployment_controller.go
+++ b/pkg/operator/deploymentcontroller/deployment_controller.go
@@ -6,10 +6,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/openshift/library-go/pkg/operator/management"
 	appsv1 "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	appsinformersv1 "k8s.io/client-go/informers/apps/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
 
 	opv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/library-go/pkg/controller/factory"
@@ -27,14 +30,18 @@ type DeploymentHookFunc func(*opv1.OperatorSpec, *appsv1.Deployment) error
 // The hook must not modify the original manifest!
 type ManifestHookFunc func(*opv1.OperatorSpec, []byte) ([]byte, error)
 
-// DeploymentController is a generic controller that manages a deployment
+// DeploymentController is a generic controller that manages a deployment.
+//
+// This controller supports removable operands, as configured in pkg/operator/management.
+//
+// This controller produces the following conditions:
 // <name>Available: indicates that the deployment controller  was successfully deployed and at least one Deployment replica is available.
 // <name>Progressing: indicates that the Deployment is in progress.
 // <name>Degraded: produced when the sync() method returns an error.
 type DeploymentController struct {
 	name           string
 	manifest       []byte
-	operatorClient v1helpers.OperatorClient
+	operatorClient v1helpers.OperatorClientWithFinalizers
 	kubeClient     kubernetes.Interface
 	deployInformer appsinformersv1.DeploymentInformer
 	// Optional hook functions to modify the deployment manifest.
@@ -56,7 +63,7 @@ func NewDeploymentController(
 	name string,
 	manifest []byte,
 	recorder events.Recorder,
-	operatorClient v1helpers.OperatorClient,
+	operatorClient v1helpers.OperatorClientWithFinalizers,
 	kubeClient kubernetes.Interface,
 	deployInformer appsinformersv1.DeploymentInformer,
 	optionalInformers []factory.Informer,
@@ -99,7 +106,7 @@ func (c *DeploymentController) Name() string {
 
 func (c *DeploymentController) sync(ctx context.Context, syncContext factory.SyncContext) error {
 	opSpec, opStatus, _, err := c.operatorClient.GetOperatorState()
-	if apierrors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) && management.IsOperatorRemovable() {
 		return nil
 	}
 	if err != nil {
@@ -110,21 +117,28 @@ func (c *DeploymentController) sync(ctx context.Context, syncContext factory.Syn
 		return nil
 	}
 
-	manifest := c.manifest
-	for i := range c.optionalManifestHooks {
-		manifest, err = c.optionalManifestHooks[i](opSpec, manifest)
+	meta, err := c.operatorClient.GetObjectMeta()
+	if err != nil {
+		return err
+	}
+	if management.IsOperatorRemovable() && meta.DeletionTimestamp != nil {
+		return c.syncDeleting(ctx, opSpec, opStatus, syncContext)
+	}
+	return c.syncManaged(ctx, opSpec, opStatus, syncContext)
+}
+
+func (c *DeploymentController) syncManaged(ctx context.Context, opSpec *opv1.OperatorSpec, opStatus *opv1.OperatorStatus, syncContext factory.SyncContext) error {
+	klog.V(4).Infof("syncManaged")
+
+	if management.IsOperatorRemovable() {
+		err := c.operatorClient.EnsureFinalizer(c.name)
 		if err != nil {
-			return fmt.Errorf("error running hook function (index=%d): %w", i, err)
+			return err
 		}
 	}
-
-	required := resourceread.ReadDeploymentV1OrDie(manifest)
-
-	for i := range c.optionalDeploymentHooks {
-		err := c.optionalDeploymentHooks[i](opSpec, required)
-		if err != nil {
-			return fmt.Errorf("error running hook function (index=%d): %w", i, err)
-		}
+	required, err := c.getDeployment(opSpec)
+	if err != nil {
+		return err
 	}
 
 	deployment, _, err := resourceapply.ApplyDeployment(
@@ -175,6 +189,49 @@ func (c *DeploymentController) sync(ctx context.Context, syncContext factory.Syn
 	)
 
 	return err
+}
+
+func (c *DeploymentController) syncDeleting(ctx context.Context, opSpec *opv1.OperatorSpec, opStatus *opv1.OperatorStatus, syncContext factory.SyncContext) error {
+	klog.V(4).Infof("syncDeleting")
+	required, err := c.getDeployment(opSpec)
+	if err != nil {
+		return err
+	}
+
+	err = c.kubeClient.AppsV1().Deployments(required.Namespace).Delete(ctx, required.Name, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	} else {
+		klog.V(2).Infof("Deleted Deployment %s/%s", required.Namespace, required.Name)
+	}
+
+	// All removed, remove the finalizer as the last step
+	err = c.operatorClient.RemoveFinalizer(c.name)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *DeploymentController) getDeployment(opSpec *opv1.OperatorSpec) (*appsv1.Deployment, error) {
+	manifest := c.manifest
+	for i := range c.optionalManifestHooks {
+		var err error
+		manifest, err = c.optionalManifestHooks[i](opSpec, manifest)
+		if err != nil {
+			return nil, fmt.Errorf("error running hook function (index=%d): %w", i, err)
+		}
+	}
+
+	required := resourceread.ReadDeploymentV1OrDie(manifest)
+
+	for i := range c.optionalDeploymentHooks {
+		err := c.optionalDeploymentHooks[i](opSpec, required)
+		if err != nil {
+			return nil, fmt.Errorf("error running hook function (index=%d): %w", i, err)
+		}
+	}
+	return required, nil
 }
 
 func isProgressing(deployment *appsv1.Deployment) (bool, string) {

--- a/pkg/operator/deploymentcontroller/deployment_controller.go
+++ b/pkg/operator/deploymentcontroller/deployment_controller.go
@@ -131,8 +131,7 @@ func (c *DeploymentController) syncManaged(ctx context.Context, opSpec *opv1.Ope
 	klog.V(4).Infof("syncManaged")
 
 	if management.IsOperatorRemovable() {
-		err := c.operatorClient.EnsureFinalizer(c.name)
-		if err != nil {
+		if err := v1helpers.EnsureFinalizer(c.operatorClient, c.name); err != nil {
 			return err
 		}
 	}
@@ -206,11 +205,7 @@ func (c *DeploymentController) syncDeleting(ctx context.Context, opSpec *opv1.Op
 	}
 
 	// All removed, remove the finalizer as the last step
-	err = c.operatorClient.RemoveFinalizer(c.name)
-	if err != nil {
-		return err
-	}
-	return nil
+	return v1helpers.RemoveFinalizer(c.operatorClient, c.name)
 }
 
 func (c *DeploymentController) getDeployment(opSpec *opv1.OperatorSpec) (*appsv1.Deployment, error) {

--- a/pkg/operator/deploymentcontroller/deployment_controller_test.go
+++ b/pkg/operator/deploymentcontroller/deployment_controller_test.go
@@ -2,13 +2,17 @@ package deploymentcontroller
 
 import (
 	"context"
+	"sort"
+	"time"
+
 	"github.com/google/go-cmp/cmp"
 	opv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/library-go/pkg/operator/management"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
 	core "k8s.io/client-go/testing"
-	"sort"
 
 	"testing"
 
@@ -35,6 +39,7 @@ const (
 	operandNamespace = "openshift-dummy-test-deployment"
 	// From github.com/openshift/library-go/pkg/operator/resource/resourceapply/apps.go
 	specHashAnnotation = "operator.openshift.io/spec-hash"
+	finalizerName      = controllerName
 )
 
 var (
@@ -44,6 +49,7 @@ var (
 
 type testCase struct {
 	name            string
+	removable       bool
 	initialObjects  testObjects
 	expectedObjects testObjects
 	expectErr       bool
@@ -229,7 +235,7 @@ func TestDeploymentCreation(t *testing.T) {
 	configInformer := configInformerFactory.Config().V1().Infrastructures().Informer()
 	configInformer.GetIndexer().Add(initialInfras[0])
 	driverInstance := makeFakeOperatorInstance()
-	fakeOperatorClient := v1helpers.NewFakeOperatorClient(&driverInstance.Spec, &driverInstance.Status, nil /*triggerErr func*/)
+	fakeOperatorClient := v1helpers.NewFakeOperatorClientWithObjectMeta(&driverInstance.ObjectMeta, &driverInstance.Spec, &driverInstance.Status, nil /*triggerErr func*/)
 	var optionalInformers []factory.Informer
 	var optionalManifestHookFuncs []ManifestHookFunc
 	optionalInformers = append(optionalInformers, configInformer)
@@ -327,6 +333,21 @@ func withFalseConditions(conditions ...string) operatorModifier {
 	}
 }
 
+func withFinalizers(finalizers ...string) operatorModifier {
+	return func(i *fakeOperatorInstance) *fakeOperatorInstance {
+		i.Finalizers = finalizers
+		return i
+	}
+}
+
+func withDeletionTimestamp() operatorModifier {
+	return func(i *fakeOperatorInstance) *fakeOperatorInstance {
+		// Use a constant time to get ObjectMeta comparison right.
+		i.DeletionTimestamp = &metav1.Time{Time: time.Unix(0, 0)}
+		return i
+	}
+}
+
 // This reactor is always enabled and bumps Deployment generation when it gets updated.
 func addGenerationReactor(client *fakecore.Clientset) {
 	client.PrependReactor("*", "deployments", func(action core.Action) (handled bool, ret runtime.Object, err error) {
@@ -374,7 +395,8 @@ func newTestContext(test testCase, t *testing.T) *testContext {
 	configInformer.GetIndexer().Add(initialInfras[0])
 
 	// fakeDriverInstance also fulfils the OperatorClient interface
-	fakeOperatorClient := v1helpers.NewFakeOperatorClient(
+	fakeOperatorClient := v1helpers.NewFakeOperatorClientWithObjectMeta(
+		&test.initialObjects.operator.ObjectMeta,
 		&test.initialObjects.operator.Spec,
 		&test.initialObjects.operator.Status,
 		nil, /*triggerErr func*/
@@ -425,9 +447,55 @@ func sanitizeInstanceStatus(status *opv1.OperatorStatus) {
 	})
 }
 
+func sanitizeObjectMeta(meta *metav1.ObjectMeta) {
+	// Treat empty array as nil for easier comparison.
+	if len(meta.Finalizers) == 0 {
+		meta.Finalizers = nil
+	}
+}
+
 func TestSync(t *testing.T) {
 	const replica1 = 1
 	testCases := []testCase{
+		{
+			// Finalizer is added to removable CR
+			// (and deployment is created)
+			name:      "add finalizer",
+			removable: true,
+			initialObjects: testObjects{
+				operator: makeFakeOperatorInstance(),
+			},
+			expectedObjects: testObjects{
+				deployment: makeDeployment(
+					withDeploymentGeneration(1, 0)),
+				operator: makeFakeOperatorInstance(
+					withGenerations(1),
+					withTrueConditions(conditionProgressing),
+					withFalseConditions(conditionAvailable),
+					withFinalizers(finalizerName),
+				),
+			},
+		},
+		{
+			// Deployment and finalizer are deleted on DeletionTimestamp
+			name:      "CR removed",
+			removable: true,
+			initialObjects: testObjects{
+				deployment: makeDeployment(
+					withDeploymentGeneration(1, 1),
+					withDeploymentStatus(replica1, replica1, replica1)),
+				operator: makeFakeOperatorInstance(
+					withGenerations(1),
+					withFinalizers(finalizerName),
+					withDeletionTimestamp()),
+			},
+			expectedObjects: testObjects{
+				operator: makeFakeOperatorInstance(
+					withGenerations(1),
+					// finalizer is removed,
+					withDeletionTimestamp()),
+			},
+		},
 		{
 			// Only CR exists, everything else is created
 			name: "initial sync",
@@ -542,6 +610,11 @@ func TestSync(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			// Initialize
+			if test.removable {
+				management.SetOperatorRemovable()
+			} else {
+				management.SetOperatorNotRemovable()
+			}
 			ctx := newTestContext(test, t)
 
 			// Act
@@ -569,18 +642,41 @@ func TestSync(t *testing.T) {
 					t.Errorf("Unexpected Deployment %+v content:\n%s", operandName, cmp.Diff(test.expectedObjects.deployment, actualDeployment))
 				}
 			}
+			if test.expectedObjects.deployment == nil && test.initialObjects.deployment != nil {
+				deployName := test.initialObjects.deployment.Name
+				actualDeployment, err := ctx.coreClient.AppsV1().Deployments(operandNamespace).Get(context.TODO(), deployName, metav1.GetOptions{})
+				if err == nil {
+					t.Errorf("Expected Deployment to be deleted, found generation %d", actualDeployment.Generation)
+				}
+				if !errors.IsNotFound(err) {
+					t.Errorf("Expecetd error to be NotFound, got %s", err)
+				}
+			}
 
-			// Check expectedObjects.driver.Status
+			// Check expectedObjects.operator.Status
 			if test.expectedObjects.operator != nil {
 				_, actualStatus, _, err := ctx.operatorClient.GetOperatorState()
 				if err != nil {
-					t.Errorf("Failed to get Driver: %v", err)
+					t.Errorf("Failed to get operator: %v", err)
 				}
 				sanitizeInstanceStatus(actualStatus)
 				sanitizeInstanceStatus(&test.expectedObjects.operator.Status)
 				if !equality.Semantic.DeepEqual(test.expectedObjects.operator.Status, *actualStatus) {
-					t.Errorf("Unexpected Driver %+v content:\n%s", operandName, cmp.Diff(test.expectedObjects.operator.Status, *actualStatus))
+					t.Errorf("Unexpected operator %+v content:\n%s", operandName, cmp.Diff(test.expectedObjects.operator.Status, *actualStatus))
 				}
+			}
+
+			// Check expected ObjectMeta
+			actualMeta, err := ctx.operatorClient.GetObjectMeta()
+			if err != nil {
+				t.Errorf("Failed to get operator: %v", err)
+			}
+			t.Logf("JSAF: actual meta: %+v", actualMeta.Finalizers)
+			sanitizeObjectMeta(actualMeta)
+			expectedMeta := &test.expectedObjects.operator.ObjectMeta
+			sanitizeObjectMeta(expectedMeta)
+			if !equality.Semantic.DeepEqual(actualMeta, expectedMeta) {
+				t.Errorf("Unexpected operator %+v ObjectMeta content:\n%s", operandName, cmp.Diff(expectedMeta, actualMeta))
 			}
 		})
 	}

--- a/pkg/operator/deploymentcontroller/deployment_controller_test.go
+++ b/pkg/operator/deploymentcontroller/deployment_controller_test.go
@@ -2,6 +2,7 @@ package deploymentcontroller
 
 import (
 	"context"
+	"os"
 	"sort"
 	"time"
 
@@ -39,7 +40,7 @@ const (
 	operandNamespace = "openshift-dummy-test-deployment"
 	// From github.com/openshift/library-go/pkg/operator/resource/resourceapply/apps.go
 	specHashAnnotation = "operator.openshift.io/spec-hash"
-	finalizerName      = controllerName
+	finalizerName      = "test.operator.openshift.io/" + controllerName
 )
 
 var (
@@ -610,6 +611,7 @@ func TestSync(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			// Initialize
+			os.Setenv("OPERATOR_NAME", "test")
 			if test.removable {
 				management.SetOperatorRemovable()
 			} else {

--- a/pkg/operator/management/management_state.go
+++ b/pkg/operator/management/management_state.go
@@ -1,7 +1,7 @@
 package management
 
 import (
-	"github.com/openshift/api/operator/v1"
+	v1 "github.com/openshift/api/operator/v1"
 )
 
 var (
@@ -27,6 +27,13 @@ func SetOperatorUnmanageable() {
 // bricked, non-automatically recoverable state.
 func SetOperatorNotRemovable() {
 	allowOperatorRemovedState = false
+}
+
+// SetOperatorRemovable is one time choice the operator author can make to indicate the operator supports
+// removing of his operand.
+// This is the default setting, provided here mostly for unit tests.
+func SetOperatorRemovable() {
+	allowOperatorRemovedState = true
 }
 
 // IsOperatorAlwaysManaged means the operator can't be set to unmanaged state.

--- a/pkg/operator/management/management_state.go
+++ b/pkg/operator/management/management_state.go
@@ -38,9 +38,14 @@ func IsOperatorAlwaysManaged() bool {
 	return !getAllowedOperatorUnmanaged()
 }
 
-// IsOperatorNotRemovable means the operator can't bet set to removed state.
+// IsOperatorNotRemovable means the operator can't be set to removed state.
 func IsOperatorNotRemovable() bool {
 	return !getAllowedOperatorRemovedState()
+}
+
+// IsOperatorRemovable means the operator can be set to removed state.
+func IsOperatorRemovable() bool {
+	return getAllowedOperatorRemovedState()
 }
 
 func IsOperatorUnknownState(state v1.ManagementState) bool {

--- a/pkg/operator/management/management_state.go
+++ b/pkg/operator/management/management_state.go
@@ -9,21 +9,17 @@ var (
 	allowOperatorRemovedState   = true
 )
 
-// These are for unit testing
-var (
-	getAllowedOperatorUnmanaged = func() bool {
-		return allowOperatorUnmanagedState
-	}
-	getAllowedOperatorRemovedState = func() bool {
-		return allowOperatorRemovedState
-	}
-)
-
 // SetOperatorAlwaysManaged is one time choice when an operator want to opt-out from supporting the "unmanaged" state.
 // This is a case of control plane operators or operators that are required to always run otherwise the cluster will
 // get into unstable state or critical components will stop working.
 func SetOperatorAlwaysManaged() {
 	allowOperatorUnmanagedState = false
+}
+
+// SetOperatorUnmanageable is one time choice when an operator wants to support the "unmanaged" state.
+// This is the default setting, provided here mostly for unit tests.
+func SetOperatorUnmanageable() {
+	allowOperatorUnmanagedState = true
 }
 
 // SetOperatorNotRemovable is one time choice the operator author can make to indicate the operator does not support
@@ -35,17 +31,17 @@ func SetOperatorNotRemovable() {
 
 // IsOperatorAlwaysManaged means the operator can't be set to unmanaged state.
 func IsOperatorAlwaysManaged() bool {
-	return !getAllowedOperatorUnmanaged()
+	return !allowOperatorUnmanagedState
 }
 
 // IsOperatorNotRemovable means the operator can't be set to removed state.
 func IsOperatorNotRemovable() bool {
-	return !getAllowedOperatorRemovedState()
+	return !allowOperatorRemovedState
 }
 
 // IsOperatorRemovable means the operator can be set to removed state.
 func IsOperatorRemovable() bool {
-	return getAllowedOperatorRemovedState()
+	return allowOperatorRemovedState
 }
 
 func IsOperatorUnknownState(state v1.ManagementState) bool {

--- a/pkg/operator/management/management_state_controller.go
+++ b/pkg/operator/management/management_state_controller.go
@@ -39,6 +39,9 @@ func NewOperatorManagementStateController(
 func (c ManagementStateController) sync(ctx context.Context, syncContext factory.SyncContext) error {
 	detailedSpec, _, _, err := c.operatorClient.GetOperatorState()
 	if apierrors.IsNotFound(err) {
+		if IsOperatorRemovable() {
+			return nil
+		}
 		syncContext.Recorder().Warningf("StatusNotFound", "Unable to determine current operator status for %s", c.operatorName)
 		return nil
 	}

--- a/pkg/operator/managementstatecontroller/management_state_controller.go
+++ b/pkg/operator/managementstatecontroller/management_state_controller.go
@@ -1,4 +1,4 @@
-package management
+package managementstatecontroller
 
 import (
 	"context"
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/condition"
 	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/management"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
 )
@@ -39,7 +40,7 @@ func NewOperatorManagementStateController(
 func (c ManagementStateController) sync(ctx context.Context, syncContext factory.SyncContext) error {
 	detailedSpec, _, _, err := c.operatorClient.GetOperatorState()
 	if apierrors.IsNotFound(err) {
-		if IsOperatorRemovable() {
+		if management.IsOperatorRemovable() {
 			return nil
 		}
 		syncContext.Recorder().Warningf("StatusNotFound", "Unable to determine current operator status for %s", c.operatorName)
@@ -51,19 +52,19 @@ func (c ManagementStateController) sync(ctx context.Context, syncContext factory
 		Status: operatorv1.ConditionFalse,
 	}
 
-	if IsOperatorAlwaysManaged() && detailedSpec.ManagementState == operatorv1.Unmanaged {
+	if management.IsOperatorAlwaysManaged() && detailedSpec.ManagementState == operatorv1.Unmanaged {
 		cond.Status = operatorv1.ConditionTrue
 		cond.Reason = "Unmanaged"
 		cond.Message = fmt.Sprintf("Unmanaged is not supported for %s operator", c.operatorName)
 	}
 
-	if IsOperatorNotRemovable() && detailedSpec.ManagementState == operatorv1.Removed {
+	if management.IsOperatorNotRemovable() && detailedSpec.ManagementState == operatorv1.Removed {
 		cond.Status = operatorv1.ConditionTrue
 		cond.Reason = "Removed"
 		cond.Message = fmt.Sprintf("Removed is not supported for %s operator", c.operatorName)
 	}
 
-	if IsOperatorUnknownState(detailedSpec.ManagementState) {
+	if management.IsOperatorUnknownState(detailedSpec.ManagementState) {
 		cond.Status = operatorv1.ConditionTrue
 		cond.Reason = "Unknown"
 		cond.Message = fmt.Sprintf("Unsupported management state %q for %s operator", detailedSpec.ManagementState, c.operatorName)

--- a/pkg/operator/v1helpers/helpers.go
+++ b/pkg/operator/v1helpers/helpers.go
@@ -234,6 +234,24 @@ func UpdateStaticPodConditionFn(cond operatorv1.OperatorCondition) UpdateStaticP
 	}
 }
 
+// EnsureFinalizer adds a new finalizer to the operator CR, if it does not exists. No-op otherwise.
+// It re-tries on conflicts.
+func EnsureFinalizer(client OperatorClientWithFinalizers, finalizer string) error {
+	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		return client.EnsureFinalizer(finalizer)
+	})
+	return err
+}
+
+// RemoveFinalizer removes a finalizer from the operator CR, if it is there. No-op otherwise.
+// It re-tries on conflicts.
+func RemoveFinalizer(client OperatorClientWithFinalizers, finalizer string) error {
+	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		return client.RemoveFinalizer(finalizer)
+	})
+	return err
+}
+
 type aggregate []error
 
 var _ utilerrors.Aggregate = aggregate{}

--- a/pkg/operator/v1helpers/helpers.go
+++ b/pkg/operator/v1helpers/helpers.go
@@ -3,6 +3,7 @@ package v1helpers
 import (
 	"errors"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -235,8 +236,10 @@ func UpdateStaticPodConditionFn(cond operatorv1.OperatorCondition) UpdateStaticP
 }
 
 // EnsureFinalizer adds a new finalizer to the operator CR, if it does not exists. No-op otherwise.
+// The finalizer name is computed from the controller name and operator name ($OPERATOR_NAME or os.Args[0])
 // It re-tries on conflicts.
-func EnsureFinalizer(client OperatorClientWithFinalizers, finalizer string) error {
+func EnsureFinalizer(client OperatorClientWithFinalizers, controllerName string) error {
+	finalizer := getFinalizerName(controllerName)
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		return client.EnsureFinalizer(finalizer)
 	})
@@ -244,12 +247,26 @@ func EnsureFinalizer(client OperatorClientWithFinalizers, finalizer string) erro
 }
 
 // RemoveFinalizer removes a finalizer from the operator CR, if it is there. No-op otherwise.
+// The finalizer name is computed from the controller name and operator name ($OPERATOR_NAME or os.Args[0])
 // It re-tries on conflicts.
-func RemoveFinalizer(client OperatorClientWithFinalizers, finalizer string) error {
+func RemoveFinalizer(client OperatorClientWithFinalizers, controllerName string) error {
+	finalizer := getFinalizerName(controllerName)
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		return client.RemoveFinalizer(finalizer)
 	})
 	return err
+}
+
+// getFinalizerName computes a nice finalizer name from controllerName and the operator name ($OPERATOR_NAME or os.Args[0]).
+func getFinalizerName(controllerName string) string {
+	return fmt.Sprintf("%s.operator.openshift.io/%s", getOperatorName(), controllerName)
+}
+
+func getOperatorName() string {
+	if name := os.Getenv("OPERATOR_NAME"); name != "" {
+		return name
+	}
+	return os.Args[0]
 }
 
 type aggregate []error

--- a/pkg/operator/v1helpers/interfaces.go
+++ b/pkg/operator/v1helpers/interfaces.go
@@ -31,3 +31,11 @@ type StaticPodOperatorClient interface {
 	// UpdateStaticPodOperatorSpec updates the spec, assuming the given resource  version.
 	UpdateStaticPodOperatorSpec(resourceVersion string, in *operatorv1.StaticPodOperatorSpec) (out *operatorv1.StaticPodOperatorSpec, newResourceVersion string, err error)
 }
+
+type OperatorClientWithFinalizers interface {
+	OperatorClient
+	// EnsureFinalizer adds a new finalizer to the operator CR, if it does not exists. No-op otherwise.
+	EnsureFinalizer(finalizer string) error
+	// RemoveFinalizer removes a finalizer from the operator CR, if it is there. No-op otherwise.
+	RemoveFinalizer(finalizer string) error
+}


### PR DESCRIPTION
This is minimal alternative of https://github.com/openshift/library-go/pull/1013. Only the controllers that are used by CSI driver operators are changed

Goal: Add support for removable operators managed by OLM, namely CSI drivers. Operands (a CSI driver) should be installed when user creates a CR and removed when user deletes it.

* Most library-go controllers log error / warning messages when the operator CR is missing. I updated only the controllers that are used in CSI driver operators to handle missing CRs and return silently.
* Reusing `management.SetOperatorNotRemovable()` to tell CSI controllers to support removing the operands.
* Removable operators may need to add/remove finalizers in the operator CR. I added a new interface `OperatorClientWithFinalizers` that can add/remove finalizers as the controller manage the operands / finish their removal. I avoided `OperatorClient` changes, because it's implemented on too many places.
  *  Again, updated only CSI controllers to add/remove finalizers for removable CSI drivers.

TODO:
  * Fix [`baseController.reportDegraded`](https://github.com/openshift/library-go/blob/4a361189f3da6f13a2a4b5c8fb8bdae68842f791/pkg/controller/factory/base_controller.go#L234) not to log errors / requeue sync with exp. backoff when the operator CR is missing.
      * CSI controllers often use `Factory.WithSyncDegradedOnError()` to simplify error handling.
      * `baseController.reportDegraded` can't use `management.IsOperatorRemovable()` to ignore NotFound for removable operators because of import loop. Shall I move `managementstate.go` to a different package?