### PR TITLE
add a simple client-cert controller for the single-cluster common case

### DIFF
--- a/pkg/operator/csr/README.md
+++ b/pkg/operator/csr/README.md
@@ -1,0 +1,14 @@
+This package provides a control loop which takes as input
+1. target secret name
+2. cert common name
+3. desired validity (recall that the signing cert can sign for less)
+
+The flow goes like this.
+1. if secret contains a valid client cert good for at least five days or 50% of validity, do nothing.  If not...
+2. create new cert/key pair in memory
+3. create CSR in the API.
+4. watch CSR in the API until it is approved or denied
+5. if denied, write degraded status and return
+6. if approved, update the secret
+
+The secrets have annotations which match our other cert rotation secrets.

--- a/pkg/operator/csr/README.md
+++ b/pkg/operator/csr/README.md
@@ -1,3 +1,5 @@
+You usually want to start with NewSimpleClientCertificateController.
+
 This package provides a control loop which takes as input
 1. target secret name
 2. cert common name

--- a/pkg/operator/csr/cert_controller.go
+++ b/pkg/operator/csr/cert_controller.go
@@ -29,19 +29,10 @@ import (
 )
 
 const (
-	// KubeconfigFile is the name of the kubeconfig file in kubeconfigSecret
-	KubeconfigFile = "kubeconfig"
 	// TLSKeyFile is the name of tls key file in kubeconfigSecret
 	TLSKeyFile = "tls.key"
 	// TLSCertFile is the name of the tls cert file in kubeconfigSecret
 	TLSCertFile = "tls.crt"
-
-	clusterNameAnnotation = "open-cluster-management.io/cluster-name"
-	ClusterNameFile       = "cluster-name"
-	AgentNameFile         = "agent-name"
-
-	ClusterNameLabel = "open-cluster-management.io/cluster-name"
-	AddonNameLabel   = "open-cluster-management.io/addon-name"
 )
 
 // ControllerResyncInterval is exposed so that integration tests can crank up the constroller sync speed.

