### PR TITLE
Bug 1963730: moves the cert directory under the target directory

### DIFF
--- a/pkg/operator/staticpod/controller/installer/installer_controller.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller.go
@@ -811,7 +811,7 @@ func (c *InstallerController) ensureInstallerPod(nodeName string, operatorSpec *
 		}
 	}
 	if len(c.certDir) > 0 {
-		args = append(args, fmt.Sprintf("--cert-dir=%s", filepath.Join(hostResourceDirDir, c.certDir)))
+		args = append(args, fmt.Sprintf("--cert-dir=%s", c.certDir))
 		for _, cm := range c.certConfigMaps {
 			if cm.Optional {
 				args = append(args, fmt.Sprintf("--optional-cert-configmaps=%s", cm.Name))

--- a/pkg/operator/staticpod/installerpod/cmd.go
+++ b/pkg/operator/staticpod/installerpod/cmd.go
@@ -287,7 +287,7 @@ func (o *InstallOptions) copyContent(ctx context.Context) error {
 
 	// Copy the current state of the certs as we see them.  This primes us once and allows a kube-apiserver to start once
 	if len(o.CertDir) > 0 {
-		if err := o.copySecretsAndConfigMaps(ctx, o.CertDir,
+		if err := o.copySecretsAndConfigMaps(ctx, path.Join(resourceDir, o.CertDir),
 			sets.NewString(o.CertSecretNames...),
 			sets.NewString(o.OptionalCertSecretNamePrefixes...),
 			sets.NewString(o.CertConfigMapNamePrefixes...),


### PR DESCRIPTION
The target directory holds all files for the current static pod manifest.

As of today, kube-apiserver-certs is accessed by at least two processes, namely the installer pod and the cert-syncer.
Up until now, there was no coordination between these processes that might have lead to many unexpected errors, like https://bugzilla.redhat.com/show_bug.cgi?id=1963730

Moving the cert directory to the target directory (revisioned) ensures that these processes won't step each other's toes.

After this PR /etc/kubernetes/static-pod-resources/kube-apiserver-pod-REVISION/kube-apiserver-certs
Previously it was /etc/kubernetes/static-pod-resources/kube-apiserver-certs