### PR TITLE
factory: fix warning event when no resync interval is specified

### DIFF
--- a/pkg/operator/secretspruner/prune_controller.go
+++ b/pkg/operator/secretspruner/prune_controller.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/openshift/library-go/pkg/controller/factory"
 	corev1 "k8s.io/api/core/v1"
@@ -59,7 +60,7 @@ func NewSecretRevisionPruneController(
 	return factory.New().WithInformers(
 		c.podInformer.Informer(),
 		c.secretInformer.Informer(),
-	).WithSync(c.sync).ToController("SecretRevisionPruneController", eventRecorder.WithComponentSuffix("secret-revision-prune-controller"))
+	).WithSync(c.sync).ResyncEvery(1*time.Minute).ToController("SecretRevisionPruneController", eventRecorder.WithComponentSuffix("secret-revision-prune-controller"))
 }
 
 func (c *SecretRevisionPruneController) sync(ctx context.Context, syncContext factory.SyncContext) error {


### PR DESCRIPTION
For controllers that do not use the time-based resync trigger a warning event is produced about they resyncing with `0s`, eg:

`FastControllerResync Controller "ConnectivityCheckController" resync interval is set to 0s which might lead to client request throttling`

This fix handle that case also add a warning when NO resync trigger is defined for a controller (which is a programmer bug as the controller should trigger based on informer or time-based trigger). 