--- a/pkg/operator/csr/cert_controller.go
+++ b/pkg/operator/csr/cert_controller.go
@@ -1,0 +1,331 @@
+package csr
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509/pkix"
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+
+	certificates "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	certificatesinformers "k8s.io/client-go/informers/certificates/v1"
+	corev1informers "k8s.io/client-go/informers/core/v1"
+	csrclient "k8s.io/client-go/kubernetes/typed/certificates/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	certificateslisters "k8s.io/client-go/listers/certificates/v1"
+	cache "k8s.io/client-go/tools/cache"
+	certutil "k8s.io/client-go/util/cert"
+	"k8s.io/client-go/util/keyutil"
+	"k8s.io/klog/v2"
+)
+
+const (
+	// KubeconfigFile is the name of the kubeconfig file in kubeconfigSecret
+	KubeconfigFile = "kubeconfig"
+	// TLSKeyFile is the name of tls key file in kubeconfigSecret
+	TLSKeyFile = "tls.key"
+	// TLSCertFile is the name of the tls cert file in kubeconfigSecret
+	TLSCertFile = "tls.crt"
+
+	clusterNameAnnotation = "open-cluster-management.io/cluster-name"
+	ClusterNameFile       = "cluster-name"
+	AgentNameFile         = "agent-name"
+
+	ClusterNameLabel = "open-cluster-management.io/cluster-name"
+	AddonNameLabel   = "open-cluster-management.io/addon-name"
+)
+
+// ControllerResyncInterval is exposed so that integration tests can crank up the constroller sync speed.
+var ControllerResyncInterval = 5 * time.Minute
+
+// CSROption includes options that is used to create and monitor csrs
+type CSROption struct {
+	// ObjectMeta is the ObjectMeta shared by all created csrs. It should use GenerateName instead of Name
+	// to generate random csr names
+	ObjectMeta metav1.ObjectMeta
+	// Subject represents the subject of the client certificate used to create csrs
+	Subject *pkix.Name
+	// DNSNames represents DNS names used to create the client certificate
+	DNSNames []string
+	// SignerName is the name of the signer specified in the created csrs
+	SignerName string
+
+	// EventFilterFunc matches csrs created with above options
+	EventFilterFunc factory.EventFilterFunc
+}
+
+// ClientCertOption includes options that is used to create client certificate
+type ClientCertOption struct {
+	// SecretNamespace is the namespace of the secret containing client certificate.
+	SecretNamespace string
+	// SecretName is the name of the secret containing client certificate. The secret will be created if
+	// it does not exist.
+	SecretName string
+	// AdditonalSecretData contains data that will be added into client certificate secret besides tls.key/tls.crt
+	AdditonalSecretData map[string][]byte
+}
+
+// clientCertificateController implements the common logic of hub client certification creation/rotation. It
+// creates a client certificate and rotates it before it becomes expired by using csrs. The client
+// certificate generated is stored in a specific secret with the keys below:
+// 1). tls.key: tls key file
+// 2). tls.crt: tls cert file
+type clientCertificateController struct {
+	ClientCertOption
+	CSROption
+
+	hubCSRLister    certificateslisters.CertificateSigningRequestLister
+	hubCSRClient    csrclient.CertificateSigningRequestInterface
+	spokeCoreClient corev1client.CoreV1Interface
+	controllerName  string
+
+	// csrName is the name of csr created by controller and waiting for approval.
+	csrName string
+
+	// keyData is the private key data used to created a csr
+	// csrName and keyData store the internal state of the controller. They are set after controller creates a new csr
+	// and cleared once the csr is approved and processed by controller. There are 4 combination of their values:
+	//   1. csrName empty, keyData empty: means we aren't trying to create a new client cert, our current one is valid
+	//   2. csrName set, keyData empty: there was bug
+	//   3. csrName set, keyData set: we are waiting for a new cert to be signed.
+	//   4. csrName empty, keydata set: the CSR failed to create, this shouldn't happen, it's a bug.
+	keyData []byte
+}
+
+// NewClientCertificateController return an instance of clientCertificateController
+func NewClientCertificateController(
+	clientCertOption ClientCertOption,
+	csrOption CSROption,
+	hubCSRInformer certificatesinformers.CertificateSigningRequestInformer,
+	hubCSRClient csrclient.CertificateSigningRequestInterface,
+	spokeSecretInformer corev1informers.SecretInformer,
+	spokeCoreClient corev1client.CoreV1Interface,
+	recorder events.Recorder,
+	controllerName string,
+) factory.Controller {
+	c := clientCertificateController{
+		ClientCertOption: clientCertOption,
+		CSROption:        csrOption,
+		hubCSRLister:     hubCSRInformer.Lister(),
+		hubCSRClient:     hubCSRClient,
+		spokeCoreClient:  spokeCoreClient,
+		controllerName:   controllerName,
+	}
+
+	return factory.New().
+		WithFilteredEventsInformersQueueKeyFunc(func(obj runtime.Object) string {
+			key, _ := cache.MetaNamespaceKeyFunc(obj)
+			return key
+		}, func(obj interface{}) bool {
+			accessor, err := meta.Accessor(obj)
+			if err != nil {
+				return false
+			}
+			// only enqueue a specific secret
+			if accessor.GetNamespace() == c.SecretNamespace && accessor.GetName() == c.SecretName {
+				return true
+			}
+			return false
+		}, spokeSecretInformer.Informer()).
+		WithFilteredEventsInformersQueueKeyFunc(func(obj runtime.Object) string {
+			accessor, _ := meta.Accessor(obj)
+			return accessor.GetName()
+		}, c.EventFilterFunc, hubCSRInformer.Informer()).
+		WithSync(c.sync).
+		ResyncEvery(ControllerResyncInterval).
+		ToController(controllerName, recorder)
+}
+
+func (c *clientCertificateController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	// get secret containing client certificate
+	secret, err := c.spokeCoreClient.Secrets(c.SecretNamespace).Get(ctx, c.SecretName, metav1.GetOptions{})
+	switch {
+	case errors.IsNotFound(err):
+		secret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: c.SecretNamespace,
+				Name:      c.SecretName,
+			},
+		}
+	case err != nil:
+		return fmt.Errorf("unable to get secret %q: %w", c.SecretNamespace+"/"+c.SecretName, err)
+	}
+
+	// reconcile pending csr if exists
+	if len(c.csrName) > 0 {
+		newSecretConfig, err := c.syncCSR(secret)
+		if err != nil {
+			c.reset()
+			return err
+		}
+		if len(newSecretConfig) == 0 {
+			return nil
+		}
+		// append additional data into client certificate secret
+		for k, v := range c.AdditonalSecretData {
+			newSecretConfig[k] = v
+		}
+		secret.Data = newSecretConfig
+		// save the changes into secret
+		if err := c.saveSecret(secret); err != nil {
+			return err
+		}
+		syncCtx.Recorder().Eventf("ClientCertificateCreated", "A new client certificate for %s is available", c.controllerName)
+		c.reset()
+		return nil
+	}
+
+	// create a csr to request new client certificate if
+	// a. there is no valid client certificate issued for the current cluster/agent
+	// b. client certificate exists and has less than a random percentage range from 20% to 25% of its life remaining
+	if c.hasValidClientCertificate(secret) {
+		notBefore, notAfter, err := getCertValidityPeriod(secret)
+		if err != nil {
+			return err
+		}
+
+		total := notAfter.Sub(*notBefore)
+		remaining := notAfter.Sub(time.Now())
+		klog.V(4).Infof("Client certificate for %s: time total=%v, remaining=%v, remaining/total=%v", c.controllerName, total, remaining, remaining.Seconds()/total.Seconds())
+		threshold := jitter(0.2, 0.25)
+		if remaining.Seconds()/total.Seconds() > threshold {
+			// Do nothing if the client certificate is valid and has more than a random percentage range from 20% to 25% of its life remaining
+			klog.V(4).Infof("Client certificate for %s is valid and has more than %.2f%% of its life remaining", c.controllerName, threshold*100)
+			return nil
+		}
+		syncCtx.Recorder().Eventf("CertificateRotationStarted", "The current client certificate for %s expires in %v. Start certificate rotation", c.controllerName, remaining.Round(time.Second))
+	} else {
+		syncCtx.Recorder().Eventf("NoValidCertificateFound", "No valid client certificate for %s is found. Bootstrap is required", c.controllerName)
+	}
+
+	// create a new private key
+	c.keyData, err = keyutil.MakeEllipticPrivateKeyPEM()
+	if err != nil {
+		return err
+	}
+
+	// create a csr
+	c.csrName, err = c.createCSR(ctx)
+	if err != nil {
+		c.reset()
+		return err
+	}
+	syncCtx.Recorder().Eventf("CSRCreated", "A csr %q is created for %s", c.csrName, c.controllerName)
+	return nil
+}
+
+func (c *clientCertificateController) syncCSR(secret *corev1.Secret) (map[string][]byte, error) {
+	// skip if there is no ongoing csr
+	if len(c.csrName) == 0 {
+		return nil, fmt.Errorf("no ongoing csr")
+	}
+
+	// skip if csr no longer exists
+	csr, err := c.hubCSRLister.Get(c.csrName)
+	switch {
+	case errors.IsNotFound(err):
+		// fallback to fetching csr from hub apiserver in case it is not cached by informer yet
+		csr, err = c.hubCSRClient.Get(context.Background(), c.csrName, metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			return nil, fmt.Errorf("unable to get csr %q. It might have already been deleted.", c.csrName)
+		}
+	case err != nil:
+		return nil, err
+	}
+
+	// skip if csr is not approved yet
+	if !isCSRApproved(csr) {
+		return nil, nil
+	}
+
+	// skip if csr has no certificate in its status yet
+	if len(csr.Status.Certificate) == 0 {
+		return nil, nil
+	}
+
+	klog.V(4).Infof("Sync csr %v", c.csrName)
+	// check if cert in csr status matches with the corresponding private key
+	if c.keyData == nil {
+		return nil, fmt.Errorf("No private key found for certificate in csr: %s", c.csrName)
+	}
+	_, err = tls.X509KeyPair(csr.Status.Certificate, c.keyData)
+	if err != nil {
+		return nil, fmt.Errorf("Private key does not match with the certificate in csr: %s", c.csrName)
+	}
+
+	data := map[string][]byte{
+		TLSCertFile: csr.Status.Certificate,
+		TLSKeyFile:  c.keyData,
+	}
+
+	return data, nil
+}
+
+func (c *clientCertificateController) createCSR(ctx context.Context) (string, error) {
+	privateKey, err := keyutil.ParsePrivateKeyPEM(c.keyData)
+	if err != nil {
+		return "", fmt.Errorf("invalid private key for certificate request: %w", err)
+	}
+	csrData, err := certutil.MakeCSR(privateKey, c.Subject, c.DNSNames, nil)
+	if err != nil {
+		return "", fmt.Errorf("unable to generate certificate request: %w", err)
+	}
+
+	csr := &certificates.CertificateSigningRequest{
+		ObjectMeta: c.ObjectMeta,
+		Spec: certificates.CertificateSigningRequestSpec{
+			Request: csrData,
+			Usages: []certificates.KeyUsage{
+				certificates.UsageDigitalSignature,
+				certificates.UsageKeyEncipherment,
+				certificates.UsageClientAuth,
+			},
+			SignerName: c.SignerName,
+		},
+	}
+
+	req, err := c.hubCSRClient.Create(ctx, csr, metav1.CreateOptions{})
+	if err != nil {
+		return "", err
+	}
+	return req.Name, nil
+}
+
+func (c *clientCertificateController) saveSecret(secret *corev1.Secret) error {
+	var err error
+	if secret.ResourceVersion == "" {
+		_, err = c.spokeCoreClient.Secrets(c.SecretNamespace).Create(context.Background(), secret, metav1.CreateOptions{})
+		return err
+	}
+	_, err = c.spokeCoreClient.Secrets(c.SecretNamespace).Update(context.Background(), secret, metav1.UpdateOptions{})
+	return err
+}
+
+func (c *clientCertificateController) reset() {
+	c.csrName = ""
+	c.keyData = nil
+}
+
+func (c *clientCertificateController) hasValidClientCertificate(secret *corev1.Secret) bool {
+	if valid, err := IsCertificateValid(secret.Data[TLSCertFile], c.Subject); err == nil {
+		return valid
+	}
+	return false
+}
+
+func jitter(percentage float64, maxFactor float64) float64 {
+	if maxFactor <= 0.0 {
+		maxFactor = 1.0
+	}
+	newPercentage := percentage + percentage*rand.Float64()*maxFactor
+	return newPercentage
+}

