### PR TITLE
staticpod/startupmonitor: update nodeStatus after readiness

### DIFF
--- a/pkg/operator/staticpod/startupmonitor/assets/startup-monitor-pod.yaml
+++ b/pkg/operator/staticpod/startupmonitor/assets/startup-monitor-pod.yaml
@@ -20,6 +20,7 @@ spec:
         - --resource-dir=/etc/kubernetes/static-pod-resources
         - --installer-lock-file=/var/lock/{{.TargetName}}-installer.lock
         - --revision=REVISION
+        - --node-name=NODE_NAME
         - --kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/kube-apiserver-cert-syncer-kubeconfig/kubeconfig #TODO: use a different config
       volumeMounts:
         - mountPath: /etc/kubernetes/manifests

--- a/pkg/operator/staticpod/startupmonitor/cmd.go
+++ b/pkg/operator/staticpod/startupmonitor/cmd.go
@@ -31,6 +31,9 @@ type Options struct {
 	// Revision identifier for this particular installation instance
 	Revision int
 
+	// NodeName as used to update the right nodeStatus struct in the static pod operator resource
+	NodeName string
+
 	// FallbackTimeout specifies a timeout after which the monitor starts the fall back procedure
 	FallbackTimeout time.Duration
 
@@ -83,7 +86,8 @@ func NewCommand(check ReadinessChecker) *cobra.Command {
 				withRevision(o.Revision).
 				withManifestPath(o.ManifestDir).
 				withStaticPodResourcesPath(o.ResourceDir).
-				withTargetName(o.TargetName)
+				withTargetName(o.TargetName).
+				withNodeName(o.NodeName)
 
 			if len(o.KubeConfig) > 0 {
 				clientConfig, err := client.GetKubeConfigOrInClusterConfig(o.KubeConfig, nil)
@@ -125,6 +129,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.ManifestDir, "manifests-dir", o.ManifestDir, "directory for the static pod manifest")
 	fs.StringVar(&o.TargetName, "target-name", o.TargetName, "identifies operand used to construct the final file name when reading the current and previous manifests")
 	fs.StringVar(&o.ResourceDir, "installer-lock-file", o.InstallerLockFile, "file path for the installer flock based lock file")
+	fs.StringVar(&o.NodeName, "node-name", o.NodeName, "the name of the node as used in the static pod operator resource")
 }
 
 func (o *Options) Validate() error {
@@ -139,6 +144,9 @@ func (o *Options) Validate() error {
 	}
 	if len(o.TargetName) == 0 {
 		return fmt.Errorf("--target-name is required")
+	}
+	if len(o.NodeName) == 0 {
+		return fmt.Errorf("--node-name is required")
 	}
 	return nil
 }

--- a/pkg/operator/staticpod/startupmonitor/cmd.go
+++ b/pkg/operator/staticpod/startupmonitor/cmd.go
@@ -79,7 +79,7 @@ func NewCommand(check ReadinessChecker) *cobra.Command {
 				withProbeInterval(time.Second).
 				withTimeout(o.FallbackTimeout)
 
-			fb := newFallback().
+			fb := newStaticPodFallback().
 				withRevision(o.Revision).
 				withManifestPath(o.ManifestDir).
 				withStaticPodResourcesPath(o.ResourceDir).

--- a/pkg/operator/staticpod/startupmonitor/fallback.go
+++ b/pkg/operator/staticpod/startupmonitor/fallback.go
@@ -39,6 +39,9 @@ type staticPodFallback struct {
 
 	// io collects file system level operations that need to be mocked out during tests
 	io ioInterface
+
+	// nodeName is the node hostname as used by the static pod operator resource.
+	nodeName string
 }
 
 var _ fallback = &staticPodFallback{}

--- a/pkg/operator/staticpod/startupmonitor/fallback.go
+++ b/pkg/operator/staticpod/startupmonitor/fallback.go
@@ -9,10 +9,12 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 
 	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
 	"github.com/openshift/library-go/pkg/operator/staticpod/startupmonitor/annotations"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
 
 // fallback implements falling back to the previous version in case the current version
@@ -39,6 +41,9 @@ type staticPodFallback struct {
 
 	// io collects file system level operations that need to be mocked out during tests
 	io ioInterface
+
+	// operatorClient is used to acknowledge readiness.
+	operatorClient v1helpers.StaticPodOperatorClient
 
 	// nodeName is the node hostname as used by the static pod operator resource.
 	nodeName string
@@ -131,7 +136,48 @@ func (f *staticPodFallback) fallbackToPreviousRevision(reason, message string) e
 }
 
 func (f *staticPodFallback) markRevisionGood() error {
-	return f.createLastKnowGoodRevisionFor(f.revision, true)
+	if err := f.createLastKnowGoodRevisionFor(f.revision, true); err != nil {
+		return err
+	}
+
+	// the startup-monitor is authorative to signal readiness of a revision. The operator
+	// is waiting for this to happen. Otherwise, the operator could assume readiness while
+	// the startup-monitor falls back, leading to an awkward situation.
+	// Note that this will retry forever, with a backoff.
+	return retry.OnError(retry.DefaultRetry, func(error) bool { return true }, func() error {
+		_, status, rv, err := f.operatorClient.GetStaticPodOperatorState()
+		if err != nil {
+			klog.Errorf("Failed to get static pod operator status.nodeStatus: %v", err)
+			return err
+		}
+
+		for i := range status.NodeStatuses {
+			s := &status.NodeStatuses[i]
+			if s.NodeName != f.nodeName {
+				continue
+			}
+
+			if int(s.TargetRevision) != f.revision {
+				// target revision mismatch
+				return nil
+			}
+
+			s.CurrentRevision = s.TargetRevision
+			s.TargetRevision = 0
+			s.LastFailedRevision = 0
+			s.LastFailedTime = nil
+			s.LastFailedCount = 0
+			s.LastFailedRevisionErrors = nil
+
+			_, err := f.operatorClient.UpdateStaticPodOperatorStatus(rv, status)
+			if err != nil {
+				klog.Errorf("Failed to update static pod operator status.nodeStatus: %v", err)
+				return err
+			}
+		}
+
+		return nil
+	})
 }
 
 func (f *staticPodFallback) createLastKnowGoodRevisionFor(revision int, strict bool) error {

--- a/pkg/operator/staticpod/startupmonitor/fallback.go
+++ b/pkg/operator/staticpod/startupmonitor/fallback.go
@@ -43,7 +43,7 @@ type staticPodFallback struct {
 
 var _ fallback = &staticPodFallback{}
 
-func newFallback() *staticPodFallback {
+func newStaticPodFallback() *staticPodFallback {
 	return &staticPodFallback{io: realFS{}}
 }
 

--- a/pkg/operator/staticpod/startupmonitor/fallback_test.go
+++ b/pkg/operator/staticpod/startupmonitor/fallback_test.go
@@ -487,7 +487,7 @@ func TestFallbackToPreviousRevision(t *testing.T) {
 }
 
 func createTestFallback(fakeIO *fakeIO) *staticPodFallback {
-	target := newFallback()
+	target := newStaticPodFallback()
 	target.io = fakeIO
 	target.revision = 8
 	target.targetName = "kube-apiserver"

--- a/pkg/operator/staticpod/startupmonitor/options.go
+++ b/pkg/operator/staticpod/startupmonitor/options.go
@@ -58,3 +58,8 @@ func (f *staticPodFallback) withRevision(revision int) *staticPodFallback {
 	f.revision = revision
 	return f
 }
+
+func (f *staticPodFallback) withNodeName(nodeName string) *staticPodFallback {
+	f.nodeName = nodeName
+	return f
+}

--- a/pkg/operator/staticpod/startupmonitor/options.go
+++ b/pkg/operator/staticpod/startupmonitor/options.go
@@ -1,6 +1,10 @@
 package startupmonitor
 
-import "time"
+import (
+	"time"
+
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
 
 // withProbeInterval probeInterval specifies a time interval at which health of the target will be assessed.
 // Be mindful of not setting it too low, on each iteration, an i/o is involved
@@ -56,6 +60,11 @@ func (f *staticPodFallback) withStaticPodResourcesPath(staticPodResourcesPath st
 // withRevision specifies the current revision number
 func (f *staticPodFallback) withRevision(revision int) *staticPodFallback {
 	f.revision = revision
+	return f
+}
+
+func (f *staticPodFallback) withOperatorClient(operatorClient v1helpers.StaticPodOperatorClient) *staticPodFallback {
+	f.operatorClient = operatorClient
 	return f
 }
 


### PR DESCRIPTION
There must not be a different understanding what readiness mean between the operator and the startup-monitor. To avoid race, we move the readiness update of the nodeStatus to the startup-monitor.