### PR TITLE
Reduce encryption qps

### DIFF
--- a/pkg/operator/encryption/controllers/condition_controller.go
+++ b/pkg/operator/encryption/controllers/condition_controller.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"k8s.io/klog/v2"
 	"strings"
 	"time"
 
@@ -58,6 +59,8 @@ func NewConditionController(
 }
 
 func (c *conditionController) sync(ctx context.Context, syncContext factory.SyncContext) error {
+	klog.Info("conditionController sync called")
+	defer klog.Info("conditionController ended calling sync")
 	if ready, err := shouldRunEncryptionController(c.operatorClient, c.provider.ShouldRunEncryptionControllers); err != nil || !ready {
 		return err // we will get re-kicked when the operator status updates
 	}

--- a/pkg/operator/encryption/controllers/key_controller.go
+++ b/pkg/operator/encryption/controllers/key_controller.go
@@ -111,6 +111,8 @@ func NewKeyController(
 }
 
 func (c *keyController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	klog.Info("keyController sync called")
+	defer klog.Info("keyController ended calling sync")
 	if ready, err := shouldRunEncryptionController(c.operatorClient, c.provider.ShouldRunEncryptionControllers); err != nil || !ready {
 		return err // we will get re-kicked when the operator status updates
 	}

--- a/pkg/operator/encryption/controllers/migration_controller.go
+++ b/pkg/operator/encryption/controllers/migration_controller.go
@@ -99,6 +99,8 @@ func NewMigrationController(
 }
 
 func (c *migrationController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	klog.Info("migrationController sync called")
+	defer klog.Info("migrationController ended calling sync")
 	if ready, err := shouldRunEncryptionController(c.operatorClient, c.provider.ShouldRunEncryptionControllers); err != nil || !ready {
 		return err // we will get re-kicked when the operator status updates
 	}

--- a/pkg/operator/encryption/controllers/prune_controller.go
+++ b/pkg/operator/encryption/controllers/prune_controller.go
@@ -71,6 +71,8 @@ func NewPruneController(
 }
 
 func (c *pruneController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	klog.Info("pruneController sync called")
+	defer klog.Info("pruneController ended calling sync")
 	if ready, err := shouldRunEncryptionController(c.operatorClient, c.provider.ShouldRunEncryptionControllers); err != nil || !ready {
 		return err // we will get re-kicked when the operator status updates
 	}

--- a/pkg/operator/encryption/controllers/reactors.go
+++ b/pkg/operator/encryption/controllers/reactors.go
@@ -1,0 +1,63 @@
+package controllers
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/diff"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+)
+
+func NewResourceVersionProtector(delegate cache.SharedIndexInformer) cache.SharedIndexInformer {
+	return &resourceVersionProtector{delegate}
+}
+
+type resourceVersionProtector struct {
+	cache.SharedIndexInformer
+}
+
+func (rvp *resourceVersionProtector) AddEventHandler(delegate cache.ResourceEventHandler) {
+	rvp.SharedIndexInformer.AddEventHandler(eventHandlerWrapper(delegate))
+}
+
+func eventHandlerWrapper(delegate cache.ResourceEventHandler) cache.ResourceEventHandlerFuncs {
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) { delegate.OnAdd(obj) },
+		UpdateFunc: func(old, new interface{}) {
+			newRuntimeObj, ok := new.(runtime.Object)
+			if !ok {
+				utilruntime.HandleError(fmt.Errorf("updated object %+v is not runtime Object", newRuntimeObj))
+				return
+			}
+			oldRunTimeObj, ok := old.(runtime.Object)
+			if !ok {
+				utilruntime.HandleError(fmt.Errorf("updated object %+v is not runtime Object", oldRunTimeObj))
+				return
+			}
+			newMetaAccessor, err := meta.Accessor(newRuntimeObj)
+			if err != nil {
+				utilruntime.HandleError(fmt.Errorf("unable to get the meta accessor from %+v due to %v", newRuntimeObj, err))
+				return
+			}
+			oldMetaAccessor, err := meta.Accessor(oldRunTimeObj)
+			if err != nil {
+				utilruntime.HandleError(fmt.Errorf("unable to get the meta accessor from %+v due to %v", oldRunTimeObj, err))
+				return
+			}
+			if newMetaAccessor.GetResourceVersion() == oldMetaAccessor.GetResourceVersion() {
+				// periodic resync will send update events two different versions of the same obj will always have different RVs.
+				// TODO: rm
+				klog.Info("periodic resync detected")
+				return
+			}
+
+			// TODO: rm
+			klog.Infof("Update function diff: %v", diff.ObjectDiff(old, new))
+			delegate.OnUpdate(old, new)
+		},
+		DeleteFunc: func(obj interface{}) { delegate.OnDelete(obj) },
+	}
+}

--- a/pkg/operator/encryption/controllers/state_controller.go
+++ b/pkg/operator/encryption/controllers/state_controller.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"k8s.io/klog/v2"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -77,6 +78,8 @@ func NewStateController(
 }
 
 func (c *stateController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	klog.Info("stateController sync called")
+	defer klog.Info("stateController ended calling sync")
 	if ready, err := shouldRunEncryptionController(c.operatorClient, c.provider.ShouldRunEncryptionControllers); err != nil || !ready {
 		return err // we will get re-kicked when the operator status updates
 	}


### PR DESCRIPTION
Synchronizing encryption controllers is expensive because they pull data directly from the servers to get the most recent data.

By default, the controllers resync every 60 seconds. However, tighter loops can be enforced on dependencies. For example, the authentication operator reconciles its resource every 20 seconds.

This PR introduces two wrappers. One for reacting to changes only if an RV has changed and the other one for ignoring updates to nodes since the node's names cannot change.

This allows us to save QPS both on the encrypted and unencrypted clusters.

In the future, we might push it a bit further and avoid QPS entirely when the encryption is disabled. 