--- a/pkg/operator/csr/certificate.go
+++ b/pkg/operator/csr/certificate.go
@@ -14,43 +14,6 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// HasValidClientCertificate checks if there exists a valid client certificate in the given secret
-// Returns true if all the conditions below are met:
-//   1. KubeconfigFile exists when hasKubeconfig is true
-//   2. TLSKeyFile exists
-//   3. TLSCertFile exists and the certificate is not expired
-//   4. If subject is specified, it matches the subject in the certificate stored in TLSCertFile
-func HasValidHubKubeconfig(secret *corev1.Secret, subject *pkix.Name) bool {
-	if len(secret.Data) == 0 {
-		klog.V(4).Infof("No data found in secret %q", secret.Namespace+"/"+secret.Name)
-		return false
-	}
-
-	if _, ok := secret.Data[KubeconfigFile]; !ok {
-		klog.V(4).Infof("No %q found in secret %q", KubeconfigFile, secret.Namespace+"/"+secret.Name)
-		return false
-	}
-
-	if _, ok := secret.Data[TLSKeyFile]; !ok {
-		klog.V(4).Infof("No %q found in secret %q", TLSKeyFile, secret.Namespace+"/"+secret.Name)
-		return false
-	}
-
-	certData, ok := secret.Data[TLSCertFile]
-	if !ok {
-		klog.V(4).Infof("No %q found in secret %q", TLSCertFile, secret.Namespace+"/"+secret.Name)
-		return false
-	}
-
-	valid, err := IsCertificateValid(certData, subject)
-	if err != nil {
-		klog.V(4).Infof("Unable to validate certificate in secret %s: %v", secret.Namespace+"/"+secret.Name, err)
-		return false
-	}
-
-	return valid
-}
-
 // IsCertificateValid return true if
 // 1) All certs in client certificate are not expired.
 // 2) At least one cert matches the given subject if specified

