### PR TITLE
OTA-260: add duplicate manifest error check

### DIFF
--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -15,23 +15,50 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 )
 
+// resourceId uniquely identifies a Kubernetes resource.
+// It is used to identify any duplicate resources within
+// a given set of manifests.
+type resourceId struct {
+	// Group identifies a set of API resources exposed together.
+	// +optional
+	Group string
+	// Kind is the name of a particular object schema.
+	Kind string
+	// Name, sometimes used with the optional Namespace, helps uniquely identify an object.
+	Name string
+	// Namespace helps uniquely identify an object.
+	// +optional
+	Namespace string
+}
+
 // Manifest stores Kubernetes object in Raw from a file.
-// It stores the GroupVersionKind for the manifest.
-// Raw and Obj should always be kept in sync such that
-// each provides the same data but in different formats.
-// To ensure Raw and Obj are always in sync, they should not
-// be set directly but rather only be set by calling
-// either method ManifestsFromFiles or ParseManifests.
+// It stores the id and the GroupVersionKind for
+// the manifest. Raw and Obj should always be kept in sync
+// such that each provides the same data but in different
+// formats. To ensure Raw and Obj are always in sync, they
+// should not be set directly but rather only be set by
+// calling either method ManifestsFromFiles or
+// ParseManifests.
 type Manifest struct {
 	// OriginalFilename is set to the filename this manifest was loaded from.
-	// It is not guaranteed to be set or be unique, but we will set it when
-	// loading from disk to provide better debuggability.
+	// It is not guaranteed to be set or be unique, but will be set when
+	// loading from disk to provide a better debug capability.
 	OriginalFilename string
+
+	id resourceId
 
 	Raw []byte
 	GVK schema.GroupVersionKind
 
 	Obj *unstructured.Unstructured
+}
+
+func (r resourceId) String() string {
+	if len(r.Namespace) == 0 {
+		return fmt.Sprintf("Group: %q Kind: %q Name: %q", r.Group, r.Kind, r.Name)
+	} else {
+		return fmt.Sprintf("Group: %q Kind: %q Namespace: %q Name: %q", r.Group, r.Kind, r.Namespace, r.Name)
+	}
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface for the Manifest
@@ -60,16 +87,25 @@ func (m *Manifest) UnmarshalJSON(in []byte) error {
 	if !ok {
 		return fmt.Errorf("expected manifest to decode into *unstructured.Unstructured, got %T", ud)
 	}
-
 	m.GVK = ud.GroupVersionKind()
 	m.Obj = ud
-	return nil
+	m.id = resourceId{
+		Group:     m.GVK.Group,
+		Kind:      m.GVK.Kind,
+		Namespace: m.Obj.GetNamespace(),
+		Name:      m.Obj.GetName(),
+	}
+	return validateResourceId(m.id)
 }
 
 // ManifestsFromFiles reads files and returns Manifests in the same order.
-// files should be list of absolute paths for the manifests on disk.
+// 'files' should be list of absolute paths for the manifests on disk. An
+// error is returned for each manifest that defines a duplicate resource
+// as compared to other manifests defined within the 'files' list.
+// Duplicate resources have the same group, kind, name, and namespace.
 func ManifestsFromFiles(files []string) ([]Manifest, error) {
 	var manifests []Manifest
+	ids := make(map[resourceId]bool)
 	var errs []error
 	for _, file := range files {
 		file, err := os.Open(file)
@@ -86,6 +122,10 @@ func ManifestsFromFiles(files []string) ([]Manifest, error) {
 		}
 		for _, m := range ms {
 			m.OriginalFilename = filepath.Base(file.Name())
+			err = addIfNotDuplicateResource(m, ids)
+			if err != nil {
+				errs = append(errs, errors.Wrapf(err, "File %s contains", file.Name()))
+			}
 		}
 		manifests = append(manifests, ms...)
 	}
@@ -99,8 +139,10 @@ func ManifestsFromFiles(files []string) ([]Manifest, error) {
 }
 
 // ParseManifests parses a YAML or JSON document that may contain one or more
-// kubernetes resources.
+// kubernetes resources. An error is returned if the input cannot be parsed
+// or contains a duplicate resource.
 func ParseManifests(r io.Reader) ([]Manifest, error) {
+	theseIds := make(map[resourceId]bool)
 	d := yaml.NewYAMLOrJSONDecoder(r, 1024)
 	var manifests []Manifest
 	for {
@@ -115,6 +157,26 @@ func ParseManifests(r io.Reader) ([]Manifest, error) {
 		if len(m.Raw) == 0 || bytes.Equal(m.Raw, []byte("null")) {
 			continue
 		}
+		if err := addIfNotDuplicateResource(m, theseIds); err != nil {
+			return manifests, err
+		}
 		manifests = append(manifests, m)
 	}
+}
+
+// validateResourceId ensures the id contains the required fields per
+// https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/#required-fields.
+func validateResourceId(id resourceId) error {
+	if id.Kind == "" || id.Name == "" {
+		return fmt.Errorf("Resource with fields %s must contain kubernetes required fields kind and name", id)
+	}
+	return nil
+}
+
+func addIfNotDuplicateResource(manifest Manifest, resourceIds map[resourceId]bool) error {
+	if _, ok := resourceIds[manifest.id]; !ok {
+		resourceIds[manifest.id] = true
+		return nil
+	}
+	return fmt.Errorf("duplicate resource: (%s)", manifest.id)
 }

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -41,6 +41,7 @@ spec:
           servicePort: 80
 `,
 		want: []Manifest{{
+			id:  resourceId{Group: "extensions", Kind: "Ingress", Name: "test-ingress", Namespace: "test-namespace"},
 			Raw: []byte(`{"apiVersion":"extensions/v1beta1","kind":"Ingress","metadata":{"name":"test-ingress","namespace":"test-namespace"},"spec":{"rules":[{"http":{"paths":[{"backend":{"serviceName":"test","servicePort":80},"path":"/testpath"}]}}]}}`),
 			GVK: schema.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "Ingress"},
 		}},
@@ -59,6 +60,7 @@ data:
     how are you?
 `,
 		want: []Manifest{{
+			id:  resourceId{Group: "", Kind: "ConfigMap", Name: "a-config", Namespace: "default"},
 			Raw: []byte(`{"apiVersion":"v1","data":{"color":"red","multi-line":"hello world\nhow are you?\n"},"kind":"ConfigMap","metadata":{"name":"a-config","namespace":"default"}}`),
 			GVK: schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"},
 		}},
@@ -91,9 +93,11 @@ data:
     how are you?
 `,
 		want: []Manifest{{
+			id:  resourceId{Group: "extensions", Kind: "Ingress", Name: "test-ingress", Namespace: "test-namespace"},
 			Raw: []byte(`{"apiVersion":"extensions/v1beta1","kind":"Ingress","metadata":{"name":"test-ingress","namespace":"test-namespace"},"spec":{"rules":[{"http":{"paths":[{"backend":{"serviceName":"test","servicePort":80},"path":"/testpath"}]}}]}}`),
 			GVK: schema.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "Ingress"},
 		}, {
+			id:  resourceId{Group: "", Kind: "ConfigMap", Name: "a-config", Namespace: "default"},
 			Raw: []byte(`{"apiVersion":"v1","data":{"color":"red","multi-line":"hello world\nhow are you?\n"},"kind":"ConfigMap","metadata":{"name":"a-config","namespace":"default"}}`),
 			GVK: schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"},
 		}},
@@ -129,9 +133,11 @@ data:
 ---
 `,
 		want: []Manifest{{
+			id:  resourceId{Group: "extensions", Kind: "Ingress", Name: "test-ingress", Namespace: "test-namespace"},
 			Raw: []byte(`{"apiVersion":"extensions/v1beta1","kind":"Ingress","metadata":{"name":"test-ingress","namespace":"test-namespace"},"spec":{"rules":[{"http":{"paths":[{"backend":{"serviceName":"test","servicePort":80},"path":"/testpath"}]}}]}}`),
 			GVK: schema.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "Ingress"},
 		}, {
+			id:  resourceId{Group: "", Kind: "ConfigMap", Name: "a-config", Namespace: "default"},
 			Raw: []byte(`{"apiVersion":"v1","data":{"color":"red","multi-line":"hello world\nhow are you?\n"},"kind":"ConfigMap","metadata":{"name":"a-config","namespace":"default"}}`),
 			GVK: schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"},
 		}},
@@ -149,6 +155,72 @@ data:
 
 			if !reflect.DeepEqual(got, test.want) {
 				t.Fatalf("mismatch found")
+			}
+		})
+	}
+
+}
+
+func TestParseManifestsDuplicates(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		wantErr string
+	}{{
+		name: "no-duplicate",
+		raw: `
+apiVersion: extensions/v1
+kind: ConfigMap
+metadata:
+  name: a-config
+  namespace: default
+---
+apiVersion: extensions/v1
+kind: ConfigMap
+metadata:
+  name: b-config
+  namespace: default
+`,
+		wantErr: "",
+	}, {
+		name: "resource-id-error",
+		raw: `
+apiVersion: extensions/v1
+kind: Kind
+metadata:
+  name:
+  namespace: default
+`,
+		wantErr: "must contain kubernetes required fields kind and name",
+	}, {
+		name: "duplicate",
+		raw: `
+apiVersion: extensions/v1
+kind: ConfigMap
+metadata:
+  name: a-config
+  namespace: default
+---
+apiVersion: extensions/v2
+kind: ConfigMap
+metadata:
+  name: a-config
+  namespace: default
+`,
+		wantErr: "duplicate resource: (Group: \"extensions\" Kind: \"ConfigMap\" Namespace: \"default\" Name: \"a-config\")",
+	}}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := ParseManifests(strings.NewReader(test.raw))
+			if err == nil {
+				if len(test.wantErr) != 0 {
+					t.Fatalf("Expected an error and got none")
+				}
+			} else if len(test.wantErr) == 0 {
+				t.Fatalf("Got unexpected error: %v", err)
+			} else if !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("Got incorrect error. Wanted it to contain %s but got %s",
+					test.wantErr, err.Error())
 			}
 		})
 	}
