### PR TITLE
Bug 1947402: csi: add hook to set Deployment replicas according to numbe of master nodes

### DIFF
--- a/pkg/operator/csi/csidrivercontrollerservicecontroller/csi_driver_controller_service_controller_test.go
+++ b/pkg/operator/csi/csidrivercontrollerservicecontroller/csi_driver_controller_service_controller_test.go
@@ -340,6 +340,13 @@ func withDeploymentGeneration(generations ...int64) deploymentModifier {
 	}
 }
 
+func withDeploymentNodeSelector(selector map[string]string) deploymentModifier {
+	return func(instance *appsv1.Deployment) *appsv1.Deployment {
+		instance.Spec.Template.Spec.NodeSelector = selector
+		return instance
+	}
+}
+
 // Infrastructure
 func makeInfra() *configv1.Infrastructure {
 	return &configv1.Infrastructure{
@@ -756,6 +763,8 @@ spec:
       labels:
         app: test-csi-driver-controller
     spec:
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
       containers:
         - name: csi-driver
           image: ${DRIVER_IMAGE}

--- a/pkg/operator/csi/csidrivernodeservicecontroller/csi_driver_node_service_controller.go
+++ b/pkg/operator/csi/csidrivernodeservicecontroller/csi_driver_node_service_controller.go
@@ -78,10 +78,11 @@ type CSIDriverNodeServiceController struct {
 func NewCSIDriverNodeServiceController(
 	name string,
 	manifest []byte,
+	recorder events.Recorder,
 	operatorClient v1helpers.OperatorClient,
 	kubeClient kubernetes.Interface,
 	dsInformer appsinformersv1.DaemonSetInformer,
-	recorder events.Recorder,
+	optionalInformers []factory.Informer,
 	optionalDaemonSetHooks ...DaemonSetHookFunc,
 ) factory.Controller {
 	c := &CSIDriverNodeServiceController{
@@ -92,10 +93,9 @@ func NewCSIDriverNodeServiceController(
 		dsInformer:             dsInformer,
 		optionalDaemonSetHooks: optionalDaemonSetHooks,
 	}
-
+	informers := append(optionalInformers, operatorClient.Informer(), dsInformer.Informer())
 	return factory.New().WithInformers(
-		operatorClient.Informer(),
-		dsInformer.Informer(),
+		informers...,
 	).WithSync(
 		c.sync,
 	).ResyncEvery(

--- a/pkg/operator/csi/csidrivernodeservicecontroller/csi_driver_node_service_controller_test.go
+++ b/pkg/operator/csi/csidrivernodeservicecontroller/csi_driver_node_service_controller_test.go
@@ -103,10 +103,11 @@ func newTestContext(test testCase, t *testing.T) *testContext {
 	controller := NewCSIDriverNodeServiceController(
 		controllerName,
 		makeFakeManifest(),
+		events.NewInMemoryRecorder(operandName),
 		fakeOperatorClient,
 		coreClient,
 		coreInformerFactory.Apps().V1().DaemonSets(),
-		events.NewInMemoryRecorder(operandName),
+		nil, /* optional informers */
 	)
 
 	// Pretend env vars are set
@@ -314,10 +315,11 @@ func TestDaemonSetHook(t *testing.T) {
 	controller := NewCSIDriverNodeServiceController(
 		controllerName,
 		makeFakeManifest(),
+		events.NewInMemoryRecorder(operandName),
 		fakeOperatorClient,
 		coreClient,
 		coreInformerFactory.Apps().V1().DaemonSets(),
-		events.NewInMemoryRecorder(operandName),
+		nil, /* optional informers */
 		daemonSetAnnotationHook,
 	)
 

--- a/pkg/operator/resource/resourceapply/generic.go
+++ b/pkg/operator/resource/resourceapply/generic.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -33,7 +34,8 @@ func init() {
 	utilruntime.Must(api.InstallKube(genericScheme))
 	utilruntime.Must(apiextensionsv1beta1.AddToScheme(genericScheme))
 	utilruntime.Must(apiextensionsv1.AddToScheme(genericScheme))
-
+	// TODO: remove once openshift/api/pull/929 is merged
+	utilruntime.Must(policyv1.AddToScheme(genericScheme))
 }
 
 type AssetFunc func(name string) ([]byte, error)
@@ -164,6 +166,12 @@ func ApplyDirectly(clients *ClientHolder, recorder events.Recorder, manifests As
 				result.Error = fmt.Errorf("missing kubeClient")
 			} else {
 				result.Result, result.Changed, result.Error = ApplyRoleBinding(clients.kubeClient.RbacV1(), recorder, t)
+			}
+		case *policyv1.PodDisruptionBudget:
+			if clients.kubeClient == nil {
+				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				result.Result, result.Changed, result.Error = ApplyPodDisruptionBudget(clients.kubeClient.PolicyV1(), recorder, t)
 			}
 		case *apiextensionsv1beta1.CustomResourceDefinition:
 			if clients.apiExtensionsClient == nil {

--- a/pkg/operator/resource/resourceapply/policy.go
+++ b/pkg/operator/resource/resourceapply/policy.go
@@ -1,0 +1,47 @@
+package resourceapply
+
+import (
+	"context"
+
+	policyv1 "k8s.io/api/policy/v1"
+	"k8s.io/klog/v2"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	policyclientv1 "k8s.io/client-go/kubernetes/typed/policy/v1"
+
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
+)
+
+func ApplyPodDisruptionBudget(client policyclientv1.PodDisruptionBudgetsGetter, recorder events.Recorder, required *policyv1.PodDisruptionBudget) (*policyv1.PodDisruptionBudget, bool, error) {
+	existing, err := client.PodDisruptionBudgets(required.Namespace).Get(context.TODO(), required.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		actual, err := client.PodDisruptionBudgets(required.Namespace).Create(context.TODO(), required, metav1.CreateOptions{})
+		reportCreateEvent(recorder, required, err)
+		return actual, true, err
+	}
+	if err != nil {
+		return nil, false, err
+	}
+
+	modified := resourcemerge.BoolPtr(false)
+	existingCopy := existing.DeepCopy()
+
+	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
+	contentSame := equality.Semantic.DeepEqual(existingCopy.Spec, required.Spec)
+	if contentSame && !*modified {
+		return existingCopy, false, nil
+	}
+
+	existingCopy.Spec = required.Spec
+
+	if klog.V(4).Enabled() {
+		klog.Infof("PodDisruptionBudget %q changes: %v", required.Name, JSONPatchNoError(existing, existingCopy))
+	}
+
+	actual, err := client.PodDisruptionBudgets(required.Namespace).Update(context.TODO(), existingCopy, metav1.UpdateOptions{})
+	reportUpdateEvent(recorder, required, err)
+	return actual, true, err
+}

--- a/pkg/operator/resource/resourceread/policy.go
+++ b/pkg/operator/resource/resourceread/policy.go
@@ -1,0 +1,25 @@
+package resourceread
+
+import (
+	policyv1 "k8s.io/api/policy/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+)
+
+var (
+	policyScheme = runtime.NewScheme()
+	policyCodecs = serializer.NewCodecFactory(policyScheme)
+)
+
+func init() {
+	utilruntime.Must(policyv1.AddToScheme(policyScheme))
+}
+
+func ReadPodDisruptionBudgetV1OrDie(objBytes []byte) *policyv1.PodDisruptionBudget {
+	requiredObj, err := runtime.Decode(policyCodecs.UniversalDecoder(policyv1.SchemeGroupVersion), objBytes)
+	if err != nil {
+		panic(err)
+	}
+	return requiredObj.(*policyv1.PodDisruptionBudget)
+}

--- a/pkg/operator/staticresourcecontroller/static_resource_controller.go
+++ b/pkg/operator/staticresourcecontroller/static_resource_controller.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -156,6 +157,8 @@ func (c *StaticResourceController) AddKubeInformers(kubeInformersByNamespace v1h
 			ret = ret.AddInformer(informer.Rbac().V1().Roles().Informer())
 		case *rbacv1.RoleBinding:
 			ret = ret.AddInformer(informer.Rbac().V1().RoleBindings().Informer())
+		case *policyv1.PodDisruptionBudget:
+			ret = ret.AddInformer(informer.Policy().V1().PodDisruptionBudgets().Informer())
 		case *storagev1.StorageClass:
 			ret = ret.AddInformer(informer.Storage().V1().StorageClasses().Informer())
 		case *storagev1.CSIDriver:


### PR DESCRIPTION
This patch adds a function hook that detects the number of master nodes in the cluster (based on the `Deployment.Spec.NodeSelector` field) and sets the `Deployment.Spec.Replicas` field accordingly.

This will allow us to set the number of Deployment replicas based on the number of master nodes available. Also, we set anti-affinity rules and This is useful for mainly two things:

1. Prevent the operator going unavailable when draining nodes where the operand is running on.
2. Support the effort of avoiding Deployment rollouts getting stuck in single-node clusters (this also requires setting `maxSurge=0` in the Deployment strategy).

This PR also adds the possibility to create/update PDBs in the static resource controller. This will be required by CSI driver operators that will use the hook introduced in this PR.

CC @openshift/storage