--- a/pkg/operator/csr/certificate.go
+++ b/pkg/operator/csr/certificate.go
@@ -1,0 +1,172 @@
+package csr
+
+import (
+	"crypto/x509/pkix"
+	"errors"
+	"fmt"
+	"time"
+
+	certificatesv1 "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
+	restclient "k8s.io/client-go/rest"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	certutil "k8s.io/client-go/util/cert"
+	"k8s.io/klog/v2"
+)
+
+// HasValidClientCertificate checks if there exists a valid client certificate in the given secret
+// Returns true if all the conditions below are met:
+//   1. KubeconfigFile exists when hasKubeconfig is true
+//   2. TLSKeyFile exists
+//   3. TLSCertFile exists and the certificate is not expired
+//   4. If subject is specified, it matches the subject in the certificate stored in TLSCertFile
+func HasValidHubKubeconfig(secret *corev1.Secret, subject *pkix.Name) bool {
+	if len(secret.Data) == 0 {
+		klog.V(4).Infof("No data found in secret %q", secret.Namespace+"/"+secret.Name)
+		return false
+	}
+
+	if _, ok := secret.Data[KubeconfigFile]; !ok {
+		klog.V(4).Infof("No %q found in secret %q", KubeconfigFile, secret.Namespace+"/"+secret.Name)
+		return false
+	}
+
+	if _, ok := secret.Data[TLSKeyFile]; !ok {
+		klog.V(4).Infof("No %q found in secret %q", TLSKeyFile, secret.Namespace+"/"+secret.Name)
+		return false
+	}
+
+	certData, ok := secret.Data[TLSCertFile]
+	if !ok {
+		klog.V(4).Infof("No %q found in secret %q", TLSCertFile, secret.Namespace+"/"+secret.Name)
+		return false
+	}
+
+	valid, err := IsCertificateValid(certData, subject)
+	if err != nil {
+		klog.V(4).Infof("Unable to validate certificate in secret %s: %v", secret.Namespace+"/"+secret.Name, err)
+		return false
+	}
+
+	return valid
+}
+
+// IsCertificateValid return true if
+// 1) All certs in client certificate are not expired.
+// 2) At least one cert matches the given subject if specified
+func IsCertificateValid(certData []byte, subject *pkix.Name) (bool, error) {
+	certs, err := certutil.ParseCertsPEM(certData)
+	if err != nil {
+		return false, errors.New("unable to parse certificate")
+	}
+
+	if len(certs) == 0 {
+		return false, errors.New("No cert found in certificate")
+	}
+
+	now := time.Now()
+	// make sure no cert in the certificate chain expired
+	for _, cert := range certs {
+		if now.After(cert.NotAfter) {
+			klog.V(4).Infof("Part of the certificate is expired: %v", cert.NotAfter)
+			return false, nil
+		}
+	}
+
+	if subject == nil {
+		return true, nil
+	}
+
+	// check subject of certificates
+	for _, cert := range certs {
+		if cert.Subject.CommonName != subject.CommonName {
+			continue
+		}
+		return true, nil
+	}
+
+	klog.V(4).Infof("Certificate is not issued for subject (cn=%s)", subject.CommonName)
+	return false, nil
+}
+
+// getCertValidityPeriod returns the validity period of the client certificate in the secret
+func getCertValidityPeriod(secret *corev1.Secret) (*time.Time, *time.Time, error) {
+	if secret.Data == nil {
+		return nil, nil, fmt.Errorf("no client certificate found in secret %q", secret.Namespace+"/"+secret.Name)
+	}
+
+	certData, ok := secret.Data[TLSCertFile]
+	if !ok {
+		return nil, nil, fmt.Errorf("no client certificate found in secret %q", secret.Namespace+"/"+secret.Name)
+	}
+
+	certs, err := certutil.ParseCertsPEM(certData)
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to parse TLS certificates: %w", err)
+	}
+
+	if len(certs) == 0 {
+		return nil, nil, errors.New("No cert found in certificate")
+	}
+
+	// find out the validity period for all certs in the certificate chain
+	var notBefore, notAfter *time.Time
+	for index, cert := range certs {
+		if index == 0 {
+			notBefore = &cert.NotBefore
+			notAfter = &cert.NotAfter
+			continue
+		}
+
+		if notBefore.Before(cert.NotBefore) {
+			notBefore = &cert.NotBefore
+		}
+
+		if notAfter.After(cert.NotAfter) {
+			notAfter = &cert.NotAfter
+		}
+	}
+
+	return notBefore, notAfter, nil
+}
+
+// BuildKubeconfig builds a kubeconfig based on a rest config template with a cert/key pair
+func BuildKubeconfig(clientConfig *restclient.Config, certPath, keyPath string) clientcmdapi.Config {
+	// Build kubeconfig.
+	kubeconfig := clientcmdapi.Config{
+		// Define a cluster stanza based on the bootstrap kubeconfig.
+		Clusters: map[string]*clientcmdapi.Cluster{"default-cluster": {
+			Server:                   clientConfig.Host,
+			InsecureSkipTLSVerify:    false,
+			CertificateAuthorityData: clientConfig.CAData,
+		}},
+		// Define auth based on the obtained client cert.
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{"default-auth": {
+			ClientCertificate: certPath,
+			ClientKey:         keyPath,
+		}},
+		// Define a context that connects the auth info and cluster, and set it as the default
+		Contexts: map[string]*clientcmdapi.Context{"default-context": {
+			Cluster:   "default-cluster",
+			AuthInfo:  "default-auth",
+			Namespace: "configuration",
+		}},
+		CurrentContext: "default-context",
+	}
+
+	return kubeconfig
+}
+
+// isCSRApproved returns true if the given csr has been approved
+func isCSRApproved(csr *certificatesv1.CertificateSigningRequest) bool {
+	approved := false
+	for _, condition := range csr.Status.Conditions {
+		if condition.Type == certificatesv1.CertificateDenied {
+			return false
+		} else if condition.Type == certificatesv1.CertificateApproved {
+			approved = true
+		}
+	}
+
+	return approved
+}

