### PR TITLE
updates some methods of the OperatorClient interface to accept context

### DIFF
--- a/pkg/controller/factory/base_controller.go
+++ b/pkg/controller/factory/base_controller.go
@@ -226,7 +226,7 @@ func (c *baseController) reportDegraded(ctx context.Context, reportedError error
 		return reportedError
 	}
 	if reportedError != nil {
-		_, _, updateErr := v1helpers.UpdateStatus(c.syncDegradedClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
+		_, _, updateErr := v1helpers.UpdateStatus(ctx, c.syncDegradedClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
 			Type:    c.name + "Degraded",
 			Status:  operatorv1.ConditionTrue,
 			Reason:  "SyncError",
@@ -237,7 +237,7 @@ func (c *baseController) reportDegraded(ctx context.Context, reportedError error
 		}
 		return reportedError
 	}
-	_, _, updateErr := v1helpers.UpdateStatus(c.syncDegradedClient,
+	_, _, updateErr := v1helpers.UpdateStatus(ctx, c.syncDegradedClient,
 		v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
 			Type:   c.name + "Degraded",
 			Status: operatorv1.ConditionFalse,

--- a/pkg/operator/apiserver/controller/apiservice/apiservice_controller.go
+++ b/pkg/operator/apiserver/controller/apiservice/apiservice_controller.go
@@ -96,7 +96,7 @@ func (c *APIServiceController) sync(ctx context.Context, syncCtx factory.SyncCon
 	}
 	ready, err := c.precondition(apiServices)
 	if err != nil {
-		if _, _, updateErr := v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
+		if _, _, updateErr := v1helpers.UpdateStatus(ctx, c.operatorClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
 			Type:    "APIServicesAvailable",
 			Status:  operatorv1.ConditionFalse,
 			Reason:  "ErrorCheckingPrecondition",
@@ -107,7 +107,7 @@ func (c *APIServiceController) sync(ctx context.Context, syncCtx factory.SyncCon
 		return err
 	}
 	if !ready {
-		if _, _, updateErr := v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
+		if _, _, updateErr := v1helpers.UpdateStatus(ctx, c.operatorClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
 			Type:    "APIServicesAvailable",
 			Status:  operatorv1.ConditionFalse,
 			Reason:  "PreconditionNotReady",
@@ -143,7 +143,7 @@ func (c *APIServiceController) sync(ctx context.Context, syncCtx factory.SyncCon
 		cond.Reason = "Error"
 		cond.Message = err.Error()
 	}
-	if _, _, updateError := v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
+	if _, _, updateError := v1helpers.UpdateStatus(ctx, c.operatorClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
 		if err == nil {
 			return updateError
 		}

--- a/pkg/operator/apiserver/controller/auditpolicy/auditpolicy_controller.go
+++ b/pkg/operator/apiserver/controller/auditpolicy/auditpolicy_controller.go
@@ -90,7 +90,7 @@ func (c *auditPolicyController) sync(ctx context.Context, syncCtx factory.SyncCo
 		cond.Reason = "Error"
 		cond.Message = err.Error()
 	}
-	if _, _, updateError := v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
+	if _, _, updateError := v1helpers.UpdateStatus(ctx, c.operatorClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
 		if err == nil {
 			return updateError
 		}

--- a/pkg/operator/apiserver/controller/workload/workload_test.go
+++ b/pkg/operator/apiserver/controller/workload/workload_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 	"time"
+	"context"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -538,6 +539,7 @@ func TestUpdateOperatorStatus(t *testing.T) {
 			// act
 			target := &Controller{operatorClient: fakeOperatorClient, targetNamespace: targetNs, podsLister: &fakePodLister{pods: scenario.pods}}
 			err := target.updateOperatorStatus(
+				context.TODO(),
 				&operatorv1.OperatorStatus{Conditions: scenario.previousConditions},
 				scenario.workload,
 				scenario.operatorConfigAtHighestRevision,

--- a/pkg/operator/apiserver/controller/workload/workload_test.go
+++ b/pkg/operator/apiserver/controller/workload/workload_test.go
@@ -1,10 +1,10 @@
 package workload
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
-	"context"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"

--- a/pkg/operator/certrotation/client_cert_rotation_controller.go
+++ b/pkg/operator/certrotation/client_cert_rotation_controller.go
@@ -94,7 +94,7 @@ func (c CertRotationController) Sync(ctx context.Context, syncCtx factory.SyncCo
 		newCondition.Reason = "RotationError"
 		newCondition.Message = syncErr.Error()
 	}
-	_, updated, updateErr := v1helpers.UpdateStaticPodStatus(c.OperatorClient, v1helpers.UpdateStaticPodConditionFn(newCondition))
+	_, updated, updateErr := v1helpers.UpdateStaticPodStatus(ctx, c.OperatorClient, v1helpers.UpdateStaticPodConditionFn(newCondition))
 	if updateErr != nil {
 		return updateErr
 	}

--- a/pkg/operator/configobserver/config_observer_controller.go
+++ b/pkg/operator/configobserver/config_observer_controller.go
@@ -159,7 +159,7 @@ func (c ConfigObserver) sync(ctx context.Context, syncCtx factory.SyncContext) e
 		errs = append(errs, errors.New("non-deterministic config observation detected"))
 	}
 
-	if err := c.updateObservedConfig(syncCtx, existingConfig, mergedObservedConfig); err != nil {
+	if err := c.updateObservedConfig(ctx, syncCtx, existingConfig, mergedObservedConfig); err != nil {
 		errs = []error{err}
 	}
 	configError := v1helpers.NewMultiLineAggregate(errs)
@@ -174,18 +174,18 @@ func (c ConfigObserver) sync(ctx context.Context, syncCtx factory.SyncContext) e
 		cond.Reason = "Error"
 		cond.Message = configError.Error()
 	}
-	if _, _, updateError := v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
+	if _, _, updateError := v1helpers.UpdateStatus(ctx, c.operatorClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
 		return updateError
 	}
 
 	return configError
 }
 
-func (c ConfigObserver) updateObservedConfig(syncCtx factory.SyncContext, existingConfig map[string]interface{}, mergedObservedConfig map[string]interface{}) error {
+func (c ConfigObserver) updateObservedConfig(ctx context.Context, syncCtx factory.SyncContext, existingConfig map[string]interface{}, mergedObservedConfig map[string]interface{}) error {
 	if len(c.nestedConfigPath) == 0 {
 		if !equality.Semantic.DeepEqual(existingConfig, mergedObservedConfig) {
 			syncCtx.Recorder().Eventf("ObservedConfigChanged", "Writing updated observed config: %v", diff.ObjectDiff(existingConfig, mergedObservedConfig))
-			return c.updateConfig(syncCtx, mergedObservedConfig, v1helpers.UpdateObservedConfigFn)
+			return c.updateConfig(ctx, syncCtx, mergedObservedConfig, v1helpers.UpdateObservedConfigFn)
 		}
 		return nil
 	}
@@ -200,15 +200,15 @@ func (c ConfigObserver) updateObservedConfig(syncCtx factory.SyncContext, existi
 	}
 	if !equality.Semantic.DeepEqual(existingConfigNested, mergedObservedConfigNested) {
 		syncCtx.Recorder().Eventf("ObservedConfigChanged", "Writing updated section (%q) of observed config: %q", strings.Join(c.nestedConfigPath, "/"), diff.ObjectDiff(existingConfigNested, mergedObservedConfigNested))
-		return c.updateConfig(syncCtx, mergedObservedConfigNested, c.updateNestedConfigHelper)
+		return c.updateConfig(ctx, syncCtx, mergedObservedConfigNested, c.updateNestedConfigHelper)
 	}
 	return nil
 }
 
 type updateObservedConfigFn func(config map[string]interface{}) v1helpers.UpdateOperatorSpecFunc
 
-func (c ConfigObserver) updateConfig(syncCtx factory.SyncContext, updatedMaybeNestedConfig map[string]interface{}, updateConfigHelper updateObservedConfigFn) error {
-	if _, _, err := v1helpers.UpdateSpec(c.operatorClient, updateConfigHelper(updatedMaybeNestedConfig)); err != nil {
+func (c ConfigObserver) updateConfig(ctx context.Context, syncCtx factory.SyncContext, updatedMaybeNestedConfig map[string]interface{}, updateConfigHelper updateObservedConfigFn) error {
+	if _, _, err := v1helpers.UpdateSpec(ctx, c.operatorClient, updateConfigHelper(updatedMaybeNestedConfig)); err != nil {
 		// At this point we failed to write the updated config. If we are permanently broken, do not pile the errors from observers
 		// but instead reset the errors and only report single error condition.
 		syncCtx.Recorder().Warningf("ObservedConfigWriteError", "Failed to write observed config: %v", err)

--- a/pkg/operator/configobserver/config_observer_controller_test.go
+++ b/pkg/operator/configobserver/config_observer_controller_test.go
@@ -43,14 +43,14 @@ func (c *fakeOperatorClient) GetOperatorState() (spec *operatorv1.OperatorSpec, 
 	return c.startingSpec, &operatorv1.OperatorStatus{}, "", nil
 }
 
-func (c *fakeOperatorClient) UpdateOperatorSpec(rv string, in *operatorv1.OperatorSpec) (spec *operatorv1.OperatorSpec, resourceVersion string, err error) {
+func (c *fakeOperatorClient) UpdateOperatorSpec(_ context.Context, rv string, in *operatorv1.OperatorSpec) (spec *operatorv1.OperatorSpec, resourceVersion string, err error) {
 	if c.specUpdateFailure != nil {
 		return &operatorv1.OperatorSpec{}, rv, c.specUpdateFailure
 	}
 	c.spec = in
 	return in, rv, c.specUpdateFailure
 }
-func (c *fakeOperatorClient) UpdateOperatorStatus(rv string, in *operatorv1.OperatorStatus) (status *operatorv1.OperatorStatus, err error) {
+func (c *fakeOperatorClient) UpdateOperatorStatus(_ context.Context, rv string, in *operatorv1.OperatorStatus) (status *operatorv1.OperatorStatus, err error) {
 	c.status = in
 	return in, nil
 }

--- a/pkg/operator/csi/credentialsrequestcontroller/credentials_request_controller.go
+++ b/pkg/operator/csi/credentialsrequestcontroller/credentials_request_controller.go
@@ -103,6 +103,7 @@ func (c CredentialsRequestController) sync(ctx context.Context, syncContext fact
 	}
 
 	_, _, err = v1helpers.UpdateStatus(
+		ctx,
 		c.operatorClient,
 		v1helpers.UpdateConditionFn(availableCondition),
 		v1helpers.UpdateConditionFn(progressingCondition),

--- a/pkg/operator/csi/csidrivernodeservicecontroller/csi_driver_node_service_controller.go
+++ b/pkg/operator/csi/csidrivernodeservicecontroller/csi_driver_node_service_controller.go
@@ -142,7 +142,7 @@ func (c *CSIDriverNodeServiceController) sync(ctx context.Context, syncContext f
 func (c *CSIDriverNodeServiceController) syncManaged(ctx context.Context, opSpec *opv1.OperatorSpec, opStatus *opv1.OperatorStatus, syncContext factory.SyncContext) error {
 	klog.V(4).Infof("syncManaged")
 	if management.IsOperatorRemovable() {
-		if err := v1helpers.EnsureFinalizer(c.operatorClient, c.name); err != nil {
+		if err := v1helpers.EnsureFinalizer(ctx, c.operatorClient, c.name); err != nil {
 			return err
 		}
 	}
@@ -194,6 +194,7 @@ func (c *CSIDriverNodeServiceController) syncManaged(ctx context.Context, opSpec
 	}
 
 	_, _, err = v1helpers.UpdateStatus(
+		ctx,
 		c.operatorClient,
 		updateStatusFn,
 		v1helpers.UpdateConditionFn(availableCondition),
@@ -274,5 +275,5 @@ func (c *CSIDriverNodeServiceController) syncDeleting(ctx context.Context, opSpe
 	}
 
 	// All removed, remove the finalizer as the last step
-	return v1helpers.RemoveFinalizer(c.operatorClient, c.name)
+	return v1helpers.RemoveFinalizer(ctx, c.operatorClient, c.name)
 }

--- a/pkg/operator/deploymentcontroller/deployment_controller.go
+++ b/pkg/operator/deploymentcontroller/deployment_controller.go
@@ -131,7 +131,7 @@ func (c *DeploymentController) syncManaged(ctx context.Context, opSpec *opv1.Ope
 	klog.V(4).Infof("syncManaged")
 
 	if management.IsOperatorRemovable() {
-		if err := v1helpers.EnsureFinalizer(c.operatorClient, c.name); err != nil {
+		if err := v1helpers.EnsureFinalizer(ctx, c.operatorClient, c.name); err != nil {
 			return err
 		}
 	}
@@ -182,6 +182,7 @@ func (c *DeploymentController) syncManaged(ctx context.Context, opSpec *opv1.Ope
 	}
 
 	_, _, err = v1helpers.UpdateStatus(
+		ctx,
 		c.operatorClient,
 		updateStatusFn,
 		v1helpers.UpdateConditionFn(availableCondition),
@@ -206,7 +207,7 @@ func (c *DeploymentController) syncDeleting(ctx context.Context, opSpec *opv1.Op
 	}
 
 	// All removed, remove the finalizer as the last step
-	return v1helpers.RemoveFinalizer(c.operatorClient, c.name)
+	return v1helpers.RemoveFinalizer(ctx, c.operatorClient, c.name)
 }
 
 func (c *DeploymentController) getDeployment(opSpec *opv1.OperatorSpec) (*appsv1.Deployment, error) {

--- a/pkg/operator/encryption/controllers/condition_controller.go
+++ b/pkg/operator/encryption/controllers/condition_controller.go
@@ -63,13 +63,13 @@ func NewConditionController(
 	).ResyncEvery(time.Minute).WithSync(c.sync).ToController("EncryptionConditionController", eventRecorder.WithComponentSuffix("encryption-condition-controller"))
 }
 
-func (c *conditionController) sync(_ context.Context, _ factory.SyncContext) (err error) {
+func (c *conditionController) sync(ctx context.Context, _ factory.SyncContext) (err error) {
 	cond := &operatorv1.OperatorCondition{Type: "Encrypted", Status: operatorv1.ConditionFalse}
 	defer func() {
 		if cond == nil {
 			return
 		}
-		if _, _, updateError := operatorv1helpers.UpdateStatus(c.operatorClient, operatorv1helpers.UpdateConditionFn(*cond)); updateError != nil {
+		if _, _, updateError := operatorv1helpers.UpdateStatus(ctx, c.operatorClient, operatorv1helpers.UpdateConditionFn(*cond)); updateError != nil {
 			err = updateError
 		}
 	}()

--- a/pkg/operator/encryption/controllers/key_controller.go
+++ b/pkg/operator/encryption/controllers/key_controller.go
@@ -113,13 +113,13 @@ func NewKeyController(
 		).ToController(c.name, eventRecorder.WithComponentSuffix("encryption-key-controller"))
 }
 
-func (c *keyController) sync(_ context.Context, syncCtx factory.SyncContext) (err error) {
+func (c *keyController) sync(ctx context.Context, syncCtx factory.SyncContext) (err error) {
 	degradedCondition := &operatorv1.OperatorCondition{Type: "EncryptionKeyControllerDegraded", Status: operatorv1.ConditionFalse}
 	defer func() {
 		if degradedCondition == nil {
 			return
 		}
-		if _, _, updateError := operatorv1helpers.UpdateStatus(c.operatorClient, operatorv1helpers.UpdateConditionFn(*degradedCondition)); updateError != nil {
+		if _, _, updateError := operatorv1helpers.UpdateStatus(ctx, c.operatorClient, operatorv1helpers.UpdateConditionFn(*degradedCondition)); updateError != nil {
 			err = updateError
 		}
 	}()

--- a/pkg/operator/encryption/controllers/migration_controller.go
+++ b/pkg/operator/encryption/controllers/migration_controller.go
@@ -116,7 +116,7 @@ func (c *migrationController) sync(ctx context.Context, syncCtx factory.SyncCont
 			v1helpers.UpdateConditionFn(*degradedCondition),
 			v1helpers.UpdateConditionFn(*progressingCondition),
 		}
-		if _, _, updateError := operatorv1helpers.UpdateStatus(c.operatorClient, conditions...); updateError != nil {
+		if _, _, updateError := operatorv1helpers.UpdateStatus(ctx, c.operatorClient, conditions...); updateError != nil {
 			err = updateError
 		}
 	}()

--- a/pkg/operator/encryption/controllers/prune_controller.go
+++ b/pkg/operator/encryption/controllers/prune_controller.go
@@ -76,13 +76,13 @@ func NewPruneController(
 	).ToController(c.name, eventRecorder.WithComponentSuffix("encryption-prune-controller"))
 }
 
-func (c *pruneController) sync(_ context.Context, syncCtx factory.SyncContext) (err error) {
+func (c *pruneController) sync(ctx context.Context, syncCtx factory.SyncContext) (err error) {
 	degradedCondition := &operatorv1.OperatorCondition{Type: "EncryptionPruneControllerDegraded", Status: operatorv1.ConditionFalse}
 	defer func() {
 		if degradedCondition == nil {
 			return
 		}
-		if _, _, updateError := operatorv1helpers.UpdateStatus(c.operatorClient, operatorv1helpers.UpdateConditionFn(*degradedCondition)); updateError != nil {
+		if _, _, updateError := operatorv1helpers.UpdateStatus(ctx, c.operatorClient, operatorv1helpers.UpdateConditionFn(*degradedCondition)); updateError != nil {
 			err = updateError
 		}
 	}()

--- a/pkg/operator/encryption/controllers/state_controller.go
+++ b/pkg/operator/encryption/controllers/state_controller.go
@@ -88,7 +88,7 @@ func (c *stateController) sync(ctx context.Context, syncCtx factory.SyncContext)
 		if degradedCondition == nil {
 			return
 		}
-		if _, _, updateError := operatorv1helpers.UpdateStatus(c.operatorClient, operatorv1helpers.UpdateConditionFn(*degradedCondition)); updateError != nil {
+		if _, _, updateError := operatorv1helpers.UpdateStatus(ctx, c.operatorClient, operatorv1helpers.UpdateConditionFn(*degradedCondition)); updateError != nil {
 			err = updateError
 		}
 	}()

--- a/pkg/operator/genericoperatorclient/dynamic_operator_client.go
+++ b/pkg/operator/genericoperatorclient/dynamic_operator_client.go
@@ -104,7 +104,7 @@ func (c dynamicOperatorClient) GetOperatorState() (*operatorv1.OperatorSpec, *op
 // UpdateOperatorSpec overwrites the operator object spec with the values given
 // in operatorv1.OperatorSpec while preserving pre-existing spec fields that have
 // no correspondence in operatorv1.OperatorSpec.
-func (c dynamicOperatorClient) UpdateOperatorSpec(resourceVersion string, spec *operatorv1.OperatorSpec) (*operatorv1.OperatorSpec, string, error) {
+func (c dynamicOperatorClient) UpdateOperatorSpec(ctx context.Context, resourceVersion string, spec *operatorv1.OperatorSpec) (*operatorv1.OperatorSpec, string, error) {
 	uncastOriginal, err := c.informer.Lister().Get(c.configName)
 	if err != nil {
 		return nil, "", err
@@ -117,7 +117,7 @@ func (c dynamicOperatorClient) UpdateOperatorSpec(resourceVersion string, spec *
 		return nil, "", err
 	}
 
-	ret, err := c.client.Update(context.TODO(), copy, metav1.UpdateOptions{})
+	ret, err := c.client.Update(ctx, copy, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, "", err
 	}
@@ -132,7 +132,7 @@ func (c dynamicOperatorClient) UpdateOperatorSpec(resourceVersion string, spec *
 // UpdateOperatorStatus overwrites the operator object status with the values given
 // in operatorv1.OperatorStatus while preserving pre-existing status fields that have
 // no correspondence in operatorv1.OperatorStatus.
-func (c dynamicOperatorClient) UpdateOperatorStatus(resourceVersion string, status *operatorv1.OperatorStatus) (*operatorv1.OperatorStatus, error) {
+func (c dynamicOperatorClient) UpdateOperatorStatus(ctx context.Context, resourceVersion string, status *operatorv1.OperatorStatus) (*operatorv1.OperatorStatus, error) {
 	uncastOriginal, err := c.informer.Lister().Get(c.configName)
 	if err != nil {
 		return nil, err
@@ -145,7 +145,7 @@ func (c dynamicOperatorClient) UpdateOperatorStatus(resourceVersion string, stat
 		return nil, err
 	}
 
-	ret, err := c.client.UpdateStatus(context.TODO(), copy, metav1.UpdateOptions{})
+	ret, err := c.client.UpdateStatus(ctx, copy, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -157,7 +157,7 @@ func (c dynamicOperatorClient) UpdateOperatorStatus(resourceVersion string, stat
 	return retStatus, nil
 }
 
-func (c dynamicOperatorClient) EnsureFinalizer(finalizer string) error {
+func (c dynamicOperatorClient) EnsureFinalizer(ctx context.Context, finalizer string) error {
 	uncastInstance, err := c.informer.Lister().Get(c.configName)
 	if err != nil {
 		return err
@@ -174,7 +174,7 @@ func (c dynamicOperatorClient) EnsureFinalizer(finalizer string) error {
 	// Change is needed
 	klog.V(4).Infof("Adding finalizer %q", finalizer)
 	newFinalizers := append(finalizers, finalizer)
-	err = c.saveFinalizers(instance, newFinalizers)
+	err = c.saveFinalizers(ctx, instance, newFinalizers)
 	if err != nil {
 		return err
 	}
@@ -182,7 +182,7 @@ func (c dynamicOperatorClient) EnsureFinalizer(finalizer string) error {
 	return err
 }
 
-func (c dynamicOperatorClient) RemoveFinalizer(finalizer string) error {
+func (c dynamicOperatorClient) RemoveFinalizer(ctx context.Context, finalizer string) error {
 	uncastInstance, err := c.informer.Lister().Get(c.configName)
 	if err != nil {
 		return err
@@ -204,7 +204,7 @@ func (c dynamicOperatorClient) RemoveFinalizer(finalizer string) error {
 	}
 
 	klog.V(4).Infof("Removing finalizer %q: %v", finalizer, newFinalizers)
-	err = c.saveFinalizers(instance, newFinalizers)
+	err = c.saveFinalizers(ctx, instance, newFinalizers)
 	if err != nil {
 		return err
 	}
@@ -212,10 +212,10 @@ func (c dynamicOperatorClient) RemoveFinalizer(finalizer string) error {
 	return nil
 }
 
-func (c dynamicOperatorClient) saveFinalizers(instance *unstructured.Unstructured, finalizers []string) error {
+func (c dynamicOperatorClient) saveFinalizers(ctx context.Context, instance *unstructured.Unstructured, finalizers []string) error {
 	clone := instance.DeepCopy()
 	clone.SetFinalizers(finalizers)
-	_, err := c.client.Update(context.TODO(), clone, metav1.UpdateOptions{})
+	_, err := c.client.Update(ctx, clone, metav1.UpdateOptions{})
 	return err
 }
 

--- a/pkg/operator/genericoperatorclient/dynamic_staticpod_operator_client.go
+++ b/pkg/operator/genericoperatorclient/dynamic_staticpod_operator_client.go
@@ -60,8 +60,8 @@ func (c dynamicStaticPodOperatorClient) GetStaticPodOperatorState() (*operatorv1
 	return spec, status, instance.GetResourceVersion(), nil
 }
 
-func (c dynamicStaticPodOperatorClient) GetStaticPodOperatorStateWithQuorum() (*operatorv1.StaticPodOperatorSpec, *operatorv1.StaticPodOperatorStatus, string, error) {
-	instance, err := c.client.Get(context.TODO(), "cluster", metav1.GetOptions{})
+func (c dynamicStaticPodOperatorClient) GetStaticPodOperatorStateWithQuorum(ctx context.Context) (*operatorv1.StaticPodOperatorSpec, *operatorv1.StaticPodOperatorStatus, string, error) {
+	instance, err := c.client.Get(ctx, "cluster", metav1.GetOptions{})
 	if err != nil {
 		return nil, nil, "", err
 	}
@@ -78,7 +78,7 @@ func (c dynamicStaticPodOperatorClient) GetStaticPodOperatorStateWithQuorum() (*
 	return spec, status, instance.GetResourceVersion(), nil
 }
 
-func (c dynamicStaticPodOperatorClient) UpdateStaticPodOperatorSpec(resourceVersion string, spec *operatorv1.StaticPodOperatorSpec) (*operatorv1.StaticPodOperatorSpec, string, error) {
+func (c dynamicStaticPodOperatorClient) UpdateStaticPodOperatorSpec(ctx context.Context, resourceVersion string, spec *operatorv1.StaticPodOperatorSpec) (*operatorv1.StaticPodOperatorSpec, string, error) {
 	uncastOriginal, err := c.informer.Lister().Get("cluster")
 	if err != nil {
 		return nil, "", err
@@ -91,7 +91,7 @@ func (c dynamicStaticPodOperatorClient) UpdateStaticPodOperatorSpec(resourceVers
 		return nil, "", err
 	}
 
-	ret, err := c.client.Update(context.TODO(), copy, metav1.UpdateOptions{})
+	ret, err := c.client.Update(ctx, copy, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, "", err
 	}
@@ -103,7 +103,7 @@ func (c dynamicStaticPodOperatorClient) UpdateStaticPodOperatorSpec(resourceVers
 	return retSpec, ret.GetResourceVersion(), nil
 }
 
-func (c dynamicStaticPodOperatorClient) UpdateStaticPodOperatorStatus(resourceVersion string, status *operatorv1.StaticPodOperatorStatus) (*operatorv1.StaticPodOperatorStatus, error) {
+func (c dynamicStaticPodOperatorClient) UpdateStaticPodOperatorStatus(ctx context.Context, resourceVersion string, status *operatorv1.StaticPodOperatorStatus) (*operatorv1.StaticPodOperatorStatus, error) {
 	uncastOriginal, err := c.informer.Lister().Get("cluster")
 	if err != nil {
 		return nil, err
@@ -116,7 +116,7 @@ func (c dynamicStaticPodOperatorClient) UpdateStaticPodOperatorStatus(resourceVe
 		return nil, err
 	}
 
-	ret, err := c.client.UpdateStatus(context.TODO(), copy, metav1.UpdateOptions{})
+	ret, err := c.client.UpdateStatus(ctx, copy, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operator/managementstatecontroller/management_state_controller.go
+++ b/pkg/operator/managementstatecontroller/management_state_controller.go
@@ -70,7 +70,7 @@ func (c ManagementStateController) sync(ctx context.Context, syncContext factory
 		cond.Message = fmt.Sprintf("Unsupported management state %q for %s operator", detailedSpec.ManagementState, c.operatorName)
 	}
 
-	if _, _, updateError := v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
+	if _, _, updateError := v1helpers.UpdateStatus(ctx, c.operatorClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
 		if err == nil {
 			return updateError
 		}

--- a/pkg/operator/managementstatecontroller/management_state_controller_test.go
+++ b/pkg/operator/managementstatecontroller/management_state_controller_test.go
@@ -135,11 +135,11 @@ func (c *statusClient) GetOperatorState() (*operatorv1.OperatorSpec, *operatorv1
 	return &c.spec, &c.status, "", nil
 }
 
-func (c *statusClient) UpdateOperatorSpec(string, *operatorv1.OperatorSpec) (spec *operatorv1.OperatorSpec, resourceVersion string, err error) {
+func (c *statusClient) UpdateOperatorSpec(context.Context, string, *operatorv1.OperatorSpec) (spec *operatorv1.OperatorSpec, resourceVersion string, err error) {
 	panic("missing")
 }
 
-func (c *statusClient) UpdateOperatorStatus(version string, s *operatorv1.OperatorStatus) (status *operatorv1.OperatorStatus, err error) {
+func (c *statusClient) UpdateOperatorStatus(ctx context.Context, version string, s *operatorv1.OperatorStatus) (status *operatorv1.OperatorStatus, err error) {
 	c.status = *s
 	return &c.status, nil
 }

--- a/pkg/operator/resourcesynccontroller/resourcesync_controller.go
+++ b/pkg/operator/resourcesynccontroller/resourcesync_controller.go
@@ -218,7 +218,7 @@ func (c *ResourceSyncController) Sync(ctx context.Context, syncCtx factory.SyncC
 			Reason:  "Error",
 			Message: v1helpers.NewMultiLineAggregate(errors).Error(),
 		}
-		if _, _, updateError := v1helpers.UpdateStatus(c.operatorConfigClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
+		if _, _, updateError := v1helpers.UpdateStatus(ctx, c.operatorConfigClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
 			return updateError
 		}
 		return nil
@@ -228,7 +228,7 @@ func (c *ResourceSyncController) Sync(ctx context.Context, syncCtx factory.SyncC
 		Type:   condition.ResourceSyncControllerDegradedConditionType,
 		Status: operatorv1.ConditionFalse,
 	}
-	if _, _, updateError := v1helpers.UpdateStatus(c.operatorConfigClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
+	if _, _, updateError := v1helpers.UpdateStatus(ctx, c.operatorConfigClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
 		return updateError
 	}
 	return nil

--- a/pkg/operator/revisioncontroller/revision_controller.go
+++ b/pkg/operator/revisioncontroller/revision_controller.go
@@ -31,7 +31,7 @@ type LatestRevisionClient interface {
 	// GetLatestRevisionState returns the spec, status and latest revision.
 	GetLatestRevisionState() (spec *operatorv1.OperatorSpec, status *operatorv1.OperatorStatus, rev int32, rv string, err error)
 	// UpdateLatestRevisionOperatorStatus updates the status with the given latestAvailableRevision and the by applying the given updateFuncs.
-	UpdateLatestRevisionOperatorStatus(latestAvailableRevision int32, updateFuncs ...v1helpers.UpdateStatusFunc) (*operatorv1.OperatorStatus, bool, error)
+	UpdateLatestRevisionOperatorStatus(ctx context.Context, latestAvailableRevision int32, updateFuncs ...v1helpers.UpdateStatusFunc) (*operatorv1.OperatorStatus, bool, error)
 }
 
 // RevisionController is a controller that watches a set of configmaps and secrets and them against a revision snapshot
@@ -112,7 +112,7 @@ func (c RevisionController) createRevisionIfNeeded(ctx context.Context, recorder
 		Type:   "RevisionControllerDegraded",
 		Status: operatorv1.ConditionFalse,
 	}
-	if _, updated, updateError := c.operatorClient.UpdateLatestRevisionOperatorStatus(nextRevision, v1helpers.UpdateConditionFn(cond)); updateError != nil {
+	if _, updated, updateError := c.operatorClient.UpdateLatestRevisionOperatorStatus(ctx, nextRevision, v1helpers.UpdateConditionFn(cond)); updateError != nil {
 		return true, updateError
 	} else if updated {
 		recorder.Eventf("RevisionCreate", "Revision %d created because %s", latestAvailableRevision, reason)
@@ -280,7 +280,7 @@ func (c RevisionController) sync(ctx context.Context, syncCtx factory.SyncContex
 		}
 		if latestRevision != 0 {
 			// Then make sure that revision number is what's in the operator status
-			_, _, err := c.operatorClient.UpdateLatestRevisionOperatorStatus(latestRevision)
+			_, _, err := c.operatorClient.UpdateLatestRevisionOperatorStatus(ctx, latestRevision)
 			if err != nil {
 				return err
 			}

--- a/pkg/operator/revisioncontroller/revision_controller.go
+++ b/pkg/operator/revisioncontroller/revision_controller.go
@@ -101,7 +101,7 @@ func (c RevisionController) createRevisionIfNeeded(ctx context.Context, recorder
 			Reason:  "ContentCreationError",
 			Message: err.Error(),
 		}
-		if _, _, updateError := v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
+		if _, _, updateError := v1helpers.UpdateStatus(ctx, c.operatorClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
 			recorder.Warningf("RevisionCreateFailed", "Failed to create revision %d: %v", nextRevision, err.Error())
 			return true, updateError
 		}
@@ -305,7 +305,7 @@ func (c RevisionController) sync(ctx context.Context, syncCtx factory.SyncContex
 		cond.Reason = "Error"
 		cond.Message = err.Error()
 	}
-	if _, _, updateError := v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
+	if _, _, updateError := v1helpers.UpdateStatus(ctx, c.operatorClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
 		if err == nil {
 			return updateError
 		}

--- a/pkg/operator/staleconditions/remove_stale_conditions.go
+++ b/pkg/operator/staleconditions/remove_stale_conditions.go
@@ -36,7 +36,7 @@ func (c RemoveStaleConditionsController) sync(ctx context.Context, syncContext f
 		return nil
 	}
 
-	if _, _, err := v1helpers.UpdateStatus(c.operatorClient, removeStaleConditionsFn); err != nil {
+	if _, _, err := v1helpers.UpdateStatus(ctx, c.operatorClient, removeStaleConditionsFn); err != nil {
 		return err
 	}
 

--- a/pkg/operator/staticpod/controller/installer/installer_controller.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller.go
@@ -498,7 +498,7 @@ func (c *InstallerController) manageInstallationPods(ctx context.Context, operat
 			// it's an extra write/read, but it makes the state debuggable from outside this process
 			if !equality.Semantic.DeepEqual(newCurrNodeState, currNodeState) {
 				klog.Infof("%q moving to %v because %s", currNodeState.NodeName, spew.Sdump(*newCurrNodeState), reason)
-				_, updated, updateError := v1helpers.UpdateStaticPodStatus(c.operatorClient, setNodeStatusFn(newCurrNodeState), setAvailableProgressingNodeInstallerFailingConditions)
+				_, updated, updateError := v1helpers.UpdateStaticPodStatus(ctx, c.operatorClient, setNodeStatusFn(newCurrNodeState), setAvailableProgressingNodeInstallerFailingConditions)
 				if updateError != nil {
 					return false, 0, updateError
 				} else if updated && currNodeState.CurrentRevision != newCurrNodeState.CurrentRevision {
@@ -530,7 +530,7 @@ func (c *InstallerController) manageInstallationPods(ctx context.Context, operat
 		// it's an extra write/read, but it makes the state debuggable from outside this process
 		if !equality.Semantic.DeepEqual(newCurrNodeState, currNodeState) {
 			klog.Infof("%q moving to %v", currNodeState.NodeName, spew.Sdump(*newCurrNodeState))
-			if _, updated, updateError := v1helpers.UpdateStaticPodStatus(c.operatorClient, setNodeStatusFn(newCurrNodeState), setAvailableProgressingNodeInstallerFailingConditions); updateError != nil {
+			if _, updated, updateError := v1helpers.UpdateStaticPodStatus(ctx, c.operatorClient, setNodeStatusFn(newCurrNodeState), setAvailableProgressingNodeInstallerFailingConditions); updateError != nil {
 				return false, 0, updateError
 			} else if updated && currNodeState.TargetRevision != newCurrNodeState.TargetRevision && newCurrNodeState.TargetRevision != 0 {
 				c.eventRecorder.Eventf("NodeTargetRevisionChanged", "Updating node %q from revision %d to %d because %s", currNodeState.NodeName,
@@ -1084,7 +1084,7 @@ func (c InstallerController) Sync(ctx context.Context, syncCtx factory.SyncConte
 		cond.Reason = "Error"
 		cond.Message = err.Error()
 	}
-	if _, _, updateError := v1helpers.UpdateStaticPodStatus(c.operatorClient, v1helpers.UpdateStaticPodConditionFn(cond), setAvailableProgressingNodeInstallerFailingConditions); updateError != nil {
+	if _, _, updateError := v1helpers.UpdateStaticPodStatus(ctx, c.operatorClient, v1helpers.UpdateStaticPodConditionFn(cond), setAvailableProgressingNodeInstallerFailingConditions); updateError != nil {
 		if err == nil {
 			return updateError
 		}

--- a/pkg/operator/staticpod/controller/installer/installer_controller_test.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller_test.go
@@ -935,7 +935,7 @@ func testSync(t *testing.T, firstInstallerBehaviour testSyncInstallerBehaviour, 
 				NodeName:        "test-node-1",
 				CurrentRevision: 3,
 			}
-			if _, err := fakeStaticPodOperatorClient.UpdateStaticPodOperatorStatus(rv, status); err != nil {
+			if _, err := fakeStaticPodOperatorClient.UpdateStaticPodOperatorStatus(context.TODO(), rv, status); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -1023,7 +1023,7 @@ func testSync(t *testing.T, firstInstallerBehaviour testSyncInstallerBehaviour, 
 			NodeName:        "test-node-1",
 			CurrentRevision: 3,
 		}
-		if _, err := fakeStaticPodOperatorClient.UpdateStaticPodOperatorStatus(rv, status); err != nil {
+		if _, err := fakeStaticPodOperatorClient.UpdateStaticPodOperatorStatus(context.TODO(), rv, status); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/pkg/operator/staticpod/controller/installerstate/installer_state_controller.go
+++ b/pkg/operator/staticpod/controller/installerstate/installer_state_controller.go
@@ -105,7 +105,7 @@ func (c *InstallerStateController) sync(ctx context.Context, syncCtx factory.Syn
 		updateConditionFuncs = append(updateConditionFuncs, v1helpers.UpdateStaticPodConditionFn(updatedCondition))
 	}
 
-	if _, _, err := v1helpers.UpdateStaticPodStatus(c.operatorClient, updateConditionFuncs...); err != nil {
+	if _, _, err := v1helpers.UpdateStaticPodStatus(ctx, c.operatorClient, updateConditionFuncs...); err != nil {
 		return err
 	}
 

--- a/pkg/operator/staticpod/controller/node/node_controller.go
+++ b/pkg/operator/staticpod/controller/node/node_controller.go
@@ -115,7 +115,7 @@ func (c NodeController) sync(ctx context.Context, syncCtx factory.SyncContext) e
 	}
 
 	oldStatus := &operatorv1.StaticPodOperatorStatus{}
-	_, updated, updateError := v1helpers.UpdateStaticPodStatus(c.operatorClient, func(status *operatorv1.StaticPodOperatorStatus) error {
+	_, updated, updateError := v1helpers.UpdateStaticPodStatus(ctx, c.operatorClient, func(status *operatorv1.StaticPodOperatorStatus) error {
 		//a hack for storing the old status (before we mutate it)
 		oldStatus = status
 		return nil

--- a/pkg/operator/staticpod/controller/startupmonitorcondition/startup_monitor_condition.go
+++ b/pkg/operator/staticpod/controller/startupmonitorcondition/startup_monitor_condition.go
@@ -41,13 +41,13 @@ func New(targetNamespace string,
 	return factory.New().WithSync(fd.sync).ResyncEvery(6*time.Minute).WithInformers(kubeInformersForNamespaces.InformersFor(targetNamespace).Core().V1().Pods().Informer(), operatorClient.Informer()).ToController("StartupMonitorPodCondition", eventRecorder)
 }
 
-func (fd *startupMonitorPodConditionController) sync(_ context.Context, _ factory.SyncContext) (err error) {
+func (fd *startupMonitorPodConditionController) sync(ctx context.Context, _ factory.SyncContext) (err error) {
 	startupPodDegraded := &operatorv1.OperatorCondition{Type: "StartupMonitorPodDegraded", Status: operatorv1.ConditionFalse}
 	startupPodContainerExcessiveRestartsDegraded := &operatorv1.OperatorCondition{Type: "StartupMonitorPodContainerExcessiveRestartsDegraded", Status: operatorv1.ConditionFalse}
 
 	defer func() {
 		if err == nil {
-			if _, _, updateError := operatorv1helpers.UpdateStatus(fd.operatorClient,
+			if _, _, updateError := operatorv1helpers.UpdateStatus(ctx, fd.operatorClient,
 				operatorv1helpers.UpdateConditionFn(*startupPodDegraded),
 				operatorv1helpers.UpdateConditionFn(*startupPodContainerExcessiveRestartsDegraded)); updateError != nil {
 				err = updateError

--- a/pkg/operator/staticpod/controller/staticpodfallback/static_pod_fallback_condition.go
+++ b/pkg/operator/staticpod/controller/staticpodfallback/static_pod_fallback_condition.go
@@ -42,11 +42,11 @@ func New(targetNamespace string,
 }
 
 // sync sets/unsets a StaticPodFallbackRevisionDegraded condition if a pod that matches the given label selector is annotated with FallbackForRevision
-func (fd *staticPodFallbackConditionController) sync(_ context.Context, _ factory.SyncContext) (err error) {
+func (fd *staticPodFallbackConditionController) sync(ctx context.Context, _ factory.SyncContext) (err error) {
 	degradedCondition := operatorv1.OperatorCondition{Type: "StaticPodFallbackRevisionDegraded", Status: operatorv1.ConditionFalse}
 	defer func() {
 		if err == nil {
-			if _, _, updateError := operatorv1helpers.UpdateStatus(fd.operatorClient, operatorv1helpers.UpdateConditionFn(degradedCondition)); updateError != nil {
+			if _, _, updateError := operatorv1helpers.UpdateStatus(ctx, fd.operatorClient, operatorv1helpers.UpdateConditionFn(degradedCondition)); updateError != nil {
 				err = updateError
 			}
 		}

--- a/pkg/operator/staticpod/controller/staticpodstate/staticpodstate_controller.go
+++ b/pkg/operator/staticpod/controller/staticpodstate/staticpodstate_controller.go
@@ -173,7 +173,7 @@ func (c *StaticPodStateController) sync(ctx context.Context, syncCtx factory.Syn
 		cond.Reason = "Error"
 		cond.Message = v1helpers.NewMultiLineAggregate(errs).Error()
 	}
-	if _, _, updateError := v1helpers.UpdateStaticPodStatus(c.operatorClient, v1helpers.UpdateStaticPodConditionFn(cond), v1helpers.UpdateStaticPodConditionFn(cond)); updateError != nil {
+	if _, _, updateError := v1helpers.UpdateStaticPodStatus(ctx, c.operatorClient, v1helpers.UpdateStaticPodConditionFn(cond), v1helpers.UpdateStaticPodConditionFn(cond)); updateError != nil {
 		return updateError
 	}
 

--- a/pkg/operator/staticresourcecontroller/static_resource_controller.go
+++ b/pkg/operator/staticresourcecontroller/static_resource_controller.go
@@ -246,7 +246,7 @@ func (c StaticResourceController) Sync(ctx context.Context, syncContext factory.
 		}
 	}
 
-	_, _, err = v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(cnd))
+	_, _, err = v1helpers.UpdateStatus(ctx, c.operatorClient, v1helpers.UpdateConditionFn(cnd))
 	if err != nil {
 		errors = append(errors, err)
 	}

--- a/pkg/operator/status/status_controller_test.go
+++ b/pkg/operator/status/status_controller_test.go
@@ -480,10 +480,10 @@ func (c *statusClient) GetOperatorState() (*operatorv1.OperatorSpec, *operatorv1
 	return &c.spec, &c.status, "", nil
 }
 
-func (c *statusClient) UpdateOperatorSpec(string, *operatorv1.OperatorSpec) (spec *operatorv1.OperatorSpec, resourceVersion string, err error) {
+func (c *statusClient) UpdateOperatorSpec(context.Context, string, *operatorv1.OperatorSpec) (spec *operatorv1.OperatorSpec, resourceVersion string, err error) {
 	panic("missing")
 }
 
-func (c *statusClient) UpdateOperatorStatus(string, *operatorv1.OperatorStatus) (status *operatorv1.OperatorStatus, err error) {
+func (c *statusClient) UpdateOperatorStatus(context.Context, string, *operatorv1.OperatorStatus) (status *operatorv1.OperatorStatus, err error) {
 	panic("missing")
 }

--- a/pkg/operator/unsupportedconfigoverridescontroller/unsupportedconfigoverrides_controller.go
+++ b/pkg/operator/unsupportedconfigoverridescontroller/unsupportedconfigoverrides_controller.go
@@ -63,7 +63,7 @@ func (c *UnsupportedConfigOverridesController) sync(ctx context.Context, syncCtx
 		}
 	}
 
-	if _, _, updateError := v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
+	if _, _, updateError := v1helpers.UpdateStatus(ctx, c.operatorClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
 		return updateError
 	}
 	return nil

--- a/pkg/operator/v1helpers/helpers.go
+++ b/pkg/operator/v1helpers/helpers.go
@@ -1,6 +1,7 @@
 package v1helpers
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -115,7 +116,7 @@ func IsOperatorConditionPresentAndEqual(conditions []operatorv1.OperatorConditio
 type UpdateOperatorSpecFunc func(spec *operatorv1.OperatorSpec) error
 
 // UpdateSpec applies the update funcs to the oldStatus and tries to update via the client.
-func UpdateSpec(client OperatorClient, updateFuncs ...UpdateOperatorSpecFunc) (*operatorv1.OperatorSpec, bool, error) {
+func UpdateSpec(ctx context.Context, client OperatorClient, updateFuncs ...UpdateOperatorSpecFunc) (*operatorv1.OperatorSpec, bool, error) {
 	updated := false
 	var operatorSpec *operatorv1.OperatorSpec
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
@@ -135,7 +136,7 @@ func UpdateSpec(client OperatorClient, updateFuncs ...UpdateOperatorSpecFunc) (*
 			return nil
 		}
 
-		operatorSpec, _, err = client.UpdateOperatorSpec(resourceVersion, newSpec)
+		operatorSpec, _, err = client.UpdateOperatorSpec(ctx, resourceVersion, newSpec)
 		updated = err == nil
 		return err
 	})
@@ -155,7 +156,7 @@ func UpdateObservedConfigFn(config map[string]interface{}) UpdateOperatorSpecFun
 type UpdateStatusFunc func(status *operatorv1.OperatorStatus) error
 
 // UpdateStatus applies the update funcs to the oldStatus and tries to update via the client.
-func UpdateStatus(client OperatorClient, updateFuncs ...UpdateStatusFunc) (*operatorv1.OperatorStatus, bool, error) {
+func UpdateStatus(ctx context.Context, client OperatorClient, updateFuncs ...UpdateStatusFunc) (*operatorv1.OperatorStatus, bool, error) {
 	updated := false
 	var updatedOperatorStatus *operatorv1.OperatorStatus
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
@@ -177,7 +178,7 @@ func UpdateStatus(client OperatorClient, updateFuncs ...UpdateStatusFunc) (*oper
 			return nil
 		}
 
-		updatedOperatorStatus, err = client.UpdateOperatorStatus(resourceVersion, newStatus)
+		updatedOperatorStatus, err = client.UpdateOperatorStatus(ctx, resourceVersion, newStatus)
 		updated = err == nil
 		return err
 	})
@@ -197,7 +198,7 @@ func UpdateConditionFn(cond operatorv1.OperatorCondition) UpdateStatusFunc {
 type UpdateStaticPodStatusFunc func(status *operatorv1.StaticPodOperatorStatus) error
 
 // UpdateStaticPodStatus applies the update funcs to the oldStatus abd tries to update via the client.
-func UpdateStaticPodStatus(client StaticPodOperatorClient, updateFuncs ...UpdateStaticPodStatusFunc) (*operatorv1.StaticPodOperatorStatus, bool, error) {
+func UpdateStaticPodStatus(ctx context.Context, client StaticPodOperatorClient, updateFuncs ...UpdateStaticPodStatusFunc) (*operatorv1.StaticPodOperatorStatus, bool, error) {
 	updated := false
 	var updatedOperatorStatus *operatorv1.StaticPodOperatorStatus
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
@@ -219,7 +220,7 @@ func UpdateStaticPodStatus(client StaticPodOperatorClient, updateFuncs ...Update
 			return nil
 		}
 
-		updatedOperatorStatus, err = client.UpdateStaticPodOperatorStatus(resourceVersion, newStatus)
+		updatedOperatorStatus, err = client.UpdateStaticPodOperatorStatus(ctx, resourceVersion, newStatus)
 		updated = err == nil
 		return err
 	})
@@ -238,10 +239,10 @@ func UpdateStaticPodConditionFn(cond operatorv1.OperatorCondition) UpdateStaticP
 // EnsureFinalizer adds a new finalizer to the operator CR, if it does not exists. No-op otherwise.
 // The finalizer name is computed from the controller name and operator name ($OPERATOR_NAME or os.Args[0])
 // It re-tries on conflicts.
-func EnsureFinalizer(client OperatorClientWithFinalizers, controllerName string) error {
+func EnsureFinalizer(ctx context.Context, client OperatorClientWithFinalizers, controllerName string) error {
 	finalizer := getFinalizerName(controllerName)
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		return client.EnsureFinalizer(finalizer)
+		return client.EnsureFinalizer(ctx, finalizer)
 	})
 	return err
 }
@@ -249,10 +250,10 @@ func EnsureFinalizer(client OperatorClientWithFinalizers, controllerName string)
 // RemoveFinalizer removes a finalizer from the operator CR, if it is there. No-op otherwise.
 // The finalizer name is computed from the controller name and operator name ($OPERATOR_NAME or os.Args[0])
 // It re-tries on conflicts.
-func RemoveFinalizer(client OperatorClientWithFinalizers, controllerName string) error {
+func RemoveFinalizer(ctx context.Context, client OperatorClientWithFinalizers, controllerName string) error {
 	finalizer := getFinalizerName(controllerName)
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		return client.RemoveFinalizer(finalizer)
+		return client.RemoveFinalizer(ctx, finalizer)
 	})
 	return err
 }

--- a/pkg/operator/v1helpers/interfaces.go
+++ b/pkg/operator/v1helpers/interfaces.go
@@ -1,6 +1,8 @@
 package v1helpers
 
 import (
+	"context"
+
 	operatorv1 "github.com/openshift/api/operator/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
@@ -13,9 +15,9 @@ type OperatorClient interface {
 	// GetOperatorState returns the operator spec, status and the resource version, potentially from a lister.
 	GetOperatorState() (spec *operatorv1.OperatorSpec, status *operatorv1.OperatorStatus, resourceVersion string, err error)
 	// UpdateOperatorSpec updates the spec of the operator, assuming the given resource version.
-	UpdateOperatorSpec(oldResourceVersion string, in *operatorv1.OperatorSpec) (out *operatorv1.OperatorSpec, newResourceVersion string, err error)
+	UpdateOperatorSpec(ctx context.Context, oldResourceVersion string, in *operatorv1.OperatorSpec) (out *operatorv1.OperatorSpec, newResourceVersion string, err error)
 	// UpdateOperatorStatus updates the status of the operator, assuming the given resource version.
-	UpdateOperatorStatus(oldResourceVersion string, in *operatorv1.OperatorStatus) (out *operatorv1.OperatorStatus, err error)
+	UpdateOperatorStatus(ctx context.Context, oldResourceVersion string, in *operatorv1.OperatorStatus) (out *operatorv1.OperatorStatus, err error)
 }
 
 type StaticPodOperatorClient interface {
@@ -25,17 +27,17 @@ type StaticPodOperatorClient interface {
 	GetStaticPodOperatorState() (spec *operatorv1.StaticPodOperatorSpec, status *operatorv1.StaticPodOperatorStatus, resourceVersion string, err error)
 	// GetStaticPodOperatorStateWithQuorum return the static pod operator spec, status and resource version
 	// directly from a server read.
-	GetStaticPodOperatorStateWithQuorum() (spec *operatorv1.StaticPodOperatorSpec, status *operatorv1.StaticPodOperatorStatus, resourceVersion string, err error)
+	GetStaticPodOperatorStateWithQuorum(ctx context.Context) (spec *operatorv1.StaticPodOperatorSpec, status *operatorv1.StaticPodOperatorStatus, resourceVersion string, err error)
 	// UpdateStaticPodOperatorStatus updates the status, assuming the given resource version.
-	UpdateStaticPodOperatorStatus(resourceVersion string, in *operatorv1.StaticPodOperatorStatus) (out *operatorv1.StaticPodOperatorStatus, err error)
+	UpdateStaticPodOperatorStatus(ctx context.Context, resourceVersion string, in *operatorv1.StaticPodOperatorStatus) (out *operatorv1.StaticPodOperatorStatus, err error)
 	// UpdateStaticPodOperatorSpec updates the spec, assuming the given resource  version.
-	UpdateStaticPodOperatorSpec(resourceVersion string, in *operatorv1.StaticPodOperatorSpec) (out *operatorv1.StaticPodOperatorSpec, newResourceVersion string, err error)
+	UpdateStaticPodOperatorSpec(ctx context.Context, resourceVersion string, in *operatorv1.StaticPodOperatorSpec) (out *operatorv1.StaticPodOperatorSpec, newResourceVersion string, err error)
 }
 
 type OperatorClientWithFinalizers interface {
 	OperatorClient
 	// EnsureFinalizer adds a new finalizer to the operator CR, if it does not exists. No-op otherwise.
-	EnsureFinalizer(finalizer string) error
+	EnsureFinalizer(ctx context.Context, finalizer string) error
 	// RemoveFinalizer removes a finalizer from the operator CR, if it is there. No-op otherwise.
-	RemoveFinalizer(finalizer string) error
+	RemoveFinalizer(ctx context.Context, finalizer string) error
 }

--- a/pkg/operator/v1helpers/test_helpers.go
+++ b/pkg/operator/v1helpers/test_helpers.go
@@ -97,11 +97,11 @@ func (c *fakeStaticPodOperatorClient) GetStaticPodOperatorState() (*operatorv1.S
 	return c.fakeStaticPodOperatorSpec, c.fakeStaticPodOperatorStatus, c.resourceVersion, nil
 }
 
-func (c *fakeStaticPodOperatorClient) GetStaticPodOperatorStateWithQuorum() (*operatorv1.StaticPodOperatorSpec, *operatorv1.StaticPodOperatorStatus, string, error) {
+func (c *fakeStaticPodOperatorClient) GetStaticPodOperatorStateWithQuorum(ctx context.Context) (*operatorv1.StaticPodOperatorSpec, *operatorv1.StaticPodOperatorStatus, string, error) {
 	return c.fakeStaticPodOperatorSpec, c.fakeStaticPodOperatorStatus, c.resourceVersion, nil
 }
 
-func (c *fakeStaticPodOperatorClient) UpdateStaticPodOperatorStatus(resourceVersion string, status *operatorv1.StaticPodOperatorStatus) (*operatorv1.StaticPodOperatorStatus, error) {
+func (c *fakeStaticPodOperatorClient) UpdateStaticPodOperatorStatus(ctx context.Context, resourceVersion string, status *operatorv1.StaticPodOperatorStatus) (*operatorv1.StaticPodOperatorStatus, error) {
 	if c.resourceVersion != resourceVersion {
 		return nil, errors.NewConflict(schema.GroupResource{Group: operatorv1.GroupName, Resource: "TestOperatorConfig"}, "instance", fmt.Errorf("invalid resourceVersion"))
 	}
@@ -119,7 +119,7 @@ func (c *fakeStaticPodOperatorClient) UpdateStaticPodOperatorStatus(resourceVers
 	return c.fakeStaticPodOperatorStatus, nil
 }
 
-func (c *fakeStaticPodOperatorClient) UpdateStaticPodOperatorSpec(resourceVersion string, spec *operatorv1.StaticPodOperatorSpec) (*operatorv1.StaticPodOperatorSpec, string, error) {
+func (c *fakeStaticPodOperatorClient) UpdateStaticPodOperatorSpec(ctx context.Context, resourceVersion string, spec *operatorv1.StaticPodOperatorSpec) (*operatorv1.StaticPodOperatorSpec, string, error) {
 	if c.resourceVersion != resourceVersion {
 		return nil, "", errors.NewConflict(schema.GroupResource{Group: operatorv1.GroupName, Resource: "TestOperatorConfig"}, "instance", fmt.Errorf("invalid resourceVersion"))
 	}
@@ -140,10 +140,10 @@ func (c *fakeStaticPodOperatorClient) UpdateStaticPodOperatorSpec(resourceVersio
 func (c *fakeStaticPodOperatorClient) GetOperatorState() (*operatorv1.OperatorSpec, *operatorv1.OperatorStatus, string, error) {
 	return &c.fakeStaticPodOperatorSpec.OperatorSpec, &c.fakeStaticPodOperatorStatus.OperatorStatus, c.resourceVersion, nil
 }
-func (c *fakeStaticPodOperatorClient) UpdateOperatorSpec(string, *operatorv1.OperatorSpec) (spec *operatorv1.OperatorSpec, resourceVersion string, err error) {
+func (c *fakeStaticPodOperatorClient) UpdateOperatorSpec(context.Context, string, *operatorv1.OperatorSpec) (spec *operatorv1.OperatorSpec, resourceVersion string, err error) {
 	panic("not supported")
 }
-func (c *fakeStaticPodOperatorClient) UpdateOperatorStatus(resourceVersion string, status *operatorv1.OperatorStatus) (*operatorv1.OperatorStatus, error) {
+func (c *fakeStaticPodOperatorClient) UpdateOperatorStatus(ctx context.Context, resourceVersion string, status *operatorv1.OperatorStatus) (*operatorv1.OperatorStatus, error) {
 	if c.resourceVersion != resourceVersion {
 		return nil, errors.NewConflict(schema.GroupResource{Group: operatorv1.GroupName, Resource: "TestOperatorConfig"}, "instance", fmt.Errorf("invalid resourceVersion"))
 	}
@@ -227,7 +227,7 @@ func (c *fakeOperatorClient) GetOperatorState() (*operatorv1.OperatorSpec, *oper
 	return c.fakeOperatorSpec, c.fakeOperatorStatus, c.resourceVersion, nil
 }
 
-func (c *fakeOperatorClient) UpdateOperatorStatus(resourceVersion string, status *operatorv1.OperatorStatus) (*operatorv1.OperatorStatus, error) {
+func (c *fakeOperatorClient) UpdateOperatorStatus(ctx context.Context, resourceVersion string, status *operatorv1.OperatorStatus) (*operatorv1.OperatorStatus, error) {
 	if c.resourceVersion != resourceVersion {
 		return nil, errors.NewConflict(schema.GroupResource{Group: operatorv1.GroupName, Resource: "TestOperatorConfig"}, "instance", fmt.Errorf("invalid resourceVersion"))
 	}
@@ -245,7 +245,7 @@ func (c *fakeOperatorClient) UpdateOperatorStatus(resourceVersion string, status
 	return c.fakeOperatorStatus, nil
 }
 
-func (c *fakeOperatorClient) UpdateOperatorSpec(resourceVersion string, spec *operatorv1.OperatorSpec) (*operatorv1.OperatorSpec, string, error) {
+func (c *fakeOperatorClient) UpdateOperatorSpec(ctx context.Context, resourceVersion string, spec *operatorv1.OperatorSpec) (*operatorv1.OperatorSpec, string, error) {
 	if c.resourceVersion != resourceVersion {
 		return nil, c.resourceVersion, errors.NewConflict(schema.GroupResource{Group: operatorv1.GroupName, Resource: "TestOperatorConfig"}, "instance", fmt.Errorf("invalid resourceVersion"))
 	}
@@ -258,7 +258,7 @@ func (c *fakeOperatorClient) UpdateOperatorSpec(resourceVersion string, spec *op
 	return c.fakeOperatorSpec, c.resourceVersion, nil
 }
 
-func (c *fakeOperatorClient) EnsureFinalizer(finalizer string) error {
+func (c *fakeOperatorClient) EnsureFinalizer(ctx context.Context, finalizer string) error {
 	if c.fakeObjectMeta == nil {
 		c.fakeObjectMeta = &metav1.ObjectMeta{}
 	}
@@ -271,7 +271,7 @@ func (c *fakeOperatorClient) EnsureFinalizer(finalizer string) error {
 	return nil
 }
 
-func (c *fakeOperatorClient) RemoveFinalizer(finalizer string) error {
+func (c *fakeOperatorClient) RemoveFinalizer(ctx context.Context, finalizer string) error {
 	newFinalizers := []string{}
 	for _, f := range c.fakeObjectMeta.Finalizers {
 		if f == finalizer {


### PR DESCRIPTION
I think I have identified all methods that need context.

The changes to the interface can be seen in https://github.com/openshift/library-go/pull/1193/commits/8e20363325ab1eaa3518242745fb42c5a1ee3847#diff-0e7fb0f95ea48e43d0cad6743df9338e45348ebb2ca9aa0c5491eda440642b45
