### PR TITLE
Add ${KUBE_RBAC_PROXY_IMAGE} replacer to CSI driver controller

### DIFF
--- a/pkg/operator/csi/csidrivercontrollerservicecontroller/csi_driver_controller_service_controller.go
+++ b/pkg/operator/csi/csidrivercontrollerservicecontroller/csi_driver_controller_service_controller.go
@@ -32,6 +32,7 @@ const (
 	resizerImageEnvName       = "RESIZER_IMAGE"
 	snapshotterImageEnvName   = "SNAPSHOTTER_IMAGE"
 	livenessProbeImageEnvName = "LIVENESS_PROBE_IMAGE"
+	kubeRBACProxyImageEnvName = "KUBE_RBAC_PROXY_IMAGE"
 
 	infraConfigName = "cluster"
 )
@@ -270,6 +271,11 @@ func replacePlaceholders(manifest []byte, spec *opv1.OperatorSpec, clusterID str
 	livenessProbe := os.Getenv(livenessProbeImageEnvName)
 	if livenessProbe != "" {
 		pairs = append(pairs, []string{"${LIVENESS_PROBE_IMAGE}", livenessProbe}...)
+	}
+
+	kubeRBACProxy := os.Getenv(kubeRBACProxyImageEnvName)
+	if kubeRBACProxy != "" {
+		pairs = append(pairs, []string{"${KUBE_RBAC_PROXY_IMAGE}", kubeRBACProxy}...)
 	}
 
 	// Cluster ID

--- a/pkg/operator/csi/csidrivernodeservicecontroller/csi_driver_node_service_controller.go
+++ b/pkg/operator/csi/csidrivernodeservicecontroller/csi_driver_node_service_controller.go
@@ -27,6 +27,7 @@ const (
 	driverImageEnvName              = "DRIVER_IMAGE"
 	nodeDriverRegistrarImageEnvName = "NODE_DRIVER_REGISTRAR_IMAGE"
 	livenessProbeImageEnvName       = "LIVENESS_PROBE_IMAGE"
+	kubeRBACProxyImageEnvName       = "KUBE_RBAC_PROXY_IMAGE"
 )
 
 // DaemonSetHookFunc is a hook function to modify the DaemonSet.
@@ -212,6 +213,11 @@ func replacePlaceholders(manifest []byte, spec *opv1.OperatorSpec) []byte {
 	livenessProbe := os.Getenv(livenessProbeImageEnvName)
 	if livenessProbe != "" {
 		pairs = append(pairs, []string{"${LIVENESS_PROBE_IMAGE}", livenessProbe}...)
+	}
+
+	kubeRBACProxy := os.Getenv(kubeRBACProxyImageEnvName)
+	if kubeRBACProxy != "" {
+		pairs = append(pairs, []string{"${KUBE_RBAC_PROXY_IMAGE}", kubeRBACProxy}...)
 	}
 
 	// Log level


### PR DESCRIPTION
We use kube-rbac-proxy to get https endpoint for metrics.

cc @bertinatto 