### PR TITLE
staticresourcectrl: Make it conditionally dynamic

### DIFF
--- a/pkg/operator/certrotation/cabundle.go
+++ b/pkg/operator/certrotation/cabundle.go
@@ -52,7 +52,7 @@ func (c CABundleRotation) ensureConfigMapCABundle(signingCertKeyPair *crypto.CA)
 		c.EventRecorder.Eventf("CABundleUpdateRequired", "%q in %q requires a new cert", c.Name, c.Namespace)
 		LabelAsManagedConfigMap(caBundleConfigMap, CertificateTypeCABundle)
 
-		actualCABundleConfigMap, modified, err := resourceapply.ApplyConfigMap(c.Client, c.EventRecorder, caBundleConfigMap)
+		actualCABundleConfigMap, modified, err := resourceapply.ApplyConfigMap(c.Client, false, c.EventRecorder, caBundleConfigMap)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/operator/certrotation/signer.go
+++ b/pkg/operator/certrotation/signer.go
@@ -51,7 +51,7 @@ func (c SigningRotation) ensureSigningCertKeyPair() (*crypto.CA, error) {
 
 		LabelAsManagedSecret(signingCertKeyPairSecret, CertificateTypeSigner)
 
-		actualSigningCertKeyPairSecret, _, err := resourceapply.ApplySecret(c.Client, c.EventRecorder, signingCertKeyPairSecret)
+		actualSigningCertKeyPairSecret, _, err := resourceapply.ApplySecret(c.Client, false, c.EventRecorder, signingCertKeyPairSecret)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/operator/certrotation/target.go
+++ b/pkg/operator/certrotation/target.go
@@ -75,7 +75,7 @@ func (c TargetRotation) ensureTargetCertKeyPair(signingCertKeyPair *crypto.CA, c
 
 		LabelAsManagedSecret(targetCertKeyPairSecret, CertificateTypeTarget)
 
-		actualTargetCertKeyPairSecret, _, err := resourceapply.ApplySecret(c.Client, c.EventRecorder, targetCertKeyPairSecret)
+		actualTargetCertKeyPairSecret, _, err := resourceapply.ApplySecret(c.Client, false, c.EventRecorder, targetCertKeyPairSecret)
 		if err != nil {
 			return err
 		}

--- a/pkg/operator/connectivitycheckcontroller/connectivity_check_controller.go
+++ b/pkg/operator/connectivitycheckcontroller/connectivity_check_controller.go
@@ -205,13 +205,17 @@ func ensureConnectivityCheckCRDExists(ctx context.Context, syncContext factory.S
 		return err
 	}
 	if errors.IsNotFound(err) {
+		resourceConditionalMaps := []resourceapply.ResourceConditionalMap{{
+			File:                  "pkg/operator/connectivitycheckcontroller/manifests/controlplane.operator.openshift.io_podnetworkconnectivitychecks.yaml",
+			DeleteConditionalFunc: nil,
+			CreateConditionalFunc: nil,
+		}}
 		// create the podnetworkconnectivitycheck crd that should exist
 		applyResults := resourceapply.ApplyDirectly(
 			resourceapply.NewClientHolder().WithAPIExtensionsClient(client),
 			syncContext.Recorder(),
 			func(name string) ([]byte, error) { return bindata.Asset(name) },
-			"pkg/operator/connectivitycheckcontroller/manifests/controlplane.operator.openshift.io_podnetworkconnectivitychecks.yaml",
-		)
+			resourceConditionalMaps)
 		if applyResults[0].Error != nil {
 			return applyResults[0].Error
 		}

--- a/pkg/operator/encryption/controllers/migration_controller.go
+++ b/pkg/operator/encryption/controllers/migration_controller.go
@@ -259,7 +259,7 @@ func (c *migrationController) migrateKeysIfNeededAndRevisionStable(syncContext f
 				return nil
 			}
 
-			_, _, updateErr := resourceapply.ApplySecret(c.secretClient, syncContext.Recorder(), s)
+			_, _, updateErr := resourceapply.ApplySecret(c.secretClient, false, syncContext.Recorder(), s)
 			return updateErr
 		}); err != nil {
 			errs = append(errs, err)

--- a/pkg/operator/encryption/controllers/state_controller.go
+++ b/pkg/operator/encryption/controllers/state_controller.go
@@ -151,7 +151,7 @@ func (c *stateController) applyEncryptionConfigSecret(encryptionConfig *apiserve
 		return false, err
 	}
 
-	_, changed, applyErr := resourceapply.ApplySecret(c.secretClient, recorder, s)
+	_, changed, applyErr := resourceapply.ApplySecret(c.secretClient, false, recorder, s)
 	return changed, applyErr
 }
 