--- a/pkg/operator/csr/certificate_test.go
+++ b/pkg/operator/csr/certificate_test.go
@@ -1,0 +1,209 @@
+package csr
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"testing"
+	"time"
+
+	"github.com/openshift/library-go/pkg/operator/csr/csrtestinghelpers"
+	certificates "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
+	certutil "k8s.io/client-go/util/cert"
+)
+
+func TestIsCSRApproved(t *testing.T) {
+	cases := []struct {
+		name        string
+		csr         *certificates.CertificateSigningRequest
+		csrApproved bool
+	}{
+		{
+			name: "pending csr",
+			csr:  csrtestinghelpers.NewCSR(csrtestinghelpers.CSRHolder{}),
+		},
+		{
+			name: "denied csr",
+			csr:  csrtestinghelpers.NewDeniedCSR(csrtestinghelpers.CSRHolder{}),
+		},
+		{
+			name:        "approved csr",
+			csr:         csrtestinghelpers.NewApprovedCSR(csrtestinghelpers.CSRHolder{}),
+			csrApproved: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			csrApproved := isCSRApproved(c.csr)
+			if csrApproved != c.csrApproved {
+				t.Errorf("expected %t, but got %t", c.csrApproved, csrApproved)
+			}
+		})
+	}
+}
+
+func TestHasValidHubKubeconfig(t *testing.T) {
+	cases := []struct {
+		name    string
+		secret  *corev1.Secret
+		subject *pkix.Name
+		isValid bool
+	}{
+		{
+			name:   "no data",
+			secret: csrtestinghelpers.NewHubKubeconfigSecret(testNamespace, testSecretName, "", nil, nil),
+		},
+		{
+			name:   "no kubeconfig",
+			secret: csrtestinghelpers.NewHubKubeconfigSecret(testNamespace, testSecretName, "", nil, map[string][]byte{}),
+		},
+		{
+			name: "no key",
+			secret: csrtestinghelpers.NewHubKubeconfigSecret(testNamespace, testSecretName, "", nil, map[string][]byte{
+				KubeconfigFile: csrtestinghelpers.NewKubeconfig(nil, nil),
+			}),
+		},
+		{
+			name: "no cert",
+			secret: csrtestinghelpers.NewHubKubeconfigSecret(testNamespace, testSecretName, "", &csrtestinghelpers.TestCert{Key: []byte("key")}, map[string][]byte{
+				KubeconfigFile: csrtestinghelpers.NewKubeconfig(nil, nil),
+			}),
+		},
+		{
+			name: "bad cert",
+			secret: csrtestinghelpers.NewHubKubeconfigSecret(testNamespace, testSecretName, "", &csrtestinghelpers.TestCert{Key: []byte("key"), Cert: []byte("bad cert")}, map[string][]byte{
+				KubeconfigFile: csrtestinghelpers.NewKubeconfig(nil, nil),
+			}),
+		},
+		{
+			name: "expired cert",
+			secret: csrtestinghelpers.NewHubKubeconfigSecret(testNamespace, testSecretName, "", csrtestinghelpers.NewTestCert("test", -60*time.Second), map[string][]byte{
+				KubeconfigFile: csrtestinghelpers.NewKubeconfig(nil, nil),
+			}),
+		},
+		{
+			name: "invalid common name",
+			secret: csrtestinghelpers.NewHubKubeconfigSecret(testNamespace, testSecretName, "", csrtestinghelpers.NewTestCert("test", 60*time.Second), map[string][]byte{
+				KubeconfigFile: csrtestinghelpers.NewKubeconfig(nil, nil),
+			}),
+			subject: &pkix.Name{
+				CommonName: "wrong-common-name",
+			},
+		},
+		{
+			name: "valid kubeconfig",
+			secret: csrtestinghelpers.NewHubKubeconfigSecret(testNamespace, testSecretName, "", csrtestinghelpers.NewTestCert("test", 60*time.Second), map[string][]byte{
+				KubeconfigFile: csrtestinghelpers.NewKubeconfig(nil, nil),
+			}),
+			subject: &pkix.Name{
+				CommonName: "test",
+			},
+			isValid: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			isValid := HasValidHubKubeconfig(c.secret, c.subject)
+			if isValid != c.isValid {
+				t.Errorf("expected %t, but got %t", c.isValid, isValid)
+			}
+		})
+	}
+}
+
+func TestIsCertificateValid(t *testing.T) {
+	cases := []struct {
+		name     string
+		testCert *csrtestinghelpers.TestCert
+		subject  *pkix.Name
+		isValid  bool
+	}{
+		{
+			name:     "no cert",
+			testCert: &csrtestinghelpers.TestCert{},
+		},
+		{
+			name:     "bad cert",
+			testCert: &csrtestinghelpers.TestCert{Cert: []byte("bad cert")},
+		},
+		{
+			name:     "expired cert",
+			testCert: csrtestinghelpers.NewTestCert("test", -60*time.Second),
+		},
+		{
+			name:     "invalid common name",
+			testCert: csrtestinghelpers.NewTestCert("test", 60*time.Second),
+			subject: &pkix.Name{
+				CommonName: "wrong-common-name",
+			},
+		},
+		{
+			name: "valid cert",
+			testCert: csrtestinghelpers.NewTestCertWithSubject(pkix.Name{
+				CommonName: "test",
+			}, 60*time.Second),
+			subject: &pkix.Name{
+				CommonName: "test",
+			},
+			isValid: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			isValid, _ := IsCertificateValid(c.testCert.Cert, c.subject)
+			if isValid != c.isValid {
+				t.Errorf("expected %t, but got %t", c.isValid, isValid)
+			}
+		})
+	}
+}
+
+func TestGetCertValidityPeriod(t *testing.T) {
+	certs := []byte{}
+	certs = append(certs, csrtestinghelpers.NewTestCert("cluster0", 10*time.Second).Cert...)
+	secondCert := csrtestinghelpers.NewTestCert("cluster0", 5*time.Second).Cert
+	certs = append(certs, secondCert...)
+	expectedCerts, _ := certutil.ParseCertsPEM(secondCert)
+	cases := []struct {
+		name         string
+		secret       *corev1.Secret
+		expectedCert *x509.Certificate
+		expectedErr  string
+	}{
+		{
+			name:        "no data",
+			secret:      csrtestinghelpers.NewHubKubeconfigSecret(testNamespace, testSecretName, "", nil, nil),
+			expectedErr: "no client certificate found in secret \"testns/testsecret\"",
+		},
+		{
+			name:        "no cert",
+			secret:      csrtestinghelpers.NewHubKubeconfigSecret(testNamespace, testSecretName, "", nil, map[string][]byte{}),
+			expectedErr: "no client certificate found in secret \"testns/testsecret\"",
+		},
+		{
+			name:        "bad cert",
+			secret:      csrtestinghelpers.NewHubKubeconfigSecret(testNamespace, testSecretName, "", &csrtestinghelpers.TestCert{Cert: []byte("bad cert")}, map[string][]byte{}),
+			expectedErr: "unable to parse TLS certificates: data does not contain any valid RSA or ECDSA certificates",
+		},
+		{
+			name:         "valid cert",
+			secret:       csrtestinghelpers.NewHubKubeconfigSecret(testNamespace, testSecretName, "", &csrtestinghelpers.TestCert{Cert: certs}, map[string][]byte{}),
+			expectedCert: expectedCerts[0],
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			notBefore, notAfter, err := getCertValidityPeriod(c.secret)
+			csrtestinghelpers.AssertError(t, err, c.expectedErr)
+			if c.expectedCert == nil {
+				return
+			}
+			if !c.expectedCert.NotBefore.Equal(*notBefore) {
+				t.Errorf("expect %v, but got %v", expectedCerts[0].NotBefore, *notBefore)
+			}
+			if !c.expectedCert.NotAfter.Equal(*notAfter) {
+				t.Errorf("expect %v, but got %v", expectedCerts[0].NotAfter, *notAfter)
+			}
+		})
+	}
+}

