### PR TITLE
encryption condition controller doesn't reset previously set conditon

### DIFF
--- a/pkg/operator/encryption/controllers/condition_controller.go
+++ b/pkg/operator/encryption/controllers/condition_controller.go
@@ -84,6 +84,8 @@ func (c *conditionController) sync(_ context.Context, _ factory.SyncContext) (er
 	encryptedGRs := c.provider.EncryptedGRs()
 	currentConfig, desiredState, foundSecrets, transitioningReason, err := statemachine.GetEncryptionConfigAndState(c.deployer, c.secretClient, c.encryptionSecretSelector, encryptedGRs)
 	if err != nil || len(transitioningReason) > 0 {
+		// do not update the encryption condition (cond). Note: progressing is set elsewhere.
+		cond = nil
 		return err
 	}
 	currentState, _ := encryptionconfig.ToEncryptionState(currentConfig, foundSecrets)


### PR DESCRIPTION
the condition controller is used to report the current state of the encryption: EncryptionCompleted, EncryptionInProgress or DecryptionCompleted

unfortunately, the previously set condition might have been cleared due to a bug in the controller every time the API server was deployed.

fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1982398