### PR TITLE
makes the apiservice controller more resilient to failures

### DIFF
--- a/pkg/operator/apiserver/controller/apiservice/apigroup.go
+++ b/pkg/operator/apiserver/controller/apiservice/apigroup.go
@@ -4,11 +4,16 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sync"
+	"time"
 
-	"github.com/openshift/library-go/pkg/operator/events"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/rest"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+
+	"github.com/openshift/library-go/pkg/operator/events"
 )
 
 func newEndpointPrecondition(kubeInformers kubeinformers.SharedInformerFactory) func(apiServices []*apiregistrationv1.APIService) (bool, error) {
@@ -65,16 +70,63 @@ func newEndpointPrecondition(kubeInformers kubeinformers.SharedInformerFactory) 
 func checkDiscoveryForByAPIServices(recorder events.Recorder, restclient rest.Interface, apiServices []*apiregistrationv1.APIService) []string {
 	missingMessages := []string{}
 	for _, apiService := range apiServices {
-		url := "/apis/" + apiService.Spec.Group + "/" + apiService.Spec.Version
-
-		statusCode := 0
-		result := restclient.Get().AbsPath(url).Do(context.TODO()).StatusCode(&statusCode)
-		if statusCode != http.StatusOK {
+		err := checkDiscoveryForAPIService(restclient, apiService)
+		if err != nil {
 			groupVersionString := fmt.Sprintf("%s.%s", apiService.Spec.Group, apiService.Spec.Version)
-			recorder.Warningf("OpenShiftAPICheckFailed", fmt.Sprintf("%q failed with HTTP status code %d (%v)", groupVersionString, statusCode, result.Error()))
-			missingMessages = append(missingMessages, fmt.Sprintf("%q is not ready: %d (%v)", groupVersionString, statusCode, result.Error()))
+			recorder.Warningf("OpenShiftAPICheckFailed", fmt.Sprintf("%q failed with %v", groupVersionString, err))
+			missingMessages = append(missingMessages, fmt.Sprintf("%q is not ready: %v", groupVersionString, err))
 		}
 	}
 
 	return missingMessages
+}
+
+func checkDiscoveryForAPIService(restclient rest.Interface, apiService *apiregistrationv1.APIService) error {
+	type statusErrTuple struct {
+		status int
+		err    error
+	}
+
+	var attempts = 5
+	var resultsCh = make(chan statusErrTuple, attempts)
+
+	var wg sync.WaitGroup
+	wg.Add(attempts)
+
+	for i := 0; i < attempts; i++ {
+		go func() {
+			var ctx context.Context
+			var ctxCancelFn context.CancelFunc
+			var statusCode int
+			defer wg.Done()
+			defer utilruntime.HandleCrash()
+
+			ctx, ctxCancelFn = context.WithTimeout(context.TODO(), 25*time.Second)
+			defer ctxCancelFn()
+
+			result := restclient.Get().AbsPath("/apis/" + apiService.Spec.Group + "/" + apiService.Spec.Version).Do(ctx).StatusCode(&statusCode)
+			resultsCh <- statusErrTuple{status: statusCode, err: result.Error()}
+		}()
+	}
+
+	wg.Wait()
+	close(resultsCh)
+
+	var successfulRequests int
+	var errs = []error{}
+	for resTuple := range resultsCh {
+		if resTuple.status != http.StatusOK {
+			errs = append(errs, fmt.Errorf("an attempt failed with statusCode = %v, err = %v", resTuple.status, resTuple.err))
+			continue
+		}
+		successfulRequests++
+	}
+
+	// we don't aim for a total availability
+	// since the API servers got better and terminate requests gracefully
+	// and since we fire 5 requests in parallel we expect at least 40% success rate
+	if successfulRequests < 2 {
+		return kerrors.NewAggregate(errs)
+	}
+	return nil
 }


### PR DESCRIPTION
previously a single failed request to the discovery endpoint of a service could make an operator report Availiable=false

to increase resiliency and avoid frequent changes in Availability we are going to send 5 requests in parallel and deemed a service as unavailable only when we didn't get at least 2 successful.