--- a/pkg/operator/csr/controller_test.go
+++ b/pkg/operator/csr/controller_test.go
@@ -1,0 +1,192 @@
+package csr
+
+import (
+	"context"
+	"crypto/x509/pkix"
+	"fmt"
+	"testing"
+	"time"
+
+	certificates "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/informers"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+
+	"github.com/openshift/library-go/pkg/operator/csr/csrtestinghelpers"
+)
+
+const (
+	testNamespace  = "testns"
+	testAgentName  = "testagent"
+	testSecretName = "testsecret"
+	testCSRName    = "testcsr"
+)
+
+var commonName = fmt.Sprintf("system:serviceaccount:%s:%s", csrtestinghelpers.TestManagedClusterName, testAgentName)
+
+func TestSync(t *testing.T) {
+	testSubject := &pkix.Name{
+		CommonName: commonName,
+	}
+
+	cases := []struct {
+		name            string
+		queueKey        string
+		secrets         []runtime.Object
+		approvedCSRCert *csrtestinghelpers.TestCert
+		keyDataExpected bool
+		csrNameExpected bool
+		validateActions func(t *testing.T, hubActions, agentActions []clienttesting.Action)
+	}{
+		{
+			name:            "agent bootstrap",
+			secrets:         []runtime.Object{},
+			queueKey:        "key",
+			keyDataExpected: true,
+			csrNameExpected: true,
+			validateActions: func(t *testing.T, hubActions, agentActions []clienttesting.Action) {
+				csrtestinghelpers.AssertActions(t, hubActions, "create")
+				actual := hubActions[0].(clienttesting.CreateActionImpl).Object
+				if _, ok := actual.(*certificates.CertificateSigningRequest); !ok {
+					t.Errorf("expected csr was created, but failed")
+				}
+
+				csrtestinghelpers.AssertActions(t, agentActions, "get")
+			},
+		},
+
+		{
+			name:     "syc csr after bootstrap",
+			queueKey: testSecretName,
+			secrets: []runtime.Object{
+				csrtestinghelpers.NewHubKubeconfigSecret(testNamespace, testSecretName, "1", nil, map[string][]byte{
+					ClusterNameFile: []byte(csrtestinghelpers.TestManagedClusterName),
+					AgentNameFile:   []byte(testAgentName),
+				},
+				),
+			},
+			approvedCSRCert: csrtestinghelpers.NewTestCert(commonName, 10*time.Second),
+			validateActions: func(t *testing.T, hubActions, agentActions []clienttesting.Action) {
+				csrtestinghelpers.AssertActions(t, hubActions, "get")
+				csrtestinghelpers.AssertActions(t, agentActions, "get", "update")
+				actual := agentActions[1].(clienttesting.UpdateActionImpl).Object
+				secret := actual.(*corev1.Secret)
+				valid, err := IsCertificateValid(secret.Data[TLSCertFile], testSubject)
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				if !valid {
+					t.Error("client certificate is invalid")
+				}
+			},
+		},
+		{
+			name:     "sync a valid hub kubeconfig secret",
+			queueKey: testSecretName,
+			secrets: []runtime.Object{
+				csrtestinghelpers.NewHubKubeconfigSecret(testNamespace, testSecretName, "1", csrtestinghelpers.NewTestCert(commonName, 10000*time.Second), map[string][]byte{
+					ClusterNameFile: []byte(csrtestinghelpers.TestManagedClusterName),
+					AgentNameFile:   []byte(testAgentName),
+					KubeconfigFile:  csrtestinghelpers.NewKubeconfig(nil, nil),
+				}),
+			},
+			validateActions: func(t *testing.T, hubActions, agentActions []clienttesting.Action) {
+				csrtestinghelpers.AssertNoActions(t, hubActions)
+				csrtestinghelpers.AssertActions(t, agentActions, "get")
+			},
+		},
+		{
+			name:     "sync an expiring hub kubeconfig secret",
+			queueKey: testSecretName,
+			secrets: []runtime.Object{
+				csrtestinghelpers.NewHubKubeconfigSecret(testNamespace, testSecretName, "1", csrtestinghelpers.NewTestCert(commonName, -3*time.Second), map[string][]byte{
+					ClusterNameFile: []byte(csrtestinghelpers.TestManagedClusterName),
+					AgentNameFile:   []byte(testAgentName),
+					KubeconfigFile:  csrtestinghelpers.NewKubeconfig(nil, nil),
+				}),
+			},
+			keyDataExpected: true,
+			csrNameExpected: true,
+			validateActions: func(t *testing.T, hubActions, agentActions []clienttesting.Action) {
+				csrtestinghelpers.AssertActions(t, hubActions, "create")
+				actual := hubActions[0].(clienttesting.CreateActionImpl).Object
+				if _, ok := actual.(*certificates.CertificateSigningRequest); !ok {
+					t.Errorf("expected csr was created, but failed")
+				}
+				csrtestinghelpers.AssertActions(t, agentActions, "get")
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			csrs := []runtime.Object{}
+			if c.approvedCSRCert != nil {
+				csr := csrtestinghelpers.NewApprovedCSR(csrtestinghelpers.CSRHolder{Name: testCSRName})
+				csr.Status.Certificate = c.approvedCSRCert.Cert
+				csrs = append(csrs, csr)
+			}
+			hubKubeClient := kubefake.NewSimpleClientset(csrs...)
+
+			// GenerateName is not working for fake clent, we set the name with prepend reactor
+			hubKubeClient.PrependReactor(
+				"create",
+				"certificatesigningrequests",
+				func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, csrtestinghelpers.NewCSR(csrtestinghelpers.CSRHolder{Name: testCSRName}), nil
+				},
+			)
+			hubInformerFactory := informers.NewSharedInformerFactory(hubKubeClient, 3*time.Minute)
+			agentKubeClient := kubefake.NewSimpleClientset(c.secrets...)
+
+			clientCertOption := ClientCertOption{
+				SecretNamespace: testNamespace,
+				SecretName:      testSecretName,
+				AdditonalSecretData: map[string][]byte{
+					ClusterNameFile: []byte(csrtestinghelpers.TestManagedClusterName),
+					AgentNameFile:   []byte(testAgentName),
+				},
+			}
+			csrOption := CSROption{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-",
+				},
+				Subject:    testSubject,
+				SignerName: certificates.KubeAPIServerClientSignerName,
+			}
+
+			controller := &clientCertificateController{
+				ClientCertOption: clientCertOption,
+				CSROption:        csrOption,
+				hubCSRLister:     hubInformerFactory.Certificates().V1().CertificateSigningRequests().Lister(),
+				hubCSRClient:     hubKubeClient.CertificatesV1().CertificateSigningRequests(),
+				spokeCoreClient:  agentKubeClient.CoreV1(),
+				controllerName:   "test-agent",
+			}
+
+			if c.approvedCSRCert != nil {
+				controller.csrName = testCSRName
+				controller.keyData = c.approvedCSRCert.Key
+			}
+
+			err := controller.sync(context.TODO(), csrtestinghelpers.NewFakeSyncContext(t, c.queueKey))
+			if err != nil {
+				t.Errorf("unexpected error %v", err)
+			}
+
+			hasKeyData := controller.keyData != nil
+			if c.keyDataExpected != hasKeyData {
+				t.Error("controller.keyData should be set")
+			}
+
+			hasCSRName := controller.csrName != ""
+			if c.csrNameExpected != hasCSRName {
+				t.Error("controller.csrName should be set")
+			}
+
+			c.validateActions(t, hubKubeClient.Actions(), agentKubeClient.Actions())
+		})
+	}
+}

