### PR TITLE
extends the maximum time the tests will wait for KAS to reach the same revision

### DIFF
--- a/test/library/apiserver/apiserver.go
+++ b/test/library/apiserver/apiserver.go
@@ -17,7 +17,7 @@ var (
 	// the following parameters specify max timeout after which
 	// apis are considered to not converged
 	waitForAPIRevisionPollInterval = 30 * time.Second
-	waitForAPIRevisionTimeout      = 15 * time.Minute
+	waitForAPIRevisionTimeout      = 22 * time.Minute
 )
 
 // WaitForAPIServerToStabilizeOnTheSameRevision waits until all API Servers are running at the same revision.


### PR DESCRIPTION
Previously the maximum time was 15 minutes, now it is 22 minutes.

I'm increasing the timeout to fix failing tests on AWS platform.
There is a known issue on that platform with the NLB, it needs way more time to remove an unhealthy instance from the service.

That time has increased from 70 seconds to 210 seconds.
That means the time needed to wait for all instances has increased at least by 7 minutes.


xref: https://github.com/openshift/cluster-kube-apiserver-operator/pull/1079