### PR TITLE
factory: add AddRateLimitedAfter to sync context queue

### DIFF
--- a/pkg/controller/factory/interfaces.go
+++ b/pkg/controller/factory/interfaces.go
@@ -3,8 +3,6 @@ package factory
 import (
 	"context"
 
-	"k8s.io/client-go/util/workqueue"
-
 	"github.com/openshift/library-go/pkg/operator/events"
 )
 
@@ -32,7 +30,7 @@ type Controller interface {
 type SyncContext interface {
 	// Queue gives access to controller queue. This can be used for manual requeue, although if a Sync() function return
 	// an error, the object is automatically re-queued. Use with caution.
-	Queue() workqueue.RateLimitingInterface
+	Queue() RateLimitedAddAfterWorkqueue
 
 	// QueueKey represents the queue key passed to the Sync function.
 	QueueKey() string

--- a/pkg/controller/factory/queue.go
+++ b/pkg/controller/factory/queue.go
@@ -1,0 +1,33 @@
+package factory
+
+import (
+	"time"
+
+	"k8s.io/client-go/util/workqueue"
+)
+
+type RateLimitedAddAfterWorkqueue interface {
+	workqueue.RateLimitingInterface
+
+	// AddRateLimitedAfter adds the items to the queue after the given duration,
+	// but not earlier than the rate-limited allows. I.e. this is a combination of
+	// AddAfter and AddRateLimited.
+	AddRateLimitedAfter(item interface{}, duration time.Duration)
+}
+
+type addRateLimitedAfterWorkqueue struct {
+	workqueue.RateLimitingInterface
+	rateLimiter workqueue.RateLimiter
+}
+
+var _ RateLimitedAddAfterWorkqueue = addRateLimitedAfterWorkqueue{}
+
+// AddRateLimitedAfter adds the items to the queue after the given duration,
+// but not earlier than the rate-limited allows. I.e. this is a combination of
+// AddAfter and AddRateLimited.
+func (q addRateLimitedAfterWorkqueue) AddRateLimitedAfter(item interface{}, duration time.Duration) {
+	if rlDelay := q.rateLimiter.When(item); rlDelay > duration {
+		duration = rlDelay
+	}
+	q.RateLimitingInterface.AddAfter(item, duration)
+}

--- a/pkg/operator/staticpod/controller/installer/installer_controller_test.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller_test.go
@@ -1728,7 +1728,7 @@ func TestInstallerController_manageInstallationPods(t *testing.T) {
 				eventRecorder:       tt.fields.eventRecorder,
 				installerPodImageFn: tt.fields.installerPodImageFn,
 			}
-			got, err := c.manageInstallationPods(context.TODO(), tt.args.operatorSpec, tt.args.originalOperatorStatus)
+			got, _, err := c.manageInstallationPods(context.TODO(), tt.args.operatorSpec, tt.args.originalOperatorStatus)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("InstallerController.manageInstallationPods() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
Controller might have to requeue the key, but after a minimum time while taking into account the rate limited. This PR exposes a `AddRateLimitedAfter` function from the sync context queue.
