### PR TITLE
adds staticPodFallbackConditionController controller

### DIFF
--- a/pkg/operator/staticpod/controller/staticpodfallback/static_pod_fallback_condition.go
+++ b/pkg/operator/staticpod/controller/staticpodfallback/static_pod_fallback_condition.go
@@ -1,0 +1,87 @@
+package staticpodfallback
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/staticpod/startupmonitor/annotations"
+	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
+
+	"k8s.io/apimachinery/pkg/labels"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+)
+
+// staticPodFallbackConditionController knows how to detect and report that a static pod was rolled back to a previous revision
+type staticPodFallbackConditionController struct {
+	operatorClient operatorv1helpers.OperatorClient
+
+	podLabelSelector labels.Selector
+	podLister        corev1listers.PodNamespaceLister
+
+	startupMonitorEnabledFn func() bool
+}
+
+// New creates a controller that detects and report roll back of a static pod
+func New(targetNamespace string,
+	podLabelSelector labels.Selector,
+	operatorClient operatorv1helpers.OperatorClient,
+	kubeInformersForNamespaces operatorv1helpers.KubeInformersForNamespaces,
+	startupMonitorEnabledFn func() bool,
+	eventRecorder events.Recorder) factory.Controller {
+	fd := &staticPodFallbackConditionController{
+		operatorClient:          operatorClient,
+		podLabelSelector:        podLabelSelector,
+		podLister:               kubeInformersForNamespaces.InformersFor(targetNamespace).Core().V1().Pods().Lister().Pods(targetNamespace),
+		startupMonitorEnabledFn: startupMonitorEnabledFn,
+	}
+	return factory.New().WithSync(fd.sync).ResyncEvery(6*time.Minute).WithInformers(kubeInformersForNamespaces.InformersFor(targetNamespace).Core().V1().Pods().Informer()).ToController("StaticPodStateFallback", eventRecorder)
+}
+
+// sync sets/unsets a StaticPodFallbackRevisionDegraded condition if a pod that matches the given label selector is annotated with FallbackForRevision
+func (fd *staticPodFallbackConditionController) sync(_ context.Context, _ factory.SyncContext) (err error) {
+	degradedCondition := operatorv1.OperatorCondition{Type: "StaticPodFallbackRevisionDegraded", Status: operatorv1.ConditionFalse}
+	defer func() {
+		if err == nil {
+			if _, _, updateError := operatorv1helpers.UpdateStatus(fd.operatorClient, operatorv1helpers.UpdateConditionFn(degradedCondition)); updateError != nil {
+				err = updateError
+			}
+		}
+	}()
+
+	// we rely on operators to provide
+	// a condition for checking we are running on a single node cluster
+	if !fd.startupMonitorEnabledFn() {
+		return nil
+	}
+
+	pods, err := fd.podLister.List(fd.podLabelSelector)
+	if err != nil {
+		return err
+	}
+
+	// we expect to get exactly one pod
+	// the error below will only show up in the operator's log not as a condition
+	if len(pods) != 1 {
+		return fmt.Errorf("unexpected number of Kube API server pods %d, expected only one pod, used %v as a pod selector", len(pods), fd.podLabelSelector)
+	}
+
+	if fallbackFor, ok := pods[0].Annotations[annotations.FallbackForRevision]; ok {
+		reason := "Unknown"
+		message := "unknown"
+		if s, ok := pods[0].Annotations[annotations.FallbackReason]; ok {
+			reason = s
+		}
+		if s, ok := pods[0].Annotations[annotations.FallbackMessage]; ok {
+			message = s
+		}
+		degradedCondition.Message = fmt.Sprintf("a static pod %v was rolled back to revision %v due to %v", pods[0].Name, fallbackFor, message)
+		degradedCondition.Reason = reason
+		degradedCondition.Status = operatorv1.ConditionTrue
+	}
+
+	return nil
+}

