### PR TITLE
certrotation: doc and clean up naming

### DIFF
--- a/pkg/operator/certrotation/cabundle.go
+++ b/pkg/operator/certrotation/cabundle.go
@@ -22,18 +22,21 @@ import (
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 )
 
-// CABundleRotation maintains a CA bundle config map, but adding new CA certs and removing expired old ones.
-type CABundleRotation struct {
+// CABundleConfigMap maintains a CA bundle config map, by adding new CA certs coming from RotatedSigningCASecret, and by removing expired old ones.
+type CABundleConfigMap struct {
+	// Namespace is the namespace of the ConfigMap to maintain.
 	Namespace string
-	Name      string
+	// Name is the name of the ConfigMap to maintain.
+	Name string
 
+	// Plumbing:
 	Informer      corev1informers.ConfigMapInformer
 	Lister        corev1listers.ConfigMapLister
 	Client        corev1client.ConfigMapsGetter
 	EventRecorder events.Recorder
 }
 
-func (c CABundleRotation) ensureConfigMapCABundle(ctx context.Context, signingCertKeyPair *crypto.CA) ([]*x509.Certificate, error) {
+func (c CABundleConfigMap) ensureConfigMapCABundle(ctx context.Context, signingCertKeyPair *crypto.CA) ([]*x509.Certificate, error) {
 	// by this point we have current signing cert/key pair.  We now need to make sure that the ca-bundle configmap has this cert and
 	// doesn't have any expired certs
 	originalCABundleConfigMap, err := c.Lister.ConfigMaps(c.Namespace).Get(c.Name)

--- a/pkg/operator/certrotation/cabundle_test.go
+++ b/pkg/operator/certrotation/cabundle_test.go
@@ -223,7 +223,7 @@ func TestEnsureConfigMapCABundle(t *testing.T) {
 				client = kubefake.NewSimpleClientset(startingObj)
 			}
 
-			c := &CABundleRotation{
+			c := &CABundleConfigMap{
 				Namespace: "ns",
 				Name:      "trust-bundle",
 

--- a/pkg/operator/certrotation/client_cert_rotation_controller.go
+++ b/pkg/operator/certrotation/client_cert_rotation_controller.go
@@ -29,43 +29,46 @@ const (
 
 // CertRotationController does:
 //
-// 1) continuously create a self-signed signing CA (via SigningRotation).
-//    It creates the next one when a given percentage of the validity of the old CA has passed.
-// 2) maintain a CA bundle with all not yet expired CA certs.
-// 3) continuously create a target cert and key signed by the latest signing CA
-//    It creates the next one when a given percentage of the validity of the previous cert has
-//    passed, or when a new CA has been created.
+// 1) continuously create a self-signed signing CA (via RotatedSigningCASecret) and store it in a secret.
+// 2) maintain a CA bundle ConfigMap with all not yet expired CA certs.
+// 3) continuously create a target cert and key signed by the latest signing CA and store it in a secret.
 type CertRotationController struct {
+	// name is used in operator conditions to identify this controller, compare CertRotationDegradedConditionTypeFmt.
 	name string
 
-	SigningRotation  SigningRotation
-	CABundleRotation CABundleRotation
-	TargetRotation   TargetRotation
-	OperatorClient   v1helpers.StaticPodOperatorClient
+	// rotatedSigningCASecret rotates a self-signed signing CA stored in a secret.
+	rotatedSigningCASecret RotatedSigningCASecret
+	// CABundleConfigMap maintains a CA bundle config map, by adding new CA certs coming from rotatedSigningCASecret, and by removing expired old ones.
+	CABundleConfigMap CABundleConfigMap
+	// RotatedSelfSignedCertKeySecret rotates a key and cert signed by a signing CA and stores it in a secret.
+	RotatedSelfSignedCertKeySecret RotatedSelfSignedCertKeySecret
+
+	// Plumbing:
+	OperatorClient v1helpers.StaticPodOperatorClient
 }
 
 func NewCertRotationController(
 	name string,
-	signingRotation SigningRotation,
-	caBundleRotation CABundleRotation,
-	targetRotation TargetRotation,
+	rotatedSigningCASecret RotatedSigningCASecret,
+	caBundleConfigMap CABundleConfigMap,
+	rotatedSelfSignedCertKeySecret RotatedSelfSignedCertKeySecret,
 	operatorClient v1helpers.StaticPodOperatorClient,
 	recorder events.Recorder,
 ) factory.Controller {
 	c := &CertRotationController{
-		name:             name,
-		SigningRotation:  signingRotation,
-		CABundleRotation: caBundleRotation,
-		TargetRotation:   targetRotation,
-		OperatorClient:   operatorClient,
+		name:                           name,
+		rotatedSigningCASecret:         rotatedSigningCASecret,
+		CABundleConfigMap:              caBundleConfigMap,
+		RotatedSelfSignedCertKeySecret: rotatedSelfSignedCertKeySecret,
+		OperatorClient:                 operatorClient,
 	}
 	return factory.New().
 		ResyncEvery(time.Minute).
 		WithSync(c.Sync).
 		WithInformers(
-			signingRotation.Informer.Informer(),
-			caBundleRotation.Informer.Informer(),
-			targetRotation.Informer.Informer(),
+			rotatedSigningCASecret.Informer.Informer(),
+			caBundleConfigMap.Informer.Informer(),
+			rotatedSelfSignedCertKeySecret.Informer.Informer(),
 		).
 		WithPostStartHooks(
 			c.targetCertRecheckerPostRunHook,
@@ -103,17 +106,17 @@ func (c CertRotationController) Sync(ctx context.Context, syncCtx factory.SyncCo
 }
 
 func (c CertRotationController) syncWorker() error {
-	signingCertKeyPair, err := c.SigningRotation.ensureSigningCertKeyPair(context.TODO())
+	signingCertKeyPair, err := c.rotatedSigningCASecret.ensureSigningCertKeyPair(context.TODO())
 	if err != nil {
 		return err
 	}
 
-	cabundleCerts, err := c.CABundleRotation.ensureConfigMapCABundle(context.TODO(), signingCertKeyPair)
+	cabundleCerts, err := c.CABundleConfigMap.ensureConfigMapCABundle(context.TODO(), signingCertKeyPair)
 	if err != nil {
 		return err
 	}
 
-	if err := c.TargetRotation.ensureTargetCertKeyPair(context.TODO(), signingCertKeyPair, cabundleCerts); err != nil {
+	if err := c.RotatedSelfSignedCertKeySecret.ensureTargetCertKeyPair(context.TODO(), signingCertKeyPair, cabundleCerts); err != nil {
 		return err
 	}
 
@@ -122,7 +125,7 @@ func (c CertRotationController) syncWorker() error {
 
 func (c CertRotationController) targetCertRecheckerPostRunHook(ctx context.Context, syncCtx factory.SyncContext) error {
 	// If we have a need to force rechecking the cert, use this channel to do it.
-	refresher, ok := c.TargetRotation.CertCreator.(TargetCertRechecker)
+	refresher, ok := c.RotatedSelfSignedCertKeySecret.CertCreator.(TargetCertRechecker)
 	if !ok {
 		return nil
 	}

--- a/pkg/operator/certrotation/signer.go
+++ b/pkg/operator/certrotation/signer.go
@@ -17,22 +17,34 @@ import (
 	corev1listers "k8s.io/client-go/listers/core/v1"
 )
 
-// SigningRotation rotates a self-signed signing CA stored in a secret. It creates a new one when <RefreshPercentage>
-// of the lifetime of the old CA has passed.
-type SigningRotation struct {
-	Namespace              string
-	Name                   string
-	Validity               time.Duration
-	Refresh                time.Duration
+// RotatedSigningCASecret rotates a self-signed signing CA stored in a secret. It creates a new one when
+// - refresh duration is over
+// - or 80% of validity is over (if RefreshOnlyWhenExpired is false)
+// - or the CA is expired.
+type RotatedSigningCASecret struct {
+	// Namespace is the namespace of the Secret.
+	Namespace string
+	// Name is the name of the Secret.
+	Name string
+	// Validity is the duration from time.Now() until the signing CA expires. If RefreshOnlyWhenExpired
+	// is false, the signing cert is rotated when 80% of validity is reached.
+	Validity time.Duration
+	// Refresh is the duration after signing CA creation when it is rotated at the latest. It is ignored
+	// if RefreshOnlyWhenExpired is true, or if Refresh > Validity.
+	Refresh time.Duration
+	// RefreshOnlyWhenExpired set to true means to ignore 80% of validity and the Refresh duration for rotation,
+	// but only rotate when the signing CA expires. This is useful for auto-recovery when we want to enforce
+	// rotation on expiration only, but not interfere with the ordinary rotation controller.
 	RefreshOnlyWhenExpired bool
 
+	// Plumbing:
 	Informer      corev1informers.SecretInformer
 	Lister        corev1listers.SecretLister
 	Client        corev1client.SecretsGetter
 	EventRecorder events.Recorder
 }
 
-func (c SigningRotation) ensureSigningCertKeyPair(ctx context.Context) (*crypto.CA, error) {
+func (c RotatedSigningCASecret) ensureSigningCertKeyPair(ctx context.Context) (*crypto.CA, error) {
 	originalSigningCertKeyPairSecret, err := c.Lister.Secrets(c.Namespace).Get(c.Name)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return nil, err
@@ -44,7 +56,7 @@ func (c SigningRotation) ensureSigningCertKeyPair(ctx context.Context) (*crypto.
 	}
 	signingCertKeyPairSecret.Type = corev1.SecretTypeTLS
 
-	if reason := needNewSigningCertKeyPair(signingCertKeyPairSecret.Annotations, c.Refresh, c.RefreshOnlyWhenExpired); len(reason) > 0 {
+	if needed, reason := needNewSigningCertKeyPair(signingCertKeyPairSecret.Annotations, c.Refresh, c.RefreshOnlyWhenExpired); needed {
 		c.EventRecorder.Eventf("SignerUpdateRequired", "%q in %q requires a new signing cert/key pair: %v", c.Name, c.Namespace, reason)
 		if err := setSigningCertKeyPairSecret(signingCertKeyPairSecret, c.Validity); err != nil {
 			return nil, err
@@ -67,32 +79,32 @@ func (c SigningRotation) ensureSigningCertKeyPair(ctx context.Context) (*crypto.
 	return signingCertKeyPair, nil
 }
 
-func needNewSigningCertKeyPair(annotations map[string]string, refresh time.Duration, refreshOnlyWhenExpired bool) string {
+func needNewSigningCertKeyPair(annotations map[string]string, refresh time.Duration, refreshOnlyWhenExpired bool) (bool, string) {
 	notBefore, notAfter, reason := getValidityFromAnnotations(annotations)
 	if len(reason) > 0 {
-		return reason
+		return true, reason
 	}
 
 	if time.Now().After(notAfter) {
-		return "already expired"
+		return true, "already expired"
 	}
 
 	if refreshOnlyWhenExpired {
-		return ""
+		return false, ""
 	}
 
-	maxWait := notAfter.Sub(notBefore) / 5
-	latestTime := notAfter.Add(-maxWait)
-	if time.Now().After(latestTime) {
-		return fmt.Sprintf("past its latest possible time %v", latestTime)
+	validity := notAfter.Sub(notBefore)
+	at80Percent := notAfter.Add(-validity / 5)
+	if time.Now().After(at80Percent) {
+		return true, fmt.Sprintf("past its latest possible time %v", at80Percent)
 	}
 
-	refreshTime := notBefore.Add(refresh)
-	if time.Now().After(refreshTime) {
-		return fmt.Sprintf("past its refresh time %v", refreshTime)
+	developerSpecifiedRefresh := notBefore.Add(refresh)
+	if time.Now().After(developerSpecifiedRefresh) {
+		return true, fmt.Sprintf("past its refresh time %v", developerSpecifiedRefresh)
 	}
 
-	return ""
+	return false, ""
 }
 
 func getValidityFromAnnotations(annotations map[string]string) (notBefore time.Time, notAfter time.Time, reason string) {

--- a/pkg/operator/certrotation/signer_test.go
+++ b/pkg/operator/certrotation/signer_test.go
@@ -108,7 +108,7 @@ func TestEnsureSigningCertKeyPair(t *testing.T) {
 				client = kubefake.NewSimpleClientset(test.initialSecret)
 			}
 
-			c := &SigningRotation{
+			c := &RotatedSigningCASecret{
 				Namespace:     "ns",
 				Name:          "signer",
 				Validity:      24 * time.Hour,

--- a/pkg/operator/certrotation/target.go
+++ b/pkg/operator/certrotation/target.go
@@ -22,19 +22,38 @@ import (
 	corev1listers "k8s.io/client-go/listers/core/v1"
 )
 
-// TargetRotation rotates a key and cert signed by a CA. It creates a new one when <RefreshPercentage>
-// of the lifetime of the old cert has passed, or if the common name of the CA changes.
-type TargetRotation struct {
+// RotatedSelfSignedCertKeySecret rotates a key and cert signed by a signing CA and stores it in a secret.
+//
+// It creates a new one when
+// - refresh duration is over
+// - or 80% of validity is over (if RefreshOnlyWhenExpired is false)
+// - or the cert is expired.
+// - or the signing CA changes.
+type RotatedSelfSignedCertKeySecret struct {
+	// Namespace is the namespace of the Secret.
 	Namespace string
-	Name      string
-	Validity  time.Duration
-	Refresh   time.Duration
+	// Name is the name of the Secret.
+	Name string
+	// Validity is the duration from time.Now() until the certificate expires. If RefreshOnlyWhenExpired
+	// is false, the key and certificate is rotated when 80% of validity is reached.
+	Validity time.Duration
+	// Refresh is the duration after certificate creation when it is rotated at the latest. It is ignored
+	// if RefreshOnlyWhenExpired is true, or if Refresh > Validity.
+	// Refresh is ignored until the signing CA at least 10% in its life-time to ensure it is deployed
+	// through-out the cluster.
+	Refresh time.Duration
 	// RefreshOnlyWhenExpired allows rotating only certs that are already expired. (for autorecovery)
 	// If false (regular flow) it rotates at the refresh interval but no later then 4/5 of the cert lifetime.
+
+	// RefreshOnlyWhenExpired set to true means to ignore 80% of validity and the Refresh duration for rotation,
+	// but only rotate when the certificate expires. This is useful for auto-recovery when we want to enforce
+	// rotation on expiration only, but not interfere with the ordinary rotation controller.
 	RefreshOnlyWhenExpired bool
 
+	// CertCreator does the actual cert generation.
 	CertCreator TargetCertCreator
 
+	// Plumbing:
 	Informer      corev1informers.SecretInformer
 	Lister        corev1listers.SecretLister
 	Client        corev1client.SecretsGetter
@@ -42,17 +61,21 @@ type TargetRotation struct {
 }
 
 type TargetCertCreator interface {
+	// NewCertificate creates a new key-cert pair with the given signer.
 	NewCertificate(signer *crypto.CA, validity time.Duration) (*crypto.TLSCertificateConfig, error)
-	NeedNewTargetCertKeyPair(annotations map[string]string, signer *crypto.CA, caBundleCerts []*x509.Certificate, refresh time.Duration, refreshOnlyWhenExpired bool) string
+	// NeedNewTargetCertKeyPair decides whether a new cert-key pair is needed. It returns a non-empty reason if it is the case.
+	NeedNewTargetCertKeyPair(currentSecretAnnotations map[string]string, signer *crypto.CA, caBundleCerts []*x509.Certificate, refresh time.Duration, refreshOnlyWhenExpired bool) string
 	// SetAnnotations gives an option to override or set additional annotations
 	SetAnnotations(cert *crypto.TLSCertificateConfig, annotations map[string]string) map[string]string
 }
 
+// TargetCertRechecker is an optional interface to be implemented by the TargetCertCreator to enforce
+// a controller run.
 type TargetCertRechecker interface {
 	RecheckChannel() <-chan struct{}
 }
 
-func (c TargetRotation) ensureTargetCertKeyPair(ctx context.Context, signingCertKeyPair *crypto.CA, caBundleCerts []*x509.Certificate) error {
+func (c RotatedSelfSignedCertKeySecret) ensureTargetCertKeyPair(ctx context.Context, signingCertKeyPair *crypto.CA, caBundleCerts []*x509.Certificate) error {
 	// at this point our trust bundle has been updated.  We don't know for sure that consumers have updated, but that's why we have a second
 	// validity percentage.  We always check to see if we need to sign.  Often we are signing with an old key or we have no target
 	// and need to mint one
@@ -130,6 +153,7 @@ func needNewTargetCertKeyPairForTime(annotations map[string]string, signer *cryp
 		return reason
 	}
 
+	// Is cert expired?
 	if time.Now().After(notAfter) {
 		return "already expired"
 	}
@@ -138,10 +162,11 @@ func needNewTargetCertKeyPairForTime(annotations map[string]string, signer *cryp
 		return ""
 	}
 
-	maxWait := notAfter.Sub(notBefore) / 5
-	latestTime := notAfter.Add(-maxWait)
-	if time.Now().After(latestTime) {
-		return fmt.Sprintf("past its latest possible time %v", latestTime)
+	// Are we at 80% of validity?
+	validity := notAfter.Sub(notBefore)
+	at80Percent := notAfter.Add(-validity / 5)
+	if time.Now().After(at80Percent) {
+		return fmt.Sprintf("past its latest possible time %v", at80Percent)
 	}
 
 	// If Certificate is past its refresh time, we may have action to take. We only do this if the signer is old enough.

--- a/pkg/operator/certrotation/target_test.go
+++ b/pkg/operator/certrotation/target_test.go
@@ -211,7 +211,7 @@ func TestEnsureTargetCertKeyPair(t *testing.T) {
 				client = kubefake.NewSimpleClientset(startingObj)
 			}
 
-			c := &TargetRotation{
+			c := &RotatedSelfSignedCertKeySecret{
 				Namespace: "ns",
 				Validity:  24 * time.Hour,
 				Refresh:   12 * time.Hour,
@@ -405,7 +405,7 @@ func TestEnsureTargetSignerCertKeyPair(t *testing.T) {
 				client = kubefake.NewSimpleClientset(startingObj)
 			}
 
-			c := &TargetRotation{
+			c := &RotatedSelfSignedCertKeySecret{
 				Namespace: "ns",
 				Validity:  24 * time.Hour,
 				Refresh:   12 * time.Hour,


### PR DESCRIPTION
When it takes 2 senior principal engineers to figure out what cert rotation does, we need better names and proper docs.