### PR TITLE
Bug 1969631: encryption precondition checker must indicate work to do when an operator is degraded

### DIFF
--- a/pkg/operator/apiserver/controllerset/apiservercontrollerset.go
+++ b/pkg/operator/apiserver/controllerset/apiservercontrollerset.go
@@ -312,12 +312,14 @@ func (cs *APIServerControllerSet) WithoutPruneController() *APIServerControllerS
 
 func (cs *APIServerControllerSet) WithEncryptionControllers(
 	component string,
+	componentClusterOperatorName string,
 	provider controllers.Provider,
 	deployer statemachine.Deployer,
 	migrator migrators.Migrator,
 	secretsClient corev1.SecretsGetter,
 	apiServerClient configv1client.APIServerInterface,
 	apiServerInformer configv1informers.APIServerInformer,
+	clusterOperatorInformer configv1informers.ClusterOperatorInformer,
 	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
 ) *APIServerControllerSet {
 
@@ -325,14 +327,16 @@ func (cs *APIServerControllerSet) WithEncryptionControllers(
 		operatorClient: cs.operatorClient,
 		eventRecorder:  cs.eventRecorder,
 
-		component:                  component,
-		provider:                   provider,
-		deployer:                   deployer,
-		migrator:                   migrator,
-		apiServerClient:            apiServerClient,
-		apiServerInformer:          apiServerInformer,
-		kubeInformersForNamespaces: kubeInformersForNamespaces,
-		secretsClient:              secretsClient,
+		component:                    component,
+		componentClusterOperatorName: componentClusterOperatorName,
+		provider:                     provider,
+		deployer:                     deployer,
+		migrator:                     migrator,
+		apiServerClient:              apiServerClient,
+		apiServerInformer:            apiServerInformer,
+		clusterOperatorInformer:      clusterOperatorInformer,
+		kubeInformersForNamespaces:   kubeInformersForNamespaces,
+		secretsClient:                secretsClient,
 	}
 
 	return cs
@@ -390,14 +394,16 @@ type encryptionControllerBuilder struct {
 	operatorClient v1helpers.OperatorClient
 	eventRecorder  events.Recorder
 
-	component                  string
-	provider                   controllers.Provider
-	deployer                   statemachine.Deployer
-	migrator                   migrators.Migrator
-	secretsClient              corev1.SecretsGetter
-	apiServerClient            configv1client.APIServerInterface
-	apiServerInformer          configv1informers.APIServerInformer
-	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces
+	component                    string
+	componentClusterOperatorName string
+	provider                     controllers.Provider
+	deployer                     statemachine.Deployer
+	migrator                     migrators.Migrator
+	secretsClient                corev1.SecretsGetter
+	apiServerClient              configv1client.APIServerInterface
+	apiServerInformer            configv1informers.APIServerInformer
+	clusterOperatorInformer      configv1informers.ClusterOperatorInformer
+	kubeInformersForNamespaces   v1helpers.KubeInformersForNamespaces
 
 	unsupportedConfigPrefix []string
 }
@@ -408,6 +414,7 @@ func (e *encryptionControllerBuilder) build() controllerWrapper {
 	}
 	e.controllerWrapper.controller, e.controllerWrapper.creationError = encryption.NewControllers(
 		e.component,
+		e.componentClusterOperatorName,
 		e.unsupportedConfigPrefix,
 		e.provider,
 		e.deployer,
@@ -415,6 +422,7 @@ func (e *encryptionControllerBuilder) build() controllerWrapper {
 		e.operatorClient,
 		e.apiServerClient,
 		e.apiServerInformer,
+		e.clusterOperatorInformer,
 		e.kubeInformersForNamespaces,
 		e.secretsClient,
 		e.eventRecorder,

--- a/pkg/operator/encryption/controllers.go
+++ b/pkg/operator/encryption/controllers.go
@@ -25,6 +25,7 @@ type runner interface {
 
 func NewControllers(
 	component string,
+	componentClusterOperatorName string,
 	unsupportedConfigPrefix []string,
 	provider controllers.Provider,
 	deployer statemachine.Deployer,
@@ -32,6 +33,7 @@ func NewControllers(
 	operatorClient operatorv1helpers.OperatorClient,
 	apiServerClient configv1client.APIServerInterface,
 	apiServerInformer configv1informers.APIServerInformer,
+	clusterOperatorInformer configv1informers.ClusterOperatorInformer,
 	kubeInformersForNamespaces operatorv1helpers.KubeInformersForNamespaces,
 	secretsClient corev1.SecretsGetter,
 	eventRecorder events.Recorder,
@@ -42,7 +44,7 @@ func NewControllers(
 	// TODO: update the eventHandlers used by the controllers to ignore components that do not match their own
 	encryptionSecretSelector := metav1.ListOptions{LabelSelector: secrets.EncryptionKeySecretsLabel + "=" + component}
 
-	encryptionEnabledChecker, err := newEncryptionEnabledPrecondition(apiServerInformer, kubeInformersForNamespaces, encryptionSecretSelector.LabelSelector)
+	encryptionEnabledChecker, err := newEncryptionEnabledPrecondition(apiServerInformer, clusterOperatorInformer, kubeInformersForNamespaces, encryptionSecretSelector.LabelSelector, component, componentClusterOperatorName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The precondition checker will run the encryption controllers when the caches haven't been synchronized.
During synchronization, the controllers send live requests to the API server.
A **single** failed request can put a controller into a degraded state and leave it in that state forever. 

Thus the precondition must take into account the status of the operator and let the controller run when it is in a degraded state.

For example, in [this](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.8-e2e-aws-upgrade/1400652395809083392/artifacts/e2e-aws-upgrade/) CI run the `kas-o` operator acquired a lock at `03:33:24`:

at `03:33:40` the `EncryptionPruneControllerDegraded` went degraded and **never** recovered.

around the same time, a few other controllers (`ResourceSyncControllerDegraded`, `RevisionControllerDegraded`, `TargetConfigControllerDegraded`) went degraded due to the same reason (`etcdserver: request timed out`) but recovered a few seconds later, around `03:33:55`