### PR TITLE
WIP: apiserver-encryption: use listers in deployers instead of client

### DIFF
--- a/pkg/operator/encryption/controllers.go
+++ b/pkg/operator/encryption/controllers.go
@@ -50,7 +50,6 @@ func NewControllers(
 				provider,
 				deployer,
 				operatorClient,
-				apiServerClient,
 				apiServerInformer,
 				kubeInformersForNamespaces,
 				secretsClient,

--- a/pkg/operator/encryption/controllers/key_controller_test.go
+++ b/pkg/operator/encryption/controllers/key_controller_test.go
@@ -48,7 +48,7 @@ func TestKeyController(t *testing.T) {
 		targetNamespace          string
 		targetGRs                []schema.GroupResource
 		// expectedActions holds actions to be verified in the form of "verb:resource:namespace"
-		expectedActions            []string
+		expectedActions            []string // excluding the initial informer list and watch
 		validateFunc               func(ts *testing.T, actions []clientgotesting.Action, targetNamespace string, targetGRs []schema.GroupResource)
 		validateOperatorClientFunc func(ts *testing.T, operatorClient v1helpers.OperatorClient)
 		expectedError              error
@@ -76,7 +76,7 @@ func TestKeyController(t *testing.T) {
 			apiServerObjects: []runtime.Object{&configv1.APIServer{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}}},
 			validateFunc: func(ts *testing.T, actions []clientgotesting.Action, targetNamespace string, targetGRs []schema.GroupResource) {
 			},
-			expectedActions: []string{"list:pods:kms"},
+			expectedActions: []string{},
 		},
 
 		{
@@ -89,7 +89,7 @@ func TestKeyController(t *testing.T) {
 			apiServerObjects: []runtime.Object{&configv1.APIServer{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}}},
 			validateFunc: func(ts *testing.T, actions []clientgotesting.Action, targetNamespace string, targetGRs []schema.GroupResource) {
 			},
-			expectedActions: []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed"},
+			expectedActions: []string{"list:secrets:openshift-config-managed"},
 		},
 
 		// Assumes a clean slate, that is, there are no previous resources in the system.
@@ -100,7 +100,7 @@ func TestKeyController(t *testing.T) {
 				{Group: "", Resource: "secrets"},
 			},
 			targetNamespace: "kms",
-			expectedActions: []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "create:secrets:openshift-config-managed", "create:events:kms"},
+			expectedActions: []string{"list:secrets:openshift-config-managed", "create:secrets:openshift-config-managed", "create:events:kms"},
 			initialObjects: []runtime.Object{
 				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
 			},
@@ -147,7 +147,7 @@ func TestKeyController(t *testing.T) {
 			},
 			apiServerObjects: apiServerAesCBC,
 			targetNamespace:  "kms",