--- a/pkg/operator/csr/controller_test.go
+++ b/pkg/operator/csr/controller_test.go
@@ -23,6 +23,9 @@ const (
 	testAgentName  = "testagent"
 	testSecretName = "testsecret"
 	testCSRName    = "testcsr"
+
+	ClusterNameFile = "cluster-name"
+	AgentNameFile   = "agent-name"
 )
 
 var commonName = fmt.Sprintf("system:serviceaccount:%s:%s", csrtestinghelpers.TestManagedClusterName, testAgentName)

--- a/pkg/operator/csr/csrtestinghelpers/assertion.go
+++ b/pkg/operator/csr/csrtestinghelpers/assertion.go
@@ -1,0 +1,41 @@
+package csrtestinghelpers
+
+import (
+	"testing"
+
+	clienttesting "k8s.io/client-go/testing"
+)
+
+// AssertError asserts the actual error representation is the same with the expected,
+// if the expected error representation is empty, the actual should be nil
+func AssertError(t *testing.T, actual error, expectedErr string) {
+	if len(expectedErr) > 0 && actual == nil {
+		t.Errorf("expected %q error", expectedErr)
+		return
+	}
+	if len(expectedErr) > 0 && actual != nil && actual.Error() != expectedErr {
+		t.Errorf("expected %q error, but got %q", expectedErr, actual.Error())
+		return
+	}
+	if len(expectedErr) == 0 && actual != nil {
+		t.Errorf("unexpected err: %v", actual)
+		return
+	}
+}
+
+// AssertActions asserts the actual actions have the expected action verb
+func AssertActions(t *testing.T, actualActions []clienttesting.Action, expectedVerbs ...string) {
+	if len(actualActions) != len(expectedVerbs) {
+		t.Fatalf("expected %d call but got: %#v", len(expectedVerbs), actualActions)
+	}
+	for i, expected := range expectedVerbs {
+		if actualActions[i].GetVerb() != expected {
+			t.Errorf("expected %s action but got: %#v", expected, actualActions[i])
+		}
+	}
+}
+
+// AssertNoActions asserts no actions are happened
+func AssertNoActions(t *testing.T, actualActions []clienttesting.Action) {
+	AssertActions(t, actualActions)
+}