--- a/pkg/operator/resource/resourceapply/core_test.go
+++ b/pkg/operator/resource/resourceapply/core_test.go
@@ -297,7 +297,7 @@ func TestApplyConfigMap(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			client := fake.NewSimpleClientset(test.existing...)
-			_, actualModified, err := ApplyConfigMap(client.CoreV1(), events.NewInMemoryRecorder("test"), test.input)
+			_, actualModified, err := ApplyConfigMap(client.CoreV1(), false, events.NewInMemoryRecorder("test"), test.input)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -510,7 +510,7 @@ func TestApplySecret(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			client := fake.NewSimpleClientset(tc.existing...)
-			got, changed, err := ApplySecret(client.CoreV1(), events.NewInMemoryRecorder("test"), tc.required)
+			got, changed, err := ApplySecret(client.CoreV1(), false, events.NewInMemoryRecorder("test"), tc.required)
 			if !reflect.DeepEqual(tc.err, err) {
 				t.Errorf("expected error %v, got %v", tc.err, err)
 				return
@@ -659,7 +659,7 @@ func TestApplyNamespace(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			client := fake.NewSimpleClientset(test.existing...)
-			_, actualModified, err := ApplyNamespace(client.CoreV1(), events.NewInMemoryRecorder("test"), test.input)
+			_, actualModified, err := ApplyNamespace(client.CoreV1(), false, events.NewInMemoryRecorder("test"), test.input)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/operator/resource/resourceapply/generic_test.go
+++ b/pkg/operator/resource/resourceapply/generic_test.go
@@ -37,7 +37,8 @@ metadata:
 `), nil
 	}
 	recorder := events.NewInMemoryRecorder("")
-	ret := ApplyDirectly((&ClientHolder{}).WithKubernetes(fakeClient), recorder, content, "pvc")
+	resourceConditionalMaps := []ResourceConditionalMap{{"pvc", nil, nil}}
+	ret := ApplyDirectly((&ClientHolder{}).WithKubernetes(fakeClient), recorder, content, resourceConditionalMaps)
 	if ret[0].Error == nil {
 		t.Fatal("missing expected error")
 	} else if ret[0].Error.Error() != "unhandled type *v1.PersistentVolumeClaim" {

--- a/pkg/operator/resource/resourceapply/migration.go
+++ b/pkg/operator/resource/resourceapply/migration.go
@@ -15,17 +15,28 @@ import (
 )
 
 // ApplyStorageVersionMigration merges objectmeta and required data.
-func ApplyStorageVersionMigration(client migrationclientv1alpha1.Interface, recorder events.Recorder, required *migrationv1alpha1.StorageVersionMigration) (*migrationv1alpha1.StorageVersionMigration, bool, error) {
+func ApplyStorageVersionMigration(client migrationclientv1alpha1.Interface, shouldDelete bool, recorder events.Recorder, required *migrationv1alpha1.StorageVersionMigration) (*migrationv1alpha1.StorageVersionMigration, bool, error) {
 	clientInterface := client.MigrationV1alpha1().StorageVersionMigrations()
 	existing, err := clientInterface.Get(context.Background(), required.Name, metav1.GetOptions{})
-	if apierrors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) && !shouldDelete {
 		requiredCopy := required.DeepCopy()
 		actual, err := clientInterface.Create(context.Background(), resourcemerge.WithCleanLabelsAndAnnotations(requiredCopy).(*v1alpha1.StorageVersionMigration), metav1.CreateOptions{})
 		reportCreateEvent(recorder, requiredCopy, err)
 		return actual, true, err
+	} else if apierrors.IsNotFound(err) && shouldDelete {
+		return nil, false, nil
 	}
 	if err != nil {
 		return nil, false, err
+	}
+
+	if shouldDelete {
+		err := clientInterface.Delete(context.TODO(), existing.Name, metav1.DeleteOptions{})
+		if err != nil {
+			return nil, false, err
+		}
+		reportDeleteEvent(recorder, required, err)
+		return nil, true, nil
 	}
 
 	modified := resourcemerge.BoolPtr(false)

--- a/pkg/operator/resource/resourceapply/migration_test.go
+++ b/pkg/operator/resource/resourceapply/migration_test.go
@@ -179,7 +179,7 @@ func TestApplyStorageVersionMigration(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			client := fake.NewSimpleClientset(test.existing...)
-			_, actualModified, err := ApplyStorageVersionMigration(client, events.NewInMemoryRecorder("test"), test.input)
+			_, actualModified, err := ApplyStorageVersionMigration(client, false, events.NewInMemoryRecorder("test"), test.input)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/operator/resource/resourceapply/monitoring_test.go
+++ b/pkg/operator/resource/resourceapply/monitoring_test.go
@@ -98,7 +98,7 @@ func TestApplyServiceMonitor(t *testing.T) {
 
 	required := resourceread.ReadUnstructuredOrDie([]byte(fakeServiceMonitor))
 
-	_, modified, err := ApplyServiceMonitor(dynamicClient, events.NewInMemoryRecorder("monitor-test"), required)
+	_, modified, err := ApplyServiceMonitor(dynamicClient, false, events.NewInMemoryRecorder("monitor-test"), required)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/operator/resource/resourceapply/policy_test.go
+++ b/pkg/operator/resource/resourceapply/policy_test.go
@@ -1,0 +1,180 @@
+package resourceapply
+
+import (
+	"github.com/davecgh/go-spew/spew"
+	"github.com/openshift/library-go/pkg/operator/events"
+	policyv1 "k8s.io/api/policy/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+	"testing"
+	"time"
+)
+
+func TestApplyPodDisruptionBudget(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing []runtime.Object
+		input    *policyv1.PodDisruptionBudget
+
+		expectedModified bool
+		shouldDelete     bool
+		verifyActions    func(actions []clienttesting.Action, t *testing.T)
+	}{
+		{
+			name: "create",
+			input: &policyv1.PodDisruptionBudget{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "abc"},
+			},
+
+			expectedModified: true,
+			shouldDelete:     false,
+			verifyActions: func(actions []clienttesting.Action, t *testing.T) {
+				if len(actions) != 2 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("get", "poddisruptionbudgets") || actions[0].(clienttesting.GetAction).GetName() != "foo" {
+					t.Error(spew.Sdump(actions))
+				}
+				if !actions[1].Matches("create", "poddisruptionbudgets") {
+					t.Error(spew.Sdump(actions))
+				}
+				expected := &policyv1.PodDisruptionBudget{
+					ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "abc"},
+				}
+				actual := actions[1].(clienttesting.CreateAction).GetObject().(*policyv1.PodDisruptionBudget)
+				if !equality.Semantic.DeepEqual(expected, actual) {
+					t.Error(JSONPatchNoError(expected, actual))
+				}
+			},
+		},
+		{
+			name: "update on missing label",
+			existing: []runtime.Object{
+				&policyv1.PodDisruptionBudget{
+					ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				},
+			},
+			input: &policyv1.PodDisruptionBudget{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo", Labels: map[string]string{"new": "merge"}},
+			},
+			expectedModified: true,
+			shouldDelete:     false,
+			verifyActions: func(actions []clienttesting.Action, t *testing.T) {
+				if len(actions) != 2 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("get", "poddisruptionbudgets") || actions[0].(clienttesting.GetAction).GetName() != "foo" {
+					t.Error(spew.Sdump(actions))
+				}
+				if !actions[1].Matches("update", "poddisruptionbudgets") {
+					t.Error(spew.Sdump(actions))
+				}
+				expected := &policyv1.PodDisruptionBudget{
+					ObjectMeta: metav1.ObjectMeta{Name: "foo", Labels: map[string]string{"new": "merge"}},
+				}
+				actual := actions[1].(clienttesting.CreateAction).GetObject().(*policyv1.PodDisruptionBudget)
+				if !equality.Semantic.DeepEqual(expected, actual) {
+					t.Error(JSONPatchNoError(expected, actual))
+				}
+			},
+		},
+		{
+			name: "don't update because existing object misses TypeMeta",
+			existing: []runtime.Object{
+				&policyv1.PodDisruptionBudget{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "foo",
+					},
+				},
+			},
+			input: &policyv1.PodDisruptionBudget{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "PodDisruptionBudget",
+					APIVersion: "policy/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+			},
+			expectedModified: false,
+			shouldDelete:     false,
+			verifyActions: func(actions []clienttesting.Action, t *testing.T) {
+				if len(actions) != 1 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("get", "poddisruptionbudgets") || actions[0].(clienttesting.GetAction).GetName() != "foo" {
+					t.Error(spew.Sdump(actions))
+				}
+			},
+		},
+		{
+			name: "don't update because existing object has creationTimestamp",
+			existing: []runtime.Object{
+				&policyv1.PodDisruptionBudget{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "foo",
+						CreationTimestamp: metav1.Time{Time: time.Now()},
+					},
+				},
+			},
+			input: &policyv1.PodDisruptionBudget{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+			},
+			expectedModified: false,
+			shouldDelete:     false,
+			verifyActions: func(actions []clienttesting.Action, t *testing.T) {
+				if len(actions) != 1 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("get", "poddisruptionbudgets") || actions[0].(clienttesting.GetAction).GetName() != "foo" {
+					t.Error(spew.Sdump(actions))
+				}
+			},
+		},
+		{
+			name: "delete PDB",
+			existing: []runtime.Object{
+				&policyv1.PodDisruptionBudget{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "abc",
+					},
+				},
+			},
+			input: &policyv1.PodDisruptionBudget{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "abc"},
+			},
+			expectedModified: true,
+			shouldDelete:     true,
+			verifyActions: func(actions []clienttesting.Action, t *testing.T) {
+				if len(actions) != 2 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("get", "poddisruptionbudgets") || actions[0].(clienttesting.GetAction).GetName() != "foo" {
+					t.Error(spew.Sdump(actions))
+				}
+				if !actions[1].Matches("delete", "poddisruptionbudgets") {
+					t.Error(spew.Sdump(actions))
+				}
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := fake.NewSimpleClientset(test.existing...)
+			_, actualModified, err := ApplyPodDisruptionBudget(client.PolicyV1(), test.shouldDelete, events.NewInMemoryRecorder("test"), test.input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if test.expectedModified != actualModified {
+				t.Errorf("expected %v, got %v", test.expectedModified, actualModified)
+			}
+			test.verifyActions(client.Actions(), t)
+		})
+	}
+}

--- a/pkg/operator/resource/resourceapply/storage.go
+++ b/pkg/operator/resource/resourceapply/storage.go
@@ -18,18 +18,28 @@ import (
 )
 
 // ApplyStorageClass merges objectmeta, tries to write everything else
-func ApplyStorageClass(client storageclientv1.StorageClassesGetter, recorder events.Recorder, required *storagev1.StorageClass) (*storagev1.StorageClass, bool,
+func ApplyStorageClass(client storageclientv1.StorageClassesGetter, shouldDelete bool, recorder events.Recorder, required *storagev1.StorageClass) (*storagev1.StorageClass, bool,
 	error) {
 	existing, err := client.StorageClasses().Get(context.TODO(), required.Name, metav1.GetOptions{})
-	if apierrors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) && !shouldDelete {
 		actual, err := client.StorageClasses().Create(context.TODO(), required, metav1.CreateOptions{})
 		reportCreateEvent(recorder, required, err)
 		return actual, true, err
+	} else if apierrors.IsNotFound(err) && shouldDelete {
+		return nil, false, nil
 	}
 	if err != nil {
 		return nil, false, err
 	}
 
+	if shouldDelete {
+		err := client.StorageClasses().Delete(context.TODO(), existing.Name, metav1.DeleteOptions{})
+		if err != nil {
+			return nil, false, err
+		}
+		reportDeleteEvent(recorder, required, err)
+		return nil, true, nil
+	}
 	// First, let's compare ObjectMeta from both objects
 	modified := resourcemerge.BoolPtr(false)
 	existingCopy := existing.DeepCopy()
@@ -58,17 +68,27 @@ func ApplyStorageClass(client storageclientv1.StorageClassesGetter, recorder eve
 }
 
 // ApplyCSIDriverV1Beta1 merges objectmeta, does not worry about anything else
-func ApplyCSIDriverV1Beta1(client storageclientv1beta1.CSIDriversGetter, recorder events.Recorder, required *storagev1beta1.CSIDriver) (*storagev1beta1.CSIDriver, bool, error) {
+func ApplyCSIDriverV1Beta1(client storageclientv1beta1.CSIDriversGetter, shouldDelete bool, recorder events.Recorder, required *storagev1beta1.CSIDriver) (*storagev1beta1.CSIDriver, bool, error) {
 	existing, err := client.CSIDrivers().Get(context.TODO(), required.Name, metav1.GetOptions{})
-	if apierrors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) && !shouldDelete {
 		actual, err := client.CSIDrivers().Create(context.TODO(), required, metav1.CreateOptions{})
 		reportCreateEvent(recorder, required, err)
 		return actual, true, err
+	} else if apierrors.IsNotFound(err) && shouldDelete {
+		return nil, false, nil
 	}
 	if err != nil {
 		return nil, false, err
 	}
 
+	if shouldDelete {
+		err := client.CSIDrivers().Delete(context.TODO(), existing.Name, metav1.DeleteOptions{})
+		if err != nil {
+			return nil, false, err
+		}
+		reportDeleteEvent(recorder, required, err)
+		return nil, true, nil
+	}
 	modified := resourcemerge.BoolPtr(false)
 	existingCopy := existing.DeepCopy()
 
@@ -87,17 +107,27 @@ func ApplyCSIDriverV1Beta1(client storageclientv1beta1.CSIDriversGetter, recorde
 }
 
 // ApplyCSIDriver merges objectmeta, does not worry about anything else
-func ApplyCSIDriver(client storageclientv1.CSIDriversGetter, recorder events.Recorder, required *storagev1.CSIDriver) (*storagev1.CSIDriver, bool, error) {
+func ApplyCSIDriver(client storageclientv1.CSIDriversGetter, shouldDelete bool, recorder events.Recorder, required *storagev1.CSIDriver) (*storagev1.CSIDriver, bool, error) {
 	existing, err := client.CSIDrivers().Get(context.TODO(), required.Name, metav1.GetOptions{})
-	if apierrors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) && !shouldDelete {
 		actual, err := client.CSIDrivers().Create(context.TODO(), required, metav1.CreateOptions{})
 		reportCreateEvent(recorder, required, err)
 		return actual, true, err
+	} else if apierrors.IsNotFound(err) && shouldDelete {
+		return nil, false, nil
 	}
 	if err != nil {
 		return nil, false, err
 	}
 
+	if shouldDelete {
+		err := client.CSIDrivers().Delete(context.TODO(), existing.Name, metav1.DeleteOptions{})
+		if err != nil {
+			return nil, false, err
+		}
+		reportDeleteEvent(recorder, required, err)
+		return nil, true, nil
+	}
 	modified := resourcemerge.BoolPtr(false)
 	existingCopy := existing.DeepCopy()
 

--- a/pkg/operator/resource/resourceapply/storage_test.go
+++ b/pkg/operator/resource/resourceapply/storage_test.go
@@ -138,7 +138,7 @@ func TestApplyStorageClass(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			client := fake.NewSimpleClientset(test.existing...)
-			_, actualModified, err := ApplyStorageClass(client.StorageV1(), events.NewInMemoryRecorder("test"), test.input)
+			_, actualModified, err := ApplyStorageClass(client.StorageV1(), false, events.NewInMemoryRecorder("test"), test.input)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -247,7 +247,7 @@ func TestApplyCSIDriver(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			client := fake.NewSimpleClientset(test.existing...)
-			_, actualModified, err := ApplyCSIDriverV1Beta1(client.StorageV1beta1(), events.NewInMemoryRecorder("test"), test.input)
+			_, actualModified, err := ApplyCSIDriverV1Beta1(client.StorageV1beta1(), false, events.NewInMemoryRecorder("test"), test.input)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/operator/resource/resourceapply/unstructured.go
+++ b/pkg/operator/resource/resourceapply/unstructured.go
@@ -11,14 +11,14 @@ import (
 
 // ApplyKnownUnstructured applies few selected Unstructured types, where it semantic knowledge
 // to merge existing & required objects intelligently. Feel free to add more.
-func ApplyKnownUnstructured(client dynamic.Interface, recorder events.Recorder, obj *unstructured.Unstructured) (*unstructured.Unstructured, bool, error) {
+func ApplyKnownUnstructured(client dynamic.Interface, shouldDelete bool, recorder events.Recorder, obj *unstructured.Unstructured) (*unstructured.Unstructured, bool, error) {
 	switch obj.GetObjectKind().GroupVersionKind().GroupKind() {
 	case schema.GroupKind{Group: "monitoring.coreos.com", Kind: "ServiceMonitor"}:
-		return ApplyServiceMonitor(client, recorder, obj)
+		return ApplyServiceMonitor(client, shouldDelete, recorder, obj)
 	case schema.GroupKind{Group: "monitoring.coreos.com", Kind: "PrometheusRule"}:
-		return ApplyPrometheusRule(client, recorder, obj)
+		return ApplyPrometheusRule(client, shouldDelete, recorder, obj)
 	case schema.GroupKind{Group: "snapshot.storage.k8s.io", Kind: "VolumeSnapshotClass"}:
-		return ApplyVolumeSnapshotClass(client, recorder, obj)
+		return ApplyVolumeSnapshotClass(client, shouldDelete, recorder, obj)
 
 	}
 

--- a/pkg/operator/resource/resourceapply/volumesnapshotclass_test.go
+++ b/pkg/operator/resource/resourceapply/volumesnapshotclass_test.go
@@ -111,7 +111,7 @@ func TestApplyVolumeSnapshotClassUpdate(t *testing.T) {
 
 			required := resourceread.ReadUnstructuredOrDie([]byte(tc.required))
 
-			_, modified, err := ApplyVolumeSnapshotClass(dynamicClient, events.NewInMemoryRecorder("volumesnapshotclass-test"), required)
+			_, modified, err := ApplyVolumeSnapshotClass(dynamicClient, false, events.NewInMemoryRecorder("volumesnapshotclass-test"), required)
 			if tc.expectedErr {
 				if err != nil {
 					return

--- a/pkg/operator/revisioncontroller/revision_controller.go
+++ b/pkg/operator/revisioncontroller/revision_controller.go
@@ -204,7 +204,7 @@ func (c RevisionController) createNewRevision(recorder events.Recorder, revision
 			"reason":   reason,
 		},
 	}
-	statusConfigMap, _, err := resourceapply.ApplyConfigMap(c.configMapGetter, recorder, statusConfigMap)
+	statusConfigMap, _, err := resourceapply.ApplyConfigMap(c.configMapGetter, false, recorder, statusConfigMap)
 	if err != nil {
 		return err
 	}
@@ -221,7 +221,7 @@ func (c RevisionController) createNewRevision(recorder events.Recorder, revision
 		}
 		if configMap.Data["status"] == prune.StatusInProgress {
 			configMap.Data["status"] = prune.StatusAbandoned
-			_, _, err = resourceapply.ApplyConfigMap(c.configMapGetter, recorder, &configMap)
+			_, _, err = resourceapply.ApplyConfigMap(c.configMapGetter, false, recorder, &configMap)
 			if err != nil {
 				return err
 			}

--- a/pkg/operator/staticpod/controller/installer/installer_controller.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller.go
@@ -491,7 +491,7 @@ func (c *InstallerController) updateConfigMapForRevision(ctx context.Context, cu
 			return err
 		}
 		statusConfigMap.Data["status"] = status
-		_, _, err = resourceapply.ApplyConfigMap(c.configMapsGetter, c.eventRecorder, statusConfigMap)
+		_, _, err = resourceapply.ApplyConfigMap(c.configMapsGetter, false, c.eventRecorder, statusConfigMap)
 		if err != nil {
 			return err
 		}
@@ -837,7 +837,7 @@ func (c *InstallerController) ensureInstallerPod(nodeName string, operatorSpec *
 		}
 	}
 
-	_, _, err = resourceapply.ApplyPod(c.podsGetter, c.eventRecorder, pod)
+	_, _, err = resourceapply.ApplyPod(c.podsGetter, false, c.eventRecorder, pod)
 	return err
 }
 

--- a/pkg/operator/staticpod/controller/prune/prune_controller.go
+++ b/pkg/operator/staticpod/controller/prune/prune_controller.go
@@ -237,7 +237,7 @@ func (c *PruneController) ensurePrunePod(recorder events.Recorder, nodeName stri
 	}
 	pod.OwnerReferences = ownerRefs
 
-	_, _, err = resourceapply.ApplyPod(c.podGetter, recorder, pod)
+	_, _, err = resourceapply.ApplyPod(c.podGetter, false, recorder, pod)
 	return err
 }
 

--- a/pkg/operator/staticresourcecontroller/static_resource_controller_test.go
+++ b/pkg/operator/staticresourcecontroller/static_resource_controller_test.go
@@ -1,14 +1,26 @@
 package staticresourcecontroller
 
 import (
+	"context"
+	"github.com/davecgh/go-spew/spew"
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
+	opv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/library-go/pkg/client/openshiftrestmapper"
+	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	"github.com/stretchr/testify/assert"
+	policyv1 "k8s.io/api/policy/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	fakecore "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/restmapper"
+	clienttesting "k8s.io/client-go/testing"
+	"k8s.io/utils/diff"
 	"testing"
 )
 
@@ -56,4 +68,396 @@ metadata:
 	src = src.AddRESTMapper(restMapper).AddCategoryExpander(expander)
 	res, _ := src.RelatedObjects()
 	assert.ElementsMatch(t, expected, res)
+}
+
+func makePDBManifest() []byte {
+	return []byte(`
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: foo
+  namespace: abc
+`)
+}
+
+func makeDeploymentManifest() []byte {
+	return []byte(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: etcd-quorum-guard
+  namespace: openshift-etcd
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      k8s-app: etcd-quorum-guard
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: etcd-quorum-guard
+        k8s-app: etcd-quorum-guard
+    spec:
+      hostNetwork: true
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: k8s-app
+                    operator: In
+                    values:
+                      - "etcd-quorum-guard"
+              topologyKey: kubernetes.io/hostname
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      priorityClassName: "system-cluster-critical"
+      terminationGracePeriodSeconds: 3
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+          operator: Exists
+        - key: node.kubernetes.io/not-ready
+          effect: NoExecute
+          operator: Exists
+        - key: node.kubernetes.io/unreachable
+          effect: NoExecute
+          operator: Exists
+        - key: node-role.kubernetes.io/etcd
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: guard
+          image: quay.io/openshift/origin-cli:latest
+          imagePullPolicy: IfNotPresent
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+            - mountPath: /var/run/secrets/etcd-client
+              name: etcd-client
+            - mountPath: /var/run/configmaps/etcd-ca
+              name: etcd-ca
+          command:
+            - /bin/bash
+          args:
+            - -c
+            - |
+              # properly handle TERM and exit as soon as it is signaled
+              set -euo pipefail
+              trap 'jobs -p | xargs -r kill; exit 0' TERM
+              sleep infinity & wait
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  declare -r health_endpoint="https://localhost:2379/health"
+                  declare -r cert="/var/run/secrets/etcd-client/tls.crt"
+                  declare -r key="/var/run/secrets/etcd-client/tls.key"
+                  declare -r cacert="/var/run/configmaps/etcd-ca/ca-bundle.crt"
+                  export NSS_SDB_USE_CACHE=no
+                  [[ -z $cert || -z $key ]] && exit 1
+                  curl --max-time 2 --silent --cert "${cert//:/\:}" --key "$key" --cacert "$cacert" "$health_endpoint" |grep '{ *"health" *: *"true" *}'
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 3
+            timeoutSeconds: 3
+          resources:
+            requests:
+              cpu: 10m
+              memory: 5Mi
+          securityContext:
+            privileged: true
+      volumes:
+        - name: etcd-client
+          secret:
+            secretName: etcd-client
+        - name: etcd-ca
+          configMap:
+            name: etcd-ca-bundle
+		`)
+}
+
+// fakeOperatorInstance is a fake Operator instance that  fullfils the OperatorClient interface.
+type fakeOperatorInstance struct {
+	metav1.ObjectMeta
+	Spec   opv1.OperatorSpec
+	Status opv1.OperatorStatus
+}
+
+func makeFakeOperatorInstance() *fakeOperatorInstance {
+	instance := &fakeOperatorInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "cluster",
+			Generation: 0,
+		},
+		Spec: opv1.OperatorSpec{
+			ManagementState: opv1.Managed,
+		},
+		Status: opv1.OperatorStatus{},
+	}
+	return instance
+}
+
+//func makeResourceConditionalMap() []resourceapply.ResourceConditionalMap {
+//
+//}
+//
+//func CreatePDBConditional() resourceapply.ConditionalFunction {
+//	return func() bool {return true}
+//}
+
+func TestStaticResourceController_Sync(t *testing.T) {
+	testCases := []struct {
+		name                   string
+		resourceConditionalMap []resourceapply.ResourceConditionalMap
+		existing               []runtime.Object
+		verifyActions          func(actions []clienttesting.Action, t *testing.T)
+	}{
+		{
+			name: "static resource with no conditionals, create resource normally",
+			resourceConditionalMap: []resourceapply.ResourceConditionalMap{
+				{
+					File:                  "pdb.yaml",
+					DeleteConditionalFunc: nil,
+					CreateConditionalFunc: nil,
+				},
+			},
+			verifyActions: func(actions []clienttesting.Action, t *testing.T) {
+				if len(actions) != 2 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("get", "poddisruptionbudgets") || actions[0].(clienttesting.GetAction).GetName() != "foo" {
+					t.Error(spew.Sdump(actions))
+				}
+				if !actions[1].Matches("create", "poddisruptionbudgets") {
+					t.Error(spew.Sdump(actions))
+				}
+				expected := &policyv1.PodDisruptionBudget{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "PodDisruptionBudget",
+						APIVersion: "policy/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "abc"},
+				}
+				actual := actions[1].(clienttesting.CreateAction).GetObject().(*policyv1.PodDisruptionBudget)
+				if !equality.Semantic.DeepEqual(expected, actual) {
+					t.Error(diff.ObjectDiff(expected, actual))
+				}
+			},
+		},
+		{
+			name: "static resource with delete conditional and no create conditional, delete will be honored",
+			resourceConditionalMap: []resourceapply.ResourceConditionalMap{
+				{
+					File:                  "pdb.yaml",
+					DeleteConditionalFunc: func() bool { return true },
+					CreateConditionalFunc: nil,
+				},
+			},
+			existing: []runtime.Object{
+				&policyv1.PodDisruptionBudget{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "abc",
+					},
+				},
+			},
+			verifyActions: func(actions []clienttesting.Action, t *testing.T) {
+				if len(actions) != 2 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("get", "poddisruptionbudgets") || actions[0].(clienttesting.GetAction).GetName() != "foo" {
+					t.Error(spew.Sdump(actions))
+				}
+				if !actions[1].Matches("delete", "poddisruptionbudgets") {
+					t.Error(spew.Sdump(actions))
+				}
+			},
+		},
+		{
+			name: "static resource with delete conditional and create conditional, delete will be honored",
+			resourceConditionalMap: []resourceapply.ResourceConditionalMap{
+				{
+					File:                  "pdb.yaml",
+					DeleteConditionalFunc: func() bool { return true },
+					CreateConditionalFunc: func() bool { return true },
+				},
+			},
+			existing: []runtime.Object{
+				&policyv1.PodDisruptionBudget{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "abc",
+					},
+				},
+			},
+			verifyActions: func(actions []clienttesting.Action, t *testing.T) {
+				if len(actions) != 2 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("get", "poddisruptionbudgets") || actions[0].(clienttesting.GetAction).GetName() != "foo" {
+					t.Error(spew.Sdump(actions))
+				}
+				if !actions[1].Matches("delete", "poddisruptionbudgets") {
+					t.Error(spew.Sdump(actions))
+				}
+			},
+		},
+		{
+			name: "static resource with no delete conditional and create conditional, creation happens",
+			resourceConditionalMap: []resourceapply.ResourceConditionalMap{
+				{
+					File:                  "pdb.yaml",
+					DeleteConditionalFunc: nil,
+					CreateConditionalFunc: func() bool { return true },
+				},
+			},
+			verifyActions: func(actions []clienttesting.Action, t *testing.T) {
+				if len(actions) != 2 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("get", "poddisruptionbudgets") || actions[0].(clienttesting.GetAction).GetName() != "foo" {
+					t.Error(spew.Sdump(actions))
+				}
+				if !actions[1].Matches("create", "poddisruptionbudgets") {
+					t.Error(spew.Sdump(actions))
+				}
+			},
+		},
+		{
+			name: "static resource with no delete conditional and false create conditional, no creation",
+			resourceConditionalMap: []resourceapply.ResourceConditionalMap{
+				{
+					File:                  "pdb.yaml",
+					DeleteConditionalFunc: nil,
+					CreateConditionalFunc: func() bool { return false },
+				},
+			},
+			verifyActions: func(actions []clienttesting.Action, t *testing.T) {
+				if len(actions) != 1 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("get", "poddisruptionbudgets") || actions[0].(clienttesting.GetAction).GetName() != "foo" {
+					t.Error(spew.Sdump(actions))
+				}
+			},
+		},
+		{
+			name: "static resource with false delete conditional and false create conditional, no creation",
+			resourceConditionalMap: []resourceapply.ResourceConditionalMap{
+				{
+					File:                  "pdb.yaml",
+					DeleteConditionalFunc: func() bool { return false },
+					CreateConditionalFunc: func() bool { return false },
+				},
+			},
+			verifyActions: func(actions []clienttesting.Action, t *testing.T) {
+				if len(actions) != 1 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("get", "poddisruptionbudgets") || actions[0].(clienttesting.GetAction).GetName() != "foo" {
+					t.Error(spew.Sdump(actions))
+				}
+			},
+		},
+		{
+			name: "static resource with false delete conditional and false create conditional, existing resource, leave it as is",
+			resourceConditionalMap: []resourceapply.ResourceConditionalMap{
+				{
+					File:                  "pdb.yaml",
+					DeleteConditionalFunc: func() bool { return false },
+					CreateConditionalFunc: func() bool { return false },
+				},
+			},
+			verifyActions: func(actions []clienttesting.Action, t *testing.T) {
+				if len(actions) != 1 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("get", "poddisruptionbudgets") || actions[0].(clienttesting.GetAction).GetName() != "foo" {
+					t.Error(spew.Sdump(actions))
+				}
+			},
+		},
+		{
+			name: "static resource with true delete conditional and false create conditional, no resource existing, " +
+				"deletion is honored, no resource created",
+			resourceConditionalMap: []resourceapply.ResourceConditionalMap{
+				{
+					File:                  "pdb.yaml",
+					DeleteConditionalFunc: func() bool { return true },
+					CreateConditionalFunc: func() bool { return false },
+				},
+			},
+			verifyActions: func(actions []clienttesting.Action, t *testing.T) {
+				if len(actions) != 1 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("get", "poddisruptionbudgets") || actions[0].(clienttesting.GetAction).GetName() != "foo" {
+					t.Error(spew.Sdump(actions))
+				}
+			},
+		},
+		{
+			name: "static resource with true delete conditional and false create conditional, resource existing, " +
+				"deletion is honored",
+			resourceConditionalMap: []resourceapply.ResourceConditionalMap{
+				{
+					File:                  "pdb.yaml",
+					DeleteConditionalFunc: func() bool { return true },
+					CreateConditionalFunc: func() bool { return false },
+				},
+			},
+			existing: []runtime.Object{
+				&policyv1.PodDisruptionBudget{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "abc",
+					},
+				},
+			},
+			verifyActions: func(actions []clienttesting.Action, t *testing.T) {
+				if len(actions) != 2 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("get", "poddisruptionbudgets") || actions[0].(clienttesting.GetAction).GetName() != "foo" {
+					t.Error(spew.Sdump(actions))
+				}
+				if !actions[1].Matches("delete", "poddisruptionbudgets") {
+					t.Error(spew.Sdump(actions))
+				}
+			},
+		},
+	}
+	for _, tc := range testCases {
+		//recorder := events.NewInMemoryRecorder("test")
+		t.Run(tc.name, func(t *testing.T) {
+			coreClient := fakecore.NewSimpleClientset(tc.existing...)
+			//coreInformerFactory := coreinformers.NewSharedInformerFactory(coreClient, 0 )
+			opInstance := makeFakeOperatorInstance()
+			fakeOperatorClient := v1helpers.NewFakeOperatorClient(&opInstance.Spec, &opInstance.Status, nil)
+			c := &StaticResourceController{
+				name:                    "static-resource-controller",
+				manifests:               func(name string) ([]byte, error) { return makePDBManifest(), nil },
+				resourceConditionalMaps: tc.resourceConditionalMap,
+				ignoreNotFoundOnCreate:  false,
+				operatorClient:          fakeOperatorClient,
+				clients:                 (&resourceapply.ClientHolder{}).WithKubernetes(coreClient),
+				eventRecorder:           events.NewInMemoryRecorder("test"),
+				factory:                 nil,
+				categoryExpander:        nil,
+			}
+			err := c.Sync(context.TODO(), factory.NewSyncContext("static-resource-controller",
+				events.NewInMemoryRecorder("test")))
+			if err != nil {
+				t.Errorf("failed sync, %v for %v", err, tc.name)
+			}
+			tc.verifyActions(coreClient.Actions(), t)
+		})
+	}
 }


### PR DESCRIPTION
As of now, static resource controller is pretty static in creating resources. This commit ensures that the static resources are created/deleted based on certain conditional functions. This brings in needed dependency on other resources and ensures static resource controller can react to it.

cc @deads2k 

I split this into another PR as the change grew more than what I anticipated. I can certainly combine this with #1095 if that makes it easier.