### PR TITLE
staticpod: remove misuse of RevisionResource type

### DIFF
--- a/pkg/operator/staticpod/controller/installer/installer_controller_test.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller_test.go
@@ -1728,7 +1728,7 @@ func TestInstallerController_manageInstallationPods(t *testing.T) {
 				eventRecorder:       tt.fields.eventRecorder,
 				installerPodImageFn: tt.fields.installerPodImageFn,
 			}
-			got, err := c.manageInstallationPods(context.TODO(), tt.args.operatorSpec, tt.args.originalOperatorStatus, tt.args.resourceVersion)
+			got, err := c.manageInstallationPods(context.TODO(), tt.args.operatorSpec, tt.args.originalOperatorStatus)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("InstallerController.manageInstallationPods() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -1994,8 +1994,8 @@ func TestSetConditions(t *testing.T) {
 func TestEnsureRequiredResources(t *testing.T) {
 	tests := []struct {
 		name           string
-		certConfigMaps []revision.RevisionResource
-		certSecrets    []revision.RevisionResource
+		certConfigMaps []UnrevisionedResource
+		certSecrets    []UnrevisionedResource
 
 		revisionNumber int32
 		configMaps     []revision.RevisionResource
@@ -2009,10 +2009,10 @@ func TestEnsureRequiredResources(t *testing.T) {
 		},
 		{
 			name: "skip-optional",
-			certConfigMaps: []revision.RevisionResource{
+			certConfigMaps: []UnrevisionedResource{
 				{Name: "foo-cm", Optional: true},
 			},
-			certSecrets: []revision.RevisionResource{
+			certSecrets: []UnrevisionedResource{
 				{Name: "foo-s", Optional: true},
 			},
 		},
@@ -2041,20 +2041,20 @@ func TestEnsureRequiredResources(t *testing.T) {
 		},
 		{
 			name: "wait-required-certs",
-			certConfigMaps: []revision.RevisionResource{
+			certConfigMaps: []UnrevisionedResource{
 				{Name: "foo-cm"},
 			},
-			certSecrets: []revision.RevisionResource{
+			certSecrets: []UnrevisionedResource{
 				{Name: "foo-s"},
 			},
 			expectedErr: "missing required resources: [configmaps: foo-cm, secrets: foo-s]",
 		},
 		{
 			name: "found-required-certs",
-			certConfigMaps: []revision.RevisionResource{
+			certConfigMaps: []UnrevisionedResource{
 				{Name: "foo-cm"},
 			},
-			certSecrets: []revision.RevisionResource{
+			certSecrets: []UnrevisionedResource{
 				{Name: "foo-s"},
 			},
 			startingResources: []runtime.Object{

--- a/pkg/operator/staticpod/controllers.go
+++ b/pkg/operator/staticpod/controllers.go
@@ -40,8 +40,8 @@ type staticPodOperatorControllerBuilder struct {
 
 	// cert information
 	certDir        string
-	certConfigMaps []revisioncontroller.RevisionResource
-	certSecrets    []revisioncontroller.RevisionResource
+	certConfigMaps []installer.UnrevisionedResource
+	certSecrets    []installer.UnrevisionedResource
 
 	// versioner information
 	versionRecorder status.VersionGetter
@@ -74,8 +74,8 @@ func NewBuilder(
 type Builder interface {
 	WithEvents(eventRecorder events.Recorder) Builder
 	WithVersioning(operandName string, versionRecorder status.VersionGetter) Builder
-	WithResources(operandNamespace, staticPodName string, revisionConfigMaps, revisionSecrets []revisioncontroller.RevisionResource) Builder
-	WithCerts(certDir string, certConfigMaps, certSecrets []revisioncontroller.RevisionResource) Builder
+	WithRevisionedResources(operandNamespace, staticPodName string, revisionConfigMaps, revisionSecrets []revisioncontroller.RevisionResource) Builder
+	WithUnrevisionedCerts(certDir string, certConfigMaps, certSecrets []installer.UnrevisionedResource) Builder
 	WithInstaller(command []string) Builder
 	WithMinReadyDuration(minReadyDuration time.Duration) Builder
 	// WithCustomInstaller allows mutating the installer pod definition just before
@@ -96,7 +96,7 @@ func (b *staticPodOperatorControllerBuilder) WithVersioning(operandName string, 
 	return b
 }
 
-func (b *staticPodOperatorControllerBuilder) WithResources(operandNamespace, staticPodName string, revisionConfigMaps, revisionSecrets []revisioncontroller.RevisionResource) Builder {
+func (b *staticPodOperatorControllerBuilder) WithRevisionedResources(operandNamespace, staticPodName string, revisionConfigMaps, revisionSecrets []revisioncontroller.RevisionResource) Builder {
 	b.operandNamespace = operandNamespace
 	b.staticPodName = staticPodName
 	b.revisionConfigMaps = revisionConfigMaps
@@ -104,7 +104,7 @@ func (b *staticPodOperatorControllerBuilder) WithResources(operandNamespace, sta
 	return b
 }
 
-func (b *staticPodOperatorControllerBuilder) WithCerts(certDir string, certConfigMaps, certSecrets []revisioncontroller.RevisionResource) Builder {
+func (b *staticPodOperatorControllerBuilder) WithUnrevisionedCerts(certDir string, certConfigMaps, certSecrets []installer.UnrevisionedResource) Builder {
 	b.certDir = certDir
 	b.certConfigMaps = certConfigMaps
 	b.certSecrets = certSecrets


### PR DESCRIPTION
For unrevisioned resources (like dynamically loaded certs) we should not misuse a type for revisioned resources. This leads to confusion when reading the code.

Steps on bump:

1. replace `WithResources` with `WithRevisionedResources`
2. replace `WithCerts` with `WithUnrevisionedCerts` and change type of last arguments from `[]revision.RevisionResource` to `[]UnrevisionedResource` (same fields).