--- a/pkg/operator/csr/csrtestinghelpers/testinghelpers.go
+++ b/pkg/operator/csr/csrtestinghelpers/testinghelpers.go
@@ -1,0 +1,231 @@
+package csrtestinghelpers
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	cryptorand "crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"math/rand"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/events/eventstesting"
+
+	certv1 "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	certutil "k8s.io/client-go/util/cert"
+	"k8s.io/client-go/util/keyutil"
+	"k8s.io/client-go/util/workqueue"
+)
+
+const (
+	TestManagedClusterName = "testmanagedcluster"
+)
+
+type FakeSyncContext struct {
+	spokeName string
+	recorder  events.Recorder
+	queue     workqueue.RateLimitingInterface
+}
+
+func (f FakeSyncContext) Queue() workqueue.RateLimitingInterface { return f.queue }
+func (f FakeSyncContext) QueueKey() string                       { return f.spokeName }
+func (f FakeSyncContext) Recorder() events.Recorder              { return f.recorder }
+
+func NewFakeSyncContext(t *testing.T, clusterName string) *FakeSyncContext {
+	return &FakeSyncContext{
+		spokeName: clusterName,
+		recorder:  eventstesting.NewTestingEventRecorder(t),
+		queue:     workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+	}
+}
+
+type CSRHolder struct {
+	Name         string
+	Labels       map[string]string
+	SignerName   string
+	CN           string
+	Orgs         []string
+	Username     string
+	ReqBlockType string
+}
+
+func NewCSR(holder CSRHolder) *certv1.CertificateSigningRequest {
+	insecureRand := rand.New(rand.NewSource(0))
+	pk, err := ecdsa.GenerateKey(elliptic.P256(), insecureRand)
+	if err != nil {
+		panic(err)
+	}
+	csrb, err := x509.CreateCertificateRequest(insecureRand, &x509.CertificateRequest{
+		Subject: pkix.Name{
+			CommonName:   holder.CN,
+			Organization: holder.Orgs,
+		},
+		DNSNames:       []string{},
+		EmailAddresses: []string{},
+		IPAddresses:    []net.IP{},
+	}, pk)
+	if err != nil {
+		panic(err)
+	}
+	return &certv1.CertificateSigningRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:         holder.Name,
+			GenerateName: "csr-",
+			Labels:       holder.Labels,
+		},
+		Spec: certv1.CertificateSigningRequestSpec{
+			Username:   holder.Username,
+			Usages:     []certv1.KeyUsage{},
+			SignerName: holder.SignerName,
+			Request:    pem.EncodeToMemory(&pem.Block{Type: holder.ReqBlockType, Bytes: csrb}),
+		},
+	}
+}
+
+func NewDeniedCSR(holder CSRHolder) *certv1.CertificateSigningRequest {
+	csr := NewCSR(holder)
+	csr.Status.Conditions = append(csr.Status.Conditions, certv1.CertificateSigningRequestCondition{
+		Type:   certv1.CertificateDenied,
+		Status: corev1.ConditionTrue,
+	})
+	return csr
+}
+
+func NewApprovedCSR(holder CSRHolder) *certv1.CertificateSigningRequest {
+	csr := NewCSR(holder)
+	csr.Status.Conditions = append(csr.Status.Conditions, certv1.CertificateSigningRequestCondition{
+		Type:   certv1.CertificateApproved,
+		Status: corev1.ConditionTrue,
+	})
+	return csr
+}
+
+func NewKubeconfig(key, cert []byte) []byte {
+	var clientKey, clientCertificate string
+	var clientKeyData, clientCertificateData []byte
+	if key != nil {
+		clientKeyData = key
+	} else {
+		clientKey = "tls.key"
+	}
+	if cert != nil {
+		clientCertificateData = cert
+	} else {
+		clientCertificate = "tls.crt"
+	}
+
+	kubeconfig := clientcmdapi.Config{
+		Clusters: map[string]*clientcmdapi.Cluster{"default-cluster": {
+			Server:                "https://127.0.0.1:6001",
+			InsecureSkipTLSVerify: true,
+		}},
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{"default-auth": {
+			ClientCertificate:     clientCertificate,
+			ClientCertificateData: clientCertificateData,
+			ClientKey:             clientKey,
+			ClientKeyData:         clientKeyData,
+		}},
+		Contexts: map[string]*clientcmdapi.Context{"default-context": {
+			Cluster:   "default-cluster",
+			AuthInfo:  "default-auth",
+			Namespace: "default",
+		}},
+		CurrentContext: "default-context",
+	}
+
+	kubeconfigData, err := clientcmd.Write(kubeconfig)
+	if err != nil {
+		panic(err)
+	}
+	return kubeconfigData
+}
+
+type TestCert struct {
+	Cert []byte
+	Key  []byte
+}
+
+func NewHubKubeconfigSecret(namespace, name, resourceVersion string, cert *TestCert, data map[string][]byte) *corev1.Secret {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       namespace,
+			Name:            name,
+			ResourceVersion: resourceVersion,
+		},
+		Data: data,
+	}
+	if cert != nil && cert.Cert != nil {
+		secret.Data["tls.crt"] = cert.Cert
+	}
+	if cert != nil && cert.Key != nil {
+		secret.Data["tls.key"] = cert.Key
+	}
+	return secret
+}
+
+func NewTestCertWithSubject(subject pkix.Name, duration time.Duration) *TestCert {
+	caKey, err := rsa.GenerateKey(cryptorand.Reader, 2048)
+	if err != nil {
+		panic(err)
+	}
+
+	caCert, err := certutil.NewSelfSignedCACert(certutil.Config{CommonName: "open-cluster-management.io"}, caKey)
+	if err != nil {
+		panic(err)
+	}
+
+	key, err := rsa.GenerateKey(cryptorand.Reader, 2048)
+	if err != nil {
+		panic(err)
+	}
+
+	certDERBytes, err := x509.CreateCertificate(
+		cryptorand.Reader,
+		&x509.Certificate{
+			Subject:      subject,
+			SerialNumber: big.NewInt(1),
+			NotBefore:    caCert.NotBefore,
+			NotAfter:     time.Now().Add(duration).UTC(),
+			KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+			ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		},
+		caCert,
+		key.Public(),
+		caKey,
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	cert, err := x509.ParseCertificate(certDERBytes)
+	if err != nil {
+		panic(err)
+	}
+
+	return &TestCert{
+		Cert: pem.EncodeToMemory(&pem.Block{
+			Type:  certutil.CertificateBlockType,
+			Bytes: cert.Raw,
+		}),
+		Key: pem.EncodeToMemory(&pem.Block{
+			Type:  keyutil.RSAPrivateKeyBlockType,
+			Bytes: x509.MarshalPKCS1PrivateKey(key),
+		}),
+	}
+}
+
+func NewTestCert(commonName string, duration time.Duration) *TestCert {
+	return NewTestCertWithSubject(pkix.Name{
+		CommonName: commonName,
+	}, duration)
+}

--- a/pkg/operator/csr/simple_clientcert_controller.go
+++ b/pkg/operator/csr/simple_clientcert_controller.go
@@ -1,0 +1,50 @@
+package csr
+
+import (
+	"crypto/x509/pkix"
+	"fmt"
+
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// NewSimpleClientCertificateController creates a controller that keeps a secret up to date with a client-cert
+// valid against the kube-apiserver. This version only works in a single cluster.  The base library allows
+// the secret in one cluster and the CSR in another.
+func NewSimpleClientCertificateController(
+	secretNamespace, secretName string,
+	commonName string, groups []string,
+	kubeInformers informers.SharedInformerFactory,
+	kubeClient kubernetes.Interface,
+	recorder events.Recorder,
+) factory.Controller {
+	certOptions := ClientCertOption{
+		SecretNamespace: secretNamespace,
+		SecretName:      secretName,
+	}
+	csrOptions := CSROption{
+		ObjectMeta: metav1.ObjectMeta{},
+		Subject: &pkix.Name{
+			Organization: groups,
+			CommonName:   commonName,
+		},
+		SignerName:      "kubernetes.io/kube-apiserver-client",
+		EventFilterFunc: nil,
+	}
+	controllerName := fmt.Sprintf("client-cert-%s[%s]", secretName, secretNamespace)
+
+	return NewClientCertificateController(
+		certOptions,
+		csrOptions,
+		kubeInformers.Certificates().V1().CertificateSigningRequests(),
+		kubeClient.CertificatesV1().CertificateSigningRequests(),
+		kubeInformers.Core().V1().Secrets(),
+		kubeClient.CoreV1(),
+		recorder,
+		controllerName,
+	)
+}


### PR DESCRIPTION
This package provides a control loop which takes as input
1. target secret name
2. cert common name
3. desired validity (recall that the signing cert can sign for less)

The flow goes like this.
1. if secret contains a valid client cert good for at least five days or 50% of validity, do nothing.  If not...
2. create new cert/key pair in memory
3. create CSR in the API.
4. watch CSR in the API until it is approved or denied
5. if denied, write degraded status and return
6. if approved, update the secret

Thanks to the OCM team who built this in https://github.com/open-cluster-management/registration/tree/a2bb6439160edafaa94610883cd2f582485b5298/pkg/clientcert

remaining tweaks
- [ ] make a separate renewal mode (used by OCM) versus the re-request flow (used by monitoring and most OCP uses). We'll keep both options
- [ ] tweak validity requirements in readme to match reality