### PR TITLE
Bug 1960758: New helper for oc adm must-gather / oc debug

### DIFF
--- a/pkg/image/imageutil/helpers.go
+++ b/pkg/image/imageutil/helpers.go
@@ -222,6 +222,16 @@ func PrioritizeTags(tags []string) {
 	}
 }
 
+// SpecHasTag returns named tag from image stream's spec and boolean whether one was found.
+func SpecHasTag(stream *imagev1.ImageStream, name string) (imagev1.TagReference, bool) {
+	for _, tag := range stream.Spec.Tags {
+		if tag.Name == name {
+			return tag, true
+		}
+	}
+	return imagev1.TagReference{}, false
+}
+
 // StatusHasTag returns named tag from image stream's status and boolean whether one was found.
 func StatusHasTag(stream *imagev1.ImageStream, name string) (imagev1.NamedTagEventList, bool) {
 	for _, tag := range stream.Status.Tags {
@@ -286,10 +296,149 @@ func ImageWithMetadataOrDie(image *imagev1.Image) {
 	}
 }
 
+// TagReferencesLocalTag returns true if the provided tag reference references another image stream tag
+// in the current image stream. This is only true when from points to an ImageStreamTag without a colon
+// or from.name is <streamName>:<tag>.
+func TagReferencesLocalTag(stream *imagev1.ImageStream, tag imagev1.TagReference) (string, bool) {
+	if tag.From == nil || tag.From.Kind != "ImageStreamTag" {
+		return "", false
+	}
+	if len(tag.From.Namespace) > 0 && tag.From.Namespace != stream.Namespace {
+		return "", false
+	}
+	ref := strings.TrimPrefix(tag.From.Name, stream.Name+":")
+	if strings.Contains(ref, ":") {
+		return "", false
+	}
+	return ref, true
+}
+
+var (
+	// ErrNoStreamRepository is returned if the status dockerImageRepository field was unset but the
+	// method required that value to create a pull spec.
+	ErrNoStreamRepository = fmt.Errorf("no image repository has been set on the image stream status")
+	// ErrWaitForPullSpec is returned when a pull spec cannot be inferred from the image stream automatically
+	// and the user requires a valid image tag.
+	ErrWaitForPullSpec = fmt.Errorf("the pull spec cannot be determined yet")
+)
+
+// ResolveNewestPullSpecForTag returns the most recent available pull spec for the given tag, even
+// if importing that pull spec is still in progress or has failed. Use this method when the current
+// state of the tag as the user sees it is important because you don't want to silently ignore a
+// newer tag request that hasn't yet been imported. Note that if no image has been tagged or pushed,
+// pullSpec will still be returned pointing to the pull spec for the tag within the image repository
+// (<status.dockerImageRepository>:<tag> unless defaultExternal is set) and isTagEmpty will be true.
+// hasStatus is true if the returned pull spec points to an imported / pushed image, or false if
+// a spec tag has not been specified, the spec tag hasn't been imported, or the import has failed.
+// An error is returned only if isTagEmpty is true and status.dockerImageRepository is unset because
+// the administrator has not installed a registry server.
+//
+// Use this method when you need the user intent pull spec and you do not want to tolerate a slightly
+// older image (tooling that needs to error if the user's intent in tagging isn't realized).
+func ResolveNewestPullSpecForTag(stream *imagev1.ImageStream, tag string, defaultExternal bool) (pullSpec string, hasStatus, isTagEmpty bool, err error) {
+	pullSpec, _, hasStatus, isTagEmpty, err = resolvePullSpecForTag(stream, tag, defaultExternal, true)
+	return pullSpec, hasStatus, isTagEmpty, err
+}
+
+// ResolveRecentPullSpecForTag returns the most recent successfully imported pull sec for the
+// given tag, i.e. "last-known-good". Use this method when you can tolerate some lag in picking up
+// the newest version. This method is roughly equivalent to the behavior of pulling the pod from
+// the internal registry. If no image has been tagged or pushed, pullSpec will still be returned
+// pointing to the pull spec for the tag within the image repository
+// (<status.dockerImageRepository>:<tag> unless defaultExternal is set) and isTagEmpty will be true.
+// hasNewer is true if the pull spec does not represent the newest user input, or false if the
+// current user spec tag has been imported successfully. hasStatus is true if the returned pull
+// spec points to an imported / pushed image, or false if a spec tag has not been specified, the
+// spec tag hasn't been imported, or the import has failed. An error is returned only if isTagEmpty
+// is true and status.dockerImageRepository is unset because the administrator has not installed a
+// registry server.
+//
+// This method is typically used by consumers that need the value at the tag and prefer to have a
+// slightly older image over not getting any image at all (or if the image can't be imported
+// due to temporary network or controller issues).
+func ResolveRecentPullSpecForTag(stream *imagev1.ImageStream, tag string, defaultExternal bool) (pullSpec string, hasNewer, hasStatus, isTagEmpty bool, err error) {
+	pullSpec, hasNewer, hasStatus, isTagEmpty, err = resolvePullSpecForTag(stream, tag, defaultExternal, false)
+	return pullSpec, hasNewer, hasStatus, isTagEmpty, err
+}
+
+// resolvePullSpecForTag handles finding the most accurate pull spec depending on whether the user
+// requires the latest or simply wants the most recent imported version (ignores pending imports).
+// If a pull spec cannot be inferred an error is returned. Otherwise the following status values are
+// returned:
+//
+// * hasNewer - a newer version of this tag is being imported but is not ready
+// * hasStatus - this pull spec points to the latest image in the status (has been imported / pushed)
+// * isTagEmpty - no pull spec or push has occurred to this tag, but it's still possible to get a pull spec
+//
+// defaultExternal is considered when isTagEmpty is true (no user input provided) and calculates the pull
+// spec from the external repository base (status.publicDockerImageRepository) if it is set.
+func resolvePullSpecForTag(stream *imagev1.ImageStream, tag string, defaultExternal, requireLatest bool) (pullSpec string, hasNewer, hasStatus, isTagEmpty bool, err error) {
+	if len(tag) == 0 {
+		tag = imagev1.DefaultImageTag
+	}
+	status, _ := StatusHasTag(stream, tag)
+	spec, hasSpec := SpecHasTag(stream, tag)
+	hasSpecTagRef := hasSpec && spec.From != nil && spec.From.Kind == "DockerImage" && spec.ReferencePolicy.Type == imagev1.SourceTagReferencePolicy
+
+	var event *imagev1.TagEvent
+	switch {
+	case len(status.Items) == 0:
+		// nothing in status:
+		// - waiting for import of first image (generation of spec > status)
+		// - spec is empty
+		// - spec is a ref tag to something else that hasn't been imported yet
+		// - spec is a ref tag to another spec tag on this same image stream that doesn't exist
+
+	case hasSpec && spec.Generation != nil && *spec.Generation > status.Items[0].Generation:
+		// waiting for import because spec generation is newer and had a previous image
+		if requireLatest {
+			// note: if spec tag doesn't have a DockerImage kind, we'll have to wait for whatever
+			// logic is necessary for import to run (this could happen if a new Kind is introduced)
+			if !hasSpecTagRef {
+				return "", hasNewer, false, false, ErrWaitForPullSpec
+			}
+		} else {
+			event = &status.Items[0]
+			hasNewer = true
+		}
+	default:
+		// this is the latest version of the image
+		event = &status.Items[0]
+	}
+
+	switch {
+	case event != nil:
+		hasStatus = true
+		pullSpec = resolveReferenceForTagEvent(stream, spec, event)
+	case hasSpecTagRef:
+		// if the user explicitly provided a spec tag we can use
+		pullSpec = resolveReferenceForTagEvent(stream, spec, &imagev1.TagEvent{
+			DockerImageReference: spec.From.Name,
+		})
+	default:
+		isTagEmpty = true
+		repositorySpec := stream.Status.DockerImageRepository
+		if defaultExternal && len(stream.Status.PublicDockerImageRepository) > 0 {
+			repositorySpec = stream.Status.PublicDockerImageRepository
+		}
+		if len(repositorySpec) == 0 {
+			return "", false, false, false, ErrNoStreamRepository
+		}
+		pullSpec = JoinImageStreamTag(repositorySpec, tag)
+	}
+	return pullSpec, hasNewer, hasStatus, isTagEmpty, nil
+}
+
 // ResolveLatestTaggedImage returns the appropriate pull spec for a given tag in
 // the image stream, handling the tag's reference policy if necessary to return
 // a resolved image. Callers that transform an ImageStreamTag into a pull spec
-// should use this method instead of LatestTaggedImage.
+// should use this method instead of LatestTaggedImage. This method ignores pending
+// imports (meaning the requested image may be stale) and will return no pull spec
+// even if one is available on the spec tag (when importing kind DockerImage) if
+// import has not completed.
+//
+// Use ResolvePullSpecForTag() if you wish more control over what type of pull spec
+// is returned and what scenarios should be handled.
 func ResolveLatestTaggedImage(stream *imagev1.ImageStream, tag string) (string, bool) {
 	if len(tag) == 0 {
 		tag = imagev1.DefaultImageTag
@@ -300,31 +449,21 @@ func ResolveLatestTaggedImage(stream *imagev1.ImageStream, tag string) (string, 
 // ResolveTagReference applies the tag reference rules for a stream, tag, and tag event for
 // that tag. It returns true if the tag is
 func resolveTagReference(stream *imagev1.ImageStream, tag string, latest *imagev1.TagEvent) (string, bool) {
+	// no image has been imported, so we can't resolve to a tagged image (we need an image id)
 	if latest == nil {
 		return "", false
 	}
-	return resolveReferenceForTagEvent(stream, tag, latest), true
-}
-
-// SpecHasTag returns named tag from image stream's spec and boolean whether one was found.
-func SpecHasTag(stream *imagev1.ImageStream, name string) (imagev1.TagReference, bool) {
-	for _, tag := range stream.Spec.Tags {
-		if tag.Name == name {
-			return tag, true
-		}
-	}
-	return imagev1.TagReference{}, false
-}
-
-// ResolveReferenceForTagEvent applies the tag reference rules for a stream, tag, and tag event for
-// that tag.
-func resolveReferenceForTagEvent(stream *imagev1.ImageStream, tag string, latest *imagev1.TagEvent) string {
 	// retrieve spec policy - if not found, we use the latest spec
 	ref, ok := SpecHasTag(stream, tag)
 	if !ok {
-		return latest.DockerImageReference
+		return latest.DockerImageReference, true
 	}
+	return resolveReferenceForTagEvent(stream, ref, latest), true
+}
 
+// resolveReferenceForTagEvent applies the tag reference rules for a stream, tag, and tag event for
+// that tag.
+func resolveReferenceForTagEvent(stream *imagev1.ImageStream, ref imagev1.TagReference, latest *imagev1.TagEvent) string {
 	switch ref.ReferencePolicy.Type {
 	// the local reference policy attempts to use image pull through on the integrated
 	// registry if possible


### PR DESCRIPTION
The ResolveLatestTaggedImage utility method was intended for callers that needed to wait for an image import to succeed (trigger controllers and build controllers that need the image SHA). A number of use cases exist where import is not required, such as oc debug and must-gather where the qualified tag is sufficient. Since the existing utility method has confused callers about its limitations and intended use, create a new utility method intended for the three most common use cases:

1. You need to get the user's *current* desired intent (oc adm release new) and want to error out if the import has errors or isn't
   complete
2. You need to get a pull spec but you don't care if it's out of date (oc debug / oc adm must-gather)
3. You need to get a pull spec and you must have imported the image

Add a new ResolvePullSpecForTag method that debug/must-gather will use.