@@ -204,8 +276,10 @@ data:
 			}},
 		},
 		want: []Manifest{{
+			id:  resourceId{Group: "extensions", Kind: "Ingress", Name: "test-ingress", Namespace: "test-namespace"},
 			GVK: schema.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "Ingress"},
 		}, {
+			id:  resourceId{Group: "", Kind: "ConfigMap", Name: "a-config", Namespace: "default"},
 			GVK: schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"},
 		}},
 	}, {
@@ -246,7 +320,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: a-config
+  name: b-config
   namespace: default
 data:
   color: "red"
@@ -257,10 +331,13 @@ data:
 			}},
 		},
 		want: []Manifest{{
+			id:  resourceId{Group: "extensions", Kind: "Ingress", Name: "test-ingress", Namespace: "test-namespace"},
 			GVK: schema.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "Ingress"},
 		}, {
+			id:  resourceId{Group: "", Kind: "ConfigMap", Name: "a-config", Namespace: "default"},
 			GVK: schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"},
 		}, {
+			id:  resourceId{Group: "", Kind: "ConfigMap", Name: "b-config", Namespace: "default"},
 			GVK: schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"},
 		}},
 	}}
@@ -287,6 +364,189 @@ data:
 			}
 			if !reflect.DeepEqual(got, test.want) {
 				t.Fatalf("mismatch \ngot: %s \nwant: %s", spew.Sdump(got), spew.Sdump(test.want))
+			}
+		})
+	}
+}
+
+func TestManifestsFromFilesDuplicates(t *testing.T) {
+	tests := []struct {
+		name    string
+		fs      dir
+		want    []string
+		wantNum int
+	}{{
+		name: "no-duplicates",
+		fs: dir{
+			name: "a",
+			files: []file{{
+				name: "f0",
+				contents: `
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: test-ingress
+  namespace: test-namespace
+`,
+			}, {
+				name: "f1",
+				contents: `
+apiVersion: v1
+kind: Ingress
+metadata:
+  name: test-ingress
+  namespace: default
+`,
+			}},
+		},
+	}, {
+		name: "duplicate",
+		fs: dir{
+			name: "a",
+			files: []file{{
+				name: "f0",
+				contents: `
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: test-ingress
+  namespace: test-namespace
+`,
+			}, {
+				name: "f1",
+				contents: `
+apiVersion: extensions/v1
+kind: Ingress
+metadata:
+  name: test-ingress
+  namespace: test-namespace
+`,
+			}},
+		},
+		want:    []string{"(Group: \"extensions\" Kind: \"Ingress\" Namespace: \"test-namespace\" Name: \"test-ingress\")"},
+		wantNum: 1,
+	}, {
+		name: "many-duplicates",
+		fs: dir{
+			name: "a",
+			files: []file{{
+				name: "f0",
+				contents: `
+apiVersion: v1beta1
+kind: ConfigMap
+metadata:               
+  name: cm1
+  namespace: test1     
+---
+apiVersion: v1beta1
+kind: ConfigMap
+metadata:               
+  name: cm1
+  namespace: test1     
+`,
+			}, {
+				name: "f1",
+				contents: `
+apiVersion: extensions/v1
+kind: Ingress
+metadata:                       
+  name: test-ingress
+  namespace: test-namespace
+---
+apiVersion: v1beta1
+kind: ConfigMap
+metadata:               
+  name: cm1
+  namespace: test1     
+---
+apiVersion: v1beta1
+kind: ConfigMap
+metadata:               
+  name: cm2
+  namespace: test1     
+---
+apiVersion: v1beta1
+kind: ConfigMap
+metadata:               
+  name: cm3
+  namespace: test1     
+---
+apiVersion: v1beta1
+kind: ConfigMap
+metadata:               
+  name: cm4
+  namespace: test1
+`,
+			}, {
+				name: "f2",
+				contents: `
+apiVersion: extensions/v1
+kind: Ingress
+metadata:                       
+  name: test-ingress
+  namespace: test-namespace
+---
+apiVersion: v1beta1
+kind: ConfigMap
+metadata:               
+  name: cm4
+  namespace: test1
+`,
+			}, {
+				name: "fs",
+				contents: `
+apiVersion: v1beta1
+kind: ConfigMap
+metadata:                       
+  name: cm2
+  namespace: test1
+---
+apiVersion: v1beta1
+kind: ConfigMap
+metadata:               
+  name: cm4
+  namespace: test1
+`,
+			}},
+		},
+		want: []string{
+			"(Group: \"extensions\" Kind: \"Ingress\" Namespace: \"test-namespace\" Name: \"test-ingress\")",
+			"(Group: \"\" Kind: \"ConfigMap\" Namespace: \"test1\" Name: \"cm1\")",
+			"(Group: \"\" Kind: \"ConfigMap\" Namespace: \"test1\" Name: \"cm2\")",
+			"(Group: \"\" Kind: \"ConfigMap\" Namespace: \"test1\" Name: \"cm4\")",
+		},
+		wantNum: 5,
+	}}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tmpdir, cleanup := setupTestFS(t, test.fs)
+			defer func() {
+				if err := cleanup(); err != nil {
+					t.Logf("error cleaning %q", tmpdir)
+				}
+			}()
+
+			files := []string{}
+			for _, f := range test.fs.files {
+				files = append(files, filepath.Join(tmpdir, test.fs.name, f.name))
+			}
+			_, dupErrs := ManifestsFromFiles(files)
+			if dupErrs == nil {
+				if len(test.want) != 0 {
+					t.Fatalf("Expected duplicate errors and got none")
+				}
+			} else {
+				dupCount := strings.Count(dupErrs.Error(), "Group:")
+				if test.wantNum != dupCount {
+					t.Fatalf("Expected %d duplicates but got %d. Duplicates error:\n%s",
+						test.wantNum, dupCount, dupErrs.Error())
+				}
+				for _, s := range test.want {
+					if !strings.Contains(dupErrs.Error(), s) ||
+						!strings.Contains(dupErrs.Error(), "duplicate resource:") {
+						t.Fatalf("Missing error for duplicate resource: %s", s)
+					}
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Ensure each manifest contains the Kubernetes required fields apiVersion, kind, and metadata.name. Use those fields along with the optional field metadata.namespace to uniquely identify each manifest. Generate an error for any duplicate manifests, i.e. any with the same unique id.

Version is removed from apiVersion to produce Group which is what is actually used to form the above mentioned unique id. Some resources, e.g. ConfigMap, have an apiVersion with only a version identifier, e.g. `v1`. In these cases the Group is set to `""` as opposed to `v1`.

See [OTA-260](https://issues.redhat.com/browse/OTA-260).