### PR TITLE
staticpod/installer: fix backoff of installers

### DIFF
--- a/pkg/operator/staticpod/controller/installer/installer_controller.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller.go
@@ -88,8 +88,9 @@ type InstallerController struct {
 
 	installerPodMutationFns []InstallerPodMutationFunc
 
-	factory *factory.Factory
-	clock   clock.Clock
+	factory          *factory.Factory
+	clock            clock.Clock
+	installerBackOff func(count int) time.Duration
 }
 
 // InstallerPodMutationFunc is a function that has a chance at changing the installer pod before it is created
@@ -160,6 +161,7 @@ func NewInstallerController(
 
 		installerPodImageFn: getInstallerPodImageFromEnv,
 		clock:               clock.RealClock{},
+		installerBackOff:    backOffDuration(10*time.Second, 1.5, 10*time.Minute),
 	}
 
 	c.ownerRefsFn = c.setOwnerRefs
@@ -372,6 +374,15 @@ func (c *InstallerController) manageInstallationPods(ctx context.Context, operat
 
 		// if we are in a transition, check to see whether our installer pod completed
 		if currNodeState.TargetRevision > currNodeState.CurrentRevision {
+			if currNodeState.LastFailedRevision == currNodeState.TargetRevision && currNodeState.LastFailedTime != nil && !currNodeState.LastFailedTime.IsZero() {
+				delay := c.installerBackOff(currNodeState.LastFailedCount)
+				earliestRetry := currNodeState.LastFailedTime.Add(delay)
+				if !c.now().After(earliestRetry) {
+					klog.V(4).Infof("Backing off node %s installer retry %d until %v", currNodeState.NodeName, currNodeState.LastFailedCount+1, earliestRetry)
+					return true, earliestRetry.Sub(c.now()), nil
+				}
+			}
+
 			if err := c.ensureInstallerPod(ctx, currNodeState.NodeName, operatorSpec, currNodeState.TargetRevision, currNodeState.LastFailedCount); err != nil {
 				c.eventRecorder.Warningf("InstallerPodFailed", "Failed to create installer pod for revision %d count %d on node %q: %v",
 					currNodeState.TargetRevision, currNodeState.NodeName, currNodeState.LastFailedCount, err)
@@ -397,10 +408,12 @@ func (c *InstallerController) manageInstallationPods(ctx context.Context, operat
 					c.eventRecorder.Eventf("NodeCurrentRevisionChanged", "Updated node %q from revision %d to %d because %s", currNodeState.NodeName,
 						currNodeState.CurrentRevision, newCurrNodeState.CurrentRevision, reason)
 				}
+
 				if err := c.updateRevisionStatus(ctx, newOperatorStatus); err != nil {
 					klog.Errorf("error updating revision status configmap: %v", err)
 				}
-				return false, 0, nil
+
+				return false, 0, nil // no requeue because UpdateStaticPodStatus triggers an external event anyway
 			} else {
 				klog.V(2).Infof("%q is in transition to %d, but has not made progress because %s", currNodeState.NodeName, currNodeState.TargetRevision, reasonWithBlame(reason))
 			}
@@ -416,15 +429,6 @@ func (c *InstallerController) manageInstallationPods(ctx context.Context, operat
 		if revisionToStart == 0 {
 			klog.V(4).Infof("%s, but node %s does not need update", nodeChoiceReason, currNodeState.NodeName)
 			continue
-		}
-
-		if currNodeState.LastFailedRevision == revisionToStart && currNodeState.LastFailedTime != nil && !currNodeState.LastFailedTime.IsZero() {
-			delay := backOffDuration(currNodeState.LastFailedCount)
-			earliestRetry := currNodeState.LastFailedTime.Add(delay)
-			if !c.now().After(earliestRetry) {
-				klog.V(4).Infof("Backing off node %s installer retry %d until %v", currNodeState.NodeName, currNodeState.LastFailedCount+1, earliestRetry)
-				return true, 0, nil
-			}
 		}
 
 		klog.Infof("%s and needs new revision %d", nodeChoiceReason, revisionToStart)
@@ -1004,12 +1008,14 @@ func statusConfigMapNameForRevision(revision int32) string {
 	return fmt.Sprintf("%s-%d", statusConfigMapName, revision)
 }
 
-func backOffDuration(count int) time.Duration {
-	d := time.Second * time.Duration(float64(10)*math.Pow(1.5, float64(count)))
-	if d > time.Minute*10 {
-		return time.Minute * 10
+func backOffDuration(base time.Duration, factor float64, max time.Duration) func(count int) time.Duration {
+	return func(count int) time.Duration {
+		d := time.Duration(float64(base) * math.Pow(factor, float64(count)))
+		if d > max {
+			return max
+		}
+		return d
 	}
-	return d
 }
 
 func nthTimeOr1st(n int) string {

--- a/pkg/operator/staticpod/controller/installer/installer_controller_test.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller_test.go
@@ -531,6 +531,17 @@ func testSync(t *testing.T, firstInstallerBehaviour testSyncInstallerBehaviour) 
 	}
 	c.installerPodImageFn = func() string { return "docker.io/foo/bar" }
 
+	installerBackOffDuration := 0 * time.Second
+	c.installerBackOff = func(count int) time.Duration {
+		return installerBackOffDuration
+	}
+	withCustomInstallerBackOff := func(d time.Duration, fn func()) {
+		old := installerBackOffDuration
+		installerBackOffDuration = d
+		defer func() { installerBackOffDuration = old }()
+		fn()
+	}
+
 	t.Log("setting target revision")
 	if err := c.Sync(context.TODO(), factory.NewSyncContext("InstallerController", eventRecorder)); err != nil {
 		t.Fatal(err)
@@ -623,10 +634,24 @@ func testSync(t *testing.T, firstInstallerBehaviour testSyncInstallerBehaviour) 
 			t.Fatalf("expected %s condition to be true", condition.NodeInstallerDegradedConditionType)
 		}
 
-		t.Log("launch 2nd installer")
-		if err := c.Sync(context.TODO(), factory.NewSyncContext("InstallerController", eventRecorder)); err != nil {
-			t.Fatal(err)
+		t.Log("try to launch 2nd installer with backoff, too early")
+
+		withCustomInstallerBackOff(10*time.Second, func() {
+			if err := c.Sync(context.TODO(), factory.NewSyncContext("InstallerController", eventRecorder)); err != nil {
+				t.Fatal(err)
+			}
+		})
+		if len(installerPods) != 1 {
+			t.Fatal("didn't expect new installer pod yet due to backoff")
 		}
+
+		t.Log("launch 2nd installer when backoff has passed")
+
+		withCustomInstallerBackOff(0*time.Second, func() {
+			if err := c.Sync(context.TODO(), factory.NewSyncContext("InstallerController", eventRecorder)); err != nil {
+				t.Fatal(err)
+			}
+		})
 		if len(installerPods) != 2 {
 			t.Fatal("expected second installer pod after failure")
 		}
@@ -1644,8 +1669,12 @@ func TestCreateInstallerPodMultiNode(t *testing.T) {
 				c.ownerRefsFn = test.ownerRefsFn
 			}
 			c.installerPodImageFn = func() string { return "docker.io/foo/bar" }
+			c.installerBackOff = func(count int) time.Duration {
+				return 0 // switch off for this test
+			}
 
 			// Each node needs at least 2 syncs to first create the pod and then acknowledge its existence.
+			// We switch off backoff which would lead to more sync.
 			for i := 1; i <= len(test.nodeStatuses)*2+1; i++ {
 				err := c.Sync(context.TODO(), factory.NewSyncContext("InstallerController", eventRecorder))
 				expectedErr := false


### PR DESCRIPTION
The DeepEqual clause for updating the operator status returned from `Sync`, after `lastFailedCount` had been increased. On next `Sync` we ran directly into new state computation and installer pod creation. The delay much further down was never effective. This PR moved the installer backoff delay up.