### PR TITLE
static-pods: always set installer reason string

### DIFF
--- a/pkg/operator/staticpod/controller/installer/installer_controller.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller.go
@@ -707,6 +707,13 @@ func (c *InstallerController) newNodeStateForInstallInProgress(ctx context.Conte
 		}
 		ret.LastFailedRevisionErrors = errors
 		return ret, true, fmt.Sprintf("installer pod failed: %v", strings.Join(errors, "\n")), nil
+
+	default:
+		if len(installerPod.Status.Message) > 0 {
+			reason = fmt.Sprintf("installer is not finished: %s", installerPod.Status.Message)
+		} else {
+			reason = fmt.Sprintf("installer is not finished, but in %s phase", installerPod.Status.Phase)
+		}
 	}
 
 	return ret, false, reason, nil

--- a/pkg/operator/staticpod/controller/installer/installer_controller_test.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller_test.go
@@ -103,6 +103,23 @@ func TestNewNodeStateForInstallInProgress(t *testing.T) {
 	}
 	for _, test := range []Test{
 		{"installer-pending", []*corev1.Pod{
+			withMessage(installer("installer-1-test-node-1", corev1.PodPending), "creating containers"),
+		}, 1, operatorv1.NodeStatus{
+			NodeName:        "test-node-1",
+			CurrentRevision: 0,
+			TargetRevision:  1,
+		}, Expected{
+			&operatorv1.NodeStatus{
+				NodeName:        "test-node-1",
+				CurrentRevision: 0,
+				TargetRevision:  1,
+			},
+			false,
+			"installer is not finished: creating containers",
+			false,
+		}},
+
+		{"installer-pending-no-message", []*corev1.Pod{
 			installer("installer-1-test-node-1", corev1.PodPending),
 		}, 1, operatorv1.NodeStatus{
 			NodeName:        "test-node-1",
@@ -115,7 +132,7 @@ func TestNewNodeStateForInstallInProgress(t *testing.T) {
 				TargetRevision:  1,
 			},
 			false,
-			"",
+			"installer is not finished, but in Pending phase",
 			false,
 		}},
 
@@ -132,7 +149,7 @@ func TestNewNodeStateForInstallInProgress(t *testing.T) {
 				TargetRevision:  1,
 			},
 			false,
-			"",
+			"installer is not finished, but in Running phase",
 			false,
 		}},
 


### PR DESCRIPTION
In pending and running phase the reason string was empty, leading to strange incomplete condition messages.