-			expectedActions:  []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed"},
+			expectedActions:  []string{"list:secrets:openshift-config-managed"},
 		},
 
 		{
@@ -161,7 +161,7 @@ func TestKeyController(t *testing.T) {
 			},
 			apiServerObjects: apiServerAesCBC,
 			targetNamespace:  "kms",
-			expectedActions:  []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed"},
+			expectedActions:  []string{"list:secrets:openshift-config-managed"},
 		},
 
 		{
@@ -175,7 +175,7 @@ func TestKeyController(t *testing.T) {
 			},
 			apiServerObjects: apiServerAesCBC,
 			targetNamespace:  "kms",
-			expectedActions:  []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "create:secrets:openshift-config-managed", "create:events:kms"},
+			expectedActions:  []string{"list:secrets:openshift-config-managed", "create:secrets:openshift-config-managed", "create:events:kms"},
 		},
 
 		{
@@ -189,7 +189,7 @@ func TestKeyController(t *testing.T) {
 			},
 			apiServerObjects: apiServerAesCBC,
 			targetNamespace:  "kms",
-			expectedActions:  []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "create:secrets:openshift-config-managed", "create:events:kms"},
+			expectedActions:  []string{"list:secrets:openshift-config-managed", "create:secrets:openshift-config-managed", "create:events:kms"},
 			validateFunc: func(ts *testing.T, actions []clientgotesting.Action, targetNamespace string, targetGRs []schema.GroupResource) {
 				wasSecretValidated := false
 				for _, action := range actions {
@@ -248,8 +248,6 @@ func TestKeyController(t *testing.T) {
 			apiServerObjects: apiServerAesCBC,
 			targetNamespace:  "kms",
 			expectedActions: []string{
-				"list:pods:kms",
-				"get:secrets:kms",
 				"list:secrets:openshift-config-managed",
 				"create:secrets:openshift-config-managed",
 				"create:events:kms",
@@ -268,7 +266,7 @@ func TestKeyController(t *testing.T) {
 			},
 			apiServerObjects: apiServerAesCBC,
 			targetNamespace:  "kms",
-			expectedActions:  []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed"},
+			expectedActions:  []string{"list:secrets:openshift-config-managed"},
 		},
 
 		{
@@ -282,7 +280,7 @@ func TestKeyController(t *testing.T) {
 			},
 			apiServerObjects: apiServerAesCBC,
 			targetNamespace:  "kms",
-			expectedActions:  []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "create:secrets:openshift-config-managed", "get:secrets:openshift-config-managed"},
+			expectedActions:  []string{"list:secrets:openshift-config-managed", "create:secrets:openshift-config-managed", "get:secrets:openshift-config-managed"},
 			validateOperatorClientFunc: func(ts *testing.T, operatorClient v1helpers.OperatorClient) {
 				expectedCondition := operatorv1.OperatorCondition{
 					Type:    "EncryptionKeyControllerDegraded",
@@ -332,12 +330,11 @@ func TestKeyController(t *testing.T) {
 			// note that the informer factory is not used in the test - it's only needed to create the controller
 			kubeInformers := v1helpers.NewKubeInformersForNamespaces(fakeKubeClient, "openshift-config-managed", scenario.targetNamespace)
 			fakeSecretClient := fakeKubeClient.CoreV1()
-			fakePodClient := fakeKubeClient.CoreV1()
 			fakeConfigClient := configv1clientfake.NewSimpleClientset(scenario.apiServerObjects...)
 			fakeApiServerClient := fakeConfigClient.ConfigV1().APIServers()
 			fakeApiServerInformer := configv1informers.NewSharedInformerFactory(fakeConfigClient, time.Minute).Config().V1().APIServers()
 
-			deployer, err := encryptiondeployer.NewRevisionLabelPodDeployer("revision", scenario.targetNamespace, kubeInformers, nil, fakePodClient, fakeSecretClient, encryptiondeployer.StaticPodNodeProvider{OperatorClient: fakeOperatorClient})
+			deployer, err := encryptiondeployer.NewRevisionLabelPodDeployer("revision", scenario.targetNamespace, kubeInformers, nil, encryptiondeployer.StaticPodNodeProvider{OperatorClient: fakeOperatorClient})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -345,10 +342,20 @@ func TestKeyController(t *testing.T) {
 
 			target := NewKeyController(scenario.targetNamespace, nil, provider, deployer, fakeOperatorClient, fakeApiServerClient, fakeApiServerInformer, kubeInformers, fakeSecretClient, scenario.encryptionSecretSelector, eventRecorder)
 
+			// start informers
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+			kubeInformers.Start(stopCh)
+			if synced := kubeInformers.WaitForCacheSync(stopCh); !synced {
+				t.Fatal("failed to sync informers")
+			}
+			informerActions := len(fakeKubeClient.Actions())
+
 			// act
 			err = target.Sync(context.TODO(), factory.NewSyncContext("test", eventRecorder))
 
 			// validate
+			nonInformerActions := fakeKubeClient.Actions()[informerActions:]
 			if err == nil && scenario.expectedError != nil {
 				t.Fatal("expected to get an error from sync() method")
 			}
@@ -358,11 +365,11 @@ func TestKeyController(t *testing.T) {
 			if err != nil && scenario.expectedError != nil && err.Error() != scenario.expectedError.Error() {
 				t.Fatalf("unexpected error returned = %v, expected = %v", err, scenario.expectedError)
 			}
-			if err := encryptiontesting.ValidateActionsVerbs(fakeKubeClient.Actions(), scenario.expectedActions); err != nil {
+			if err := encryptiontesting.ValidateActionsVerbs(nonInformerActions, scenario.expectedActions); err != nil {
 				t.Fatalf("incorrect action(s) detected: %v", err)
 			}
 			if scenario.validateFunc != nil {
-				scenario.validateFunc(t, fakeKubeClient.Actions(), scenario.targetNamespace, scenario.targetGRs)
+				scenario.validateFunc(t, nonInformerActions, scenario.targetNamespace, scenario.targetGRs)
 			}
 			if scenario.validateOperatorClientFunc != nil {
 				scenario.validateOperatorClientFunc(t, fakeOperatorClient)

--- a/pkg/operator/encryption/controllers/state_controller_test.go
+++ b/pkg/operator/encryption/controllers/state_controller_test.go
@@ -54,7 +54,7 @@ func TestStateController(t *testing.T) {
 			initialResources: []runtime.Object{
 				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
 			},
-			expectedActions: []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed"},
+			expectedActions: []string{"list:secrets:openshift-config-managed"},
 		},
 
 		// scenario 2: validates if "encryption-config-kms" secret with EncryptionConfiguration in "openshift-config-managed" namespace is created,
@@ -70,7 +70,7 @@ func TestStateController(t *testing.T) {
 				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
 				encryptiontesting.CreateEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 1, []byte("61def964fb967f5d7c44a2af8dab6865")),
 			},
-			expectedActions:       []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config-managed", "create:secrets:openshift-config-managed", "create:events:kms", "create:events:kms"},
+			expectedActions:       []string{"list:secrets:openshift-config-managed", "get:secrets:openshift-config-managed", "create:secrets:openshift-config-managed", "create:events:kms", "create:events:kms"},
 			expectedEncryptionCfg: encryptiontesting.CreateEncryptionCfgNoWriteKey("1", "NjFkZWY5NjRmYjk2N2Y1ZDdjNDRhMmFmOGRhYjY4NjU=", "secrets"),
 			validateFunc: func(ts *testing.T, actions []clientgotesting.Action, destName string, expectedEncryptionCfg *apiserverconfigv1.EncryptionConfiguration) {
 				wasSecretValidated := false
@@ -122,8 +122,6 @@ func TestStateController(t *testing.T) {
 				return ec
 			}(),
 			expectedActions: []string{
-				"list:pods:kms",
-				"get:secrets:kms",
 				"list:secrets:openshift-config-managed",
 				"get:secrets:openshift-config-managed",
 				"create:secrets:openshift-config-managed",
@@ -190,7 +188,7 @@ func TestStateController(t *testing.T) {
 					return ecs
 				}(),
 			},
-			expectedActions: []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config-managed"},
+			expectedActions: []string{"list:secrets:openshift-config-managed", "get:secrets:openshift-config-managed"},
 		},
 
 		// scenario 5
@@ -260,8 +258,6 @@ func TestStateController(t *testing.T) {
 				return ec
 			}(),
 			expectedActions: []string{
-				"list:pods:kms",
-				"get:secrets:kms",
 				"list:secrets:openshift-config-managed",
 				"get:secrets:openshift-config-managed",
 				"update:secrets:openshift-config-managed",
@@ -372,7 +368,7 @@ func TestStateController(t *testing.T) {
 				ec := encryptiontesting.CreateEncryptionCfgWithWriteKey([]encryptiontesting.EncryptionKeysResourceTuple{keysRes})
 				return ec
 			}(),
-			expectedActions: []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config-managed", "update:secrets:openshift-config-managed", "create:events:kms", "create:events:kms"},
+			expectedActions: []string{"list:secrets:openshift-config-managed", "get:secrets:openshift-config-managed", "update:secrets:openshift-config-managed", "create:events:kms", "create:events:kms"},
 			validateFunc: func(ts *testing.T, actions []clientgotesting.Action, destName string, expectedEncryptionCfg *apiserverconfigv1.EncryptionConfiguration) {
 				wasSecretValidated := false
 				for _, action := range actions {
@@ -462,8 +458,6 @@ func TestStateController(t *testing.T) {
 				return ec
 			}(),
 			expectedActions: []string{
-				"list:pods:kms",
-				"get:secrets:kms",
 				"list:secrets:openshift-config-managed",
 				"get:secrets:openshift-config-managed",
 				"update:secrets:openshift-config-managed",
@@ -553,7 +547,7 @@ func TestStateController(t *testing.T) {
 					}
 				*/
 			},
-			expectedActions: []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config-managed", "update:secrets:openshift-config-managed", "create:events:kms", "create:events:kms"},
+			expectedActions: []string{"list:secrets:openshift-config-managed", "get:secrets:openshift-config-managed", "update:secrets:openshift-config-managed", "create:events:kms", "create:events:kms"},
 		},
 
 		// scenario 9
@@ -651,7 +645,7 @@ func TestStateController(t *testing.T) {
 					ts.Errorf("the secret wasn't created and validated")
 				}
 			},
-			expectedActions: []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config-managed", "update:secrets:openshift-config-managed", "create:events:kms", "create:events:kms"},
+			expectedActions: []string{"list:secrets:openshift-config-managed", "get:secrets:openshift-config-managed", "update:secrets:openshift-config-managed", "create:events:kms", "create:events:kms"},
 		},
 
 		// scenario 10
@@ -664,7 +658,7 @@ func TestStateController(t *testing.T) {
 			initialResources: []runtime.Object{
 				encryptiontesting.CreateDummyKubeAPIPodInUnknownPhase("kube-apiserver-1", "kms", "node-1"),
 			},
-			expectedActions: []string{"list:pods:kms"},
+			expectedActions: []string{},
 			expectedError:   errors.New("failed to get converged static pod revision: api server pod kube-apiserver-1 in unknown phase"),
 			validateOperatorClientFunc: func(ts *testing.T, operatorClient v1helpers.OperatorClient) {
 				expectedCondition := operatorv1.OperatorCondition{
@@ -692,7 +686,7 @@ func TestStateController(t *testing.T) {
 					return ecs
 				}(),
 			},
-			expectedActions: []string{"list:pods:kms", "get:secrets:kms"},
+			expectedActions: []string{},
 			expectedError:   fmt.Errorf("invalid encryption config kms/encryption-config-1: yaml: control characters are not allowed"),
 			validateOperatorClientFunc: func(ts *testing.T, operatorClient v1helpers.OperatorClient) {
 				expectedCondition := operatorv1.OperatorCondition{
@@ -741,9 +735,8 @@ func TestStateController(t *testing.T) {
 			// note that the informer factory is not used in the test - it's only needed to create the controller
 			kubeInformers := v1helpers.NewKubeInformersForNamespaces(fakeKubeClient, "openshift-config-managed", scenario.targetNamespace)
 			fakeSecretClient := fakeKubeClient.CoreV1()
-			fakePodClient := fakeKubeClient.CoreV1()
 
-			deployer, err := encryptiondeployer.NewRevisionLabelPodDeployer("revision", scenario.targetNamespace, kubeInformers, nil, fakePodClient, fakeSecretClient, encryptiondeployer.StaticPodNodeProvider{OperatorClient: fakeOperatorClient})
+			deployer, err := encryptiondeployer.NewRevisionLabelPodDeployer("revision", scenario.targetNamespace, kubeInformers, nil, encryptiondeployer.StaticPodNodeProvider{OperatorClient: fakeOperatorClient})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -760,10 +753,20 @@ func TestStateController(t *testing.T) {
 				eventRecorder,
 			)
 
+			// start informers
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+			kubeInformers.Start(stopCh)
+			if synced := kubeInformers.WaitForCacheSync(stopCh); !synced {
+				t.Fatal("failed to sync informers")
+			}
+			informerActions := len(fakeKubeClient.Actions())
+
 			// act
 			err = target.Sync(context.TODO(), factory.NewSyncContext("test", eventRecorder))
 
 			// validate
+			nonInformerActions := fakeKubeClient.Actions()[informerActions:]
 			if err == nil && scenario.expectedError != nil {
 				t.Fatal("expected to get an error from sync() method")
 			}
@@ -773,11 +776,11 @@ func TestStateController(t *testing.T) {
 			if err != nil && scenario.expectedError != nil && err.Error() != scenario.expectedError.Error() {
 				t.Fatalf("unexpected error returned = %v, expected = %v", err, scenario.expectedError)
 			}
-			if err := encryptiontesting.ValidateActionsVerbs(fakeKubeClient.Actions(), scenario.expectedActions); err != nil {
+			if err := encryptiontesting.ValidateActionsVerbs(nonInformerActions, scenario.expectedActions); err != nil {
 				t.Fatalf("incorrect action(s) detected: %v", err)
 			}
 			if scenario.validateFunc != nil {
-				scenario.validateFunc(t, fakeKubeClient.Actions(), fmt.Sprintf("%s-%s", encryptionconfig.EncryptionConfSecretName, scenario.targetNamespace), scenario.expectedEncryptionCfg)
+				scenario.validateFunc(t, nonInformerActions, fmt.Sprintf("%s-%s", encryptionconfig.EncryptionConfSecretName, scenario.targetNamespace), scenario.expectedEncryptionCfg)
 			}
 			if scenario.validateOperatorClientFunc != nil {
 				scenario.validateOperatorClientFunc(t, fakeOperatorClient)

--- a/pkg/operator/encryption/deployer/revisionedpod_test.go
+++ b/pkg/operator/encryption/deployer/revisionedpod_test.go
@@ -11,7 +11,7 @@ import (
 func TestCategorizePods(t *testing.T) {
 	tests := []struct {
 		name                      string
-		pods                      []corev1.Pod
+		pods                      []*corev1.Pod
 		nodes                     []string
 		wantGood                  []*corev1.Pod
 		wantBad                   []*corev1.Pod
@@ -23,39 +23,39 @@ func TestCategorizePods(t *testing.T) {
 	}{
 		{"no pod", nil, nil, nil, nil, true, false, "", false},
 		{
-			"good pods, same revision", []corev1.Pod{
-				*newPod(corev1.PodRunning, corev1.ConditionTrue, "3", "node1"),
-				*newPod(corev1.PodRunning, corev1.ConditionTrue, "3", "node2"),
+			"good pods, same revision", []*corev1.Pod{
+				newPod(corev1.PodRunning, corev1.ConditionTrue, "3", "node1"),
+				newPod(corev1.PodRunning, corev1.ConditionTrue, "3", "node2"),
 			}, []string{"node1", "node2"}, []*corev1.Pod{
 				newPod(corev1.PodRunning, corev1.ConditionTrue, "3", "node1"),
 				newPod(corev1.PodRunning, corev1.ConditionTrue, "3", "node2"),
 			}, nil, false, false, "3", false,
 		},
 		{
-			"good pods, different revision", []corev1.Pod{
-				*newPod(corev1.PodRunning, corev1.ConditionTrue, "3", "node1"),
-				*newPod(corev1.PodRunning, corev1.ConditionTrue, "5", "node2"),
+			"good pods, different revision", []*corev1.Pod{
+				newPod(corev1.PodRunning, corev1.ConditionTrue, "3", "node1"),
+				newPod(corev1.PodRunning, corev1.ConditionTrue, "5", "node2"),
 			}, []string{"node1", "node2"}, []*corev1.Pod{
 				newPod(corev1.PodRunning, corev1.ConditionTrue, "3", "node1"),
 				newPod(corev1.PodRunning, corev1.ConditionTrue, "5", "node2"),
 			}, nil, false, false, "", false,
 		},
 		{
-			"ready and unready pods", []corev1.Pod{
-				*newPod(corev1.PodRunning, corev1.ConditionTrue, "3", "node1"),
-				*newPod(corev1.PodRunning, corev1.ConditionFalse, "3", "node2"),
+			"ready and unready pods", []*corev1.Pod{
+				newPod(corev1.PodRunning, corev1.ConditionTrue, "3", "node1"),
+				newPod(corev1.PodRunning, corev1.ConditionFalse, "3", "node2"),
 			}, []string{"node1", "node2"}, nil, nil, true, false, "3", false,
 		},
 		{
-			"good pods and pending pods", []corev1.Pod{
-				*newPod(corev1.PodRunning, corev1.ConditionTrue, "3", "node1"),
-				*newPod(corev1.PodPending, corev1.ConditionFalse, "3", "node2"),
+			"good pods and pending pods", []*corev1.Pod{
+				newPod(corev1.PodRunning, corev1.ConditionTrue, "3", "node1"),
+				newPod(corev1.PodPending, corev1.ConditionFalse, "3", "node2"),
 			}, []string{"node1", "node2"}, nil, nil, true, false, "3", false,
 		},
 		{
-			"good pods and failed pods", []corev1.Pod{
-				*newPod(corev1.PodRunning, corev1.ConditionTrue, "3", "node1"),
-				*newPod(corev1.PodFailed, corev1.ConditionFalse, "3", "node2"),
+			"good pods and failed pods", []*corev1.Pod{
+				newPod(corev1.PodRunning, corev1.ConditionTrue, "3", "node1"),
+				newPod(corev1.PodFailed, corev1.ConditionFalse, "3", "node2"),
 			}, []string{"node1", "node2"}, []*corev1.Pod{
 				newPod(corev1.PodRunning, corev1.ConditionTrue, "3", "node1"),
 			}, []*corev1.Pod{
@@ -63,9 +63,9 @@ func TestCategorizePods(t *testing.T) {
 			}, false, false, "3", false,
 		},
 		{
-			"good pods and succeeded pods", []corev1.Pod{
-				*newPod(corev1.PodRunning, corev1.ConditionTrue, "3", "node1"),
-				*newPod(corev1.PodSucceeded, corev1.ConditionFalse, "3", "node2"),
+			"good pods and succeeded pods", []*corev1.Pod{
+				newPod(corev1.PodRunning, corev1.ConditionTrue, "3", "node1"),
+				newPod(corev1.PodSucceeded, corev1.ConditionFalse, "3", "node2"),
 			}, []string{"node1", "node2"}, []*corev1.Pod{
 				newPod(corev1.PodRunning, corev1.ConditionTrue, "3", "node1"),
 			}, []*corev1.Pod{
@@ -73,42 +73,42 @@ func TestCategorizePods(t *testing.T) {
 			}, false, false, "3", false,
 		},
 		{
-			"good pods and unknown phase pods", []corev1.Pod{
-				*newPod(corev1.PodRunning, corev1.ConditionTrue, "3", "node1"),
-				*newPod(corev1.PodUnknown, corev1.ConditionFalse, "3", "node2"),
+			"good pods and unknown phase pods", []*corev1.Pod{
+				newPod(corev1.PodRunning, corev1.ConditionTrue, "3", "node1"),
+				newPod(corev1.PodUnknown, corev1.ConditionFalse, "3", "node2"),
 			}, []string{"node1", "node2"}, nil, nil, false, true, "", false,
 		},
 		{
-			"all empty revision", []corev1.Pod{
-				*newPod(corev1.PodRunning, corev1.ConditionTrue, "", "node1"),
-				*newPod(corev1.PodRunning, corev1.ConditionTrue, "", "node2"),
+			"all empty revision", []*corev1.Pod{
+				newPod(corev1.PodRunning, corev1.ConditionTrue, "", "node1"),
+				newPod(corev1.PodRunning, corev1.ConditionTrue, "", "node2"),
 			}, []string{"node1", "node2"}, []*corev1.Pod{
 				newPod(corev1.PodRunning, corev1.ConditionTrue, "", "node1"),
 				newPod(corev1.PodRunning, corev1.ConditionTrue, "", "node2"),
 			}, nil, false, false, "0", false,
 		},
 		{
-			"one empty revision", []corev1.Pod{
-				*newPod(corev1.PodRunning, corev1.ConditionTrue, "", "node1"),
-				*newPod(corev1.PodRunning, corev1.ConditionTrue, "1", "node2"),
+			"one empty revision", []*corev1.Pod{
+				newPod(corev1.PodRunning, corev1.ConditionTrue, "", "node1"),
+				newPod(corev1.PodRunning, corev1.ConditionTrue, "1", "node2"),
 			}, []string{"node1", "node2"}, []*corev1.Pod{
 				newPod(corev1.PodRunning, corev1.ConditionTrue, "", "node1"),
 				newPod(corev1.PodRunning, corev1.ConditionTrue, "1", "node2"),
 			}, nil, false, false, "1", false,
 		},
 		{
-			"one empty revision, one zero", []corev1.Pod{
-				*newPod(corev1.PodRunning, corev1.ConditionTrue, "", "node1"),
-				*newPod(corev1.PodRunning, corev1.ConditionTrue, "0", "node2"),
+			"one empty revision, one zero", []*corev1.Pod{
+				newPod(corev1.PodRunning, corev1.ConditionTrue, "", "node1"),
+				newPod(corev1.PodRunning, corev1.ConditionTrue, "0", "node2"),
 			}, []string{"node1", "node2"}, []*corev1.Pod{
 				newPod(corev1.PodRunning, corev1.ConditionTrue, "", "node1"),
 				newPod(corev1.PodRunning, corev1.ConditionTrue, "0", "node2"),
 			}, nil, false, false, "0", false,
 		},
 		{
-			"one invalid revision", []corev1.Pod{
-				*newPod(corev1.PodRunning, corev1.ConditionTrue, "", "node1"),
-				*newPod(corev1.PodRunning, corev1.ConditionTrue, "abc", "node2"),
+			"one invalid revision", []*corev1.Pod{
+				newPod(corev1.PodRunning, corev1.ConditionTrue, "", "node1"),
+				newPod(corev1.PodRunning, corev1.ConditionTrue, "abc", "node2"),
 			}, []string{"node1", "node2"}, []*corev1.Pod{
 				newPod(corev1.PodRunning, corev1.ConditionTrue, "", "node1"),
 				newPod(corev1.PodRunning, corev1.ConditionTrue, "abc", "node2"),


### PR DESCRIPTION
We did consistent client reads in the apiserver encryption deployers while eventual consistency with a cache (lister) is good enough.