### PR TITLE
extends the threshold for considering the servers stable

### DIFF
--- a/test/library/apiserver/apiserver.go
+++ b/test/library/apiserver/apiserver.go
@@ -11,7 +11,7 @@ import (
 var (
 	// the following parameters specify for how long apis must
 	// stay on the same revision to be considered stable
-	waitForAPIRevisionSuccessThreshold = 3
+	waitForAPIRevisionSuccessThreshold = 6
 	waitForAPIRevisionSuccessInterval  = 1 * time.Minute
 
 	// the following parameters specify max timeout after which


### PR DESCRIPTION
Previously the Kube APIs had to stay on the same revision for 3 minutes to be considered stable.
This is no longer true on AWS platform. The maximum time a server needs to shut down is 270 seconds + the time needed to start the new server.
Thus I am m increasing the threshold to 6 minutes to fix failing tests on AWS platform.