### PR TITLE
CSI: Unify assetFuncs for all controllers

### DIFF
--- a/pkg/operator/csi/csicontrollerset/csi_controller_set.go
+++ b/pkg/operator/csi/csicontrollerset/csi_controller_set.go
@@ -2,6 +2,7 @@ package csicontrollerset
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -101,11 +102,14 @@ func (c *CSIControllerSet) WithStaticResourcesController(
 func (c *CSIControllerSet) WithCredentialsRequestController(
 	name string,
 	operandNamespace string,
-	assetFunc func(string) []byte,
+	assetFunc resourceapply.AssetFunc,
 	file string,
 	dynamicClient dynamic.Interface,
 ) *CSIControllerSet {
-	manifestFile := assetFunc(file)
+	manifestFile, err := assetFunc(file)
+	if err != nil {
+		panic(fmt.Sprintf("asset: Asset(%v): %v", file, err))
+	}
 	c.credentialsRequestController = credentialsrequestcontroller.NewCredentialsRequestController(
 		name,
 		operandNamespace,
@@ -132,7 +136,7 @@ func (c *CSIControllerSet) WithCSIConfigObserverController(
 
 func (c *CSIControllerSet) WithCSIDriverControllerService(
 	name string,
-	assetFunc func(string) []byte,
+	assetFunc resourceapply.AssetFunc,
 	file string,
 	kubeClient kubernetes.Interface,
 	namespacedInformerFactory informers.SharedInformerFactory,
@@ -140,7 +144,10 @@ func (c *CSIControllerSet) WithCSIDriverControllerService(
 	optionalInformers []factory.Informer,
 	optionalDeploymentHooks ...csidrivercontrollerservicecontroller.DeploymentHookFunc,
 ) *CSIControllerSet {
-	manifestFile := assetFunc(file)
+	manifestFile, err := assetFunc(file)
+	if err != nil {
+		panic(fmt.Sprintf("asset: Asset(%v): %v", file, err))
+	}
 	c.csiDriverControllerServiceController = csidrivercontrollerservicecontroller.NewCSIDriverControllerServiceController(
 		name,
 		manifestFile,
@@ -157,14 +164,17 @@ func (c *CSIControllerSet) WithCSIDriverControllerService(
 
 func (c *CSIControllerSet) WithCSIDriverNodeService(
 	name string,
-	assetFunc func(string) []byte,
+	assetFunc resourceapply.AssetFunc,
 	file string,
 	kubeClient kubernetes.Interface,
 	namespacedInformerFactory informers.SharedInformerFactory,
 	optionalInformers []factory.Informer,
 	optionalDaemonSetHooks ...csidrivernodeservicecontroller.DaemonSetHookFunc,
 ) *CSIControllerSet {
-	manifestFile := assetFunc(file)
+	manifestFile, err := assetFunc(file)
+	if err != nil {
+		panic(fmt.Sprintf("asset: Asset(%v): %v", file, err))
+	}
 	c.csiDriverNodeServiceController = csidrivernodeservicecontroller.NewCSIDriverNodeServiceController(
 		name,
 		manifestFile,


### PR DESCRIPTION
Now there is some inconsistency between CSI controllers, some of which require the asset function to return an error and others to panic immediately. 

Due to the transition to embed module that provides only a function that returns an error[1], we need to unify our interfaces for the controllers.

This commit does this by requiring that all controllers now accept a function that returns an error. For controllers that should have panicked, we do an explicit check in the code.

[1] https://golang.org/pkg/embed/#FS.ReadFile