### PR TITLE
Migrate csi deployment to use generic deployment

### DIFF
--- a/pkg/operator/csi/csicontrollerset/csi_controller_set.go
+++ b/pkg/operator/csi/csicontrollerset/csi_controller_set.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/csi/csiconfigobservercontroller"
 	"github.com/openshift/library-go/pkg/operator/csi/csidrivercontrollerservicecontroller"
 	"github.com/openshift/library-go/pkg/operator/csi/csidrivernodeservicecontroller"
+	"github.com/openshift/library-go/pkg/operator/deploymentcontroller"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/loglevel"
 	"github.com/openshift/library-go/pkg/operator/management"
@@ -142,7 +143,7 @@ func (c *CSIControllerSet) WithCSIDriverControllerService(
 	namespacedInformerFactory informers.SharedInformerFactory,
 	configInformer configinformers.SharedInformerFactory,
 	optionalInformers []factory.Informer,
-	optionalDeploymentHooks ...csidrivercontrollerservicecontroller.DeploymentHookFunc,
+	optionalDeploymentHooks ...deploymentcontroller.DeploymentHookFunc,
 ) *CSIControllerSet {
 	manifestFile, err := assetFunc(file)
 	if err != nil {

--- a/pkg/operator/csi/csidrivercontrollerservicecontroller/csi_driver_controller_service_controller.go
+++ b/pkg/operator/csi/csidrivercontrollerservicecontroller/csi_driver_controller_service_controller.go
@@ -1,44 +1,17 @@
 package csidrivercontrollerservicecontroller
 
 import (
-	"context"
-	"fmt"
-	"os"
-	"strconv"
-	"strings"
-	"time"
-
-	appsv1 "k8s.io/api/apps/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	appsinformersv1 "k8s.io/client-go/informers/apps/v1"
 	"k8s.io/client-go/kubernetes"
 
-	opv1 "github.com/openshift/api/operator/v1"
 	configinformers "github.com/openshift/client-go/config/informers/externalversions"
 
 	"github.com/openshift/library-go/pkg/controller/factory"
+	dc "github.com/openshift/library-go/pkg/operator/deploymentcontroller"
 	"github.com/openshift/library-go/pkg/operator/events"
-	"github.com/openshift/library-go/pkg/operator/loglevel"
-	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
-	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
-	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
+
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
-
-const (
-	driverImageEnvName        = "DRIVER_IMAGE"
-	provisionerImageEnvName   = "PROVISIONER_IMAGE"
-	attacherImageEnvName      = "ATTACHER_IMAGE"
-	resizerImageEnvName       = "RESIZER_IMAGE"
-	snapshotterImageEnvName   = "SNAPSHOTTER_IMAGE"
-	livenessProbeImageEnvName = "LIVENESS_PROBE_IMAGE"
-	kubeRBACProxyImageEnvName = "KUBE_RBAC_PROXY_IMAGE"
-
-	infraConfigName = "cluster"
-)
-
-// DeploymentHookFunc is a hook function to modify the Deployment.
-type DeploymentHookFunc func(*opv1.OperatorSpec, *appsv1.Deployment) error
 
 // CSIDriverControllerServiceController is a controller that deploys a CSI Controller Service to a given namespace.
 //
@@ -78,19 +51,6 @@ type DeploymentHookFunc func(*opv1.OperatorSpec, *appsv1.Deployment) error
 // <name>Available: indicates that the CSI Controller Service was successfully deployed and at least one Deployment replica is available.
 // <name>Progressing: indicates that the CSI Controller Service is being deployed.
 // <name>Degraded: produced when the sync() method returns an error.
-type CSIDriverControllerServiceController struct {
-	name           string
-	manifest       []byte
-	operatorClient v1helpers.OperatorClient
-	kubeClient     kubernetes.Interface
-	deployInformer appsinformersv1.DeploymentInformer
-	configInformer configinformers.SharedInformerFactory
-	// Optional hook functions to modify the Deployment.
-	// If one of these functions returns an error, the sync
-	// fails indicating the ordinal position of the failed function.
-	// Also, in that scenario the Degraded status is set to True.
-	optionalDeploymentHooks []DeploymentHookFunc
-}
 
 func NewCSIDriverControllerServiceController(
 	name string,
@@ -101,187 +61,11 @@ func NewCSIDriverControllerServiceController(
 	deployInformer appsinformersv1.DeploymentInformer,
 	configInformer configinformers.SharedInformerFactory,
 	optionalInformers []factory.Informer,
-	optionalDeploymentHooks ...DeploymentHookFunc,
+	optionalDeploymentHooks ...dc.DeploymentHookFunc,
 ) factory.Controller {
-	c := &CSIDriverControllerServiceController{
-		name:                    name,
-		manifest:                manifest,
-		operatorClient:          operatorClient,
-		kubeClient:              kubeClient,
-		deployInformer:          deployInformer,
-		configInformer:          configInformer,
-		optionalDeploymentHooks: optionalDeploymentHooks,
-	}
+	optionalInformers = append(optionalInformers, configInformer.Config().V1().Infrastructures().Informer())
+	var optionalManifestHooks []dc.ManifestHookFunc
+	optionalManifestHooks = append(optionalManifestHooks, WithPlaceholdersHook(configInformer))
+	return dc.NewDeploymentController(name, manifest, recorder, operatorClient, kubeClient, deployInformer, optionalInformers, optionalManifestHooks, optionalDeploymentHooks...)
 
-	informers := append(
-		optionalInformers,
-		operatorClient.Informer(),
-		deployInformer.Informer(),
-		configInformer.Config().V1().Infrastructures().Informer(),
-	)
-
-	return factory.New().WithInformers(
-		informers...,
-	).WithSync(
-		c.sync,
-	).ResyncEvery(
-		time.Minute,
-	).WithSyncDegradedOnError(
-		operatorClient,
-	).ToController(
-		c.name,
-		recorder.WithComponentSuffix("csi-driver-controller-service_"+strings.ToLower(name)),
-	)
-}
-
-func (c *CSIDriverControllerServiceController) Name() string {
-	return c.name
-}
-
-func (c *CSIDriverControllerServiceController) sync(ctx context.Context, syncContext factory.SyncContext) error {
-	opSpec, opStatus, _, err := c.operatorClient.GetOperatorState()
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil
-		}
-		return err
-	}
-
-	if opSpec.ManagementState != opv1.Managed {
-		return nil
-	}
-
-	infra, err := c.configInformer.Config().V1().Infrastructures().Lister().Get(infraConfigName)
-	if err != nil {
-		return err
-	}
-	clusterID := infra.Status.InfrastructureName
-
-	manifest := replacePlaceholders(c.manifest, opSpec, clusterID)
-	required := resourceread.ReadDeploymentV1OrDie(manifest)
-
-	for i := range c.optionalDeploymentHooks {
-		err := c.optionalDeploymentHooks[i](opSpec, required)
-		if err != nil {
-			return fmt.Errorf("error running hook function (index=%d): %w", i, err)
-		}
-	}
-
-	deployment, _, err := resourceapply.ApplyDeployment(
-		c.kubeClient.AppsV1(),
-		syncContext.Recorder(),
-		required,
-		resourcemerge.ExpectedDeploymentGeneration(required, opStatus.Generations),
-	)
-	if err != nil {
-		return err
-	}
-
-	availableCondition := opv1.OperatorCondition{
-		Type:   c.name + opv1.OperatorStatusTypeAvailable,
-		Status: opv1.ConditionTrue,
-	}
-
-	if deployment.Status.AvailableReplicas > 0 {
-		availableCondition.Status = opv1.ConditionTrue
-	} else {
-		availableCondition.Status = opv1.ConditionFalse
-		availableCondition.Message = "Waiting for Deployment to deploy the CSI Controller Service"
-		availableCondition.Reason = "Deploying"
-	}
-
-	progressingCondition := opv1.OperatorCondition{
-		Type:   c.name + opv1.OperatorStatusTypeProgressing,
-		Status: opv1.ConditionFalse,
-	}
-
-	if ok, msg := isProgressing(opStatus, deployment); ok {
-		progressingCondition.Status = opv1.ConditionTrue
-		progressingCondition.Message = msg
-		progressingCondition.Reason = "Deploying"
-	}
-
-	updateStatusFn := func(newStatus *opv1.OperatorStatus) error {
-		// TODO: set ObservedGeneration (the last stable generation change we dealt with)
-		resourcemerge.SetDeploymentGeneration(&newStatus.Generations, deployment)
-		return nil
-	}
-
-	_, _, err = v1helpers.UpdateStatus(
-		c.operatorClient,
-		updateStatusFn,
-		v1helpers.UpdateConditionFn(availableCondition),
-		v1helpers.UpdateConditionFn(progressingCondition),
-	)
-
-	return err
-}
-
-func isProgressing(status *opv1.OperatorStatus, deployment *appsv1.Deployment) (bool, string) {
-	var deploymentExpectedReplicas int32
-	if deployment.Spec.Replicas != nil {
-		deploymentExpectedReplicas = *deployment.Spec.Replicas
-	}
-
-	switch {
-	case deployment.Generation != deployment.Status.ObservedGeneration:
-		return true, "Waiting for Deployment to act on changes"
-	case deployment.Status.UnavailableReplicas > 0:
-		return true, "Waiting for Deployment to deploy pods"
-	case deployment.Status.UpdatedReplicas < deploymentExpectedReplicas:
-		return true, "Waiting for Deployment to update pods"
-	case deployment.Status.AvailableReplicas < deploymentExpectedReplicas:
-		return true, "Waiting for Deployment to deploy pods"
-	}
-	return false, ""
-}
-
-func replacePlaceholders(manifest []byte, spec *opv1.OperatorSpec, clusterID string) []byte {
-	pairs := []string{}
-
-	// Replace container images by env vars if they are set
-	csiDriver := os.Getenv(driverImageEnvName)
-	if csiDriver != "" {
-		pairs = append(pairs, []string{"${DRIVER_IMAGE}", csiDriver}...)
-	}
-
-	provisioner := os.Getenv(provisionerImageEnvName)
-	if provisioner != "" {
-		pairs = append(pairs, []string{"${PROVISIONER_IMAGE}", provisioner}...)
-	}
-
-	attacher := os.Getenv(attacherImageEnvName)
-	if attacher != "" {
-		pairs = append(pairs, []string{"${ATTACHER_IMAGE}", attacher}...)
-	}
-
-	resizer := os.Getenv(resizerImageEnvName)
-	if resizer != "" {
-		pairs = append(pairs, []string{"${RESIZER_IMAGE}", resizer}...)
-	}
-
-	snapshotter := os.Getenv(snapshotterImageEnvName)
-	if snapshotter != "" {
-		pairs = append(pairs, []string{"${SNAPSHOTTER_IMAGE}", snapshotter}...)
-	}
-
-	livenessProbe := os.Getenv(livenessProbeImageEnvName)
-	if livenessProbe != "" {
-		pairs = append(pairs, []string{"${LIVENESS_PROBE_IMAGE}", livenessProbe}...)
-	}
-
-	kubeRBACProxy := os.Getenv(kubeRBACProxyImageEnvName)
-	if kubeRBACProxy != "" {
-		pairs = append(pairs, []string{"${KUBE_RBAC_PROXY_IMAGE}", kubeRBACProxy}...)
-	}
-
-	// Cluster ID
-	pairs = append(pairs, []string{"${CLUSTER_ID}", clusterID}...)
-
-	// Log level
-	logLevel := loglevel.LogLevelToVerbosity(spec.LogLevel)
-	pairs = append(pairs, []string{"${LOG_LEVEL}", strconv.Itoa(logLevel)}...)
-
-	replaced := strings.NewReplacer(pairs...).Replace(string(manifest))
-	return []byte(replaced)
 }

--- a/pkg/operator/csi/csidrivercontrollerservicecontroller/csi_driver_controller_service_controller_test.go
+++ b/pkg/operator/csi/csidrivercontrollerservicecontroller/csi_driver_controller_service_controller_test.go
@@ -3,29 +3,22 @@ package csidrivercontrollerservicecontroller
 import (
 	"context"
 	"fmt"
-	"os"
-	"sort"
 	"strings"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	coreinformers "k8s.io/client-go/informers"
 	fakecore "k8s.io/client-go/kubernetes/fake"
-	core "k8s.io/client-go/testing"
 
-	"github.com/google/go-cmp/cmp"
 	configv1 "github.com/openshift/api/config/v1"
 	opv1 "github.com/openshift/api/operator/v1"
 	fakeconfig "github.com/openshift/client-go/config/clientset/versioned/fake"
 	configinformers "github.com/openshift/client-go/config/informers/externalversions"
-
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
-	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
@@ -44,17 +37,10 @@ const (
 	livenessProbeContainerName = "csi-liveness-probe"
 	kubeRBACProxyContainerName = "provisioner-kube-rbac-proxy"
 
-	// From github.com/openshift/library-go/pkg/operator/resource/resourceapply/apps.go
-	specHashAnnotation = "operator.openshift.io/spec-hash"
-	defaultClusterID   = "ID1234"
+	defaultClusterID = "ID1234"
 
 	hookDeploymentAnnKey = "operator.openshift.io/foo"
 	hookDeploymentAnnVal = "bar"
-)
-
-var (
-	conditionAvailable   = controllerName + opv1.OperatorStatusTypeAvailable
-	conditionProgressing = controllerName + opv1.OperatorStatusTypeProgressing
 )
 
 type images struct {
@@ -65,87 +51,6 @@ type images struct {
 	snapshotter   string
 	livenessProbe string
 	kubeRBACProxy string
-}
-
-type testCase struct {
-	name            string
-	images          images
-	initialObjects  testObjects
-	expectedObjects testObjects
-	expectErr       bool
-}
-
-type testObjects struct {
-	deployment *appsv1.Deployment
-	driver     *fakeDriverInstance
-}
-
-type testContext struct {
-	controller     factory.Controller
-	operatorClient v1helpers.OperatorClient
-	coreClient     *fakecore.Clientset
-	coreInformers  coreinformers.SharedInformerFactory
-}
-
-func newTestContext(test testCase, t *testing.T) *testContext {
-	// Add deployment to informer
-	var initialObjects []runtime.Object
-	if test.initialObjects.deployment != nil {
-		resourceapply.SetSpecHashAnnotation(&test.initialObjects.deployment.ObjectMeta, test.initialObjects.deployment.Spec)
-		initialObjects = append(initialObjects, test.initialObjects.deployment)
-	}
-
-	coreClient := fakecore.NewSimpleClientset(initialObjects...)
-	coreInformerFactory := coreinformers.NewSharedInformerFactory(coreClient, 0 /*no resync */)
-
-	// Fill the informer
-	if test.initialObjects.deployment != nil {
-		coreInformerFactory.Apps().V1().Deployments().Informer().GetIndexer().Add(test.initialObjects.deployment)
-	}
-
-	// Add global reactors
-	addGenerationReactor(coreClient)
-
-	// Add a fake Infrastructure object to informer. This is not
-	// optional because it is always present in the cluster.
-	initialInfras := []runtime.Object{makeInfra()}
-	configClient := fakeconfig.NewSimpleClientset(initialInfras...)
-	configInformerFactory := configinformers.NewSharedInformerFactory(configClient, 0)
-	configInformerFactory.Config().V1().Infrastructures().Informer().GetIndexer().Add(initialInfras[0])
-
-	// fakeDriverInstance also fulfils the OperatorClient interface
-	fakeOperatorClient := v1helpers.NewFakeOperatorClient(
-		&test.initialObjects.driver.Spec,
-		&test.initialObjects.driver.Status,
-		nil, /*triggerErr func*/
-	)
-	controller := NewCSIDriverControllerServiceController(
-		controllerName,
-		makeFakeManifest(),
-		events.NewInMemoryRecorder(operandName),
-		fakeOperatorClient,
-		coreClient,
-		coreInformerFactory.Apps().V1().Deployments(),
-		configInformerFactory,
-		nil, /* optional informers */
-	)
-
-	// Pretend env vars are set
-	// TODO: inject these in New() instead
-	os.Setenv(driverImageEnvName, test.images.csiDriver)
-	os.Setenv(provisionerImageEnvName, test.images.provisioner)
-	os.Setenv(attacherImageEnvName, test.images.attacher)
-	os.Setenv(snapshotterImageEnvName, test.images.snapshotter)
-	os.Setenv(resizerImageEnvName, test.images.resizer)
-	os.Setenv(livenessProbeImageEnvName, test.images.livenessProbe)
-	os.Setenv(kubeRBACProxyImageEnvName, test.images.kubeRBACProxy)
-
-	return &testContext{
-		controller:     controller,
-		operatorClient: fakeOperatorClient,
-		coreClient:     coreClient,
-		coreInformers:  coreInformerFactory,
-	}
 }
 
 // Drivers
@@ -167,68 +72,6 @@ func makeFakeDriverInstance(modifiers ...driverModifier) *fakeDriverInstance {
 		instance = modifier(instance)
 	}
 	return instance
-}
-
-func withLogLevel(logLevel opv1.LogLevel) driverModifier {
-	return func(i *fakeDriverInstance) *fakeDriverInstance {
-		i.Spec.LogLevel = logLevel
-		return i
-	}
-}
-
-func withGeneration(generations ...int64) driverModifier {
-	return func(i *fakeDriverInstance) *fakeDriverInstance {
-		i.Generation = generations[0]
-		if len(generations) > 1 {
-			i.Status.ObservedGeneration = generations[1]
-		}
-		return i
-	}
-}
-
-func withGenerations(deployment int64) driverModifier {
-	return func(i *fakeDriverInstance) *fakeDriverInstance {
-		i.Status.Generations = []opv1.GenerationStatus{
-			{
-				Group:          appsv1.GroupName,
-				LastGeneration: deployment,
-				Name:           deploymentName,
-				Namespace:      operandNamespace,
-				Resource:       "deployments",
-			},
-		}
-		return i
-	}
-}
-
-func withTrueConditions(conditions ...string) driverModifier {
-	return func(i *fakeDriverInstance) *fakeDriverInstance {
-		if i.Status.Conditions == nil {
-			i.Status.Conditions = []opv1.OperatorCondition{}
-		}
-		for _, cond := range conditions {
-			i.Status.Conditions = append(i.Status.Conditions, opv1.OperatorCondition{
-				Type:   cond,
-				Status: opv1.ConditionTrue,
-			})
-		}
-		return i
-	}
-}
-
-func withFalseConditions(conditions ...string) driverModifier {
-	return func(i *fakeDriverInstance) *fakeDriverInstance {
-		if i.Status.Conditions == nil {
-			i.Status.Conditions = []opv1.OperatorCondition{}
-		}
-		for _, c := range conditions {
-			i.Status.Conditions = append(i.Status.Conditions, opv1.OperatorCondition{
-				Type:   c,
-				Status: opv1.ConditionFalse,
-			})
-		}
-		return i
-	}
 }
 
 func getIndex(containers []v1.Container, name string) int {
@@ -315,15 +158,6 @@ func makeDeployment(clusterID string, logLevel int, images images, modifiers ...
 	return dep
 }
 
-func withDeploymentStatus(readyReplicas, availableReplicas, updatedReplicas int32) deploymentModifier {
-	return func(instance *appsv1.Deployment) *appsv1.Deployment {
-		instance.Status.ReadyReplicas = readyReplicas
-		instance.Status.AvailableReplicas = availableReplicas
-		instance.Status.UpdatedReplicas = updatedReplicas
-		return instance
-	}
-}
-
 func withDeploymentReplicas(replicas int32) deploymentModifier {
 	return func(instance *appsv1.Deployment) *appsv1.Deployment {
 		instance.Spec.Replicas = &replicas
@@ -337,13 +171,6 @@ func withDeploymentGeneration(generations ...int64) deploymentModifier {
 		if len(generations) > 1 {
 			instance.Status.ObservedGeneration = generations[1]
 		}
-		return instance
-	}
-}
-
-func withDeploymentNodeSelector(selector map[string]string) deploymentModifier {
-	return func(instance *appsv1.Deployment) *appsv1.Deployment {
-		instance.Spec.Template.Spec.NodeSelector = selector
 		return instance
 	}
 }
@@ -363,25 +190,6 @@ func makeInfra() *configv1.Infrastructure {
 			},
 		},
 	}
-}
-
-// This reactor is always enabled and bumps Deployment generation when it gets updated.
-func addGenerationReactor(client *fakecore.Clientset) {
-	client.PrependReactor("*", "deployments", func(action core.Action) (handled bool, ret runtime.Object, err error) {
-		switch a := action.(type) {
-		case core.CreateActionImpl:
-			object := a.GetObject()
-			deployment := object.(*appsv1.Deployment)
-			deployment.Generation++
-			return false, deployment, nil
-		case core.UpdateActionImpl:
-			object := a.GetObject()
-			deployment := object.(*appsv1.Deployment)
-			deployment.Generation++
-			return false, deployment, nil
-		}
-		return false, nil, nil
-	})
 }
 
 func deploymentAnnotationHook(opSpec *opv1.OperatorSpec, instance *appsv1.Deployment) error {
@@ -432,294 +240,6 @@ func TestDeploymentHook(t *testing.T) {
 	}
 }
 
-func TestSync(t *testing.T) {
-	const (
-		replica0 = 0
-		replica1 = 1
-		replica2 = 2
-	)
-	var (
-		argsLevel2 = 2
-		argsLevel6 = 6
-	)
-
-	testCases := []testCase{
-		{
-			// Only CR exists, everything else is created
-			name:   "initial sync",
-			images: defaultImages(),
-			initialObjects: testObjects{
-				driver: makeFakeDriverInstance(),
-			},
-			expectedObjects: testObjects{
-				deployment: makeDeployment(
-					defaultClusterID,
-					argsLevel2,
-					defaultImages(),
-					withDeploymentGeneration(1, 0)),
-				driver: makeFakeDriverInstance(
-					// withStatus(replica0),
-					withGenerations(1),
-					withTrueConditions(conditionProgressing),
-					withFalseConditions(conditionAvailable)), // Degraded is set later on
-			},
-		},
-		{
-			// Deployment is fully deployed and its status is synced to CR
-			name:   "deployment fully deployed",
-			images: defaultImages(),
-			initialObjects: testObjects{
-				deployment: makeDeployment(
-					defaultClusterID,
-					argsLevel2,
-					defaultImages(),
-					withDeploymentGeneration(1, 1),
-					withDeploymentStatus(replica1, replica1, replica1)),
-				driver: makeFakeDriverInstance(withGenerations(1)),
-			},
-			expectedObjects: testObjects{
-				deployment: makeDeployment(
-					defaultClusterID,
-					argsLevel2,
-					defaultImages(),
-					withDeploymentGeneration(1, 1),
-					withDeploymentStatus(replica1, replica1, replica1)),
-				driver: makeFakeDriverInstance(
-					// withStatus(replica1),
-					withGenerations(1),
-					withTrueConditions(conditionAvailable),
-					withFalseConditions(conditionProgressing)),
-			},
-		},
-		{
-			// Deployment has wrong nr. of replicas, modified by user, and gets replaced by the operator.
-			name:   "deployment modified by user",
-			images: defaultImages(),
-			initialObjects: testObjects{
-				deployment: makeDeployment(
-					defaultClusterID,
-					argsLevel2,
-					defaultImages(),
-					withDeploymentReplicas(2),      // User changed replicas
-					withDeploymentGeneration(2, 1), // ... which changed Generation
-					withDeploymentStatus(replica1, replica1, replica1)),
-				driver: makeFakeDriverInstance(withGenerations(1)), // the operator knows the old generation of the Deployment
-			},
-			expectedObjects: testObjects{
-				deployment: makeDeployment(
-					defaultClusterID,
-					argsLevel2,
-					defaultImages(),
-					withDeploymentReplicas(1),      // The operator fixed replica count
-					withDeploymentGeneration(3, 1), // ... which bumps generation again
-					withDeploymentStatus(replica1, replica1, replica1)),
-				driver: makeFakeDriverInstance(
-					// withStatus(replica1),
-					withGenerations(3), // now the operator knows generation 1
-					withTrueConditions(conditionAvailable, conditionProgressing), // Progressing due to Generation change
-				),
-			},
-		},
-		{
-			// Deployment gets degraded for some reason
-			name:   "deployment degraded",
-			images: defaultImages(),
-			initialObjects: testObjects{
-				deployment: makeDeployment(
-					defaultClusterID,
-					argsLevel2,
-					defaultImages(),
-					withDeploymentGeneration(1, 1),
-					withDeploymentStatus(0, 0, 0)), // the Deployment has no pods
-				driver: makeFakeDriverInstance(
-					// withStatus(replica1),
-					withGenerations(1),
-					withGeneration(1, 1),
-					withTrueConditions(conditionAvailable),
-					withFalseConditions(conditionProgressing)),
-			},
-			expectedObjects: testObjects{
-				deployment: makeDeployment(
-					defaultClusterID,
-					argsLevel2,
-					defaultImages(),
-					withDeploymentGeneration(1, 1),
-					withDeploymentStatus(0, 0, 0)), // no change to the Deployment
-				driver: makeFakeDriverInstance(
-					// withStatus(replica0),
-					withGenerations(1),
-					withGeneration(1, 1),
-					withTrueConditions(conditionProgressing), // The operator is Progressing
-					withFalseConditions(conditionAvailable)), // The operator is not Available (controller not running...)
-			},
-		},
-		{
-			// Deployment is updating pods
-			name:   "update",
-			images: defaultImages(),
-			initialObjects: testObjects{
-				deployment: makeDeployment(
-					defaultClusterID,
-					argsLevel2,
-					defaultImages(),
-					withDeploymentGeneration(1, 1),
-					withDeploymentStatus(1 /*ready*/, 1 /*available*/, 0 /*updated*/)), // the Deployment is updating 1 pod
-				driver: makeFakeDriverInstance(
-					// withStatus(replica1),
-					withGenerations(1),
-					withGeneration(1, 1),
-					withTrueConditions(conditionAvailable),
-					withFalseConditions(conditionProgressing)),
-			},
-			expectedObjects: testObjects{
-				deployment: makeDeployment(
-					defaultClusterID,
-					argsLevel2,
-					defaultImages(),
-					withDeploymentGeneration(1, 1),
-					withDeploymentStatus(1, 1, 0)), // no change to the Deployment
-				driver: makeFakeDriverInstance(
-					// withStatus(replica0),
-					withGenerations(1),
-					withGeneration(1, 1),
-					withTrueConditions(conditionAvailable, conditionProgressing)), // The operator is Progressing, but still Available
-			},
-		},
-		{
-			// User changes log level and it's projected into the Deployment
-			name:   "log level change",
-			images: defaultImages(),
-			initialObjects: testObjects{
-				deployment: makeDeployment(
-					defaultClusterID,
-					argsLevel2,
-					defaultImages(),
-					withDeploymentGeneration(1, 1),
-					withDeploymentStatus(replica1, replica1, replica1)),
-				driver: makeFakeDriverInstance(
-					withGenerations(1),
-					withLogLevel(opv1.Trace), // User changed the log level...
-					withGeneration(2, 1)),    //... which caused the Generation to increase
-			},
-			expectedObjects: testObjects{
-				deployment: makeDeployment(
-					defaultClusterID,
-					argsLevel6, // The operator changed cmdline arguments with a new log level
-					defaultImages(),
-					withDeploymentGeneration(2, 1), // ... which caused the Generation to increase
-					withDeploymentStatus(replica1, replica1, replica1)),
-				driver: makeFakeDriverInstance(
-					// withStatus(replica1),
-					withLogLevel(opv1.Trace),
-					withGenerations(2),
-					withGeneration(2, 1), // TODO: should I increase the observed generation?
-					withTrueConditions(conditionAvailable, conditionProgressing)), // Progressing due to Generation change
-			},
-		},
-		{
-			// Deployment updates images
-			name:   "image change",
-			images: defaultImages(),
-			initialObjects: testObjects{
-				deployment: makeDeployment(
-					defaultClusterID,
-					argsLevel2,
-					oldImages(),
-					withDeploymentGeneration(1, 1),
-					withDeploymentStatus(replica1, replica1, replica1)),
-				driver: makeFakeDriverInstance(
-					// withStatus(replica1),k
-					withGenerations(1),
-					withTrueConditions(conditionAvailable),
-					withFalseConditions(conditionProgressing)),
-			},
-			expectedObjects: testObjects{
-				deployment: makeDeployment(
-					defaultClusterID,
-					argsLevel2,
-					defaultImages(),
-					withDeploymentGeneration(2, 1),
-					withDeploymentStatus(replica1, replica1, replica1)),
-				driver: makeFakeDriverInstance(
-					// withStatus(replica1),
-					withGenerations(2),
-					withTrueConditions(conditionAvailable, conditionProgressing)),
-			},
-		},
-	}
-
-	for _, test := range testCases {
-		t.Run(test.name, func(t *testing.T) {
-			// Initialize
-			ctx := newTestContext(test, t)
-
-			// Act
-			err := ctx.controller.Sync(context.TODO(), factory.NewSyncContext(controllerName, events.NewInMemoryRecorder("test-csi-driver")))
-
-			// Assert
-			// Check error
-			if err != nil && !test.expectErr {
-				t.Errorf("sync() returned unexpected error: %v", err)
-			}
-			if err == nil && test.expectErr {
-				t.Error("sync() unexpectedly succeeded when error was expected")
-			}
-
-			// Check expectedObjects.deployment
-			if test.expectedObjects.deployment != nil {
-				deployName := test.expectedObjects.deployment.Name
-				actualDeployment, err := ctx.coreClient.AppsV1().Deployments(operandNamespace).Get(context.TODO(), deployName, metav1.GetOptions{})
-				if err != nil {
-					t.Errorf("Failed to get Deployment %s: %v", deployName, err)
-				}
-				sanitizeDeployment(actualDeployment)
-				sanitizeDeployment(test.expectedObjects.deployment)
-				if !equality.Semantic.DeepEqual(test.expectedObjects.deployment, actualDeployment) {
-					t.Errorf("Unexpected Deployment %+v content:\n%s", operandName, cmp.Diff(test.expectedObjects.deployment, actualDeployment))
-				}
-			}
-
-			// Check expectedObjects.driver.Status
-			if test.expectedObjects.driver != nil {
-				_, actualStatus, _, err := ctx.operatorClient.GetOperatorState()
-				if err != nil {
-					t.Errorf("Failed to get Driver: %v", err)
-				}
-				sanitizeInstanceStatus(actualStatus)
-				sanitizeInstanceStatus(&test.expectedObjects.driver.Status)
-				if !equality.Semantic.DeepEqual(test.expectedObjects.driver.Status, *actualStatus) {
-					t.Errorf("Unexpected Driver %+v content:\n%s", operandName, cmp.Diff(test.expectedObjects.driver.Status, *actualStatus))
-				}
-			}
-		})
-	}
-}
-
-func sanitizeDeployment(deployment *appsv1.Deployment) {
-	// nil and empty array are the same
-	if len(deployment.Labels) == 0 {
-		deployment.Labels = nil
-	}
-	if len(deployment.Annotations) == 0 {
-		deployment.Annotations = nil
-	}
-	// Remove random annotations set by ApplyDeployment
-	delete(deployment.Annotations, specHashAnnotation)
-}
-
-func sanitizeInstanceStatus(status *opv1.OperatorStatus) {
-	// Remove condition texts
-	for i := range status.Conditions {
-		status.Conditions[i].LastTransitionTime = metav1.Time{}
-		status.Conditions[i].Message = ""
-		status.Conditions[i].Reason = ""
-	}
-	// Sort the conditions by name to have consistent position in the array
-	sort.Slice(status.Conditions, func(i, j int) bool {
-		return status.Conditions[i].Type < status.Conditions[j].Type
-	})
-}
-
 func defaultImages() images {
 	return images{
 		csiDriver:     "quay.io/openshift/origin-test-csi-driver:latest",
@@ -729,18 +249,6 @@ func defaultImages() images {
 		snapshotter:   "quay.io/openshift/origin-csi-external-snapshotter:latest",
 		livenessProbe: "quay.io/openshift/origin-csi-livenessprobe:latest",
 		kubeRBACProxy: "quay.io/openshift/origin-kube-rbac-proxy:latest",
-	}
-}
-
-func oldImages() images {
-	return images{
-		csiDriver:     "quay.io/openshift/origin-test-csi-driver:old",
-		provisioner:   "quay.io/openshift/origin-csi-external-provisioner:old",
-		attacher:      "quay.io/openshift/origin-csi-external-attacher:old",
-		resizer:       "quay.io/openshift/origin-csi-external-resizer:old",
-		snapshotter:   "quay.io/openshift/origin-csi-external-snapshotter:old",
-		livenessProbe: "quay.io/openshift/origin-csi-livenessprobe:old",
-		kubeRBACProxy: "quay.io/openshift/origin-kube-rbac-proxy:old",
 	}
 }
 

--- a/pkg/operator/csi/csidrivercontrollerservicecontroller/helpers.go
+++ b/pkg/operator/csi/csidrivercontrollerservicecontroller/helpers.go
@@ -3,6 +3,8 @@ package csidrivercontrollerservicecontroller
 import (
 	"crypto/sha256"
 	"fmt"
+	"os"
+	"strconv"
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -11,14 +13,28 @@ import (
 	corev1listers "k8s.io/client-go/listers/core/v1"
 
 	opv1 "github.com/openshift/api/operator/v1"
-
+	configinformers "github.com/openshift/client-go/config/informers/externalversions"
 	"github.com/openshift/library-go/pkg/operator/csi/csiconfigobservercontroller"
+	dc "github.com/openshift/library-go/pkg/operator/deploymentcontroller"
+	"github.com/openshift/library-go/pkg/operator/loglevel"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcehash"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
 
+const (
+	driverImageEnvName        = "DRIVER_IMAGE"
+	provisionerImageEnvName   = "PROVISIONER_IMAGE"
+	attacherImageEnvName      = "ATTACHER_IMAGE"
+	resizerImageEnvName       = "RESIZER_IMAGE"
+	snapshotterImageEnvName   = "SNAPSHOTTER_IMAGE"
+	livenessProbeImageEnvName = "LIVENESS_PROBE_IMAGE"
+	kubeRBACProxyImageEnvName = "KUBE_RBAC_PROXY_IMAGE"
+
+	infraConfigName = "cluster"
+)
+
 // WithObservedProxyDeploymentHook creates a deployment hook that injects into the deployment's containers the observed proxy config.
-func WithObservedProxyDeploymentHook() DeploymentHookFunc {
+func WithObservedProxyDeploymentHook() dc.DeploymentHookFunc {
 	return func(opSpec *opv1.OperatorSpec, deployment *appsv1.Deployment) error {
 		containerNamesString := deployment.Annotations["config.openshift.io/inject-proxy"]
 		err := v1helpers.InjectObservedProxyIntoContainers(
@@ -36,7 +52,7 @@ func WithSecretHashAnnotationHook(
 	namespace string,
 	secretName string,
 	secretInformer corev1.SecretInformer,
-) DeploymentHookFunc {
+) dc.DeploymentHookFunc {
 	return func(opSpec *opv1.OperatorSpec, deployment *appsv1.Deployment) error {
 		inputHashes, err := resourcehash.MultipleObjectHashStringMapForObjectReferenceFromLister(
 			nil,
@@ -73,7 +89,7 @@ func WithSecretHashAnnotationHook(
 // When node ports or hostNetwork are used, maxSurge=0 should be set in the
 // Deployment RollingUpdate strategy to prevent the new pod from getting stuck
 // waiting for a node with free ports.
-func WithReplicasHook(nodeLister corev1listers.NodeLister) DeploymentHookFunc {
+func WithReplicasHook(nodeLister corev1listers.NodeLister) dc.DeploymentHookFunc {
 	return func(_ *opv1.OperatorSpec, deployment *appsv1.Deployment) error {
 		nodeSelector := deployment.Spec.Template.Spec.NodeSelector
 		nodes, err := nodeLister.List(labels.SelectorFromSet(nodeSelector))
@@ -86,5 +102,62 @@ func WithReplicasHook(nodeLister corev1listers.NodeLister) DeploymentHookFunc {
 		}
 		deployment.Spec.Replicas = &replicas
 		return nil
+	}
+}
+
+// WithPlaceholdersHook is a manifest hook which replaces the variable with appropriate values set
+func WithPlaceholdersHook(configInformer configinformers.SharedInformerFactory) dc.ManifestHookFunc {
+	return func(spec *opv1.OperatorSpec, manifest []byte) ([]byte, error) {
+		pairs := []string{}
+		infra, err := configInformer.Config().V1().Infrastructures().Lister().Get(infraConfigName)
+		if err != nil {
+			return nil, err
+		}
+		clusterID := infra.Status.InfrastructureName
+		// Replace container images by env vars if they are set
+		csiDriver := os.Getenv(driverImageEnvName)
+		if csiDriver != "" {
+			pairs = append(pairs, []string{"${DRIVER_IMAGE}", csiDriver}...)
+		}
+
+		provisioner := os.Getenv(provisionerImageEnvName)
+		if provisioner != "" {
+			pairs = append(pairs, []string{"${PROVISIONER_IMAGE}", provisioner}...)
+		}
+
+		attacher := os.Getenv(attacherImageEnvName)
+		if attacher != "" {
+			pairs = append(pairs, []string{"${ATTACHER_IMAGE}", attacher}...)
+		}
+
+		resizer := os.Getenv(resizerImageEnvName)
+		if resizer != "" {
+			pairs = append(pairs, []string{"${RESIZER_IMAGE}", resizer}...)
+		}
+
+		snapshotter := os.Getenv(snapshotterImageEnvName)
+		if snapshotter != "" {
+			pairs = append(pairs, []string{"${SNAPSHOTTER_IMAGE}", snapshotter}...)
+		}
+
+		livenessProbe := os.Getenv(livenessProbeImageEnvName)
+		if livenessProbe != "" {
+			pairs = append(pairs, []string{"${LIVENESS_PROBE_IMAGE}", livenessProbe}...)
+		}
+
+		kubeRBACProxy := os.Getenv(kubeRBACProxyImageEnvName)
+		if kubeRBACProxy != "" {
+			pairs = append(pairs, []string{"${KUBE_RBAC_PROXY_IMAGE}", kubeRBACProxy}...)
+		}
+
+		// Cluster ID
+		pairs = append(pairs, []string{"${CLUSTER_ID}", clusterID}...)
+
+		// Log level
+		logLevel := loglevel.LogLevelToVerbosity(spec.LogLevel)
+		pairs = append(pairs, []string{"${LOG_LEVEL}", strconv.Itoa(logLevel)}...)
+
+		replaced := strings.NewReplacer(pairs...).Replace(string(manifest))
+		return []byte(replaced), nil
 	}
 }

--- a/pkg/operator/deploymentcontroller/deployment_controller.go
+++ b/pkg/operator/deploymentcontroller/deployment_controller.go
@@ -1,0 +1,196 @@
+package deploymentcontroller
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	appsinformersv1 "k8s.io/client-go/informers/apps/v1"
+	"k8s.io/client-go/kubernetes"
+
+	opv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+// DeploymentHookFunc is a hook function to modify the Deployment.
+type DeploymentHookFunc func(*opv1.OperatorSpec, *appsv1.Deployment) error
+
+// ManifestHookFunc is a hook function to modify the manifest in raw format.
+type ManifestHookFunc func(*opv1.OperatorSpec, []byte) ([]byte, error)
+
+// DeploymentController is a generic controller that manages a deployment
+// <name>Available: indicates that the deployment controller  was successfully deployed and at least one Deployment replica is available.
+// <name>Progressing: indicates that the Deployment is in progress.
+// <name>Degraded: produced when the sync() method returns an error.
+type DeploymentController struct {
+	name           string
+	manifest       []byte
+	operatorClient v1helpers.OperatorClient
+	kubeClient     kubernetes.Interface
+	deployInformer appsinformersv1.DeploymentInformer
+	// Optional hook functions to modify the deployment manifest.
+	// This helps in modifying the manifests before it deployment
+	// is created from the manifest.
+	// If one of these functions returns an error, the sync
+	// fails indicating the ordinal position of the failed function.
+	// Also, in that scenario the Degraded status is set to True.
+	// TODO: Collapse this into optional deployment hook.
+	optionalManifestHooks []ManifestHookFunc
+	// Optional hook functions to modify the Deployment.
+	// If one of these functions returns an error, the sync
+	// fails indicating the ordinal position of the failed function.
+	// Also, in that scenario the Degraded status is set to True.
+	optionalDeploymentHooks []DeploymentHookFunc
+}
+
+func NewDeploymentController(
+	name string,
+	manifest []byte,
+	recorder events.Recorder,
+	operatorClient v1helpers.OperatorClient,
+	kubeClient kubernetes.Interface,
+	deployInformer appsinformersv1.DeploymentInformer,
+	optionalInformers []factory.Informer,
+	optionalManifestHooks []ManifestHookFunc,
+	optionalDeploymentHooks ...DeploymentHookFunc,
+) factory.Controller {
+	c := &DeploymentController{
+		name:                    name,
+		manifest:                manifest,
+		operatorClient:          operatorClient,
+		kubeClient:              kubeClient,
+		deployInformer:          deployInformer,
+		optionalManifestHooks:   optionalManifestHooks,
+		optionalDeploymentHooks: optionalDeploymentHooks,
+	}
+
+	informers := append(
+		optionalInformers,
+		operatorClient.Informer(),
+		deployInformer.Informer(),
+	)
+
+	return factory.New().WithInformers(
+		informers...,
+	).WithSync(
+		c.sync,
+	).ResyncEvery(
+		time.Minute,
+	).WithSyncDegradedOnError(
+		operatorClient,
+	).ToController(
+		c.name,
+		recorder.WithComponentSuffix(strings.ToLower(name)+"-deployment-controller-"),
+	)
+}
+
+func (c *DeploymentController) Name() string {
+	return c.name
+}
+
+func (c *DeploymentController) sync(ctx context.Context, syncContext factory.SyncContext) error {
+	opSpec, opStatus, _, err := c.operatorClient.GetOperatorState()
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	if opSpec.ManagementState != opv1.Managed {
+		return nil
+	}
+
+	for i := range c.optionalManifestHooks {
+		manifest, err := c.optionalManifestHooks[i](opSpec, c.manifest)
+		if err != nil {
+			return fmt.Errorf("error running hook function (index=%d): %w", i, err)
+		}
+		c.manifest = manifest
+	}
+
+	required := resourceread.ReadDeploymentV1OrDie(c.manifest)
+
+	for i := range c.optionalDeploymentHooks {
+		err := c.optionalDeploymentHooks[i](opSpec, required)
+		if err != nil {
+			return fmt.Errorf("error running hook function (index=%d): %w", i, err)
+		}
+	}
+
+	deployment, _, err := resourceapply.ApplyDeployment(
+		c.kubeClient.AppsV1(),
+		syncContext.Recorder(),
+		required,
+		resourcemerge.ExpectedDeploymentGeneration(required, opStatus.Generations),
+	)
+	if err != nil {
+		return err
+	}
+
+	availableCondition := opv1.OperatorCondition{
+		Type:   c.name + opv1.OperatorStatusTypeAvailable,
+		Status: opv1.ConditionTrue,
+	}
+
+	if deployment.Status.AvailableReplicas > 0 {
+		availableCondition.Status = opv1.ConditionTrue
+	} else {
+		availableCondition.Status = opv1.ConditionFalse
+		availableCondition.Message = "Waiting for Deployment"
+		availableCondition.Reason = "Deploying"
+	}
+
+	progressingCondition := opv1.OperatorCondition{
+		Type:   c.name + opv1.OperatorStatusTypeProgressing,
+		Status: opv1.ConditionFalse,
+	}
+
+	if ok, msg := isProgressing(deployment); ok {
+		progressingCondition.Status = opv1.ConditionTrue
+		progressingCondition.Message = msg
+		progressingCondition.Reason = "Deploying"
+	}
+
+	updateStatusFn := func(newStatus *opv1.OperatorStatus) error {
+		// TODO: set ObservedGeneration (the last stable generation change we dealt with)
+		resourcemerge.SetDeploymentGeneration(&newStatus.Generations, deployment)
+		return nil
+	}
+
+	_, _, err = v1helpers.UpdateStatus(
+		c.operatorClient,
+		updateStatusFn,
+		v1helpers.UpdateConditionFn(availableCondition),
+		v1helpers.UpdateConditionFn(progressingCondition),
+	)
+
+	return err
+}
+
+func isProgressing(deployment *appsv1.Deployment) (bool, string) {
+	var deploymentExpectedReplicas int32
+	if deployment.Spec.Replicas != nil {
+		deploymentExpectedReplicas = *deployment.Spec.Replicas
+	}
+
+	switch {
+	case deployment.Generation != deployment.Status.ObservedGeneration:
+		return true, "Waiting for Deployment to act on changes"
+	case deployment.Status.UnavailableReplicas > 0:
+		return true, "Waiting for Deployment to deploy pods"
+	case deployment.Status.UpdatedReplicas < deploymentExpectedReplicas:
+		return true, "Waiting for Deployment to update pods"
+	case deployment.Status.AvailableReplicas < deploymentExpectedReplicas:
+		return true, "Waiting for Deployment to deploy pods"
+	}
+	return false, ""
+}

--- a/pkg/operator/deploymentcontroller/deployment_controller_test.go
+++ b/pkg/operator/deploymentcontroller/deployment_controller_test.go
@@ -1,0 +1,587 @@
+package deploymentcontroller
+
+import (
+	"context"
+	"github.com/google/go-cmp/cmp"
+	opv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	core "k8s.io/client-go/testing"
+	"sort"
+
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	fakeconfig "github.com/openshift/client-go/config/clientset/versioned/fake"
+	configinformers "github.com/openshift/client-go/config/informers/externalversions"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	coreinformers "k8s.io/client-go/informers"
+	fakecore "k8s.io/client-go/kubernetes/fake"
+)
+
+const (
+	infraConfigName  = "cluster"
+	deploymentName   = "dummy-deployment"
+	defaultClusterID = "ID1234"
+	controllerName   = "TestDeploymentController"
+	operandName      = "dummy-controller"
+	operandNamespace = "openshift-dummy-test-deployment"
+	// From github.com/openshift/library-go/pkg/operator/resource/resourceapply/apps.go
+	specHashAnnotation = "operator.openshift.io/spec-hash"
+)
+
+var (
+	conditionAvailable   = controllerName + opv1.OperatorStatusTypeAvailable
+	conditionProgressing = controllerName + opv1.OperatorStatusTypeProgressing
+)
+
+type testCase struct {
+	name            string
+	initialObjects  testObjects
+	expectedObjects testObjects
+	expectErr       bool
+}
+
+type testObjects struct {
+	deployment *appsv1.Deployment
+	operator   *fakeOperatorInstance
+}
+
+type testContext struct {
+	controller     factory.Controller
+	operatorClient v1helpers.OperatorClient
+	coreClient     *fakecore.Clientset
+	coreInformers  coreinformers.SharedInformerFactory
+}
+
+// fakeOperatorInstance is a fake Operator instance that  fullfils the OperatorClient interface.
+type fakeOperatorInstance struct {
+	metav1.ObjectMeta
+	Spec   opv1.OperatorSpec
+	Status opv1.OperatorStatus
+}
+
+// Infrastructure
+func makeInfra() *configv1.Infrastructure {
+	return &configv1.Infrastructure{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      infraConfigName,
+			Namespace: v1.NamespaceAll,
+		},
+		Status: configv1.InfrastructureStatus{
+			InfrastructureName: defaultClusterID,
+			Platform:           configv1.AWSPlatformType,
+			PlatformStatus: &configv1.PlatformStatus{
+				AWS: &configv1.AWSPlatformStatus{},
+			},
+		},
+	}
+}
+
+func makeFakeManifest() []byte {
+	return []byte(`
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: dummy-deployment
+  namespace: openshift-dummy-test-deployment
+spec:
+  selector:
+    matchLabels:
+      app: test-csi-driver-controller
+  serviceName: test-csi-driver-controller
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: test-csi-driver-controller
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      containers:
+        - name: csi-driver
+          image: ${DRIVER_IMAGE}
+          args:
+            - --endpoint=$(CSI_ENDPOINT)
+            - --k8s-tag-cluster-id=${CLUSTER_ID}
+            - --logtostderr
+            - --v=${LOG_LEVEL}
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+          ports:
+            - name: healthz
+              containerPort: 19808
+              protocol: TCP
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: csi-provisioner
+          image: ${PROVISIONER_IMAGE}
+          args:
+            - --provisioner=test.csi.openshift.io
+            - --csi-address=$(ADDRESS)
+            - --feature-gates=Topology=true
+            - --http-endpoint=localhost:8202
+            - --v=${LOG_LEVEL}
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        # In reality, each sidecar needs its own kube-rbac-proxy. Using just one for the unit tests.
+        - name: provisioner-kube-rbac-proxy
+          args:
+          - --secure-listen-address=0.0.0.0:9202
+          - --upstream=http://127.0.0.1:8202/
+          - --tls-cert-file=/etc/tls/private/tls.crt
+          - --tls-private-key-file=/etc/tls/private/tls.key
+          - --logtostderr=true
+          image: ${KUBE_RBAC_PROXY_IMAGE}
+          imagePullPolicy: IfNotPresent
+          ports:
+          - containerPort: 9202
+            name: provisioner-m
+            protocol: TCP
+          resources:
+            requests:
+              memory: 20Mi
+              cpu: 10m
+          volumeMounts:
+          - mountPath: /etc/tls/private
+            name: metrics-serving-cert
+        - name: csi-attacher
+          image: ${ATTACHER_IMAGE}
+          args:
+            - --csi-address=$(ADDRESS)
+            - --v=${LOG_LEVEL}
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: csi-resizer
+          image: ${RESIZER_IMAGE}
+          args:
+            - --csi-address=$(ADDRESS)
+            - --v=${LOG_LEVEL}
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: csi-snapshotter
+          image: ${SNAPSHOTTER_IMAGE}
+          args:
+            - --csi-address=$(ADDRESS)
+            - --v=${LOG_LEVEL}
+          env:
+          - name: ADDRESS
+            value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+          - mountPath: /var/lib/csi/sockets/pluginproxy/
+            name: socket-dir
+      volumes:
+        - name: socket-dir
+          emptyDir: {}
+        - name: metrics-serving-cert
+          secret:
+            secretName: gcp-pd-csi-driver-controller-metrics-serving-cert
+`)
+}
+
+type operatorModifier func(instance *fakeOperatorInstance) *fakeOperatorInstance
+
+func makeFakeOperatorInstance(modifiers ...operatorModifier) *fakeOperatorInstance {
+	instance := &fakeOperatorInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "cluster",
+			Generation: 0,
+		},
+		Spec: opv1.OperatorSpec{
+			ManagementState: opv1.Managed,
+		},
+		Status: opv1.OperatorStatus{},
+	}
+	for _, modifier := range modifiers {
+		instance = modifier(instance)
+	}
+	return instance
+}
+
+func TestDeploymentCreation(t *testing.T) {
+	// Initialize
+	coreClient := fakecore.NewSimpleClientset()
+	coreInformerFactory := coreinformers.NewSharedInformerFactory(coreClient, 0 /*no resync */)
+	initialInfras := []runtime.Object{makeInfra()}
+	configClient := fakeconfig.NewSimpleClientset(initialInfras...)
+	configInformerFactory := configinformers.NewSharedInformerFactory(configClient, 0)
+	configInformer := configInformerFactory.Config().V1().Infrastructures().Informer()
+	configInformer.GetIndexer().Add(initialInfras[0])
+	driverInstance := makeFakeOperatorInstance()
+	fakeOperatorClient := v1helpers.NewFakeOperatorClient(&driverInstance.Spec, &driverInstance.Status, nil /*triggerErr func*/)
+	var optionalInformers []factory.Informer
+	var optionalManifestHookFuncs []ManifestHookFunc
+	optionalInformers = append(optionalInformers, configInformer)
+	controller := NewDeploymentController(
+		controllerName,
+		makeFakeManifest(),
+		events.NewInMemoryRecorder(operandName),
+		fakeOperatorClient,
+		coreClient,
+		coreInformerFactory.Apps().V1().Deployments(),
+		optionalInformers,
+		optionalManifestHookFuncs, // optional manifest hooks no optional deployment hooks
+	)
+
+	// Act
+	err := controller.Sync(context.TODO(), factory.NewSyncContext(controllerName, events.NewInMemoryRecorder("dummy-controller")))
+	if err != nil {
+		t.Fatalf("sync() returned unexpected error: %v", err)
+	}
+
+	// Assert
+	actualDeployment, err := coreClient.AppsV1().Deployments(operandNamespace).Get(context.TODO(), deploymentName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get Deployment %s: %v", deploymentName, err)
+	}
+
+	// Deployment should have the annotation specified in the hook function. We should expect a spec-hash for the deployment
+	// since it got created from a manifest
+	if _, ok := actualDeployment.ObjectMeta.Annotations[specHashAnnotation]; !ok {
+		t.Fatalf("expected deployment created from manifest to have %s annotation", specHashAnnotation)
+	}
+}
+
+func withGeneration(generations ...int64) operatorModifier {
+	return func(i *fakeOperatorInstance) *fakeOperatorInstance {
+		i.Generation = generations[0]
+		if len(generations) > 1 {
+			i.Status.ObservedGeneration = generations[1]
+		}
+		return i
+	}
+}
+
+func withGenerations(deployment int64) operatorModifier {
+	return func(i *fakeOperatorInstance) *fakeOperatorInstance {
+		i.Status.Generations = []opv1.GenerationStatus{
+			{
+				Group:          appsv1.GroupName,
+				LastGeneration: deployment,
+				Name:           deploymentName,
+				Namespace:      operandNamespace,
+				Resource:       "deployments",
+			},
+		}
+		return i
+	}
+}
+
+func withTrueConditions(conditions ...string) operatorModifier {
+	return func(i *fakeOperatorInstance) *fakeOperatorInstance {
+		if i.Status.Conditions == nil {
+			i.Status.Conditions = []opv1.OperatorCondition{}
+		}
+		for _, cond := range conditions {
+			i.Status.Conditions = append(i.Status.Conditions, opv1.OperatorCondition{
+				Type:   cond,
+				Status: opv1.ConditionTrue,
+			})
+		}
+		return i
+	}
+}
+
+func withDeploymentStatus(readyReplicas, availableReplicas, updatedReplicas int32) deploymentModifier {
+	return func(instance *appsv1.Deployment) *appsv1.Deployment {
+		instance.Status.ReadyReplicas = readyReplicas
+		instance.Status.AvailableReplicas = availableReplicas
+		instance.Status.UpdatedReplicas = updatedReplicas
+		return instance
+	}
+}
+
+func withFalseConditions(conditions ...string) operatorModifier {
+	return func(i *fakeOperatorInstance) *fakeOperatorInstance {
+		if i.Status.Conditions == nil {
+			i.Status.Conditions = []opv1.OperatorCondition{}
+		}
+		for _, c := range conditions {
+			i.Status.Conditions = append(i.Status.Conditions, opv1.OperatorCondition{
+				Type:   c,
+				Status: opv1.ConditionFalse,
+			})
+		}
+		return i
+	}
+}
+
+// This reactor is always enabled and bumps Deployment generation when it gets updated.
+func addGenerationReactor(client *fakecore.Clientset) {
+	client.PrependReactor("*", "deployments", func(action core.Action) (handled bool, ret runtime.Object, err error) {
+		switch a := action.(type) {
+		case core.CreateActionImpl:
+			object := a.GetObject()
+			deployment := object.(*appsv1.Deployment)
+			deployment.Generation++
+			return false, deployment, nil
+		case core.UpdateActionImpl:
+			object := a.GetObject()
+			deployment := object.(*appsv1.Deployment)
+			deployment.Generation++
+			return false, deployment, nil
+		}
+		return false, nil, nil
+	})
+}
+
+func newTestContext(test testCase, t *testing.T) *testContext {
+	// Add deployment to informer
+	var initialObjects []runtime.Object
+	if test.initialObjects.deployment != nil {
+		resourceapply.SetSpecHashAnnotation(&test.initialObjects.deployment.ObjectMeta, test.initialObjects.deployment.Spec)
+		initialObjects = append(initialObjects, test.initialObjects.deployment)
+	}
+
+	coreClient := fakecore.NewSimpleClientset(initialObjects...)
+	coreInformerFactory := coreinformers.NewSharedInformerFactory(coreClient, 0 /*no resync */)
+
+	// Fill the informer
+	if test.initialObjects.deployment != nil {
+		coreInformerFactory.Apps().V1().Deployments().Informer().GetIndexer().Add(test.initialObjects.deployment)
+	}
+
+	// Add global reactors
+	addGenerationReactor(coreClient)
+
+	// Add a fake Infrastructure object to informer. This is not
+	// optional because it is always present in the cluster.
+	initialInfras := []runtime.Object{makeInfra()}
+	configClient := fakeconfig.NewSimpleClientset(initialInfras...)
+	configInformerFactory := configinformers.NewSharedInformerFactory(configClient, 0)
+	configInformer := configInformerFactory.Config().V1().Infrastructures().Informer()
+	configInformer.GetIndexer().Add(initialInfras[0])
+
+	// fakeDriverInstance also fulfils the OperatorClient interface
+	fakeOperatorClient := v1helpers.NewFakeOperatorClient(
+		&test.initialObjects.operator.Spec,
+		&test.initialObjects.operator.Status,
+		nil, /*triggerErr func*/
+	)
+	optionalInformers := []factory.Informer{configInformer}
+	var optionalManifestHookFuncs []ManifestHookFunc
+	controller := NewDeploymentController(
+		controllerName,
+		makeFakeManifest(),
+		events.NewInMemoryRecorder(operandName),
+		fakeOperatorClient,
+		coreClient,
+		coreInformerFactory.Apps().V1().Deployments(),
+		optionalInformers,
+		optionalManifestHookFuncs,
+	)
+
+	return &testContext{
+		controller:     controller,
+		operatorClient: fakeOperatorClient,
+		coreClient:     coreClient,
+		coreInformers:  coreInformerFactory,
+	}
+}
+
+func sanitizeDeployment(deployment *appsv1.Deployment) {
+	// nil and empty array are the same
+	if len(deployment.Labels) == 0 {
+		deployment.Labels = nil
+	}
+	if len(deployment.Annotations) == 0 {
+		deployment.Annotations = nil
+	}
+	// Remove random annotations set by ApplyDeployment
+	delete(deployment.Annotations, specHashAnnotation)
+}
+
+func sanitizeInstanceStatus(status *opv1.OperatorStatus) {
+	// Remove condition texts
+	for i := range status.Conditions {
+		status.Conditions[i].LastTransitionTime = metav1.Time{}
+		status.Conditions[i].Message = ""
+		status.Conditions[i].Reason = ""
+	}
+	// Sort the conditions by name to have consistent position in the array
+	sort.Slice(status.Conditions, func(i, j int) bool {
+		return status.Conditions[i].Type < status.Conditions[j].Type
+	})
+}
+
+func TestSync(t *testing.T) {
+	const replica1 = 1
+	testCases := []testCase{
+		{
+			// Only CR exists, everything else is created
+			name: "initial sync",
+			initialObjects: testObjects{
+				operator: makeFakeOperatorInstance(),
+			},
+			expectedObjects: testObjects{
+				deployment: makeDeployment(
+					withDeploymentGeneration(1, 0)),
+				operator: makeFakeOperatorInstance(
+					// withStatus(replica0),
+					withGenerations(1),
+					withTrueConditions(conditionProgressing),
+					withFalseConditions(conditionAvailable)), // Degraded is set later on
+			},
+		},
+		{
+			// Deployment is fully deployed and its status is synced to CR
+			name: "deployment fully deployed",
+			initialObjects: testObjects{
+				deployment: makeDeployment(
+					withDeploymentGeneration(1, 1),
+					withDeploymentStatus(replica1, replica1, replica1)),
+				operator: makeFakeOperatorInstance(withGenerations(1)),
+			},
+			expectedObjects: testObjects{
+				deployment: makeDeployment(
+					withDeploymentGeneration(1, 1),
+					withDeploymentStatus(replica1, replica1, replica1)),
+				operator: makeFakeOperatorInstance(
+					// withStatus(replica1),
+					withGenerations(1),
+					withTrueConditions(conditionAvailable),
+					withFalseConditions(conditionProgressing)),
+			},
+		},
+		{
+			// Deployment has wrong nr. of replicas, modified by user, and gets replaced by the operator.
+			name: "deployment modified by user",
+			initialObjects: testObjects{
+				deployment: makeDeployment(
+					withDeploymentReplicas(2),      // User changed replicas
+					withDeploymentGeneration(2, 1), // ... which changed Generation
+					withDeploymentStatus(replica1, replica1, replica1)),
+				operator: makeFakeOperatorInstance(withGenerations(1)), // the operator knows the old generation of the Deployment
+			},
+			expectedObjects: testObjects{
+				deployment: makeDeployment(
+					withDeploymentReplicas(1),      // The operator fixed replica count
+					withDeploymentGeneration(3, 1), // ... which bumps generation again
+					withDeploymentStatus(replica1, replica1, replica1)),
+				operator: makeFakeOperatorInstance(
+					// withStatus(replica1),
+					withGenerations(3), // now the operator knows generation 1
+					withTrueConditions(conditionAvailable, conditionProgressing), // Progressing due to Generation change
+				),
+			},
+		},
+		{
+			// Deployment gets degraded for some reason
+			name: "deployment degraded",
+			initialObjects: testObjects{
+				deployment: makeDeployment(
+					withDeploymentGeneration(1, 1),
+					withDeploymentStatus(0, 0, 0)), // the Deployment has no pods
+				operator: makeFakeOperatorInstance(
+					// withStatus(replica1),
+					withGenerations(1),
+					withGeneration(1, 1),
+					withTrueConditions(conditionAvailable),
+					withFalseConditions(conditionProgressing)),
+			},
+			expectedObjects: testObjects{
+				deployment: makeDeployment(
+					withDeploymentGeneration(1, 1),
+					withDeploymentStatus(0, 0, 0)), // no change to the Deployment
+				operator: makeFakeOperatorInstance(
+					// withStatus(replica0),
+					withGenerations(1),
+					withGeneration(1, 1),
+					withTrueConditions(conditionProgressing), // The operator is Progressing
+					withFalseConditions(conditionAvailable)), // The operator is not Available (controller not running...)
+			},
+		},
+		{
+			// Deployment is updating pods
+			name: "update",
+			initialObjects: testObjects{
+				deployment: makeDeployment(
+					withDeploymentGeneration(1, 1),
+					withDeploymentStatus(1 /*ready*/, 1 /*available*/, 0 /*updated*/)), // the Deployment is updating 1 pod
+				operator: makeFakeOperatorInstance(
+					// withStatus(replica1),
+					withGenerations(1),
+					withGeneration(1, 1),
+					withTrueConditions(conditionAvailable),
+					withFalseConditions(conditionProgressing)),
+			},
+			expectedObjects: testObjects{
+				deployment: makeDeployment(
+					withDeploymentGeneration(1, 1),
+					withDeploymentStatus(1, 1, 0)), // no change to the Deployment
+				operator: makeFakeOperatorInstance(
+					// withStatus(replica0),
+					withGenerations(1),
+					withGeneration(1, 1),
+					withTrueConditions(conditionAvailable, conditionProgressing)), // The operator is Progressing, but still Available
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			// Initialize
+			ctx := newTestContext(test, t)
+
+			// Act
+			err := ctx.controller.Sync(context.TODO(), factory.NewSyncContext(controllerName, events.NewInMemoryRecorder("test-csi-driver")))
+
+			// Assert
+			// Check error
+			if err != nil && !test.expectErr {
+				t.Errorf("sync() returned unexpected error: %v", err)
+			}
+			if err == nil && test.expectErr {
+				t.Error("sync() unexpectedly succeeded when error was expected")
+			}
+
+			// Check expectedObjects.deployment
+			if test.expectedObjects.deployment != nil {
+				deployName := test.expectedObjects.deployment.Name
+				actualDeployment, err := ctx.coreClient.AppsV1().Deployments(operandNamespace).Get(context.TODO(), deployName, metav1.GetOptions{})
+				if err != nil {
+					t.Errorf("Failed to get Deployment %s: %v", deployName, err)
+				}
+				sanitizeDeployment(actualDeployment)
+				sanitizeDeployment(test.expectedObjects.deployment)
+				if !equality.Semantic.DeepEqual(test.expectedObjects.deployment, actualDeployment) {
+					t.Errorf("Unexpected Deployment %+v content:\n%s", operandName, cmp.Diff(test.expectedObjects.deployment, actualDeployment))
+				}
+			}
+
+			// Check expectedObjects.driver.Status
+			if test.expectedObjects.operator != nil {
+				_, actualStatus, _, err := ctx.operatorClient.GetOperatorState()
+				if err != nil {
+					t.Errorf("Failed to get Driver: %v", err)
+				}
+				sanitizeInstanceStatus(actualStatus)
+				sanitizeInstanceStatus(&test.expectedObjects.operator.Status)
+				if !equality.Semantic.DeepEqual(test.expectedObjects.operator.Status, *actualStatus) {
+					t.Errorf("Unexpected Driver %+v content:\n%s", operandName, cmp.Diff(test.expectedObjects.operator.Status, *actualStatus))
+				}
+			}
+		})
+	}
+}

--- a/pkg/operator/deploymentcontroller/helpers.go
+++ b/pkg/operator/deploymentcontroller/helpers.go
@@ -1,0 +1,40 @@
+package deploymentcontroller
+
+import (
+	"fmt"
+	"os"
+
+	opv1 "github.com/openshift/api/operator/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+)
+
+// WithReplicasHook sets the deployment.Spec.Replicas field according to the number
+// of available nodes. The number of nodes is determined by the node
+// selector specified in the field deployment.Spec.Templates.NodeSelector.
+func WithReplicasHook(nodeLister corev1listers.NodeLister) DeploymentHookFunc {
+	return func(_ *opv1.OperatorSpec, deployment *appsv1.Deployment) error {
+		nodeSelector := deployment.Spec.Template.Spec.NodeSelector
+		nodes, err := nodeLister.List(labels.SelectorFromSet(nodeSelector))
+		if err != nil {
+			return err
+		}
+		replicas := int32(len(nodes))
+		deployment.Spec.Replicas = &replicas
+		return nil
+	}
+}
+
+// WithImageHook sets the image associated with the deployment with the value provided
+// for CLI_IMAGE env variable.
+func WithImageHook() DeploymentHookFunc {
+	return func(_ *opv1.OperatorSpec, deployment *appsv1.Deployment) error {
+		image := os.Getenv("CLI_IMAGE")
+		if image == "" {
+			return fmt.Errorf("CLI_IMAGE is not populated")
+		}
+		deployment.Spec.Template.Spec.Containers[0].Image = image
+		return nil
+	}
+}

--- a/pkg/operator/deploymentcontroller/helpers_test.go
+++ b/pkg/operator/deploymentcontroller/helpers_test.go
@@ -1,0 +1,229 @@
+package deploymentcontroller
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
+
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	coreinformers "k8s.io/client-go/informers"
+	fakecore "k8s.io/client-go/kubernetes/fake"
+)
+
+type deploymentModifier func(*appsv1.Deployment) *appsv1.Deployment
+
+func makeDeployment(modifiers ...deploymentModifier) *appsv1.Deployment {
+	manifest := makeFakeManifest()
+	dep := resourceread.ReadDeploymentV1OrDie(manifest)
+
+	var one int32 = 1
+	dep.Spec.Replicas = &one
+
+	for _, modifier := range modifiers {
+		dep = modifier(dep)
+	}
+
+	return dep
+}
+
+func makeNode(suffix string, labels map[string]string) *v1.Node {
+	return &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   fmt.Sprintf("node-%s", suffix),
+			Labels: labels,
+		},
+	}
+}
+
+func withDeploymentReplicas(replicas int32) deploymentModifier {
+	return func(instance *appsv1.Deployment) *appsv1.Deployment {
+		instance.Spec.Replicas = &replicas
+		return instance
+	}
+}
+
+func withDeploymentImage(image string) deploymentModifier {
+	return func(instance *appsv1.Deployment) *appsv1.Deployment {
+		instance.Spec.Template.Spec.Containers[0].Image = image
+		return instance
+	}
+}
+
+func withDeploymentGeneration(generations ...int64) deploymentModifier {
+	return func(instance *appsv1.Deployment) *appsv1.Deployment {
+		instance.Generation = generations[0]
+		if len(generations) > 1 {
+			instance.Status.ObservedGeneration = generations[1]
+		}
+		return instance
+	}
+}
+
+func TestWithReplicasHook(t *testing.T) {
+	var (
+		masterNodeLabels = map[string]string{"node-role.kubernetes.io/master": ""}
+		workerNodeLabels = map[string]string{"node-role.kubernetes.io/worker": ""}
+	)
+	testCases := []struct {
+		name               string
+		initialOperator    *fakeOperatorInstance
+		initialNodes       []*v1.Node
+		initialDeployment  *appsv1.Deployment
+		expectedDeployment *appsv1.Deployment
+		expectError        bool
+	}{
+		{
+			name:            "three-node control-plane",
+			initialOperator: makeFakeOperatorInstance(),
+			initialNodes: []*v1.Node{
+				makeNode("A", masterNodeLabels),
+				makeNode("B", masterNodeLabels),
+				makeNode("C", masterNodeLabels),
+			},
+			initialDeployment: makeDeployment(
+				withDeploymentReplicas(1),
+				withDeploymentGeneration(1, 0)),
+			expectedDeployment: makeDeployment(
+				withDeploymentReplicas(3),
+				withDeploymentGeneration(1, 0)),
+			expectError: false,
+		},
+		{
+			name:            "three-node control-plane with one worker node",
+			initialOperator: makeFakeOperatorInstance(),
+			initialNodes: []*v1.Node{
+				makeNode("A", masterNodeLabels),
+				makeNode("B", masterNodeLabels),
+				makeNode("C", masterNodeLabels),
+				makeNode("D", workerNodeLabels),
+			},
+			initialDeployment: makeDeployment(
+				withDeploymentReplicas(1),
+				withDeploymentGeneration(1, 0)),
+			expectedDeployment: makeDeployment(
+				withDeploymentReplicas(3),
+				withDeploymentGeneration(1, 0)),
+			expectError: false,
+		},
+		{
+			name:            "two-node control-plane",
+			initialOperator: makeFakeOperatorInstance(),
+			initialNodes: []*v1.Node{
+				makeNode("A", masterNodeLabels),
+				makeNode("B", masterNodeLabels),
+			},
+			initialDeployment: makeDeployment(
+				withDeploymentReplicas(1),
+				withDeploymentGeneration(1, 0)),
+			expectedDeployment: makeDeployment(
+				withDeploymentReplicas(2),
+				withDeploymentGeneration(1, 0)),
+			expectError: false,
+		},
+		{
+			name:            "single-node control-plane with one worker node",
+			initialOperator: makeFakeOperatorInstance(),
+			initialNodes: []*v1.Node{
+				makeNode("A", masterNodeLabels),
+				makeNode("B", workerNodeLabels),
+			},
+			initialDeployment: makeDeployment(
+				withDeploymentReplicas(1),
+				withDeploymentGeneration(1, 0)),
+			expectedDeployment: makeDeployment(
+				withDeploymentReplicas(1),
+				withDeploymentGeneration(1, 0)),
+			expectError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var initialObjects []runtime.Object
+
+			// Add deployment to slice of objects to be added to client and informer
+			initialObjects = append(initialObjects, tc.initialDeployment)
+
+			// Do the same with nodes
+			for _, node := range tc.initialNodes {
+				initialObjects = append(initialObjects, node)
+			}
+
+			// Create fake client and informer
+			coreClient := fakecore.NewSimpleClientset(initialObjects...)
+			coreInformerFactory := coreinformers.NewSharedInformerFactory(coreClient, 0 /*no resync */)
+
+			// Fill the fake informer with the initial deployment and nodes
+			coreInformerFactory.Apps().V1().Deployments().Informer().GetIndexer().Add(tc.initialDeployment)
+			for _, node := range initialObjects {
+				coreInformerFactory.Core().V1().Nodes().Informer().GetIndexer().Add(node)
+			}
+
+			fn := WithReplicasHook(coreInformerFactory.Core().V1().Nodes().Lister())
+			err := fn(&tc.initialOperator.Spec, tc.initialDeployment)
+			if err != nil && !tc.expectError {
+				t.Errorf("Expected no error running hook function, got: %v", err)
+
+			}
+			if !equality.Semantic.DeepEqual(tc.initialDeployment, tc.expectedDeployment) {
+				t.Errorf("Unexpected Deployment content:\n%s", cmp.Diff(tc.initialDeployment, tc.expectedDeployment))
+			}
+		})
+	}
+}
+
+func TestWithImageHook(t *testing.T) {
+	testCases := []struct {
+		name               string
+		initialOperator    *fakeOperatorInstance
+		initialDeployment  *appsv1.Deployment
+		image              string
+		expectedDeployment *appsv1.Deployment
+		expectError        bool
+	}{
+		{
+			name:            "check if image is properly updated",
+			initialOperator: makeFakeOperatorInstance(),
+			image:           "quay.io/openshift/origin-test-csi-driver:latest",
+			initialDeployment: makeDeployment(
+				withDeploymentReplicas(1),
+				withDeploymentGeneration(1, 0)),
+			expectedDeployment: makeDeployment(
+				withDeploymentReplicas(1),
+				withDeploymentImage("quay.io/openshift/origin-test-csi-driver:latest"),
+				withDeploymentGeneration(1, 0)),
+			expectError: false,
+		},
+		{
+			name:            "empty image, we except and error",
+			initialOperator: makeFakeOperatorInstance(),
+			image:           "",
+			initialDeployment: makeDeployment(
+				withDeploymentReplicas(1),
+				withDeploymentGeneration(1, 0)),
+			expectedDeployment: makeDeployment(
+				withDeploymentReplicas(1),
+				withDeploymentImage(""),
+				withDeploymentGeneration(1, 0)),
+			expectError: true,
+		},
+	}
+	for _, tc := range testCases {
+		os.Setenv("CLI_IMAGE", tc.image)
+		fn := WithImageHook()
+		err := fn(&tc.initialOperator.Spec, tc.initialDeployment)
+		if err != nil && !tc.expectError {
+			t.Errorf("Expected no error running hook function, got: %v", err)
+		}
+		if tc.expectedDeployment.Spec.Template.Spec.Containers[0].Image != tc.image {
+			t.Errorf("Unexpected Deployment content:\n%s", cmp.Diff(tc.initialDeployment, tc.expectedDeployment))
+		}
+	}
+}


### PR DESCRIPTION
The 2 commits in this PR are picked from #1095 to make sure that the storage team is not blocked on static pod guard controller for the PR.