### PR TITLE
Wire context properly to all resource apply helpers

### DIFF
--- a/pkg/operator/apiserver/controller/apiservice/apiservice_controller.go
+++ b/pkg/operator/apiserver/controller/apiservice/apiservice_controller.go
@@ -118,7 +118,7 @@ func (c *APIServiceController) sync(ctx context.Context, syncCtx factory.SyncCon
 		return err
 	}
 
-	err = c.syncAPIServices(apiServices, syncCtx.Recorder())
+	err = c.syncAPIServices(ctx, apiServices, syncCtx.Recorder())
 
 	// update failing condition
 	cond := operatorv1.OperatorCondition{
@@ -139,13 +139,13 @@ func (c *APIServiceController) sync(ctx context.Context, syncCtx factory.SyncCon
 	return err
 }
 
-func (c *APIServiceController) syncAPIServices(apiServices []*apiregistrationv1.APIService, recorder events.Recorder) error {
+func (c *APIServiceController) syncAPIServices(ctx context.Context, apiServices []*apiregistrationv1.APIService, recorder events.Recorder) error {
 	errs := []error{}
 	var availableConditionMessages []string
 
 	for _, apiService := range apiServices {
 		apiregistrationv1.SetDefaults_ServiceReference(apiService.Spec.Service)
-		apiService, _, err := resourceapply.ApplyAPIService(c.apiregistrationv1Client, recorder, apiService)
+		apiService, _, err := resourceapply.ApplyAPIService(ctx, c.apiregistrationv1Client, recorder, apiService)
 		if err != nil {
 			errs = append(errs, err)
 			continue

--- a/pkg/operator/certrotation/cabundle.go
+++ b/pkg/operator/certrotation/cabundle.go
@@ -1,6 +1,7 @@
 package certrotation
 
 import (
+	"context"
 	"crypto/x509"
 	"fmt"
 	"reflect"
@@ -32,7 +33,7 @@ type CABundleRotation struct {
 	EventRecorder events.Recorder
 }
 
-func (c CABundleRotation) ensureConfigMapCABundle(signingCertKeyPair *crypto.CA) ([]*x509.Certificate, error) {
+func (c CABundleRotation) ensureConfigMapCABundle(ctx context.Context, signingCertKeyPair *crypto.CA) ([]*x509.Certificate, error) {
 	// by this point we have current signing cert/key pair.  We now need to make sure that the ca-bundle configmap has this cert and
 	// doesn't have any expired certs
 	originalCABundleConfigMap, err := c.Lister.ConfigMaps(c.Namespace).Get(c.Name)
@@ -52,7 +53,7 @@ func (c CABundleRotation) ensureConfigMapCABundle(signingCertKeyPair *crypto.CA)
 		c.EventRecorder.Eventf("CABundleUpdateRequired", "%q in %q requires a new cert", c.Name, c.Namespace)
 		LabelAsManagedConfigMap(caBundleConfigMap, CertificateTypeCABundle)
 
-		actualCABundleConfigMap, modified, err := resourceapply.ApplyConfigMap(c.Client, c.EventRecorder, caBundleConfigMap)
+		actualCABundleConfigMap, modified, err := resourceapply.ApplyConfigMap(ctx, c.Client, c.EventRecorder, caBundleConfigMap)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/operator/certrotation/cabundle_test.go
+++ b/pkg/operator/certrotation/cabundle_test.go
@@ -1,6 +1,7 @@
 package certrotation
 
 import (
+	"context"
 	gcrypto "crypto"
 	"crypto/rand"
 	"crypto/x509"
@@ -235,7 +236,7 @@ func TestEnsureConfigMapCABundle(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			_, err = c.ensureConfigMapCABundle(newCA)
+			_, err = c.ensureConfigMapCABundle(context.TODO(), newCA)
 			switch {
 			case err != nil && len(test.expectedError) == 0:
 				t.Error(err)

--- a/pkg/operator/certrotation/client_cert_rotation_controller.go
+++ b/pkg/operator/certrotation/client_cert_rotation_controller.go
@@ -103,17 +103,17 @@ func (c CertRotationController) Sync(ctx context.Context, syncCtx factory.SyncCo
 }
 
 func (c CertRotationController) syncWorker() error {
-	signingCertKeyPair, err := c.SigningRotation.ensureSigningCertKeyPair()
+	signingCertKeyPair, err := c.SigningRotation.ensureSigningCertKeyPair(context.TODO())
 	if err != nil {
 		return err
 	}
 
-	cabundleCerts, err := c.CABundleRotation.ensureConfigMapCABundle(signingCertKeyPair)
+	cabundleCerts, err := c.CABundleRotation.ensureConfigMapCABundle(context.TODO(), signingCertKeyPair)
 	if err != nil {
 		return err
 	}
 
-	if err := c.TargetRotation.ensureTargetCertKeyPair(signingCertKeyPair, cabundleCerts); err != nil {
+	if err := c.TargetRotation.ensureTargetCertKeyPair(context.TODO(), signingCertKeyPair, cabundleCerts); err != nil {
 		return err
 	}
 

--- a/pkg/operator/certrotation/signer.go
+++ b/pkg/operator/certrotation/signer.go
@@ -2,6 +2,7 @@ package certrotation
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"time"
 
@@ -31,7 +32,7 @@ type SigningRotation struct {
 	EventRecorder events.Recorder
 }
 
-func (c SigningRotation) ensureSigningCertKeyPair() (*crypto.CA, error) {
+func (c SigningRotation) ensureSigningCertKeyPair(ctx context.Context) (*crypto.CA, error) {
 	originalSigningCertKeyPairSecret, err := c.Lister.Secrets(c.Namespace).Get(c.Name)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return nil, err
@@ -51,7 +52,7 @@ func (c SigningRotation) ensureSigningCertKeyPair() (*crypto.CA, error) {
 
 		LabelAsManagedSecret(signingCertKeyPairSecret, CertificateTypeSigner)
 
-		actualSigningCertKeyPairSecret, _, err := resourceapply.ApplySecret(c.Client, c.EventRecorder, signingCertKeyPairSecret)
+		actualSigningCertKeyPairSecret, _, err := resourceapply.ApplySecret(ctx, c.Client, c.EventRecorder, signingCertKeyPairSecret)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/operator/certrotation/signer_test.go
+++ b/pkg/operator/certrotation/signer_test.go
@@ -1,6 +1,7 @@
 package certrotation
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -117,7 +118,7 @@ func TestEnsureSigningCertKeyPair(t *testing.T) {
 				EventRecorder: events.NewInMemoryRecorder("test"),
 			}
 
-			_, err := c.ensureSigningCertKeyPair()
+			_, err := c.ensureSigningCertKeyPair(context.TODO())
 			switch {
 			case err != nil && len(test.expectedError) == 0:
 				t.Error(err)

--- a/pkg/operator/certrotation/target.go
+++ b/pkg/operator/certrotation/target.go
@@ -1,6 +1,7 @@
 package certrotation
 
 import (
+	"context"
 	"crypto/x509"
 	"fmt"
 	"strings"
@@ -51,7 +52,7 @@ type TargetCertRechecker interface {
 	RecheckChannel() <-chan struct{}
 }
 
-func (c TargetRotation) ensureTargetCertKeyPair(signingCertKeyPair *crypto.CA, caBundleCerts []*x509.Certificate) error {
+func (c TargetRotation) ensureTargetCertKeyPair(ctx context.Context, signingCertKeyPair *crypto.CA, caBundleCerts []*x509.Certificate) error {
 	// at this point our trust bundle has been updated.  We don't know for sure that consumers have updated, but that's why we have a second
 	// validity percentage.  We always check to see if we need to sign.  Often we are signing with an old key or we have no target
 	// and need to mint one
@@ -75,7 +76,7 @@ func (c TargetRotation) ensureTargetCertKeyPair(signingCertKeyPair *crypto.CA, c
 
 		LabelAsManagedSecret(targetCertKeyPairSecret, CertificateTypeTarget)
 
-		actualTargetCertKeyPairSecret, _, err := resourceapply.ApplySecret(c.Client, c.EventRecorder, targetCertKeyPairSecret)
+		actualTargetCertKeyPairSecret, _, err := resourceapply.ApplySecret(ctx, c.Client, c.EventRecorder, targetCertKeyPairSecret)
 		if err != nil {
 			return err
 		}

--- a/pkg/operator/certrotation/target_test.go
+++ b/pkg/operator/certrotation/target_test.go
@@ -1,6 +1,7 @@
 package certrotation
 
 import (
+	"context"
 	"crypto/x509/pkix"
 	"strings"
 	"testing"
@@ -228,7 +229,7 @@ func TestEnsureTargetCertKeyPair(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = c.ensureTargetCertKeyPair(newCA, newCA.Config.Certs)
+			err = c.ensureTargetCertKeyPair(context.TODO(), newCA, newCA.Config.Certs)
 			switch {
 			case err != nil && len(test.expectedError) == 0:
 				t.Error(err)
@@ -422,7 +423,7 @@ func TestEnsureTargetSignerCertKeyPair(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = c.ensureTargetCertKeyPair(newCA, newCA.Config.Certs)
+			err = c.ensureTargetCertKeyPair(context.TODO(), newCA, newCA.Config.Certs)
 			switch {
 			case err != nil && len(test.expectedError) == 0:
 				t.Error(err)

--- a/pkg/operator/connectivitycheckcontroller/connectivity_check_controller.go
+++ b/pkg/operator/connectivitycheckcontroller/connectivity_check_controller.go
@@ -207,6 +207,7 @@ func ensureConnectivityCheckCRDExists(ctx context.Context, syncContext factory.S
 	if errors.IsNotFound(err) {
 		// create the podnetworkconnectivitycheck crd that should exist
 		applyResults := resourceapply.ApplyDirectly(
+			context.TODO(),
 			resourceapply.NewClientHolder().WithAPIExtensionsClient(client),
 			syncContext.Recorder(),
 			func(name string) ([]byte, error) { return bindata.Asset(name) },

--- a/pkg/operator/csi/credentialsrequestcontroller/credentials_request_controller.go
+++ b/pkg/operator/csi/credentialsrequestcontroller/credentials_request_controller.go
@@ -73,7 +73,7 @@ func (c CredentialsRequestController) sync(ctx context.Context, syncContext fact
 		return err
 	}
 
-	cr, err := c.syncCredentialsRequest(status, syncContext)
+	cr, err := c.syncCredentialsRequest(ctx, status, syncContext)
 	if err != nil {
 		return err
 	}
@@ -111,6 +111,7 @@ func (c CredentialsRequestController) sync(ctx context.Context, syncContext fact
 }
 
 func (c CredentialsRequestController) syncCredentialsRequest(
+	ctx context.Context,
 	status *opv1.OperatorStatus,
 	syncContext factory.SyncContext,
 ) (*unstructured.Unstructured, error) {
@@ -133,7 +134,7 @@ func (c CredentialsRequestController) syncCredentialsRequest(
 		expectedGeneration = generation.LastGeneration
 	}
 
-	cr, _, err = resourceapply.ApplyCredentialsRequest(c.dynamicClient, syncContext.Recorder(), cr, expectedGeneration)
+	cr, _, err = resourceapply.ApplyCredentialsRequest(ctx, c.dynamicClient, syncContext.Recorder(), cr, expectedGeneration)
 	return cr, err
 }
 

--- a/pkg/operator/csi/csidrivernodeservicecontroller/csi_driver_node_service_controller.go
+++ b/pkg/operator/csi/csidrivernodeservicecontroller/csi_driver_node_service_controller.go
@@ -136,6 +136,7 @@ func (c *CSIDriverNodeServiceController) sync(ctx context.Context, syncContext f
 	}
 
 	daemonSet, _, err := resourceapply.ApplyDaemonSet(
+		ctx,
 		c.kubeClient.AppsV1(),
 		syncContext.Recorder(),
 		required,

--- a/pkg/operator/deploymentcontroller/deployment_controller.go
+++ b/pkg/operator/deploymentcontroller/deployment_controller.go
@@ -128,6 +128,7 @@ func (c *DeploymentController) sync(ctx context.Context, syncContext factory.Syn
 	}
 
 	deployment, _, err := resourceapply.ApplyDeployment(
+		context.TODO(),
 		c.kubeClient.AppsV1(),
 		syncContext.Recorder(),
 		required,

--- a/pkg/operator/encryption/controllers/migration_controller.go
+++ b/pkg/operator/encryption/controllers/migration_controller.go
@@ -109,7 +109,7 @@ func (c *migrationController) sync(ctx context.Context, syncCtx factory.SyncCont
 		return err // we will get re-kicked when the operator status updates
 	}
 
-	migratingResources, migrationError := c.migrateKeysIfNeededAndRevisionStable(syncCtx, c.provider.EncryptedGRs())
+	migratingResources, migrationError := c.migrateKeysIfNeededAndRevisionStable(ctx, syncCtx, c.provider.EncryptedGRs())
 
 	// update failing condition
 	degraded := operatorv1.OperatorCondition{
@@ -157,7 +157,7 @@ func (c *migrationController) setProgressing(migrating bool, reason, message str
 }
 
 // TODO doc
-func (c *migrationController) migrateKeysIfNeededAndRevisionStable(syncContext factory.SyncContext, encryptedGRs []schema.GroupResource) (migratingResources []schema.GroupResource, err error) {
+func (c *migrationController) migrateKeysIfNeededAndRevisionStable(ctx context.Context, syncContext factory.SyncContext, encryptedGRs []schema.GroupResource) (migratingResources []schema.GroupResource, err error) {
 	// no storage migration during revision changes
 	currentEncryptionConfig, desiredEncryptionState, _, isTransitionalReason, err := statemachine.GetEncryptionConfigAndState(c.deployer, c.secretClient, c.encryptionSecretSelector, encryptedGRs)
 	if err != nil {
@@ -259,7 +259,7 @@ func (c *migrationController) migrateKeysIfNeededAndRevisionStable(syncContext f
 				return nil
 			}
 
-			_, _, updateErr := resourceapply.ApplySecret(c.secretClient, syncContext.Recorder(), s)
+			_, _, updateErr := resourceapply.ApplySecret(ctx, c.secretClient, syncContext.Recorder(), s)
 			return updateErr
 		}); err != nil {
 			errs = append(errs, err)

--- a/pkg/operator/resource/resourceapply/admissionregistration.go
+++ b/pkg/operator/resource/resourceapply/admissionregistration.go
@@ -20,7 +20,7 @@ import (
 // mutatingwebhookconfiguration will be merged with the existing mutatingwebhookconfiguration
 // and an update performed if the mutatingwebhookconfiguration spec and metadata differ from
 // the previously required spec and metadata based on generation change.
-func ApplyMutatingWebhookConfiguration(client admissionregistrationclientv1.MutatingWebhookConfigurationsGetter, recorder events.Recorder,
+func ApplyMutatingWebhookConfiguration(ctx context.Context, client admissionregistrationclientv1.MutatingWebhookConfigurationsGetter, recorder events.Recorder,
 	requiredOriginal *admissionregistrationv1.MutatingWebhookConfiguration, expectedGeneration int64) (*admissionregistrationv1.MutatingWebhookConfiguration, bool, error) {
 
 	if requiredOriginal == nil {
@@ -28,9 +28,9 @@ func ApplyMutatingWebhookConfiguration(client admissionregistrationclientv1.Muta
 	}
 	required := requiredOriginal.DeepCopy()
 
-	existing, err := client.MutatingWebhookConfigurations().Get(context.TODO(), required.GetName(), metav1.GetOptions{})
+	existing, err := client.MutatingWebhookConfigurations().Get(ctx, required.GetName(), metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		actual, err := client.MutatingWebhookConfigurations().Create(context.TODO(), required, metav1.CreateOptions{})
+		actual, err := client.MutatingWebhookConfigurations().Create(ctx, required, metav1.CreateOptions{})
 		reportCreateEvent(recorder, required, err)
 		if err != nil {
 			return nil, false, err
@@ -54,7 +54,7 @@ func ApplyMutatingWebhookConfiguration(client admissionregistrationclientv1.Muta
 
 	klog.V(4).Infof("MutatingWebhookConfiguration %q changes: %v", required.GetNamespace()+"/"+required.GetName(), JSONPatchNoError(existing, toWrite))
 
-	actual, err := client.MutatingWebhookConfigurations().Update(context.TODO(), toWrite, metav1.UpdateOptions{})
+	actual, err := client.MutatingWebhookConfigurations().Update(ctx, toWrite, metav1.UpdateOptions{})
 	reportUpdateEvent(recorder, required, err)
 	if err != nil {
 		return nil, false, err
@@ -83,16 +83,16 @@ func copyMutatingWebhookCABundle(from, to *admissionregistrationv1.MutatingWebho
 // validatingwebhookconfiguration will be merged with the existing validatingwebhookconfiguration
 // and an update performed if the validatingwebhookconfiguration spec and metadata differ from
 // the previously required spec and metadata based on generation change.
-func ApplyValidatingWebhookConfiguration(client admissionregistrationclientv1.ValidatingWebhookConfigurationsGetter, recorder events.Recorder,
+func ApplyValidatingWebhookConfiguration(ctx context.Context, client admissionregistrationclientv1.ValidatingWebhookConfigurationsGetter, recorder events.Recorder,
 	requiredOriginal *admissionregistrationv1.ValidatingWebhookConfiguration, expectedGeneration int64) (*admissionregistrationv1.ValidatingWebhookConfiguration, bool, error) {
 	if requiredOriginal == nil {
 		return nil, false, fmt.Errorf("Unexpected nil instead of an object")
 	}
 	required := requiredOriginal.DeepCopy()
 
-	existing, err := client.ValidatingWebhookConfigurations().Get(context.TODO(), required.GetName(), metav1.GetOptions{})
+	existing, err := client.ValidatingWebhookConfigurations().Get(ctx, required.GetName(), metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		actual, err := client.ValidatingWebhookConfigurations().Create(context.TODO(), required, metav1.CreateOptions{})
+		actual, err := client.ValidatingWebhookConfigurations().Create(ctx, required, metav1.CreateOptions{})
 		reportCreateEvent(recorder, required, err)
 		if err != nil {
 			return nil, false, err
@@ -116,7 +116,7 @@ func ApplyValidatingWebhookConfiguration(client admissionregistrationclientv1.Va
 
 	klog.V(4).Infof("ValidatingWebhookConfiguration %q changes: %v", required.GetNamespace()+"/"+required.GetName(), JSONPatchNoError(existing, toWrite))
 
-	actual, err := client.ValidatingWebhookConfigurations().Update(context.TODO(), toWrite, metav1.UpdateOptions{})
+	actual, err := client.ValidatingWebhookConfigurations().Update(ctx, toWrite, metav1.UpdateOptions{})
 	reportUpdateEvent(recorder, required, err)
 	if err != nil {
 		return nil, false, err

--- a/pkg/operator/resource/resourceapply/admissionregistration_test.go
+++ b/pkg/operator/resource/resourceapply/admissionregistration_test.go
@@ -1,6 +1,7 @@
 package resourceapply
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -207,6 +208,7 @@ func TestApplyMutatingConfiguration(t *testing.T) {
 
 			testApply := func(expectedGeneration int64, expectModify bool) {
 				updatedHook, modified, err := ApplyMutatingWebhookConfiguration(
+					context.TODO(),
 					client.AdmissionregistrationV1(),
 					recorder, test.input(), expectedGeneration)
 				if err != nil {
@@ -435,6 +437,7 @@ func TestApplyValidatingConfiguration(t *testing.T) {
 
 			testApply := func(expectedGeneration int64, expectModify bool) {
 				updatedHook, modified, err := ApplyValidatingWebhookConfiguration(
+					context.TODO(),
 					client.AdmissionregistrationV1(),
 					recorder, test.input(), expectedGeneration)
 				if err != nil {

--- a/pkg/operator/resource/resourceapply/apiextensions.go
+++ b/pkg/operator/resource/resourceapply/apiextensions.go
@@ -6,48 +6,17 @@ import (
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextclientv1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
-	apiextclientv1beta1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 )
 
-// ApplyCustomResourceDefinitionV1Beta1 applies the required CustomResourceDefinition to the cluster.
-func ApplyCustomResourceDefinitionV1Beta1(client apiextclientv1beta1.CustomResourceDefinitionsGetter, recorder events.Recorder, required *apiextv1beta1.CustomResourceDefinition) (*apiextv1beta1.CustomResourceDefinition, bool, error) {
-	existing, err := client.CustomResourceDefinitions().Get(context.TODO(), required.Name, metav1.GetOptions{})
-	if apierrors.IsNotFound(err) {
-		actual, err := client.CustomResourceDefinitions().Create(context.TODO(), required, metav1.CreateOptions{})
-		reportCreateEvent(recorder, required, err)
-		return actual, true, err
-	}
-	if err != nil {
-		return nil, false, err
-	}
-
-	modified := resourcemerge.BoolPtr(false)
-	existingCopy := existing.DeepCopy()
-	resourcemerge.EnsureCustomResourceDefinitionV1Beta1(modified, existingCopy, *required)
-	if !*modified {
-		return existing, false, nil
-	}
-
-	if klog.V(4).Enabled() {
-		klog.Infof("CustomResourceDefinition %q changes: %s", existing.Name, JSONPatchNoError(existing, existingCopy))
-	}
-
-	actual, err := client.CustomResourceDefinitions().Update(context.TODO(), existingCopy, metav1.UpdateOptions{})
-	reportUpdateEvent(recorder, required, err)
-
-	return actual, true, err
-}
-
 // ApplyCustomResourceDefinitionV1 applies the required CustomResourceDefinition to the cluster.
-func ApplyCustomResourceDefinitionV1(client apiextclientv1.CustomResourceDefinitionsGetter, recorder events.Recorder, required *apiextensionsv1.CustomResourceDefinition) (*apiextensionsv1.CustomResourceDefinition, bool, error) {
-	existing, err := client.CustomResourceDefinitions().Get(context.TODO(), required.Name, metav1.GetOptions{})
+func ApplyCustomResourceDefinitionV1(ctx context.Context, client apiextclientv1.CustomResourceDefinitionsGetter, recorder events.Recorder, required *apiextensionsv1.CustomResourceDefinition) (*apiextensionsv1.CustomResourceDefinition, bool, error) {
+	existing, err := client.CustomResourceDefinitions().Get(ctx, required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		actual, err := client.CustomResourceDefinitions().Create(context.TODO(), required, metav1.CreateOptions{})
+		actual, err := client.CustomResourceDefinitions().Create(ctx, required, metav1.CreateOptions{})
 		reportCreateEvent(recorder, required, err)
 		return actual, true, err
 	}
@@ -66,7 +35,7 @@ func ApplyCustomResourceDefinitionV1(client apiextclientv1.CustomResourceDefinit
 		klog.Infof("CustomResourceDefinition %q changes: %s", existing.Name, JSONPatchNoError(existing, existingCopy))
 	}
 
-	actual, err := client.CustomResourceDefinitions().Update(context.TODO(), existingCopy, metav1.UpdateOptions{})
+	actual, err := client.CustomResourceDefinitions().Update(ctx, existingCopy, metav1.UpdateOptions{})
 	reportUpdateEvent(recorder, required, err)
 
 	return actual, true, err

--- a/pkg/operator/resource/resourceapply/apiregistration.go
+++ b/pkg/operator/resource/resourceapply/apiregistration.go
@@ -15,10 +15,10 @@ import (
 )
 
 // ApplyAPIService merges objectmeta and requires apiservice coordinates.  It does not touch CA bundles, which should be managed via service CA controller.
-func ApplyAPIService(client apiregistrationv1client.APIServicesGetter, recorder events.Recorder, required *apiregistrationv1.APIService) (*apiregistrationv1.APIService, bool, error) {
-	existing, err := client.APIServices().Get(context.TODO(), required.Name, metav1.GetOptions{})
+func ApplyAPIService(ctx context.Context, client apiregistrationv1client.APIServicesGetter, recorder events.Recorder, required *apiregistrationv1.APIService) (*apiregistrationv1.APIService, bool, error) {
+	existing, err := client.APIServices().Get(ctx, required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		actual, err := client.APIServices().Create(context.TODO(), required, metav1.CreateOptions{})
+		actual, err := client.APIServices().Create(ctx, required, metav1.CreateOptions{})
 		reportCreateEvent(recorder, required, err)
 		return actual, true, err
 	}
@@ -43,7 +43,7 @@ func ApplyAPIService(client apiregistrationv1client.APIServicesGetter, recorder 
 	if klog.V(4).Enabled() {
 		klog.Infof("APIService %q changes: %s", existing.Name, JSONPatchNoError(existing, existingCopy))
 	}
-	actual, err := client.APIServices().Update(context.TODO(), existingCopy, metav1.UpdateOptions{})
+	actual, err := client.APIServices().Update(ctx, existingCopy, metav1.UpdateOptions{})
 	reportUpdateEvent(recorder, required, err)
 	return actual, true, err
 }

--- a/pkg/operator/resource/resourceapply/apps_test.go
+++ b/pkg/operator/resource/resourceapply/apps_test.go
@@ -1,6 +1,7 @@
 package resourceapply_test
 
 import (
+	"context"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -113,7 +114,7 @@ func TestApplyDeployment(t *testing.T) {
 				fakeKubeClient = fake.NewSimpleClientset(tt.actualDeployment)
 			}
 
-			updatedDeployment, updated, err := resourceapply.ApplyDeployment(fakeKubeClient.AppsV1(), eventRecorder, tt.desiredDeployment, tt.expectedGeneration)
+			updatedDeployment, updated, err := resourceapply.ApplyDeployment(context.TODO(), fakeKubeClient.AppsV1(), eventRecorder, tt.desiredDeployment, tt.expectedGeneration)
 			if tt.expectError && err == nil {
 				t.Fatal("expected to get an error")
 			}
@@ -187,7 +188,7 @@ func TestApplyDeploymentWithForce(t *testing.T) {
 				fakeKubeClient = fake.NewSimpleClientset(tt.actualDeployment)
 			}
 
-			updatedDeployment, updated, err := resourceapply.ApplyDeploymentWithForce(fakeKubeClient.AppsV1(), eventRecorder, tt.desiredDeployment, tt.expectedGeneration, tt.forceRollout)
+			updatedDeployment, updated, err := resourceapply.ApplyDeploymentWithForce(context.TODO(), fakeKubeClient.AppsV1(), eventRecorder, tt.desiredDeployment, tt.expectedGeneration, tt.forceRollout)
 			if tt.expectError && err == nil {
 				t.Fatal("expected to get an error")
 			}

--- a/pkg/operator/resource/resourceapply/core.go
+++ b/pkg/operator/resource/resourceapply/core.go
@@ -21,12 +21,12 @@ import (
 )
 
 // ApplyNamespace merges objectmeta, does not worry about anything else
-func ApplyNamespace(client coreclientv1.NamespacesGetter, recorder events.Recorder, required *corev1.Namespace) (*corev1.Namespace, bool, error) {
-	existing, err := client.Namespaces().Get(context.TODO(), required.Name, metav1.GetOptions{})
+func ApplyNamespace(ctx context.Context, client coreclientv1.NamespacesGetter, recorder events.Recorder, required *corev1.Namespace) (*corev1.Namespace, bool, error) {
+	existing, err := client.Namespaces().Get(ctx, required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		requiredCopy := required.DeepCopy()
 		actual, err := client.Namespaces().
-			Create(context.TODO(), resourcemerge.WithCleanLabelsAndAnnotations(requiredCopy).(*corev1.Namespace), metav1.CreateOptions{})
+			Create(ctx, resourcemerge.WithCleanLabelsAndAnnotations(requiredCopy).(*corev1.Namespace), metav1.CreateOptions{})
 		reportCreateEvent(recorder, requiredCopy, err)
 		return actual, true, err
 	}
@@ -46,7 +46,7 @@ func ApplyNamespace(client coreclientv1.NamespacesGetter, recorder events.Record
 		klog.Infof("Namespace %q changes: %v", required.Name, JSONPatchNoError(existing, existingCopy))
 	}
 
-	actual, err := client.Namespaces().Update(context.TODO(), existingCopy, metav1.UpdateOptions{})
+	actual, err := client.Namespaces().Update(ctx, existingCopy, metav1.UpdateOptions{})
 	reportUpdateEvent(recorder, required, err)
 	return actual, true, err
 }
@@ -54,12 +54,12 @@ func ApplyNamespace(client coreclientv1.NamespacesGetter, recorder events.Record
 // ApplyService merges objectmeta and requires
 // TODO, since this cannot determine whether changes are due to legitimate actors (api server) or illegitimate ones (users), we cannot update
 // TODO I've special cased the selector for now
-func ApplyService(client coreclientv1.ServicesGetter, recorder events.Recorder, required *corev1.Service) (*corev1.Service, bool, error) {
-	existing, err := client.Services(required.Namespace).Get(context.TODO(), required.Name, metav1.GetOptions{})
+func ApplyService(ctx context.Context, client coreclientv1.ServicesGetter, recorder events.Recorder, required *corev1.Service) (*corev1.Service, bool, error) {
+	existing, err := client.Services(required.Namespace).Get(ctx, required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		requiredCopy := required.DeepCopy()
 		actual, err := client.Services(requiredCopy.Namespace).
-			Create(context.TODO(), resourcemerge.WithCleanLabelsAndAnnotations(requiredCopy).(*corev1.Service), metav1.CreateOptions{})
+			Create(ctx, resourcemerge.WithCleanLabelsAndAnnotations(requiredCopy).(*corev1.Service), metav1.CreateOptions{})
 		reportCreateEvent(recorder, requiredCopy, err)
 		return actual, true, err
 	}
@@ -91,18 +91,18 @@ func ApplyService(client coreclientv1.ServicesGetter, recorder events.Recorder, 
 		klog.Infof("Service %q changes: %v", required.Namespace+"/"+required.Name, JSONPatchNoError(existing, required))
 	}
 
-	actual, err := client.Services(required.Namespace).Update(context.TODO(), existingCopy, metav1.UpdateOptions{})
+	actual, err := client.Services(required.Namespace).Update(ctx, existingCopy, metav1.UpdateOptions{})
 	reportUpdateEvent(recorder, required, err)
 	return actual, true, err
 }
 
 // ApplyPod merges objectmeta, does not worry about anything else
-func ApplyPod(client coreclientv1.PodsGetter, recorder events.Recorder, required *corev1.Pod) (*corev1.Pod, bool, error) {
-	existing, err := client.Pods(required.Namespace).Get(context.TODO(), required.Name, metav1.GetOptions{})
+func ApplyPod(ctx context.Context, client coreclientv1.PodsGetter, recorder events.Recorder, required *corev1.Pod) (*corev1.Pod, bool, error) {
+	existing, err := client.Pods(required.Namespace).Get(ctx, required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		requiredCopy := required.DeepCopy()
 		actual, err := client.Pods(requiredCopy.Namespace).
-			Create(context.TODO(), resourcemerge.WithCleanLabelsAndAnnotations(requiredCopy).(*corev1.Pod), metav1.CreateOptions{})
+			Create(ctx, resourcemerge.WithCleanLabelsAndAnnotations(requiredCopy).(*corev1.Pod), metav1.CreateOptions{})
 		reportCreateEvent(recorder, requiredCopy, err)
 		return actual, true, err
 	}
@@ -122,18 +122,18 @@ func ApplyPod(client coreclientv1.PodsGetter, recorder events.Recorder, required
 		klog.Infof("Pod %q changes: %v", required.Namespace+"/"+required.Name, JSONPatchNoError(existing, required))
 	}
 
-	actual, err := client.Pods(required.Namespace).Update(context.TODO(), existingCopy, metav1.UpdateOptions{})
+	actual, err := client.Pods(required.Namespace).Update(ctx, existingCopy, metav1.UpdateOptions{})
 	reportUpdateEvent(recorder, required, err)
 	return actual, true, err
 }
 
 // ApplyServiceAccount merges objectmeta, does not worry about anything else
-func ApplyServiceAccount(client coreclientv1.ServiceAccountsGetter, recorder events.Recorder, required *corev1.ServiceAccount) (*corev1.ServiceAccount, bool, error) {
-	existing, err := client.ServiceAccounts(required.Namespace).Get(context.TODO(), required.Name, metav1.GetOptions{})
+func ApplyServiceAccount(ctx context.Context, client coreclientv1.ServiceAccountsGetter, recorder events.Recorder, required *corev1.ServiceAccount) (*corev1.ServiceAccount, bool, error) {
+	existing, err := client.ServiceAccounts(required.Namespace).Get(ctx, required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		requiredCopy := required.DeepCopy()
 		actual, err := client.ServiceAccounts(requiredCopy.Namespace).
-			Create(context.TODO(), resourcemerge.WithCleanLabelsAndAnnotations(requiredCopy).(*corev1.ServiceAccount), metav1.CreateOptions{})
+			Create(ctx, resourcemerge.WithCleanLabelsAndAnnotations(requiredCopy).(*corev1.ServiceAccount), metav1.CreateOptions{})
 		reportCreateEvent(recorder, requiredCopy, err)
 		return actual, true, err
 	}
@@ -151,18 +151,18 @@ func ApplyServiceAccount(client coreclientv1.ServiceAccountsGetter, recorder eve
 	if klog.V(4).Enabled() {
 		klog.Infof("ServiceAccount %q changes: %v", required.Namespace+"/"+required.Name, JSONPatchNoError(existing, required))
 	}
-	actual, err := client.ServiceAccounts(required.Namespace).Update(context.TODO(), existingCopy, metav1.UpdateOptions{})
+	actual, err := client.ServiceAccounts(required.Namespace).Update(ctx, existingCopy, metav1.UpdateOptions{})
 	reportUpdateEvent(recorder, required, err)
 	return actual, true, err
 }
 
 // ApplyConfigMap merges objectmeta, requires data
-func ApplyConfigMap(client coreclientv1.ConfigMapsGetter, recorder events.Recorder, required *corev1.ConfigMap) (*corev1.ConfigMap, bool, error) {
-	existing, err := client.ConfigMaps(required.Namespace).Get(context.TODO(), required.Name, metav1.GetOptions{})
+func ApplyConfigMap(ctx context.Context, client coreclientv1.ConfigMapsGetter, recorder events.Recorder, required *corev1.ConfigMap) (*corev1.ConfigMap, bool, error) {
+	existing, err := client.ConfigMaps(required.Namespace).Get(ctx, required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		requiredCopy := required.DeepCopy()
 		actual, err := client.ConfigMaps(requiredCopy.Namespace).
-			Create(context.TODO(), resourcemerge.WithCleanLabelsAndAnnotations(requiredCopy).(*corev1.ConfigMap), metav1.CreateOptions{})
+			Create(ctx, resourcemerge.WithCleanLabelsAndAnnotations(requiredCopy).(*corev1.ConfigMap), metav1.CreateOptions{})
 		reportCreateEvent(recorder, requiredCopy, err)
 		return actual, true, err
 	}
@@ -220,7 +220,7 @@ func ApplyConfigMap(client coreclientv1.ConfigMapsGetter, recorder events.Record
 		existingCopy.Data["ca-bundle.crt"] = existingCABundle
 	}
 
-	actual, err := client.ConfigMaps(required.Namespace).Update(context.TODO(), existingCopy, metav1.UpdateOptions{})
+	actual, err := client.ConfigMaps(required.Namespace).Update(ctx, existingCopy, metav1.UpdateOptions{})
 
 	var details string
 	if !dataSame {
@@ -235,7 +235,7 @@ func ApplyConfigMap(client coreclientv1.ConfigMapsGetter, recorder events.Record
 }
 
 // ApplySecret merges objectmeta, requires data
-func ApplySecret(client coreclientv1.SecretsGetter, recorder events.Recorder, requiredInput *corev1.Secret) (*corev1.Secret, bool, error) {
+func ApplySecret(ctx context.Context, client coreclientv1.SecretsGetter, recorder events.Recorder, requiredInput *corev1.Secret) (*corev1.Secret, bool, error) {
 	// copy the stringData to data.  Error on a data content conflict inside required.  This is usually a bug.
 	required := requiredInput.DeepCopy()
 	if required.Data == nil {
@@ -251,11 +251,11 @@ func ApplySecret(client coreclientv1.SecretsGetter, recorder events.Recorder, re
 	}
 	required.StringData = nil
 
-	existing, err := client.Secrets(required.Namespace).Get(context.TODO(), required.Name, metav1.GetOptions{})
+	existing, err := client.Secrets(required.Namespace).Get(ctx, required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		requiredCopy := required.DeepCopy()
 		actual, err := client.Secrets(requiredCopy.Namespace).
-			Create(context.TODO(), resourcemerge.WithCleanLabelsAndAnnotations(requiredCopy).(*corev1.Secret), metav1.CreateOptions{})
+			Create(ctx, resourcemerge.WithCleanLabelsAndAnnotations(requiredCopy).(*corev1.Secret), metav1.CreateOptions{})
 		reportCreateEvent(recorder, requiredCopy, err)
 		return actual, true, err
 	}
@@ -305,7 +305,7 @@ func ApplySecret(client coreclientv1.SecretsGetter, recorder events.Recorder, re
 	 * We need to explicitly opt for delete+create in that case.
 	 */
 	if existingCopy.Type == existing.Type {
-		actual, err = client.Secrets(required.Namespace).Update(context.TODO(), existingCopy, metav1.UpdateOptions{})
+		actual, err = client.Secrets(required.Namespace).Update(ctx, existingCopy, metav1.UpdateOptions{})
 		reportUpdateEvent(recorder, existingCopy, err)
 
 		if err == nil {
@@ -317,29 +317,29 @@ func ApplySecret(client coreclientv1.SecretsGetter, recorder events.Recorder, re
 	}
 
 	// if the field was immutable on a secret, we're going to be stuck until we delete it.  Try to delete and then create
-	deleteErr := client.Secrets(required.Namespace).Delete(context.TODO(), existingCopy.Name, metav1.DeleteOptions{})
+	deleteErr := client.Secrets(required.Namespace).Delete(ctx, existingCopy.Name, metav1.DeleteOptions{})
 	reportDeleteEvent(recorder, existingCopy, deleteErr)
 
 	// clear the RV and track the original actual and error for the return like our create value.
 	existingCopy.ResourceVersion = ""
-	actual, err = client.Secrets(required.Namespace).Create(context.TODO(), existingCopy, metav1.CreateOptions{})
+	actual, err = client.Secrets(required.Namespace).Create(ctx, existingCopy, metav1.CreateOptions{})
 	reportCreateEvent(recorder, existingCopy, err)
 
 	return actual, true, err
 }
 
 // SyncConfigMap applies a ConfigMap from a location `sourceNamespace/sourceName` to `targetNamespace/targetName`
-func SyncConfigMap(client coreclientv1.ConfigMapsGetter, recorder events.Recorder, sourceNamespace, sourceName, targetNamespace, targetName string, ownerRefs []metav1.OwnerReference) (*corev1.ConfigMap, bool, error) {
-	return SyncPartialConfigMap(client, recorder, sourceNamespace, sourceName, targetNamespace, targetName, nil, ownerRefs)
+func SyncConfigMap(ctx context.Context, client coreclientv1.ConfigMapsGetter, recorder events.Recorder, sourceNamespace, sourceName, targetNamespace, targetName string, ownerRefs []metav1.OwnerReference) (*corev1.ConfigMap, bool, error) {
+	return SyncPartialConfigMap(ctx, client, recorder, sourceNamespace, sourceName, targetNamespace, targetName, nil, ownerRefs)
 }
 
 // SyncPartialConfigMap does what SyncConfigMap does but it only synchronizes a subset of keys given by `syncedKeys`.
 // SyncPartialConfigMap will delete the target if `syncedKeys` are set but the source does not contain any of these keys.
-func SyncPartialConfigMap(client coreclientv1.ConfigMapsGetter, recorder events.Recorder, sourceNamespace, sourceName, targetNamespace, targetName string, syncedKeys sets.String, ownerRefs []metav1.OwnerReference) (*corev1.ConfigMap, bool, error) {
-	source, err := client.ConfigMaps(sourceNamespace).Get(context.TODO(), sourceName, metav1.GetOptions{})
+func SyncPartialConfigMap(ctx context.Context, client coreclientv1.ConfigMapsGetter, recorder events.Recorder, sourceNamespace, sourceName, targetNamespace, targetName string, syncedKeys sets.String, ownerRefs []metav1.OwnerReference) (*corev1.ConfigMap, bool, error) {
+	source, err := client.ConfigMaps(sourceNamespace).Get(ctx, sourceName, metav1.GetOptions{})
 	switch {
 	case apierrors.IsNotFound(err):
-		modified, err := deleteConfigMapSyncTarget(client, recorder, targetNamespace, targetName)
+		modified, err := deleteConfigMapSyncTarget(ctx, client, recorder, targetNamespace, targetName)
 		return nil, modified, err
 	case err != nil:
 		return nil, false, err
@@ -358,7 +358,7 @@ func SyncPartialConfigMap(client coreclientv1.ConfigMapsGetter, recorder events.
 
 			// remove the synced CM if the requested fields are not present in source
 			if len(source.Data)+len(source.BinaryData) == 0 {
-				modified, err := deleteConfigMapSyncTarget(client, recorder, targetNamespace, targetName)
+				modified, err := deleteConfigMapSyncTarget(ctx, client, recorder, targetNamespace, targetName)
 				return nil, modified, err
 			}
 		}
@@ -367,12 +367,12 @@ func SyncPartialConfigMap(client coreclientv1.ConfigMapsGetter, recorder events.
 		source.Name = targetName
 		source.ResourceVersion = ""
 		source.OwnerReferences = ownerRefs
-		return ApplyConfigMap(client, recorder, source)
+		return ApplyConfigMap(ctx, client, recorder, source)
 	}
 }
 
-func deleteConfigMapSyncTarget(client coreclientv1.ConfigMapsGetter, recorder events.Recorder, targetNamespace, targetName string) (bool, error) {
-	err := client.ConfigMaps(targetNamespace).Delete(context.TODO(), targetName, metav1.DeleteOptions{})
+func deleteConfigMapSyncTarget(ctx context.Context, client coreclientv1.ConfigMapsGetter, recorder events.Recorder, targetNamespace, targetName string) (bool, error) {
+	err := client.ConfigMaps(targetNamespace).Delete(ctx, targetName, metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
 		return false, nil
 	}
@@ -384,17 +384,17 @@ func deleteConfigMapSyncTarget(client coreclientv1.ConfigMapsGetter, recorder ev
 }
 
 // SyncSecret applies a Secret from a location `sourceNamespace/sourceName` to `targetNamespace/targetName`
-func SyncSecret(client coreclientv1.SecretsGetter, recorder events.Recorder, sourceNamespace, sourceName, targetNamespace, targetName string, ownerRefs []metav1.OwnerReference) (*corev1.Secret, bool, error) {
-	return SyncPartialSecret(client, recorder, sourceNamespace, sourceName, targetNamespace, targetName, nil, ownerRefs)
+func SyncSecret(ctx context.Context, client coreclientv1.SecretsGetter, recorder events.Recorder, sourceNamespace, sourceName, targetNamespace, targetName string, ownerRefs []metav1.OwnerReference) (*corev1.Secret, bool, error) {
+	return SyncPartialSecret(ctx, client, recorder, sourceNamespace, sourceName, targetNamespace, targetName, nil, ownerRefs)
 }
 
 // SyncPartialSecret does what SyncSecret does but it only synchronizes a subset of keys given by `syncedKeys`.
 // SyncPartialSecret will delete the target if `syncedKeys` are set but the source does not contain any of these keys.
-func SyncPartialSecret(client coreclientv1.SecretsGetter, recorder events.Recorder, sourceNamespace, sourceName, targetNamespace, targetName string, syncedKeys sets.String, ownerRefs []metav1.OwnerReference) (*corev1.Secret, bool, error) {
-	source, err := client.Secrets(sourceNamespace).Get(context.TODO(), sourceName, metav1.GetOptions{})
+func SyncPartialSecret(ctx context.Context, client coreclientv1.SecretsGetter, recorder events.Recorder, sourceNamespace, sourceName, targetNamespace, targetName string, syncedKeys sets.String, ownerRefs []metav1.OwnerReference) (*corev1.Secret, bool, error) {
+	source, err := client.Secrets(sourceNamespace).Get(ctx, sourceName, metav1.GetOptions{})
 	switch {
 	case apierrors.IsNotFound(err):
-		modified, err := deleteSecretSyncTarget(client, recorder, targetNamespace, targetName)
+		modified, err := deleteSecretSyncTarget(ctx, client, recorder, targetNamespace, targetName)
 		return nil, modified, err
 	case err != nil:
 		return nil, false, err
@@ -431,7 +431,7 @@ func SyncPartialSecret(client coreclientv1.SecretsGetter, recorder events.Record
 
 			// remove the synced secret if the requested fields are not present in source
 			if len(source.Data)+len(source.StringData) == 0 {
-				modified, err := deleteSecretSyncTarget(client, recorder, targetNamespace, targetName)
+				modified, err := deleteSecretSyncTarget(ctx, client, recorder, targetNamespace, targetName)
 				return nil, modified, err
 			}
 		}
@@ -440,12 +440,12 @@ func SyncPartialSecret(client coreclientv1.SecretsGetter, recorder events.Record
 		source.Name = targetName
 		source.ResourceVersion = ""
 		source.OwnerReferences = ownerRefs
-		return ApplySecret(client, recorder, source)
+		return ApplySecret(ctx, client, recorder, source)
 	}
 }
 
-func deleteSecretSyncTarget(client coreclientv1.SecretsGetter, recorder events.Recorder, targetNamespace, targetName string) (bool, error) {
-	err := client.Secrets(targetNamespace).Delete(context.TODO(), targetName, metav1.DeleteOptions{})
+func deleteSecretSyncTarget(ctx context.Context, client coreclientv1.SecretsGetter, recorder events.Recorder, targetNamespace, targetName string) (bool, error) {
+	err := client.Secrets(targetNamespace).Delete(ctx, targetName, metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
 		return false, nil
 	}

--- a/pkg/operator/resource/resourceapply/core_test.go
+++ b/pkg/operator/resource/resourceapply/core_test.go
@@ -1,6 +1,7 @@
 package resourceapply
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"testing"
@@ -297,7 +298,7 @@ func TestApplyConfigMap(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			client := fake.NewSimpleClientset(test.existing...)
-			_, actualModified, err := ApplyConfigMap(client.CoreV1(), events.NewInMemoryRecorder("test"), test.input)
+			_, actualModified, err := ApplyConfigMap(context.TODO(), client.CoreV1(), events.NewInMemoryRecorder("test"), test.input)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -510,7 +511,7 @@ func TestApplySecret(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			client := fake.NewSimpleClientset(tc.existing...)
-			got, changed, err := ApplySecret(client.CoreV1(), events.NewInMemoryRecorder("test"), tc.required)
+			got, changed, err := ApplySecret(context.TODO(), client.CoreV1(), events.NewInMemoryRecorder("test"), tc.required)
 			if !reflect.DeepEqual(tc.err, err) {
 				t.Errorf("expected error %v, got %v", tc.err, err)
 				return
@@ -659,7 +660,7 @@ func TestApplyNamespace(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			client := fake.NewSimpleClientset(test.existing...)
-			_, actualModified, err := ApplyNamespace(client.CoreV1(), events.NewInMemoryRecorder("test"), test.input)
+			_, actualModified, err := ApplyNamespace(context.TODO(), client.CoreV1(), events.NewInMemoryRecorder("test"), test.input)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -873,7 +874,7 @@ func TestSyncSecret(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			client := fake.NewSimpleClientset(tc.existingObjects...)
-			secret, changed, err := SyncSecret(client.CoreV1(), events.NewInMemoryRecorder("test"), tc.sourceNamespace, tc.sourceName, tc.targetNamespace, tc.targetName, tc.ownerRefs)
+			secret, changed, err := SyncSecret(context.TODO(), client.CoreV1(), events.NewInMemoryRecorder("test"), tc.sourceNamespace, tc.sourceName, tc.targetNamespace, tc.targetName, tc.ownerRefs)
 
 			if !reflect.DeepEqual(err, tc.expectedErr) {
 				t.Errorf("expected error %v, got %v", tc.expectedErr, err)
@@ -1134,7 +1135,7 @@ func TestSyncPartialSync(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			client := fake.NewSimpleClientset(tc.existingObjects...)
-			secret, changed, err := SyncPartialSecret(client.CoreV1(), events.NewInMemoryRecorder("test"), tc.sourceNamespace, tc.sourceName, tc.targetNamespace, tc.targetName, tc.syncedKeys, tc.ownerRefs)
+			secret, changed, err := SyncPartialSecret(context.TODO(), client.CoreV1(), events.NewInMemoryRecorder("test"), tc.sourceNamespace, tc.sourceName, tc.targetNamespace, tc.targetName, tc.syncedKeys, tc.ownerRefs)
 
 			if !reflect.DeepEqual(err, tc.expectedErr) {
 				t.Errorf("expected error %v, got %v", tc.expectedErr, err)

--- a/pkg/operator/resource/resourceapply/credentialsrequest.go
+++ b/pkg/operator/resource/resourceapply/credentialsrequest.go
@@ -44,6 +44,7 @@ func AddCredentialsRequestHash(cr *unstructured.Unstructured) error {
 }
 
 func ApplyCredentialsRequest(
+	ctx context.Context,
 	client dynamic.Interface,
 	recorder events.Recorder,
 	required *unstructured.Unstructured,
@@ -58,9 +59,9 @@ func ApplyCredentialsRequest(
 	}
 
 	crClient := client.Resource(credentialsRequestResourceGVR).Namespace(required.GetNamespace())
-	existing, err := crClient.Get(context.TODO(), required.GetName(), metav1.GetOptions{})
+	existing, err := crClient.Get(ctx, required.GetName(), metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		actual, err := crClient.Create(context.TODO(), required, metav1.CreateOptions{})
+		actual, err := crClient.Create(ctx, required, metav1.CreateOptions{})
 		if err == nil {
 			recorder.Eventf(
 				fmt.Sprintf("%sCreated", required.GetKind()),
@@ -97,7 +98,7 @@ func ApplyCredentialsRequest(
 
 	requiredCopy := required.DeepCopy()
 	existing.Object["spec"] = requiredCopy.Object["spec"]
-	actual, err := crClient.Update(context.TODO(), existing, metav1.UpdateOptions{})
+	actual, err := crClient.Update(ctx, existing, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/operator/resource/resourceapply/generic.go
+++ b/pkg/operator/resource/resourceapply/generic.go
@@ -1,6 +1,7 @@
 package resourceapply
 
 import (
+	"context"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -93,7 +94,7 @@ func (c *ClientHolder) WithMigrationClient(client migrationclient.Interface) *Cl
 }
 
 // ApplyDirectly applies the given manifest files to API server.
-func ApplyDirectly(clients *ClientHolder, recorder events.Recorder, manifests AssetFunc, files ...string) []ApplyResult {
+func ApplyDirectly(ctx context.Context, clients *ClientHolder, recorder events.Recorder, manifests AssetFunc, files ...string) []ApplyResult {
 	ret := []ApplyResult{}
 
 	for _, file := range files {
@@ -118,105 +119,99 @@ func ApplyDirectly(clients *ClientHolder, recorder events.Recorder, manifests As
 			if clients.kubeClient == nil {
 				result.Error = fmt.Errorf("missing kubeClient")
 			} else {
-				result.Result, result.Changed, result.Error = ApplyNamespace(clients.kubeClient.CoreV1(), recorder, t)
+				result.Result, result.Changed, result.Error = ApplyNamespace(ctx, clients.kubeClient.CoreV1(), recorder, t)
 			}
 		case *corev1.Service:
 			if clients.kubeClient == nil {
 				result.Error = fmt.Errorf("missing kubeClient")
 			} else {
-				result.Result, result.Changed, result.Error = ApplyService(clients.kubeClient.CoreV1(), recorder, t)
+				result.Result, result.Changed, result.Error = ApplyService(ctx, clients.kubeClient.CoreV1(), recorder, t)
 			}
 		case *corev1.Pod:
 			if clients.kubeClient == nil {
 				result.Error = fmt.Errorf("missing kubeClient")
 			} else {
-				result.Result, result.Changed, result.Error = ApplyPod(clients.kubeClient.CoreV1(), recorder, t)
+				result.Result, result.Changed, result.Error = ApplyPod(ctx, clients.kubeClient.CoreV1(), recorder, t)
 			}
 		case *corev1.ServiceAccount:
 			if clients.kubeClient == nil {
 				result.Error = fmt.Errorf("missing kubeClient")
 			} else {
-				result.Result, result.Changed, result.Error = ApplyServiceAccount(clients.kubeClient.CoreV1(), recorder, t)
+				result.Result, result.Changed, result.Error = ApplyServiceAccount(ctx, clients.kubeClient.CoreV1(), recorder, t)
 			}
 		case *corev1.ConfigMap:
 			client := clients.configMapsGetter()
 			if client == nil {
 				result.Error = fmt.Errorf("missing kubeClient")
 			} else {
-				result.Result, result.Changed, result.Error = ApplyConfigMap(client, recorder, t)
+				result.Result, result.Changed, result.Error = ApplyConfigMap(ctx, client, recorder, t)
 			}
 		case *corev1.Secret:
 			client := clients.secretsGetter()
 			if client == nil {
 				result.Error = fmt.Errorf("missing kubeClient")
 			} else {
-				result.Result, result.Changed, result.Error = ApplySecret(client, recorder, t)
+				result.Result, result.Changed, result.Error = ApplySecret(ctx, client, recorder, t)
 			}
 		case *rbacv1.ClusterRole:
 			if clients.kubeClient == nil {
 				result.Error = fmt.Errorf("missing kubeClient")
 			} else {
-				result.Result, result.Changed, result.Error = ApplyClusterRole(clients.kubeClient.RbacV1(), recorder, t)
+				result.Result, result.Changed, result.Error = ApplyClusterRole(ctx, clients.kubeClient.RbacV1(), recorder, t)
 			}
 		case *rbacv1.ClusterRoleBinding:
 			if clients.kubeClient == nil {
 				result.Error = fmt.Errorf("missing kubeClient")
 			} else {
-				result.Result, result.Changed, result.Error = ApplyClusterRoleBinding(clients.kubeClient.RbacV1(), recorder, t)
+				result.Result, result.Changed, result.Error = ApplyClusterRoleBinding(ctx, clients.kubeClient.RbacV1(), recorder, t)
 			}
 		case *rbacv1.Role:
 			if clients.kubeClient == nil {
 				result.Error = fmt.Errorf("missing kubeClient")
 			} else {
-				result.Result, result.Changed, result.Error = ApplyRole(clients.kubeClient.RbacV1(), recorder, t)
+				result.Result, result.Changed, result.Error = ApplyRole(ctx, clients.kubeClient.RbacV1(), recorder, t)
 			}
 		case *rbacv1.RoleBinding:
 			if clients.kubeClient == nil {
 				result.Error = fmt.Errorf("missing kubeClient")
 			} else {
-				result.Result, result.Changed, result.Error = ApplyRoleBinding(clients.kubeClient.RbacV1(), recorder, t)
+				result.Result, result.Changed, result.Error = ApplyRoleBinding(ctx, clients.kubeClient.RbacV1(), recorder, t)
 			}
 		case *policyv1.PodDisruptionBudget:
 			if clients.kubeClient == nil {
 				result.Error = fmt.Errorf("missing kubeClient")
 			} else {
-				result.Result, result.Changed, result.Error = ApplyPodDisruptionBudget(clients.kubeClient.PolicyV1(), recorder, t)
-			}
-		case *apiextensionsv1beta1.CustomResourceDefinition:
-			if clients.apiExtensionsClient == nil {
-				result.Error = fmt.Errorf("missing apiExtensionsClient")
-			} else {
-				result.Result, result.Changed, result.Error = ApplyCustomResourceDefinitionV1Beta1(clients.apiExtensionsClient.ApiextensionsV1beta1(), recorder, t)
+				result.Result, result.Changed, result.Error = ApplyPodDisruptionBudget(ctx, clients.kubeClient.PolicyV1(), recorder, t)
 			}
 		case *apiextensionsv1.CustomResourceDefinition:
 			if clients.apiExtensionsClient == nil {
 				result.Error = fmt.Errorf("missing apiExtensionsClient")
 			} else {
-				result.Result, result.Changed, result.Error = ApplyCustomResourceDefinitionV1(clients.apiExtensionsClient.ApiextensionsV1(), recorder, t)
+				result.Result, result.Changed, result.Error = ApplyCustomResourceDefinitionV1(ctx, clients.apiExtensionsClient.ApiextensionsV1(), recorder, t)
 			}
 		case *storagev1.StorageClass:
 			if clients.kubeClient == nil {
 				result.Error = fmt.Errorf("missing kubeClient")
 			} else {
-				result.Result, result.Changed, result.Error = ApplyStorageClass(clients.kubeClient.StorageV1(), recorder, t)
+				result.Result, result.Changed, result.Error = ApplyStorageClass(ctx, clients.kubeClient.StorageV1(), recorder, t)
 			}
 		case *storagev1.CSIDriver:
 			if clients.kubeClient == nil {
 				result.Error = fmt.Errorf("missing kubeClient")
 			} else {
-				result.Result, result.Changed, result.Error = ApplyCSIDriver(clients.kubeClient.StorageV1(), recorder, t)
+				result.Result, result.Changed, result.Error = ApplyCSIDriver(ctx, clients.kubeClient.StorageV1(), recorder, t)
 			}
 		case *migrationv1alpha1.StorageVersionMigration:
 			if clients.migrationClient == nil {
 				result.Error = fmt.Errorf("missing migrationClient")
 			} else {
-				result.Result, result.Changed, result.Error = ApplyStorageVersionMigration(clients.migrationClient, recorder, t)
+				result.Result, result.Changed, result.Error = ApplyStorageVersionMigration(ctx, clients.migrationClient, recorder, t)
 			}
 		case *unstructured.Unstructured:
 			if clients.dynamicClient == nil {
 				result.Error = fmt.Errorf("missing dynamicClient")
 			} else {
-				result.Result, result.Changed, result.Error = ApplyKnownUnstructured(clients.dynamicClient, recorder, t)
+				result.Result, result.Changed, result.Error = ApplyKnownUnstructured(ctx, clients.dynamicClient, recorder, t)
 			}
 		default:
 			result.Error = fmt.Errorf("unhandled type %T", requiredObj)

--- a/pkg/operator/resource/resourceapply/generic_test.go
+++ b/pkg/operator/resource/resourceapply/generic_test.go
@@ -1,6 +1,7 @@
 package resourceapply
 
 import (
+	"context"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
@@ -37,7 +38,7 @@ metadata:
 `), nil
 	}
 	recorder := events.NewInMemoryRecorder("")
-	ret := ApplyDirectly((&ClientHolder{}).WithKubernetes(fakeClient), recorder, content, "pvc")
+	ret := ApplyDirectly(context.TODO(), (&ClientHolder{}).WithKubernetes(fakeClient), recorder, content, "pvc")
 	if ret[0].Error == nil {
 		t.Fatal("missing expected error")
 	} else if ret[0].Error.Error() != "unhandled type *v1.PersistentVolumeClaim" {

--- a/pkg/operator/resource/resourceapply/migration.go
+++ b/pkg/operator/resource/resourceapply/migration.go
@@ -15,12 +15,12 @@ import (
 )
 
 // ApplyStorageVersionMigration merges objectmeta and required data.
-func ApplyStorageVersionMigration(client migrationclientv1alpha1.Interface, recorder events.Recorder, required *migrationv1alpha1.StorageVersionMigration) (*migrationv1alpha1.StorageVersionMigration, bool, error) {
+func ApplyStorageVersionMigration(ctx context.Context, client migrationclientv1alpha1.Interface, recorder events.Recorder, required *migrationv1alpha1.StorageVersionMigration) (*migrationv1alpha1.StorageVersionMigration, bool, error) {
 	clientInterface := client.MigrationV1alpha1().StorageVersionMigrations()
-	existing, err := clientInterface.Get(context.Background(), required.Name, metav1.GetOptions{})
+	existing, err := clientInterface.Get(ctx, required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		requiredCopy := required.DeepCopy()
-		actual, err := clientInterface.Create(context.Background(), resourcemerge.WithCleanLabelsAndAnnotations(requiredCopy).(*v1alpha1.StorageVersionMigration), metav1.CreateOptions{})
+		actual, err := clientInterface.Create(ctx, resourcemerge.WithCleanLabelsAndAnnotations(requiredCopy).(*v1alpha1.StorageVersionMigration), metav1.CreateOptions{})
 		reportCreateEvent(recorder, requiredCopy, err)
 		return actual, true, err
 	}
@@ -40,7 +40,7 @@ func ApplyStorageVersionMigration(client migrationclientv1alpha1.Interface, reco
 	}
 
 	required.Spec.Resource.DeepCopyInto(&existingCopy.Spec.Resource)
-	actual, err := clientInterface.Update(context.Background(), existingCopy, metav1.UpdateOptions{})
+	actual, err := clientInterface.Update(ctx, existingCopy, metav1.UpdateOptions{})
 	reportUpdateEvent(recorder, required, err)
 	return actual, true, err
 }

--- a/pkg/operator/resource/resourceapply/migration_test.go
+++ b/pkg/operator/resource/resourceapply/migration_test.go
@@ -1,6 +1,7 @@
 package resourceapply
 
 import (
+	"context"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
@@ -179,7 +180,7 @@ func TestApplyStorageVersionMigration(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			client := fake.NewSimpleClientset(test.existing...)
-			_, actualModified, err := ApplyStorageVersionMigration(client, events.NewInMemoryRecorder("test"), test.input)
+			_, actualModified, err := ApplyStorageVersionMigration(context.TODO(), client, events.NewInMemoryRecorder("test"), test.input)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/operator/resource/resourceapply/monitoring.go
+++ b/pkg/operator/resource/resourceapply/monitoring.go
@@ -55,12 +55,12 @@ type equalityChecker interface {
 }
 
 // ApplyServiceMonitor applies the Prometheus service monitor.
-func ApplyServiceMonitor(client dynamic.Interface, recorder events.Recorder, required *unstructured.Unstructured) (*unstructured.Unstructured, bool, error) {
+func ApplyServiceMonitor(ctx context.Context, client dynamic.Interface, recorder events.Recorder, required *unstructured.Unstructured) (*unstructured.Unstructured, bool, error) {
 	namespace := required.GetNamespace()
 
-	existing, err := client.Resource(serviceMonitorGVR).Namespace(namespace).Get(context.TODO(), required.GetName(), metav1.GetOptions{})
+	existing, err := client.Resource(serviceMonitorGVR).Namespace(namespace).Get(ctx, required.GetName(), metav1.GetOptions{})
 	if errors.IsNotFound(err) {
-		newObj, createErr := client.Resource(serviceMonitorGVR).Namespace(namespace).Create(context.TODO(), required, metav1.CreateOptions{})
+		newObj, createErr := client.Resource(serviceMonitorGVR).Namespace(namespace).Create(ctx, required, metav1.CreateOptions{})
 		if createErr != nil {
 			recorder.Warningf("ServiceMonitorCreateFailed", "Failed to create ServiceMonitor.monitoring.coreos.com/v1: %v", createErr)
 			return nil, true, createErr
@@ -87,7 +87,7 @@ func ApplyServiceMonitor(client dynamic.Interface, recorder events.Recorder, req
 		klog.Infof("ServiceMonitor %q changes: %v", namespace+"/"+required.GetName(), JSONPatchNoError(existing, toUpdate))
 	}
 
-	newObj, err := client.Resource(serviceMonitorGVR).Namespace(namespace).Update(context.TODO(), toUpdate, metav1.UpdateOptions{})
+	newObj, err := client.Resource(serviceMonitorGVR).Namespace(namespace).Update(ctx, toUpdate, metav1.UpdateOptions{})
 	if err != nil {
 		recorder.Warningf("ServiceMonitorUpdateFailed", "Failed to update ServiceMonitor.monitoring.coreos.com/v1: %v", err)
 		return nil, true, err
@@ -100,12 +100,12 @@ func ApplyServiceMonitor(client dynamic.Interface, recorder events.Recorder, req
 var prometheusRuleGVR = schema.GroupVersionResource{Group: "monitoring.coreos.com", Version: "v1", Resource: "prometheusrules"}
 
 // ApplyPrometheusRule applies the PrometheusRule
-func ApplyPrometheusRule(client dynamic.Interface, recorder events.Recorder, required *unstructured.Unstructured) (*unstructured.Unstructured, bool, error) {
+func ApplyPrometheusRule(ctx context.Context, client dynamic.Interface, recorder events.Recorder, required *unstructured.Unstructured) (*unstructured.Unstructured, bool, error) {
 	namespace := required.GetNamespace()
 
-	existing, err := client.Resource(prometheusRuleGVR).Namespace(namespace).Get(context.TODO(), required.GetName(), metav1.GetOptions{})
+	existing, err := client.Resource(prometheusRuleGVR).Namespace(namespace).Get(ctx, required.GetName(), metav1.GetOptions{})
 	if errors.IsNotFound(err) {
-		newObj, createErr := client.Resource(prometheusRuleGVR).Namespace(namespace).Create(context.TODO(), required, metav1.CreateOptions{})
+		newObj, createErr := client.Resource(prometheusRuleGVR).Namespace(namespace).Create(ctx, required, metav1.CreateOptions{})
 		if createErr != nil {
 			recorder.Warningf("PrometheusRuleCreateFailed", "Failed to create PrometheusRule.monitoring.coreos.com/v1: %v", createErr)
 			return nil, true, createErr
@@ -132,7 +132,7 @@ func ApplyPrometheusRule(client dynamic.Interface, recorder events.Recorder, req
 		klog.Infof("PrometheusRule %q changes: %v", namespace+"/"+required.GetName(), JSONPatchNoError(existing, toUpdate))
 	}
 
-	newObj, err := client.Resource(prometheusRuleGVR).Namespace(namespace).Update(context.TODO(), toUpdate, metav1.UpdateOptions{})
+	newObj, err := client.Resource(prometheusRuleGVR).Namespace(namespace).Update(ctx, toUpdate, metav1.UpdateOptions{})
 	if err != nil {
 		recorder.Warningf("PrometheusRuleUpdateFailed", "Failed to update PrometheusRule.monitoring.coreos.com/v1: %v", err)
 		return nil, true, err

--- a/pkg/operator/resource/resourceapply/monitoring_test.go
+++ b/pkg/operator/resource/resourceapply/monitoring_test.go
@@ -1,6 +1,7 @@
 package resourceapply
 
 import (
+	"context"
 	"reflect"
 	"sort"
 	"testing"
@@ -98,7 +99,7 @@ func TestApplyServiceMonitor(t *testing.T) {
 
 	required := resourceread.ReadUnstructuredOrDie([]byte(fakeServiceMonitor))
 
-	_, modified, err := ApplyServiceMonitor(dynamicClient, events.NewInMemoryRecorder("monitor-test"), required)
+	_, modified, err := ApplyServiceMonitor(context.TODO(), dynamicClient, events.NewInMemoryRecorder("monitor-test"), required)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/operator/resource/resourceapply/policy.go
+++ b/pkg/operator/resource/resourceapply/policy.go
@@ -15,10 +15,10 @@ import (
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
 )
 
-func ApplyPodDisruptionBudget(client policyclientv1.PodDisruptionBudgetsGetter, recorder events.Recorder, required *policyv1.PodDisruptionBudget) (*policyv1.PodDisruptionBudget, bool, error) {
-	existing, err := client.PodDisruptionBudgets(required.Namespace).Get(context.TODO(), required.Name, metav1.GetOptions{})
+func ApplyPodDisruptionBudget(ctx context.Context, client policyclientv1.PodDisruptionBudgetsGetter, recorder events.Recorder, required *policyv1.PodDisruptionBudget) (*policyv1.PodDisruptionBudget, bool, error) {
+	existing, err := client.PodDisruptionBudgets(required.Namespace).Get(ctx, required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		actual, err := client.PodDisruptionBudgets(required.Namespace).Create(context.TODO(), required, metav1.CreateOptions{})
+		actual, err := client.PodDisruptionBudgets(required.Namespace).Create(ctx, required, metav1.CreateOptions{})
 		reportCreateEvent(recorder, required, err)
 		return actual, true, err
 	}
@@ -41,7 +41,7 @@ func ApplyPodDisruptionBudget(client policyclientv1.PodDisruptionBudgetsGetter, 
 		klog.Infof("PodDisruptionBudget %q changes: %v", required.Name, JSONPatchNoError(existing, existingCopy))
 	}
 
-	actual, err := client.PodDisruptionBudgets(required.Namespace).Update(context.TODO(), existingCopy, metav1.UpdateOptions{})
+	actual, err := client.PodDisruptionBudgets(required.Namespace).Update(ctx, existingCopy, metav1.UpdateOptions{})
 	reportUpdateEvent(recorder, required, err)
 	return actual, true, err
 }

--- a/pkg/operator/resource/resourceapply/rbac.go
+++ b/pkg/operator/resource/resourceapply/rbac.go
@@ -17,14 +17,14 @@ import (
 )
 
 // ApplyClusterRole merges objectmeta, requires rules, aggregation rules are not allowed for now.
-func ApplyClusterRole(client rbacclientv1.ClusterRolesGetter, recorder events.Recorder, required *rbacv1.ClusterRole) (*rbacv1.ClusterRole, bool, error) {
+func ApplyClusterRole(ctx context.Context, client rbacclientv1.ClusterRolesGetter, recorder events.Recorder, required *rbacv1.ClusterRole) (*rbacv1.ClusterRole, bool, error) {
 	if required.AggregationRule != nil && len(required.AggregationRule.ClusterRoleSelectors) != 0 {
 		return nil, false, fmt.Errorf("cannot create an aggregated cluster role")
 	}
 
-	existing, err := client.ClusterRoles().Get(context.TODO(), required.Name, metav1.GetOptions{})
+	existing, err := client.ClusterRoles().Get(ctx, required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		actual, err := client.ClusterRoles().Create(context.TODO(), required, metav1.CreateOptions{})
+		actual, err := client.ClusterRoles().Create(ctx, required, metav1.CreateOptions{})
 		reportCreateEvent(recorder, required, err)
 		return actual, true, err
 	}
@@ -48,17 +48,17 @@ func ApplyClusterRole(client rbacclientv1.ClusterRolesGetter, recorder events.Re
 		klog.Infof("ClusterRole %q changes: %v", required.Name, JSONPatchNoError(existing, existingCopy))
 	}
 
-	actual, err := client.ClusterRoles().Update(context.TODO(), existingCopy, metav1.UpdateOptions{})
+	actual, err := client.ClusterRoles().Update(ctx, existingCopy, metav1.UpdateOptions{})
 	reportUpdateEvent(recorder, required, err)
 	return actual, true, err
 }
 
 // ApplyClusterRoleBinding merges objectmeta, requires subjects and role refs
 // TODO on non-matching roleref, delete and recreate
-func ApplyClusterRoleBinding(client rbacclientv1.ClusterRoleBindingsGetter, recorder events.Recorder, required *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, bool, error) {
-	existing, err := client.ClusterRoleBindings().Get(context.TODO(), required.Name, metav1.GetOptions{})
+func ApplyClusterRoleBinding(ctx context.Context, client rbacclientv1.ClusterRoleBindingsGetter, recorder events.Recorder, required *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, bool, error) {
+	existing, err := client.ClusterRoleBindings().Get(ctx, required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		actual, err := client.ClusterRoleBindings().Create(context.TODO(), required, metav1.CreateOptions{})
+		actual, err := client.ClusterRoleBindings().Create(ctx, required, metav1.CreateOptions{})
 		reportCreateEvent(recorder, required, err)
 		return actual, true, err
 	}
@@ -101,16 +101,16 @@ func ApplyClusterRoleBinding(client rbacclientv1.ClusterRoleBindingsGetter, reco
 		klog.Infof("ClusterRoleBinding %q changes: %v", requiredCopy.Name, JSONPatchNoError(existing, existingCopy))
 	}
 
-	actual, err := client.ClusterRoleBindings().Update(context.TODO(), existingCopy, metav1.UpdateOptions{})
+	actual, err := client.ClusterRoleBindings().Update(ctx, existingCopy, metav1.UpdateOptions{})
 	reportUpdateEvent(recorder, requiredCopy, err)
 	return actual, true, err
 }
 
 // ApplyRole merges objectmeta, requires rules
-func ApplyRole(client rbacclientv1.RolesGetter, recorder events.Recorder, required *rbacv1.Role) (*rbacv1.Role, bool, error) {
-	existing, err := client.Roles(required.Namespace).Get(context.TODO(), required.Name, metav1.GetOptions{})
+func ApplyRole(ctx context.Context, client rbacclientv1.RolesGetter, recorder events.Recorder, required *rbacv1.Role) (*rbacv1.Role, bool, error) {
+	existing, err := client.Roles(required.Namespace).Get(ctx, required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		actual, err := client.Roles(required.Namespace).Create(context.TODO(), required, metav1.CreateOptions{})
+		actual, err := client.Roles(required.Namespace).Create(ctx, required, metav1.CreateOptions{})
 		reportCreateEvent(recorder, required, err)
 		return actual, true, err
 	}
@@ -132,17 +132,17 @@ func ApplyRole(client rbacclientv1.RolesGetter, recorder events.Recorder, requir
 	if klog.V(4).Enabled() {
 		klog.Infof("Role %q changes: %v", required.Namespace+"/"+required.Name, JSONPatchNoError(existing, existingCopy))
 	}
-	actual, err := client.Roles(required.Namespace).Update(context.TODO(), existingCopy, metav1.UpdateOptions{})
+	actual, err := client.Roles(required.Namespace).Update(ctx, existingCopy, metav1.UpdateOptions{})
 	reportUpdateEvent(recorder, required, err)
 	return actual, true, err
 }
 
 // ApplyRoleBinding merges objectmeta, requires subjects and role refs
 // TODO on non-matching roleref, delete and recreate
-func ApplyRoleBinding(client rbacclientv1.RoleBindingsGetter, recorder events.Recorder, required *rbacv1.RoleBinding) (*rbacv1.RoleBinding, bool, error) {
-	existing, err := client.RoleBindings(required.Namespace).Get(context.TODO(), required.Name, metav1.GetOptions{})
+func ApplyRoleBinding(ctx context.Context, client rbacclientv1.RoleBindingsGetter, recorder events.Recorder, required *rbacv1.RoleBinding) (*rbacv1.RoleBinding, bool, error) {
+	existing, err := client.RoleBindings(required.Namespace).Get(ctx, required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		actual, err := client.RoleBindings(required.Namespace).Create(context.TODO(), required, metav1.CreateOptions{})
+		actual, err := client.RoleBindings(required.Namespace).Create(ctx, required, metav1.CreateOptions{})
 		reportCreateEvent(recorder, required, err)
 		return actual, true, err
 	}
@@ -185,7 +185,7 @@ func ApplyRoleBinding(client rbacclientv1.RoleBindingsGetter, recorder events.Re
 		klog.Infof("RoleBinding %q changes: %v", requiredCopy.Namespace+"/"+requiredCopy.Name, JSONPatchNoError(existing, existingCopy))
 	}
 
-	actual, err := client.RoleBindings(requiredCopy.Namespace).Update(context.TODO(), existingCopy, metav1.UpdateOptions{})
+	actual, err := client.RoleBindings(requiredCopy.Namespace).Update(ctx, existingCopy, metav1.UpdateOptions{})
 	reportUpdateEvent(recorder, requiredCopy, err)
 	return actual, true, err
 }

--- a/pkg/operator/resource/resourceapply/storage.go
+++ b/pkg/operator/resource/resourceapply/storage.go
@@ -18,11 +18,11 @@ import (
 )
 
 // ApplyStorageClass merges objectmeta, tries to write everything else
-func ApplyStorageClass(client storageclientv1.StorageClassesGetter, recorder events.Recorder, required *storagev1.StorageClass) (*storagev1.StorageClass, bool,
+func ApplyStorageClass(ctx context.Context, client storageclientv1.StorageClassesGetter, recorder events.Recorder, required *storagev1.StorageClass) (*storagev1.StorageClass, bool,
 	error) {
-	existing, err := client.StorageClasses().Get(context.TODO(), required.Name, metav1.GetOptions{})
+	existing, err := client.StorageClasses().Get(ctx, required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		actual, err := client.StorageClasses().Create(context.TODO(), required, metav1.CreateOptions{})
+		actual, err := client.StorageClasses().Create(ctx, required, metav1.CreateOptions{})
 		reportCreateEvent(recorder, required, err)
 		return actual, true, err
 	}
@@ -52,16 +52,16 @@ func ApplyStorageClass(client storageclientv1.StorageClassesGetter, recorder eve
 	}
 
 	// TODO if provisioner, parameters, reclaimpolicy, or volumebindingmode are different, update will fail so delete and recreate
-	actual, err := client.StorageClasses().Update(context.TODO(), requiredCopy, metav1.UpdateOptions{})
+	actual, err := client.StorageClasses().Update(ctx, requiredCopy, metav1.UpdateOptions{})
 	reportUpdateEvent(recorder, required, err)
 	return actual, true, err
 }
 
 // ApplyCSIDriverV1Beta1 merges objectmeta, does not worry about anything else
-func ApplyCSIDriverV1Beta1(client storageclientv1beta1.CSIDriversGetter, recorder events.Recorder, required *storagev1beta1.CSIDriver) (*storagev1beta1.CSIDriver, bool, error) {
-	existing, err := client.CSIDrivers().Get(context.TODO(), required.Name, metav1.GetOptions{})
+func ApplyCSIDriverV1Beta1(ctx context.Context, client storageclientv1beta1.CSIDriversGetter, recorder events.Recorder, required *storagev1beta1.CSIDriver) (*storagev1beta1.CSIDriver, bool, error) {
+	existing, err := client.CSIDrivers().Get(ctx, required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		actual, err := client.CSIDrivers().Create(context.TODO(), required, metav1.CreateOptions{})
+		actual, err := client.CSIDrivers().Create(ctx, required, metav1.CreateOptions{})
 		reportCreateEvent(recorder, required, err)
 		return actual, true, err
 	}
@@ -81,16 +81,16 @@ func ApplyCSIDriverV1Beta1(client storageclientv1beta1.CSIDriversGetter, recorde
 		klog.Infof("CSIDriver %q changes: %v", required.Name, JSONPatchNoError(existing, existingCopy))
 	}
 
-	actual, err := client.CSIDrivers().Update(context.TODO(), existingCopy, metav1.UpdateOptions{})
+	actual, err := client.CSIDrivers().Update(ctx, existingCopy, metav1.UpdateOptions{})
 	reportUpdateEvent(recorder, required, err)
 	return actual, true, err
 }
 
 // ApplyCSIDriver merges objectmeta, does not worry about anything else
-func ApplyCSIDriver(client storageclientv1.CSIDriversGetter, recorder events.Recorder, required *storagev1.CSIDriver) (*storagev1.CSIDriver, bool, error) {
-	existing, err := client.CSIDrivers().Get(context.TODO(), required.Name, metav1.GetOptions{})
+func ApplyCSIDriver(ctx context.Context, client storageclientv1.CSIDriversGetter, recorder events.Recorder, required *storagev1.CSIDriver) (*storagev1.CSIDriver, bool, error) {
+	existing, err := client.CSIDrivers().Get(ctx, required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		actual, err := client.CSIDrivers().Create(context.TODO(), required, metav1.CreateOptions{})
+		actual, err := client.CSIDrivers().Create(ctx, required, metav1.CreateOptions{})
 		reportCreateEvent(recorder, required, err)
 		return actual, true, err
 	}
@@ -111,7 +111,7 @@ func ApplyCSIDriver(client storageclientv1.CSIDriversGetter, recorder events.Rec
 	}
 
 	// TODO: Spec is read-only, so this will fail if user changes it. Should we simply ignore it?
-	actual, err := client.CSIDrivers().Update(context.TODO(), existingCopy, metav1.UpdateOptions{})
+	actual, err := client.CSIDrivers().Update(ctx, existingCopy, metav1.UpdateOptions{})
 	reportUpdateEvent(recorder, required, err)
 	return actual, true, err
 }

--- a/pkg/operator/resource/resourceapply/storage_test.go
+++ b/pkg/operator/resource/resourceapply/storage_test.go
@@ -1,6 +1,7 @@
 package resourceapply
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -138,7 +139,7 @@ func TestApplyStorageClass(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			client := fake.NewSimpleClientset(test.existing...)
-			_, actualModified, err := ApplyStorageClass(client.StorageV1(), events.NewInMemoryRecorder("test"), test.input)
+			_, actualModified, err := ApplyStorageClass(context.TODO(), client.StorageV1(), events.NewInMemoryRecorder("test"), test.input)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -247,7 +248,7 @@ func TestApplyCSIDriver(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			client := fake.NewSimpleClientset(test.existing...)
-			_, actualModified, err := ApplyCSIDriverV1Beta1(client.StorageV1beta1(), events.NewInMemoryRecorder("test"), test.input)
+			_, actualModified, err := ApplyCSIDriverV1Beta1(context.TODO(), client.StorageV1beta1(), events.NewInMemoryRecorder("test"), test.input)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/operator/resource/resourceapply/unstructured.go
+++ b/pkg/operator/resource/resourceapply/unstructured.go
@@ -1,6 +1,7 @@
 package resourceapply
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/openshift/library-go/pkg/operator/events"
@@ -11,14 +12,14 @@ import (
 
 // ApplyKnownUnstructured applies few selected Unstructured types, where it semantic knowledge
 // to merge existing & required objects intelligently. Feel free to add more.
-func ApplyKnownUnstructured(client dynamic.Interface, recorder events.Recorder, obj *unstructured.Unstructured) (*unstructured.Unstructured, bool, error) {
+func ApplyKnownUnstructured(ctx context.Context, client dynamic.Interface, recorder events.Recorder, obj *unstructured.Unstructured) (*unstructured.Unstructured, bool, error) {
 	switch obj.GetObjectKind().GroupVersionKind().GroupKind() {
 	case schema.GroupKind{Group: "monitoring.coreos.com", Kind: "ServiceMonitor"}:
-		return ApplyServiceMonitor(client, recorder, obj)
+		return ApplyServiceMonitor(ctx, client, recorder, obj)
 	case schema.GroupKind{Group: "monitoring.coreos.com", Kind: "PrometheusRule"}:
-		return ApplyPrometheusRule(client, recorder, obj)
+		return ApplyPrometheusRule(ctx, client, recorder, obj)
 	case schema.GroupKind{Group: "snapshot.storage.k8s.io", Kind: "VolumeSnapshotClass"}:
-		return ApplyVolumeSnapshotClass(client, recorder, obj)
+		return ApplyVolumeSnapshotClass(ctx, client, recorder, obj)
 
 	}
 

--- a/pkg/operator/resource/resourceapply/volumesnapshotclass.go
+++ b/pkg/operator/resource/resourceapply/volumesnapshotclass.go
@@ -77,10 +77,10 @@ func ensureGenericVolumeSnapshotClass(required, existing *unstructured.Unstructu
 }
 
 // ApplyVolumeSnapshotClass applies Volume Snapshot Class.
-func ApplyVolumeSnapshotClass(client dynamic.Interface, recorder events.Recorder, required *unstructured.Unstructured) (*unstructured.Unstructured, bool, error) {
-	existing, err := client.Resource(volumeSnapshotClassResourceGVR).Get(context.TODO(), required.GetName(), metav1.GetOptions{})
+func ApplyVolumeSnapshotClass(ctx context.Context, client dynamic.Interface, recorder events.Recorder, required *unstructured.Unstructured) (*unstructured.Unstructured, bool, error) {
+	existing, err := client.Resource(volumeSnapshotClassResourceGVR).Get(ctx, required.GetName(), metav1.GetOptions{})
 	if errors.IsNotFound(err) {
-		newObj, createErr := client.Resource(volumeSnapshotClassResourceGVR).Create(context.TODO(), required, metav1.CreateOptions{})
+		newObj, createErr := client.Resource(volumeSnapshotClassResourceGVR).Create(ctx, required, metav1.CreateOptions{})
 		if createErr != nil {
 			recorder.Warningf("VolumeSnapshotClassCreateFailed", "Failed to create VolumeSnapshotClass.snapshot.storage.k8s.io/v1: %v", createErr)
 			return nil, true, createErr
@@ -105,7 +105,7 @@ func ApplyVolumeSnapshotClass(client dynamic.Interface, recorder events.Recorder
 		klog.Infof("VolumeSnapshotClass %q changes: %v", required.GetName(), JSONPatchNoError(existing, toUpdate))
 	}
 
-	newObj, err := client.Resource(volumeSnapshotClassResourceGVR).Update(context.TODO(), toUpdate, metav1.UpdateOptions{})
+	newObj, err := client.Resource(volumeSnapshotClassResourceGVR).Update(ctx, toUpdate, metav1.UpdateOptions{})
 	if err != nil {
 		recorder.Warningf("VolumeSnapshotClassFailed", "Failed to update VolumeSnapshotClass.snapshot.storage.k8s.io/v1: %v", err)
 		return nil, true, err

--- a/pkg/operator/resource/resourceapply/volumesnapshotclass_test.go
+++ b/pkg/operator/resource/resourceapply/volumesnapshotclass_test.go
@@ -1,6 +1,7 @@
 package resourceapply
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -111,7 +112,7 @@ func TestApplyVolumeSnapshotClassUpdate(t *testing.T) {
 
 			required := resourceread.ReadUnstructuredOrDie([]byte(tc.required))
 
-			_, modified, err := ApplyVolumeSnapshotClass(dynamicClient, events.NewInMemoryRecorder("volumesnapshotclass-test"), required)
+			_, modified, err := ApplyVolumeSnapshotClass(context.TODO(), dynamicClient, events.NewInMemoryRecorder("volumesnapshotclass-test"), required)
 			if tc.expectedErr {
 				if err != nil {
 					return

--- a/pkg/operator/resourcesynccontroller/resourcesync_controller.go
+++ b/pkg/operator/resourcesynccontroller/resourcesync_controller.go
@@ -185,7 +185,7 @@ func (c *ResourceSyncController) Sync(ctx context.Context, syncCtx factory.SyncC
 			continue
 		}
 
-		_, _, err := resourceapply.SyncPartialConfigMap(c.configMapGetter, syncCtx.Recorder(), source.Namespace, source.Name, destination.Namespace, destination.Name, source.syncedKeys, []metav1.OwnerReference{})
+		_, _, err := resourceapply.SyncPartialConfigMap(ctx, c.configMapGetter, syncCtx.Recorder(), source.Namespace, source.Name, destination.Namespace, destination.Name, source.syncedKeys, []metav1.OwnerReference{})
 		if err != nil {
 			errors = append(errors, errorWithProvider(source.Provider, err))
 		}
@@ -205,7 +205,7 @@ func (c *ResourceSyncController) Sync(ctx context.Context, syncCtx factory.SyncC
 			continue
 		}
 
-		_, _, err := resourceapply.SyncPartialSecret(c.secretGetter, syncCtx.Recorder(), source.Namespace, source.Name, destination.Namespace, destination.Name, source.syncedKeys, []metav1.OwnerReference{})
+		_, _, err := resourceapply.SyncPartialSecret(ctx, c.secretGetter, syncCtx.Recorder(), source.Namespace, source.Name, destination.Namespace, destination.Name, source.syncedKeys, []metav1.OwnerReference{})
 		if err != nil {
 			errors = append(errors, errorWithProvider(source.Provider, err))
 		}

--- a/pkg/operator/staticpod/controller/installer/installer_controller_test.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller_test.go
@@ -959,7 +959,7 @@ func TestEnsureInstallerPod(t *testing.T) {
 			c.ownerRefsFn = func(revision int32) ([]metav1.OwnerReference, error) {
 				return []metav1.OwnerReference{}, nil
 			}
-			err := c.ensureInstallerPod("test-node-1", &operatorv1.StaticPodOperatorSpec{}, 1, 0)
+			err := c.ensureInstallerPod(context.TODO(), "test-node-1", &operatorv1.StaticPodOperatorSpec{}, 1, 0)
 			if err != nil {
 				if tt.expectedErr == "" {
 					t.Errorf("InstallerController.ensureInstallerPod() expected no error, got = %v", err)

--- a/pkg/operator/staticpod/controller/prune/prune_controller_test.go
+++ b/pkg/operator/staticpod/controller/prune/prune_controller_test.go
@@ -474,7 +474,7 @@ func TestPruneDiskResources(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error %q", err)
 			}
-			if diskErr := c.pruneDiskResources(eventRecorder, operatorStatus, excludedRevisions, excludedRevisions[len(excludedRevisions)-1]); diskErr != nil {
+			if diskErr := c.pruneDiskResources(context.TODO(), eventRecorder, operatorStatus, excludedRevisions, excludedRevisions[len(excludedRevisions)-1]); diskErr != nil {
 				t.Fatalf("unexpected error %q", diskErr)
 			}
 

--- a/pkg/operator/staticresourcecontroller/static_resource_controller.go
+++ b/pkg/operator/staticresourcecontroller/static_resource_controller.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
+	"time"
+
 	configv1 "github.com/openshift/api/config/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/restmapper"
-	"strings"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
@@ -33,10 +34,6 @@ import (
 	"github.com/openshift/library-go/pkg/operator/management"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
-)
-
-const (
-	workQueueKey = "key"
 )
 
 var (
@@ -212,7 +209,7 @@ func (c StaticResourceController) Sync(ctx context.Context, syncContext factory.
 
 	errors := []error{}
 	var notFoundErrorsCount int
-	directResourceResults := resourceapply.ApplyDirectly(c.clients, syncContext.Recorder(), c.manifests, c.files...)
+	directResourceResults := resourceapply.ApplyDirectly(ctx, c.clients, syncContext.Recorder(), c.manifests, c.files...)
 	for _, currResult := range directResourceResults {
 		if apierrors.IsNotFound(currResult.Error) {
 			notFoundErrorsCount++


### PR DESCRIPTION
This replaces `context.TODO()` in resource helpers with context argument which is properly wired from the controller. Every sync() function from the controller factory has a context parameter that is wired to controller context and it is properly closed when the controller is asked to gracefully shut down. 