### PR TITLE
CSI: allow to set dynamic client to static resource controller

### DIFF
--- a/pkg/operator/csi/csicontrollerset/csi_controller_set.go
+++ b/pkg/operator/csi/csicontrollerset/csi_controller_set.go
@@ -96,6 +96,7 @@ func (c *CSIControllerSet) WithManagementStateController(operandName string, sup
 func (c *CSIControllerSet) WithStaticResourcesController(
 	name string,
 	kubeClient kubernetes.Interface,
+	dynamicClient dynamic.Interface,
 	kubeInformersForNamespace v1helpers.KubeInformersForNamespaces,
 	manifests resourceapply.AssetFunc,
 	files []string,
@@ -104,7 +105,7 @@ func (c *CSIControllerSet) WithStaticResourcesController(
 		name,
 		manifests,
 		files,
-		(&resourceapply.ClientHolder{}).WithKubernetes(kubeClient),
+		(&resourceapply.ClientHolder{}).WithKubernetes(kubeClient).WithDynamicClient(dynamicClient),
 		c.operatorClient,
 		c.eventRecorder,
 	).AddKubeInformers(kubeInformersForNamespace)


### PR DESCRIPTION
To manage VolumeSnapshotClass objects static resource controller should have a dynamic client[1].
This patch adds a new parameter called `dynamicClient` to `WithStaticResourcesController` function, that allows to specify
the client.

[1] https://github.com/openshift/library-go/pull/1067