--- a/pkg/operator/staticpod/controller/staticpodfallback/static_pod_fallback_condition_test.go
+++ b/pkg/operator/staticpod/controller/staticpodfallback/static_pod_fallback_condition_test.go
@@ -1,0 +1,147 @@
+package staticpodfallback
+
+import (
+	"fmt"
+	"testing"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestStaticPodStateFallback(t *testing.T) {
+	scenarios := []struct {
+		name               string
+		initialObjects     []runtime.Object
+		previousConditions []operatorv1.OperatorCondition
+		expectedConditions []operatorv1.OperatorCondition
+	}{
+		{
+			name:           "scenario 1: happy path",
+			initialObjects: []runtime.Object{newPod(corev1.PodRunning, corev1.ConditionTrue, "3", "kas")},
+			expectedConditions: []operatorv1.OperatorCondition{
+				{
+					Type:   "StaticPodFallbackRevisionDegraded",
+					Status: operatorv1.ConditionFalse,
+					Reason: "",
+				},
+			},
+		},
+
+		{
+			name: "scenario 2: fallback detected, degraded condition set",
+			initialObjects: []runtime.Object{
+				func() *corev1.Pod {
+					pod := newPod(corev1.PodRunning, corev1.ConditionTrue, "3", "kas")
+					pod.Annotations["startup-monitor.static-pods.openshift.io/fallback-for-revision"] = "3"
+					pod.Annotations["startup-monitor.static-pods.openshift.io/fallback-reason"] = "SomeReason"
+					pod.Annotations["startup-monitor.static-pods.openshift.io/fallback-message"] = "SomeMsg"
+					return pod
+				}(),
+			},
+			expectedConditions: []operatorv1.OperatorCondition{
+				{
+					Type:    "StaticPodFallbackRevisionDegraded",
+					Status:  operatorv1.ConditionTrue,
+					Reason:  "SomeReason",
+					Message: fmt.Sprintf("a static pod %v was rolled back to revision %v due to %v", "kas", "3", "SomeMsg"),
+				},
+			},
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			// test data
+			fakeOperatorClient := v1helpers.NewFakeOperatorClient(
+				nil,
+				&operatorv1.OperatorStatus{
+					Conditions: scenario.previousConditions,
+				},
+				nil,
+			)
+			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			for _, obj := range scenario.initialObjects {
+				if err := indexer.Add(obj); err != nil {
+					t.Error(err)
+				}
+			}
+
+			// act
+			target := &staticPodFallbackConditionController{
+				podLister:        corev1listers.NewPodLister(indexer).Pods("openshift-kube-apiserver"),
+				operatorClient:   fakeOperatorClient,
+				podLabelSelector: labels.Set{"apiserver": "true"}.AsSelector(),
+				startupMonitorEnabledFn: func() bool {
+					return true
+				},
+			}
+
+			err := target.sync(nil, nil)
+			if err != nil {
+				t.Error(err)
+			}
+
+			// validate
+			_, actualOperatorStatus, _, err := fakeOperatorClient.GetOperatorState()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := areCondidtionsEqual(scenario.expectedConditions, actualOperatorStatus.Conditions); err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}
+
+func areCondidtionsEqual(expectedConditions []operatorv1.OperatorCondition, actualConditions []operatorv1.OperatorCondition) error {
+	if len(expectedConditions) != len(actualConditions) {
+		return fmt.Errorf("expected %d conditions but got %d", len(expectedConditions), len(actualConditions))
+	}
+	for _, expectedCondition := range expectedConditions {
+		actualConditionPtr := v1helpers.FindOperatorCondition(actualConditions, expectedCondition.Type)
+		if actualConditionPtr == nil {
+			return fmt.Errorf("%q condition hasn't been found", expectedCondition.Type)
+		}
+		// we don't care about the last transition time
+		actualConditionPtr.LastTransitionTime = metav1.Time{}
+		// so that we don't compare ref vs value types
+		actualCondition := *actualConditionPtr
+		if !equality.Semantic.DeepEqual(actualCondition, expectedCondition) {
+			return fmt.Errorf("conditions mismatch, diff = %s", diff.ObjectDiff(actualCondition, expectedCondition))
+		}
+	}
+	return nil
+}
+
+func newPod(phase corev1.PodPhase, ready corev1.ConditionStatus, revision, name string) *corev1.Pod {
+	pod := corev1.Pod{
+		TypeMeta: metav1.TypeMeta{Kind: "Pod"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   "openshift-kube-apiserver",
+			Annotations: map[string]string{},
+			Labels: map[string]string{
+				"revision":  revision,
+				"apiserver": "true",
+			}},
+		Spec: corev1.PodSpec{},
+		Status: corev1.PodStatus{
+			Phase: phase,
+			Conditions: []corev1.PodCondition{{
+				Type:   corev1.PodReady,
+				Status: ready,
+			}},
+		},
+	}
+
+	return &pod
+}


### PR DESCRIPTION
it is meant to be run on a SNO cluster.
it knows how to detect and report that a static pod was rolled back to a previous revision.
it sets/unsets StaticPodFallbackRevisionDegraded condition.

wiring in a follow-up PR.

xref: https://github.com/openshift/enhancements/pull/833