### PR TITLE
Bug 1963730: writes the dynamic certs atomically

### DIFF
--- a/pkg/operator/staticpod/certsyncpod/certsync_controller.go
+++ b/pkg/operator/staticpod/certsyncpod/certsync_controller.go
@@ -157,7 +157,8 @@ func (c *CertSyncController) sync(ctx context.Context, syncCtx factory.SyncConte
 				continue
 			}
 
-			if err := staticpod.WriteFileAtomic([]byte(content), 0644, "configmap", contentDir, filename); err != nil {
+			klog.Infof("Writing configmap manifest %q ...", fullFilename)
+			if err := staticpod.WriteFileAtomic([]byte(content), 0644, contentDir, filename); err != nil {
 				c.eventRecorder.Warningf("CertificateUpdateFailed", "Failed writing file for configmap: %s/%s: %v", configMap.Namespace, configMap.Name, err)
 				errors = append(errors, err)
 				continue
@@ -262,7 +263,8 @@ func (c *CertSyncController) sync(ctx context.Context, syncCtx factory.SyncConte
 				continue
 			}
 
-			if err := staticpod.WriteFileAtomic(content, 0644, "secret", contentDir, filename); err != nil {
+			klog.Infof("Writing secret manifest %q ...", fullFilename)
+			if err := staticpod.WriteFileAtomic(content, 0644, contentDir, filename); err != nil {
 				c.eventRecorder.Warningf("CertificateUpdateFailed", "Failed writing file for secret: %s/%s: %v", secret.Namespace, secret.Name, err)
 				errors = append(errors, err)
 				continue

--- a/pkg/operator/staticpod/certsyncpod/certsync_controller.go
+++ b/pkg/operator/staticpod/certsyncpod/certsync_controller.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/staticpod"
 	"github.com/openshift/library-go/pkg/operator/staticpod/controller/installer"
 )
 
@@ -156,8 +157,7 @@ func (c *CertSyncController) sync(ctx context.Context, syncCtx factory.SyncConte
 				continue
 			}
 
-			klog.Infof("Writing configmap manifest %q ...", fullFilename)
-			if err := ioutil.WriteFile(fullFilename, []byte(content), 0644); err != nil {
+			if err := staticpod.WriteFileAtomic([]byte(content), 0644, "configmap", contentDir, filename); err != nil {
 				c.eventRecorder.Warningf("CertificateUpdateFailed", "Failed writing file for configmap: %s/%s: %v", configMap.Namespace, configMap.Name, err)
 				errors = append(errors, err)
 				continue
@@ -262,8 +262,7 @@ func (c *CertSyncController) sync(ctx context.Context, syncCtx factory.SyncConte
 				continue
 			}
 
-			klog.Infof("Writing secret manifest %q ...", fullFilename)
-			if err := ioutil.WriteFile(fullFilename, content, 0644); err != nil {
+			if err := staticpod.WriteFileAtomic(content, 0644, "secret", contentDir, filename); err != nil {
 				c.eventRecorder.Warningf("CertificateUpdateFailed", "Failed writing file for secret: %s/%s: %v", secret.Namespace, secret.Name, err)
 				errors = append(errors, err)
 				continue

--- a/pkg/operator/staticpod/certsyncpod/certsync_controller.go
+++ b/pkg/operator/staticpod/certsyncpod/certsync_controller.go
@@ -158,7 +158,7 @@ func (c *CertSyncController) sync(ctx context.Context, syncCtx factory.SyncConte
 			}
 
 			klog.Infof("Writing configmap manifest %q ...", fullFilename)
-			if err := staticpod.WriteFileAtomic([]byte(content), 0644, contentDir, filename); err != nil {
+			if err := staticpod.WriteFileAtomic([]byte(content), 0644, fullFilename); err != nil {
 				c.eventRecorder.Warningf("CertificateUpdateFailed", "Failed writing file for configmap: %s/%s: %v", configMap.Namespace, configMap.Name, err)
 				errors = append(errors, err)
 				continue
@@ -264,7 +264,7 @@ func (c *CertSyncController) sync(ctx context.Context, syncCtx factory.SyncConte
 			}
 
 			klog.Infof("Writing secret manifest %q ...", fullFilename)
-			if err := staticpod.WriteFileAtomic(content, 0644, contentDir, filename); err != nil {
+			if err := staticpod.WriteFileAtomic(content, 0644, fullFilename); err != nil {
 				c.eventRecorder.Warningf("CertificateUpdateFailed", "Failed writing file for secret: %s/%s: %v", secret.Namespace, secret.Name, err)
 				errors = append(errors, err)
 				continue

--- a/pkg/operator/staticpod/controller/prune/prune_controller.go
+++ b/pkg/operator/staticpod/controller/prune/prune_controller.go
@@ -28,7 +28,7 @@ import (
 // PruneController is a controller that watches static installer pod revision statuses and spawns
 // a pruner pod to delete old revision resources from disk
 type PruneController struct {
-	targetNamespace, podResourcePrefix string
+	targetNamespace, podResourcePrefix, certDir string
 	// command is the string to use for the pruning pod command
 	command []string
 
@@ -57,6 +57,7 @@ const (
 func NewPruneController(
 	targetNamespace string,
 	podResourcePrefix string,
+	certDir string,
 	command []string,
 	configMapGetter corev1client.ConfigMapsGetter,
 	secretGetter corev1client.SecretsGetter,
@@ -67,6 +68,7 @@ func NewPruneController(
 	c := &PruneController{
 		targetNamespace:   targetNamespace,
 		podResourcePrefix: podResourcePrefix,
+		certDir:           certDir,
 		command:           command,
 
 		operatorClient:  operatorClient,
@@ -225,6 +227,7 @@ func (c *PruneController) ensurePrunePod(recorder events.Recorder, nodeName stri
 		fmt.Sprintf("--max-eligible-revision=%d", maxEligibleRevision),
 		fmt.Sprintf("--protected-revisions=%s", revisionsToString(protectedRevisions)),
 		fmt.Sprintf("--resource-dir=%s", "/etc/kubernetes/static-pod-resources"),
+		fmt.Sprintf("--cert-dir=%s", c.certDir),
 		fmt.Sprintf("--static-pod-name=%s", c.podResourcePrefix),
 	)
 

--- a/pkg/operator/staticpod/controller/prune/prune_controller_test.go
+++ b/pkg/operator/staticpod/controller/prune/prune_controller_test.go
@@ -495,6 +495,7 @@ func TestPruneDiskResources(t *testing.T) {
 				fmt.Sprintf("--max-eligible-revision=%d", test.maxEligibleRevision),
 				fmt.Sprintf("--protected-revisions=%s", test.protectedRevisions),
 				fmt.Sprintf("--resource-dir=%s", "/etc/kubernetes/static-pod-resources"),
+				fmt.Sprintf("--cert-dir=%s", ""),
 				fmt.Sprintf("--static-pod-name=%s", "test-pod"),
 			}
 

--- a/pkg/operator/staticpod/controllers.go
+++ b/pkg/operator/staticpod/controllers.go
@@ -230,6 +230,7 @@ func (b *staticPodOperatorControllerBuilder) ToControllers() (manager.Controller
 		manager.WithController(prune.NewPruneController(
 			b.operandNamespace,
 			b.staticPodPrefix,
+			b.certDir,
 			b.pruneCommand,
 			configMapClient,
 			secretClient,

--- a/pkg/operator/staticpod/file_utils.go
+++ b/pkg/operator/staticpod/file_utils.go
@@ -1,0 +1,36 @@
+package staticpod
+
+import (
+	"os"
+	"path"
+
+	"io/ioutil"
+	"k8s.io/klog/v2"
+)
+
+func WriteFileAtomic(content []byte, filePerms os.FileMode, resource, contentDir, filename string) error {
+	tmpFile, err := writeTemporaryFile(content, filePerms, contentDir, filename)
+	if err != nil {
+		return err
+	}
+
+	klog.Infof("Renaming %s manifest %q to %q ...", resource, tmpFile, path.Join(contentDir, filename))
+	return os.Rename(tmpFile, path.Join(contentDir, filename))
+}
+
+func writeTemporaryFile(content []byte, filePerms os.FileMode, contentDir, filename string) (string, error) {
+	klog.Infof("Creating a temporary file for %q ...", path.Join(contentDir, filename))
+	tmpfile, err := ioutil.TempFile(contentDir, filename)
+	if err != nil {
+		return "", err
+	}
+	defer tmpfile.Close()
+	if err := tmpfile.Chmod(filePerms); err != nil {
+		return "", err
+	}
+	klog.Infof("Writing to the temporary file %q ...", tmpfile)
+	if _, err := tmpfile.Write(content); err != nil {
+		return "", err
+	}
+	return tmpfile.Name(), nil
+}

--- a/pkg/operator/staticpod/file_utils.go
+++ b/pkg/operator/staticpod/file_utils.go
@@ -1,6 +1,7 @@
 package staticpod
 
 import (
+	"fmt"
 	"os"
 	"path"
 
@@ -20,7 +21,7 @@ func WriteFileAtomic(content []byte, filePerms os.FileMode, resource, contentDir
 
 func writeTemporaryFile(content []byte, filePerms os.FileMode, contentDir, filename string) (string, error) {
 	klog.Infof("Creating a temporary file for %q ...", path.Join(contentDir, filename))
-	tmpfile, err := ioutil.TempFile(contentDir, filename)
+	tmpfile, err := ioutil.TempFile(contentDir, fmt.Sprintf("%s.tmp", filename))
 	if err != nil {
 		return "", err
 	}
@@ -28,7 +29,7 @@ func writeTemporaryFile(content []byte, filePerms os.FileMode, contentDir, filen
 	if err := tmpfile.Chmod(filePerms); err != nil {
 		return "", err
 	}
-	klog.Infof("Writing to the temporary file %q ...", tmpfile)
+	klog.Infof("Writing to the temporary file %q ...", tmpfile.Name())
 	if _, err := tmpfile.Write(content); err != nil {
 		return "", err
 	}

--- a/pkg/operator/staticpod/file_utils.go
+++ b/pkg/operator/staticpod/file_utils.go
@@ -6,21 +6,18 @@ import (
 	"path"
 
 	"io/ioutil"
-	"k8s.io/klog/v2"
 )
 
-func WriteFileAtomic(content []byte, filePerms os.FileMode, resource, contentDir, filename string) error {
+func WriteFileAtomic(content []byte, filePerms os.FileMode, contentDir, filename string) error {
 	tmpFile, err := writeTemporaryFile(content, filePerms, contentDir, filename)
 	if err != nil {
 		return err
 	}
 
-	klog.Infof("Renaming %s manifest %q to %q ...", resource, tmpFile, path.Join(contentDir, filename))
 	return os.Rename(tmpFile, path.Join(contentDir, filename))
 }
 
 func writeTemporaryFile(content []byte, filePerms os.FileMode, contentDir, filename string) (string, error) {
-	klog.Infof("Creating a temporary file for %q ...", path.Join(contentDir, filename))
 	tmpfile, err := ioutil.TempFile(contentDir, fmt.Sprintf("%s.tmp", filename))
 	if err != nil {
 		return "", err
@@ -29,7 +26,6 @@ func writeTemporaryFile(content []byte, filePerms os.FileMode, contentDir, filen
 	if err := tmpfile.Chmod(filePerms); err != nil {
 		return "", err
 	}
-	klog.Infof("Writing to the temporary file %q ...", tmpfile.Name())
 	if _, err := tmpfile.Write(content); err != nil {
 		return "", err
 	}

--- a/pkg/operator/staticpod/file_utils.go
+++ b/pkg/operator/staticpod/file_utils.go
@@ -3,21 +3,23 @@ package staticpod
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 
 	"io/ioutil"
 )
 
-func WriteFileAtomic(content []byte, filePerms os.FileMode, contentDir, filename string) error {
-	tmpFile, err := writeTemporaryFile(content, filePerms, contentDir, filename)
+func WriteFileAtomic(content []byte, filePerms os.FileMode, fullFilename string) error {
+	tmpFile, err := writeTemporaryFile(content, filePerms, fullFilename)
 	if err != nil {
 		return err
 	}
 
-	return os.Rename(tmpFile, path.Join(contentDir, filename))
+	return os.Rename(tmpFile, fullFilename)
 }
 
-func writeTemporaryFile(content []byte, filePerms os.FileMode, contentDir, filename string) (string, error) {
+func writeTemporaryFile(content []byte, filePerms os.FileMode, fullFilename string) (string, error) {
+	contentDir := filepath.Dir(fullFilename)
+	filename := filepath.Base(fullFilename)
 	tmpfile, err := ioutil.TempFile(contentDir, fmt.Sprintf("%s.tmp", filename))
 	if err != nil {
 		return "", err

--- a/pkg/operator/staticpod/installerpod/cmd.go
+++ b/pkg/operator/staticpod/installerpod/cmd.go
@@ -400,25 +400,27 @@ func (o *InstallOptions) Run(ctx context.Context) error {
 }
 
 func writeConfig(content []byte, atomic bool, contentDir, filename string) error {
+	klog.Infof("Writing config file %q ...", path.Join(contentDir, filename))
+
 	filePerms := os.FileMode(0644)
 	if strings.HasSuffix(filename, ".sh") {
 		filePerms = 0755
 	}
 	if !atomic {
-		klog.Infof("Writing config file %q ...", path.Join(contentDir, filename))
 		return ioutil.WriteFile(path.Join(contentDir, filename), content, filePerms)
 	}
-	return staticpod.WriteFileAtomic(content, filePerms, "config", contentDir, filename)
+	return staticpod.WriteFileAtomic(content, filePerms, contentDir, filename)
 }
 
 func writeSecret(content []byte, atomic bool, contentDir, filename string) error {
+	klog.Infof("Writing secret manifest %q ...", path.Join(contentDir, filename))
+
 	filePerms := os.FileMode(0600)
 	if strings.HasSuffix(filename, ".sh") {
 		filePerms = 0700
 	}
 	if !atomic {
-		klog.Infof("Writing secret manifest %q ...", path.Join(contentDir, filename))
 		return ioutil.WriteFile(path.Join(contentDir, filename), content, filePerms)
 	}
-	return staticpod.WriteFileAtomic(content, filePerms, "secret", contentDir, filename)
+	return staticpod.WriteFileAtomic(content, filePerms, contentDir, filename)
 }

--- a/pkg/operator/staticpod/installerpod/cmd.go
+++ b/pkg/operator/staticpod/installerpod/cmd.go
@@ -3,6 +3,7 @@ package installerpod
 import (
 	"context"
 	"fmt"
+	"github.com/openshift/library-go/pkg/operator/staticpod"
 	"io/ioutil"
 	"os"
 	"path"
@@ -176,7 +177,7 @@ func (o *InstallOptions) prefixFor(name string) string {
 }
 
 func (o *InstallOptions) copySecretsAndConfigMaps(ctx context.Context, resourceDir string,
-	secretNames, optionalSecretNames, configNames, optionalConfigNames sets.String, prefixed bool) error {
+	secretNames, optionalSecretNames, configNames, optionalConfigNames sets.String, prefixed, atomic bool) error {
 	klog.Infof("Creating target resource directory %q ...", resourceDir)
 	if err := os.MkdirAll(resourceDir, 0755); err != nil && !os.IsExist(err) {
 		return err
@@ -222,12 +223,7 @@ func (o *InstallOptions) copySecretsAndConfigMaps(ctx context.Context, resourceD
 			return err
 		}
 		for filename, content := range secret.Data {
-			klog.Infof("Writing secret manifest %q ...", path.Join(contentDir, filename))
-			filePerms := os.FileMode(0600)
-			if strings.HasSuffix(filename, ".sh") {
-				filePerms = 0700
-			}
-			if err := ioutil.WriteFile(path.Join(contentDir, filename), content, filePerms); err != nil {
+			if err := writeSecret(content, atomic, contentDir, filename); err != nil {
 				return err
 			}
 		}
@@ -243,15 +239,9 @@ func (o *InstallOptions) copySecretsAndConfigMaps(ctx context.Context, resourceD
 			return err
 		}
 		for filename, content := range configmap.Data {
-			klog.Infof("Writing config file %q ...", path.Join(contentDir, filename))
-			filePerms := os.FileMode(0644)
-			if strings.HasSuffix(filename, ".sh") {
-				filePerms = 0755
-			}
-			if err := ioutil.WriteFile(path.Join(contentDir, filename), []byte(content), filePerms); err != nil {
+			if err := writeConfig([]byte(content), atomic, contentDir, filename); err != nil {
 				return err
 			}
-
 		}
 	}
 
@@ -281,7 +271,7 @@ func (o *InstallOptions) copyContent(ctx context.Context) error {
 	for _, prefix := range o.OptionalConfigMapNamePrefixes {
 		optionalConfigPrefixes.Insert(o.nameFor(prefix))
 	}
-	if err := o.copySecretsAndConfigMaps(ctx, resourceDir, secretPrefixes, optionalSecretPrefixes, configPrefixes, optionalConfigPrefixes, true); err != nil {
+	if err := o.copySecretsAndConfigMaps(ctx, resourceDir, secretPrefixes, optionalSecretPrefixes, configPrefixes, optionalConfigPrefixes, true, false); err != nil {
 		return err
 	}
 
@@ -292,7 +282,7 @@ func (o *InstallOptions) copyContent(ctx context.Context) error {
 			sets.NewString(o.OptionalCertSecretNamePrefixes...),
 			sets.NewString(o.CertConfigMapNamePrefixes...),
 			sets.NewString(o.OptionalCertConfigMapNamePrefixes...),
-			false,
+			false, true,
 		); err != nil {
 			return err
 		}
@@ -407,4 +397,28 @@ func (o *InstallOptions) Run(ctx context.Context) error {
 
 	recorder.Eventf("StaticPodInstallerCompleted", "Successfully installed revision %s", o.Revision)
 	return nil
+}
+
+func writeConfig(content []byte, atomic bool, contentDir, filename string) error {
+	filePerms := os.FileMode(0644)
+	if strings.HasSuffix(filename, ".sh") {
+		filePerms = 0755
+	}
+	if !atomic {
+		klog.Infof("Writing config file %q ...", path.Join(contentDir, filename))
+		return ioutil.WriteFile(path.Join(contentDir, filename), content, filePerms)
+	}
+	return staticpod.WriteFileAtomic(content, filePerms, "config", contentDir, filename)
+}
+
+func writeSecret(content []byte, atomic bool, contentDir, filename string) error {
+	filePerms := os.FileMode(0600)
+	if strings.HasSuffix(filename, ".sh") {
+		filePerms = 0700
+	}
+	if !atomic {
+		klog.Infof("Writing secret manifest %q ...", path.Join(contentDir, filename))
+		return ioutil.WriteFile(path.Join(contentDir, filename), content, filePerms)
+	}
+	return staticpod.WriteFileAtomic(content, filePerms, "secret", contentDir, filename)
 }

--- a/pkg/operator/staticpod/prune/cmd.go
+++ b/pkg/operator/staticpod/prune/cmd.go
@@ -5,8 +5,10 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/spf13/cobra"
@@ -21,6 +23,7 @@ type PruneOptions struct {
 	ProtectedRevisions  []int
 
 	ResourceDir   string
+	CertDir       string
 	StaticPodName string
 }
 
@@ -57,6 +60,7 @@ func (o *PruneOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.IntSliceVar(&o.ProtectedRevisions, "protected-revisions", o.ProtectedRevisions, "list of revision IDs to preserve (not delete)")
 	fs.StringVar(&o.ResourceDir, "resource-dir", o.ResourceDir, "directory for all files supporting the static pod manifest")
 	fs.StringVar(&o.StaticPodName, "static-pod-name", o.StaticPodName, "name of the static pod")
+	fs.StringVar(&o.CertDir, "cert-dir", o.CertDir, "directory for all certs")
 }
 
 func (o *PruneOptions) Validate() error {
@@ -112,5 +116,37 @@ func (o *PruneOptions) Run() error {
 			return err
 		}
 	}
-	return nil
+
+	// prune any temporary certificate files
+	// we do create temporary files to atomically "write" various certificates to disk
+	// usually, these files are short-lived because they are immediately renamed, the following loop removes old/unused/dangling files
+	//
+	// the temporary files have the following form:
+	//  /etc/kubernetes/static-pod-resources/kube-apiserver-certs/configmaps/control-plane-node-kubeconfig/kubeconfig.tmp753375784
+	//  /etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/service-network-serving-certkey/tls.key.tmp643092404
+	if len(o.CertDir) == 0 {
+		return nil
+	}
+
+	return filepath.Walk(path.Join(o.ResourceDir, o.CertDir),
+		func(filePath string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.IsDir() {
+				return nil
+			}
+			// info.Name() gives just a filename like tls.key or tls.key.tmp643092404
+			if !strings.Contains(info.Name(), ".tmp") {
+				return nil
+			}
+			if time.Now().Sub(info.ModTime()) > 30*time.Minute {
+				klog.Infof("Removing %s, the last time it was modified was %v", filePath, info.ModTime())
+				if err := os.RemoveAll(filePath); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	)
 }


### PR DESCRIPTION
As of today, the dynamic certificates i.e. `kube-apiserver-certs` are accessed by at least two processes, namely the installer pod and the cert-syncer.
Up until now, there was no coordination between these processes that might have lead to many unexpected errors, like https://bugzilla.redhat.com/show_bug.cgi?id=1963730

This PR writes all certificates in an atomic way by first creating a temporary file, writing the content to it, and then renaming it to the original file. 

`os.Rename` calls `syscall.Rename` which in turn uses the rename syscall (Linux) which provides atomicity (https://man7.org/linux/man-pages/man2/rename.2.html)


The previous attempt didn't work as it would break the DR scripts - https://github.com/openshift/library-go/pull/1098