### PR TITLE
image/registryclient: set insecure and return early in blobMirroredRepository

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,6 @@ require (
 	github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1 // indirect
 	go.etcd.io/etcd v0.5.0-alpha.5.0.20200910180754-dd1b699fc489
 	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83
-	golang.org/x/net v0.0.0-20210224082022-3d97a244fca7
 	golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba
 	gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d // indirect

--- a/pkg/image/registryclient/client.go
+++ b/pkg/image/registryclient/client.go
@@ -1,6 +1,7 @@
 package registryclient
 
 import (
+	"context"
 	"fmt"
 	"hash"
 	"io"
@@ -12,7 +13,6 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
 	"golang.org/x/time/rate"
 
 	"k8s.io/klog/v2"

--- a/pkg/image/registryclient/client.go
+++ b/pkg/image/registryclient/client.go
@@ -236,6 +236,7 @@ func (c *Context) Repository(ctx context.Context, registry *url.URL, repoName st
 	}
 	return &blobMirroredRepository{
 		locator:   locator,
+		insecure:  insecure,
 		strategy:  c.Alternates,
 		retriever: c,
 	}, nil

--- a/pkg/image/registryclient/client_mirrored.go
+++ b/pkg/image/registryclient/client_mirrored.go
@@ -216,6 +216,9 @@ func (r *blobMirroredRepository) alternates(ctx context.Context, fn func(r Repos
 		if err != nil {
 			return err
 		}
+		if len(alternates) == 0 {
+			return attemptErr
+		}
 		if alternateErr := r.attemptRepos(ctx, alternates, fn); alternateErr != nil {
 			return attemptErr
 		}

--- a/pkg/image/registryclient/client_mirrored.go
+++ b/pkg/image/registryclient/client_mirrored.go
@@ -1,6 +1,7 @@
 package registryclient
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/distribution"
 	"github.com/opencontainers/go-digest"
 	"github.com/openshift/library-go/pkg/image/reference"
-	"golang.org/x/net/context"
 	"k8s.io/klog/v2"
 
 	distributionreference "github.com/docker/distribution/reference"

--- a/pkg/image/registryclient/client_test.go
+++ b/pkg/image/registryclient/client_test.go
@@ -2,6 +2,7 @@ package registryclient
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"flag"
 	"fmt"
@@ -27,7 +28,6 @@ import (
 	registryclient "github.com/docker/distribution/registry/client"
 	"github.com/opencontainers/go-digest"
 	imagereference "github.com/openshift/library-go/pkg/image/reference"
-	"golang.org/x/net/context"
 )
 
 type mockRetriever struct {

--- a/pkg/operator/staticpod/installerpod/copy.go
+++ b/pkg/operator/staticpod/installerpod/copy.go
@@ -1,12 +1,12 @@
 package installerpod
 
 import (
-	"golang.org/x/net/context"
-	"k8s.io/klog/v2"
+	"context"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
 
 	"github.com/openshift/library-go/pkg/operator/resource/retry"
 )

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -367,7 +367,6 @@ golang.org/x/crypto/openpgp/s2k
 golang.org/x/crypto/poly1305
 golang.org/x/crypto/salsa20/salsa
 # golang.org/x/net v0.0.0-20210224082022-3d97a244fca7
-## explicit
 golang.org/x/net/context
 golang.org/x/net/context/ctxhttp
 golang.org/x/net/http/httpguts


### PR DESCRIPTION
This is followup to https://github.com/openshift/library-go/pull/1084 fixing:
- setting `insecure` properly for `blobMirroredRepository`
- return proper error if no alternates found
- unit tests for the above two
- replace `golang.org/x/net/context` with built-in `context` package
 
