### PR TITLE
Bug 1987025: CSI driver controller: modify nodeselector based on control plane topology

### DIFF
--- a/pkg/operator/csi/csidrivercontrollerservicecontroller/csi_driver_controller_service_controller.go
+++ b/pkg/operator/csi/csidrivercontrollerservicecontroller/csi_driver_controller_service_controller.go
@@ -66,5 +66,8 @@ func NewCSIDriverControllerServiceController(
 	optionalInformers = append(optionalInformers, configInformer.Config().V1().Infrastructures().Informer())
 	var optionalManifestHooks []dc.ManifestHookFunc
 	optionalManifestHooks = append(optionalManifestHooks, WithPlaceholdersHook(configInformer))
-	return dc.NewDeploymentController(name, manifest, recorder, operatorClient, kubeClient, deployInformer, optionalInformers, optionalManifestHooks, optionalDeploymentHooks...)
+	var deploymentHooks []dc.DeploymentHookFunc
+	deploymentHooks = append(deploymentHooks, optionalDeploymentHooks...)
+	deploymentHooks = append(deploymentHooks, WithControlPlaneTopologyHook(configInformer))
+	return dc.NewDeploymentController(name, manifest, recorder, operatorClient, kubeClient, deployInformer, optionalInformers, optionalManifestHooks, deploymentHooks...)
 }


### PR DESCRIPTION
Adds a deployment hook that removes the master node selector from CSI controller deployments when deploying on a topology with external infrastructure.