### PR TITLE
startup-monitor: always try to delete the symlink before creating it

### DIFF
--- a/pkg/operator/staticpod/startupmonitor/cmd.go
+++ b/pkg/operator/staticpod/startupmonitor/cmd.go
@@ -191,6 +191,7 @@ func run(ctx context.Context, installerLock Locker, m Monitor, fb fallback, s su
 			return err
 		}
 	} else {
+		klog.Info("Falling back to a previous revision, the target %v hasn't become ready in the allotted time")
 		if err := fb.fallbackToPreviousRevision(reason, message); err != nil {
 			return err
 		}


### PR DESCRIPTION
the existing `fileExists` method checks only the target file and creating a symlink fails when it already exists