### PR TITLE
startup-monitor: releases the lock on each iteration to prevent fight with the installer

### DIFF
--- a/pkg/operator/staticpod/startupmonitor/cmd_test.go
+++ b/pkg/operator/staticpod/startupmonitor/cmd_test.go
@@ -8,8 +8,6 @@ import (
 )
 
 func Test_run(t *testing.T) {
-	type args struct {
-	}
 	tests := []struct {
 		name string
 

--- a/pkg/operator/staticpod/startupmonitor/monitor.go
+++ b/pkg/operator/staticpod/startupmonitor/monitor.go
@@ -78,6 +78,7 @@ func (m *monitor) Run(ctx context.Context, installerLock Locker) (ready bool, re
 	klog.Infof("Waiting for readiness (interval %v, timeout %v)...", m.probeInterval, m.timeout)
 
 	lastReady := false
+	var lastError error
 	var lastReason, lastMessage string
 	iteration := func(ctx context.Context) {
 		// acquire an exclusive lock to coordinate work with the installer pod, e.g.:
@@ -87,15 +88,14 @@ func (m *monitor) Run(ctx context.Context, installerLock Locker) (ready bool, re
 		// the installer writes the new file and we immediately overwrite it
 		//
 		// additional benefit is that we read consistent operand's manifest
-		if err := installerLock.Lock(ctx); err != nil {
-			klog.Error(err)
+		if lastError = installerLock.Lock(ctx); lastError != nil {
+			klog.Error(lastError)
 			return
 		}
 
-		var err error
-		lastReady, lastReason, lastMessage, err = m.isReady(ctx)
-		if err != nil {
-			klog.Error(err)
+		lastReady, lastReason, lastMessage, lastError = m.isReady(ctx)
+		if lastError != nil {
+			klog.Error(lastError)
 			return
 		}
 		if len(lastReason) > 0 {
@@ -106,18 +106,19 @@ func (m *monitor) Run(ctx context.Context, installerLock Locker) (ready bool, re
 	// we use wait.Until because it uses sliding interval, wait.Poll does not.
 	withTimeoutCtx, cancel := context.WithTimeout(ctx, m.timeout-m.probeInterval) // last iteration is done manually to have control over the Unlock
 	wait.UntilWithContext(withTimeoutCtx, func(ctx context.Context) {
-		defer func() {
-			if lastReady {
-				installerLock.Unlock()
-			}
-		}()
+		defer installerLock.Unlock()
 		iteration(ctx)
 		if lastReady {
 			cancel()
 		}
 	}, m.probeInterval)
-	if !lastReady {
-		iteration(ctx) // do last iteration without Unlock
+
+	// do last iteration without calling Unlock()
+	iteration(ctx)
+	if lastError != nil {
+		// release the lock since we are exiting anyway
+		installerLock.Unlock()
+		return false, lastReason, lastMessage, lastError
 	}
 
 	if lastReady {
@@ -143,7 +144,8 @@ func (m *monitor) isReady(ctx context.Context) (ready bool, reason string, messa
 		return false, "", "", err
 	}
 	if m.revision != currentTargetRevision {
-		return false, "UnexpectedRevision", fmt.Sprintf("expected revision %d, found %d", m.revision, currentTargetRevision), nil
+		// return an error so that we won't fallback when we fail to monitor unexpected target
+		return false, "", "", fmt.Errorf("expected revision %d, found %d", m.revision, currentTargetRevision)
 	}
 
 	// first check if the target is ready.

--- a/pkg/operator/staticpod/startupmonitor/monitor_test.go
+++ b/pkg/operator/staticpod/startupmonitor/monitor_test.go
@@ -1,8 +1,95 @@
 package startupmonitor
 
 import (
+	"context"
+	"fmt"
 	"testing"
+	"time"
 )
+
+func TestMonitorRun(t *testing.T) {
+	scenarios := []struct {
+		name          string
+		readiness     ReadinessFunc
+		installerLock *fakeLock
+		validateFn    func(t *testing.T, installerLock *fakeLock, ready bool, reason string, message string, err error)
+	}{
+		{
+			name:          "lock is released on error",
+			installerLock: &fakeLock{},
+			readiness: func(ctx context.Context, revision int) (ready bool, reason string, message string, err error) {
+				return false, "", "", fmt.Errorf("fake err")
+			},
+			validateFn: func(t *testing.T, installerLock *fakeLock, ready bool, reason string, message string, err error) {
+				if ready != false || len(reason) > 0 || len(message) > 0 {
+					t.Fatalf("expected ready = false, empty reason and message, got ready = %v, reason = %v, message = %v", ready, reason, message)
+				}
+				if err == nil || err.Error() != "fake err" {
+					t.Fatalf("unexpected err = %v, expected \"fake err\"", err)
+				}
+				if installerLock.locked {
+					t.Fatal("the lock wasn't released")
+				}
+			},
+		},
+
+		{
+			name:          "lock is kept when target ready",
+			installerLock: &fakeLock{},
+			readiness: func(ctx context.Context, revision int) (ready bool, reason string, message string, err error) {
+				return true, "", "", nil
+			},
+			validateFn: func(t *testing.T, installerLock *fakeLock, ready bool, reason string, message string, err error) {
+				if ready != true || len(reason) > 0 || len(message) > 0 {
+					t.Fatalf("expected ready = false, empty reason and message, got ready = %v, reason = %v, message = %v", ready, reason, message)
+				}
+				if err != nil {
+					t.Fatalf("unexpected err = %v, expected \"fake err\"", err)
+				}
+				if !installerLock.locked {
+					t.Fatal("the lock was released")
+				}
+			},
+		},
+
+		{
+			name:          "lock is kept when target unready",
+			installerLock: &fakeLock{},
+			readiness: func(ctx context.Context, revision int) (ready bool, reason string, message string, err error) {
+				return false, "", "", nil
+			},
+			validateFn: func(t *testing.T, installerLock *fakeLock, ready bool, reason string, message string, err error) {
+				if ready != false || len(reason) > 0 || len(message) > 0 {
+					t.Fatalf("expected ready = false, empty reason and message, got ready = %v, reason = %v, message = %v", ready, reason, message)
+				}
+				if err != nil {
+					t.Fatalf("unexpected err = %v, expected \"fake err\"", err)
+				}
+				if !installerLock.locked {
+					t.Fatal("the lock was released")
+				}
+			},
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			// test data
+			target := newMonitor(scenario.readiness)
+			target.probeInterval = 100 * time.Millisecond
+			target.timeout = 300 * time.Millisecond
+			target.manifestsPath = "./testdata"
+			target.targetName = "scenario-1"
+			target.revision = 8
+
+			// act
+			ready, reason, message, err := target.Run(context.TODO(), scenario.installerLock)
+
+			// validate
+			scenario.validateFn(t, scenario.installerLock, ready, reason, message, err)
+		})
+	}
+}
 
 func TestLoadTargetManifestAndExtractRevision(t *testing.T) {
 	scenarios := []struct {


### PR DESCRIPTION
additionally, it doesn't fall back when the target revision doesn't match the expected one.
this usually means something bad happened, in that case, we should report an error (the startup controller will put an operator into a degraded state)