### PR TITLE
static-pods: allow fast-forward to next revision with pending installer

### DIFF
--- a/pkg/operator/staticpod/controller/installer/installer_controller.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller.go
@@ -621,21 +621,33 @@ func (c *InstallerController) newNodeStateForInstallInProgress(ctx context.Conte
 		return nil, false, "", err
 	}
 
+	// quickly move to new revision even when an old installer has been seen, if necessary with force by
+	// deleting the old installer (it might be frozen).
+	if pendingNewRevision := latestRevisionAvailable > currNodeState.TargetRevision; pendingNewRevision {
+		switch installerPod.Status.Phase {
+		case corev1.PodSucceeded, corev1.PodFailed:
+			// stop early, don't wait for ready static operand pod because a new revision is waiting
+		default:
+			// delete non-terminated pod. It may be in some state where it would never terminate, e.g. ContainerCreating
+			if err := c.podsGetter.Pods(c.targetNamespace).Delete(ctx, installerPodName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+				return ret, false, "", err
+			}
+		}
+
+		ret.LastFailedRevision = 0
+		ret.LastFailedTime = nil
+		ret.LastFailedCount = 0
+		ret.TargetRevision = 0
+		ret.LastFailedRevisionErrors = nil
+
+		return ret, false, "new revision pending", nil
+	}
+
 	errors := []string{}
 	reason = ""
 
 	switch installerPod.Status.Phase {
 	case corev1.PodSucceeded:
-		if pendingNewRevision := latestRevisionAvailable > currNodeState.TargetRevision; pendingNewRevision {
-			// stop early, don't wait for ready static pod because a new revision is waiting
-			ret.LastFailedRevision = 0
-			ret.LastFailedTime = nil
-			ret.LastFailedCount = 0
-			ret.TargetRevision = 0
-			ret.LastFailedRevisionErrors = nil
-			return ret, false, "new revision pending", nil
-		}
-
 		state, currentRevision, staticPodReason, failedErrors, err := c.getStaticPodState(ctx, currNodeState.NodeName)
 		if err != nil && apierrors.IsNotFound(err) {
 			// pod not launched yet

--- a/pkg/operator/staticpod/controller/installer/installer_controller_test.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller_test.go
@@ -315,16 +315,12 @@ func TestNewNodeStateForInstallInProgress(t *testing.T) {
 			TargetRevision:  1,
 		}, Expected{
 			&operatorv1.NodeStatus{
-				NodeName:                 "test-node-1",
-				CurrentRevision:          0,
-				TargetRevision:           1, // this is changed to 2 outside of newNodeStateForInstallInProgress
-				LastFailedRevisionErrors: []string{"container: bla bla OOM bla bla"},
-				LastFailedRevision:       1,
-				LastFailedCount:          1,
-				LastFailedTime:           &now,
+				NodeName:        "test-node-1",
+				CurrentRevision: 0,
+				TargetRevision:  0,
 			},
-			true,
-			"installer pod failed: container: bla bla OOM bla bla",
+			false,
+			"new revision pending",
 			false,
 		}},
 
@@ -340,16 +336,29 @@ func TestNewNodeStateForInstallInProgress(t *testing.T) {
 			LastFailedTime:           &before,
 		}, Expected{
 			&operatorv1.NodeStatus{
-				NodeName:                 "test-node-1",
-				CurrentRevision:          0,
-				TargetRevision:           1, // this is changed to 2 outside of newNodeStateForInstallInProgress
-				LastFailedRevisionErrors: []string{"container: bla bla OOM bla bla 2"},
-				LastFailedRevision:       1,
-				LastFailedCount:          3,
-				LastFailedTime:           &now,
+				NodeName:        "test-node-1",
+				CurrentRevision: 0,
+				TargetRevision:  0,
 			},
-			true,
-			"installer pod failed: container: bla bla OOM bla bla 2",
+			false,
+			"new revision pending",
+			false,
+		}},
+
+		{"installer-pending-and-new-revision-pending", []*corev1.Pod{
+			installer("installer-1-test-node-1", corev1.PodPending),
+		}, 2, operatorv1.NodeStatus{
+			NodeName:        "test-node-1",
+			CurrentRevision: 0,
+			TargetRevision:  1,
+		}, Expected{
+			&operatorv1.NodeStatus{
+				NodeName:        "test-node-1",
+				CurrentRevision: 0,
+				TargetRevision:  0,
+			},
+			false,
+			"new revision pending",
 			false,
 		}},
 	} {


### PR DESCRIPTION
Pods that are not terminated, but will never run, block the installer controller today. Typical case: `ContainerCreating` state.