### PR TITLE
Bug 1991357: installer_controller: only degraded if lastFailedRevision > currentRe…

### DIFF
--- a/pkg/operator/staticpod/controller/installer/installer_controller.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller.go
@@ -573,7 +573,9 @@ func setAvailableProgressingNodeInstallerFailingConditions(newStatus *operatorv1
 		}
 
 		// keep track of failures so that we can report failing status
-		if currNodeStatus.LastFailedRevision != 0 && currNodeStatus.LastFailedReason != nodeStatusOperandFailedFallbackReason {
+		if currNodeStatus.LastFailedRevision != 0 &&
+			currNodeStatus.LastFailedRevision == currNodeStatus.TargetRevision &&
+			currNodeStatus.LastFailedReason != nodeStatusOperandFailedFallbackReason {
 			failingCount[currNodeStatus.LastFailedRevision] = failingCount[currNodeStatus.LastFailedRevision] + 1
 			failing[currNodeStatus.LastFailedRevision] = append(failing[currNodeStatus.LastFailedRevision], currNodeStatus.LastFailedRevisionErrors...)
 		}

--- a/pkg/operator/staticpod/controller/installer/installer_controller_test.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller_test.go
@@ -2286,13 +2286,14 @@ func TestSetConditions(t *testing.T) {
 		lastFailedRevision        int32
 		lastFailedTime            *metav1.Time
 		lastFailedCount           int
+		targetRevision            int32
 		currentRevisions          []int32
 		expectedAvailableStatus   operatorv1.ConditionStatus
 		expectedProgressingStatus operatorv1.ConditionStatus
 		expectedFailingStatus     operatorv1.ConditionStatus
 	}
 
-	testCase := func(name string, available, progressing, failed bool, lastFailedRevision int32, lastFailedCount int, latest int32, current ...int32) TestCase {
+	testCase := func(name string, available, progressing, failed bool, lastFailedRevision int32, lastFailedCount int, latest, target int32, current ...int32) TestCase {
 		availableStatus := operatorv1.ConditionFalse
 		pendingStatus := operatorv1.ConditionFalse
 		expectedFailingStatus := operatorv1.ConditionFalse
@@ -2310,17 +2311,18 @@ func TestSetConditions(t *testing.T) {
 			now := metav1.NewTime(time.Now())
 			lastFailedTime = &now
 		}
-		return TestCase{name, latest, lastFailedRevision, lastFailedTime, lastFailedCount, current, availableStatus, pendingStatus, expectedFailingStatus}
+		return TestCase{name, latest, lastFailedRevision, lastFailedTime, lastFailedCount, target, current, availableStatus, pendingStatus, expectedFailingStatus}
 	}
 
 	testCases := []TestCase{
-		testCase("AvailableProgressingDegraded", true, true, true, 1, 1, 2, 2, 1, 2, 1),
-		testCase("AvailableProgressingDegraded", true, true, true, 1, 3, 2, 2, 1, 2, 1),
-		testCase("AvailableProgressing", true, true, false, 0, 1, 2, 2, 1, 2, 1),
-		testCase("AvailableNotProgressing", true, false, false, 0, 1, 2, 2, 2, 2),
-		testCase("NotAvailableProgressing", false, true, false, 0, 1, 2, 0, 0),
-		testCase("NotAvailableAtOldLevelProgressing", true, true, false, 0, 1, 2, 1, 1),
-		testCase("NotAvailableNotProgressing", false, false, false, 0, 1, 2),
+		testCase("AvailableProgressingDegraded", true, true, true, 3, 1, 2, 3, 2, 1, 2, 1),
+		testCase("AvailableProgressingDegraded", true, true, true, 3, 3, 2, 3, 2, 1, 2, 1),
+		testCase("AvailableProgressing", true, true, false, 1, 3, 2, 2, 2, 1, 2, 1),
+		testCase("AvailableProgressing", true, true, false, 0, 1, 2, 2, 2, 1, 2, 1),
+		testCase("AvailableNotProgressing", true, false, false, 0, 1, 2, 2, 2, 2, 2),
+		testCase("NotAvailableProgressing", false, true, false, 0, 1, 2, 2, 0, 0),
+		testCase("NotAvailableAtOldLevelProgressing", true, true, false, 0, 1, 2, 2, 1, 1),
+		testCase("NotAvailableNotProgressing", false, false, false, 0, 1, 2, 2),
 	}
 
 	for _, tc := range testCases {
@@ -2334,6 +2336,7 @@ func TestSetConditions(t *testing.T) {
 					LastFailedRevision: tc.lastFailedRevision,
 					LastFailedTime:     tc.lastFailedTime,
 					LastFailedCount:    tc.lastFailedCount,
+					TargetRevision:     tc.targetRevision,
 				})
 			}
 			setAvailableProgressingNodeInstallerFailingConditions(status)


### PR DESCRIPTION
…vision

Ccurrently the clusteroperator shows the component as degraded despite the last failing version is not the current version, and the operator was sucessfully installed.

Per example, it has degraded to True because something failed at revision 4
```
kube-apiserver             4.9.0-0.nightly-2021-08-07-175228   True        False         True       22m     NodeInstallerDegraded: 1 nodes are failing on revision 4:
```


However, the component is correct at revision 7
```
    reason: NodeInstaller_InstallerPodFailed
    status: "True"
    type: Degraded
  - lastTransitionTime: "2021-08-09T05:07:23Z"
    message: 'NodeInstallerProgressing: 3 nodes are at revision 7'
    reason: AsExpected
    status: "False"
    type: Progressing
  - lastTransitionTime: "2021-08-09T05:04:45Z"
    message: 'StaticPodsAvailable: 3 nodes are active; 3 nodes are at revision 7'
    reason: AsExpected
    status: "True"
    type: Available
  - lastTransitionTime: "2021-08-09T04:43:36Z"
    message: All is well
    reason: AsExpected
    status: "True"
    type: Upgradeable
```




Signed-off-by: Antonio Ojea <aojea@redhat.com>