### PR TITLE
clear encryption conditions when there is no work to be done

### DIFF
--- a/pkg/operator/encryption/controllers/prune_controller.go
+++ b/pkg/operator/encryption/controllers/prune_controller.go
@@ -76,27 +76,30 @@ func NewPruneController(
 	).ToController(c.name, eventRecorder.WithComponentSuffix("encryption-prune-controller"))
 }
 
-func (c *pruneController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
+func (c *pruneController) sync(_ context.Context, syncCtx factory.SyncContext) (err error) {
+	degradedCondition := &operatorv1.OperatorCondition{Type: "EncryptionPruneControllerDegraded", Status: operatorv1.ConditionFalse}
+	defer func() {
+		if degradedCondition == nil {
+			return
+		}
+		if _, _, updateError := operatorv1helpers.UpdateStatus(c.operatorClient, operatorv1helpers.UpdateConditionFn(*degradedCondition)); updateError != nil {
+			err = updateError
+		}
+	}()
+
 	if ready, err := shouldRunEncryptionController(c.operatorClient, c.preconditionsFulfilledFn, c.provider.ShouldRunEncryptionControllers); err != nil || !ready {
+		if err != nil {
+			degradedCondition = nil
+		}
 		return err // we will get re-kicked when the operator status updates
 	}
 
 	configError := c.deleteOldMigratedSecrets(syncCtx, c.provider.EncryptedGRs())
-
-	// update failing condition
-	cond := operatorv1.OperatorCondition{
-		Type:   "EncryptionPruneControllerDegraded",
-		Status: operatorv1.ConditionFalse,
-	}
 	if configError != nil {
-		cond.Status = operatorv1.ConditionTrue
-		cond.Reason = "Error"
-		cond.Message = configError.Error()
+		degradedCondition.Status = operatorv1.ConditionTrue
+		degradedCondition.Reason = "Error"
+		degradedCondition.Message = configError.Error()
 	}
-	if _, _, updateError := operatorv1helpers.UpdateStatus(c.operatorClient, operatorv1helpers.UpdateConditionFn(cond)); updateError != nil {
-		return updateError
-	}
-
 	return configError
 }
 

--- a/pkg/operator/encryption/controllers/state_controller.go
+++ b/pkg/operator/encryption/controllers/state_controller.go
@@ -82,27 +82,30 @@ func NewStateController(
 
 }
 
-func (c *stateController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
+func (c *stateController) sync(ctx context.Context, syncCtx factory.SyncContext) (err error) {
+	degradedCondition := &operatorv1.OperatorCondition{Type: "EncryptionStateControllerDegraded", Status: operatorv1.ConditionFalse}
+	defer func() {
+		if degradedCondition == nil {
+			return
+		}
+		if _, _, updateError := operatorv1helpers.UpdateStatus(c.operatorClient, operatorv1helpers.UpdateConditionFn(*degradedCondition)); updateError != nil {
+			err = updateError
+		}
+	}()
+
 	if ready, err := shouldRunEncryptionController(c.operatorClient, c.preconditionsFulfilledFn, c.provider.ShouldRunEncryptionControllers); err != nil || !ready {
+		if err != nil {
+			degradedCondition = nil
+		}
 		return err // we will get re-kicked when the operator status updates
 	}
 
 	configError := c.generateAndApplyCurrentEncryptionConfigSecret(syncCtx.Queue(), syncCtx.Recorder(), c.provider.EncryptedGRs())
-
-	// update failing condition
-	cond := operatorv1.OperatorCondition{
-		Type:   "EncryptionStateControllerDegraded",
-		Status: operatorv1.ConditionFalse,
-	}
 	if configError != nil {
-		cond.Status = operatorv1.ConditionTrue
-		cond.Reason = "Error"
-		cond.Message = configError.Error()
+		degradedCondition.Status = operatorv1.ConditionTrue
+		degradedCondition.Reason = "Error"
+		degradedCondition.Message = configError.Error()
 	}
-	if _, _, updateError := operatorv1helpers.UpdateStatus(c.operatorClient, operatorv1helpers.UpdateConditionFn(cond)); updateError != nil {
-		return updateError
-	}
-
 	return configError
 }
 


### PR DESCRIPTION
It turns out that the new precondition checker added in 4.8 might prevent the encryption controllers from running and clearing the stale conditions.
This can happen especially on upgrades from 4.7 to 4.8.

This PR changes the encryption controllers to clear stale conditions when the preconditions are not fulfilled.