### PR TITLE
startup-monitor: allows for logging to a log file in addition to stderr

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac
 	gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d // indirect
 	gopkg.in/ldap.v2 v2.5.1
+	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	k8s.io/api v0.22.1
 	k8s.io/apiextensions-apiserver v0.22.1
 	k8s.io/apimachinery v0.22.1

--- a/pkg/operator/staticpod/startupmonitor/assets/startup-monitor-pod.yaml
+++ b/pkg/operator/staticpod/startupmonitor/assets/startup-monitor-pod.yaml
@@ -22,6 +22,15 @@ spec:
         - --revision=REVISION
         - --node-name=NODE_NAME
         - --kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/kube-apiserver-cert-syncer-kubeconfig/kubeconfig #TODO: use a different config
+        {{- if .LogFilePath}}
+        - --log-file-path={{.LogFilePath}}
+        # since klog binds to go's std flag pkg
+        # indicate that we want to log to a file
+        # this is necessary, otherwise logging to stderr and a file won't work
+        - --logtostderr=false
+        # now indicate that we want to log to stderr and a file
+        - --alsologtostderr=true
+        {{- end}}
       volumeMounts:
         - mountPath: /etc/kubernetes/manifests
           name: manifests
@@ -37,6 +46,10 @@ spec:
           readOnly: true
         - mountPath: /var/lock
           name: var-lock
+        {{- if .LogFileDir}}
+        - mountPath: {{ .LogFileDir}}
+          name: var-log
+        {{- end}}
       resources:
         requests:
           memory: 50Mi
@@ -61,3 +74,8 @@ spec:
     - hostPath:
         path: /var/lock
       name: var-lock
+   {{- if .LogFileDir}}
+    - hostPath:
+        path: {{ .LogFileDir}}
+      name: var-log
+    {{- end}}

--- a/pkg/operator/staticpod/startupmonitor/pod_template.go
+++ b/pkg/operator/staticpod/startupmonitor/pod_template.go
@@ -3,6 +3,7 @@ package startupmonitor
 import (
 	"bytes"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"text/template"
 
@@ -15,9 +16,11 @@ type startupMonitorTemplate struct {
 	TargetName      string
 	OperatorImage   string
 	Verbosity       string
+	LogFilePath     string
+	LogFileDir      string
 }
 
-func GeneratePodTemplate(operatorSpec *operatorv1.StaticPodOperatorSpec, command []string, targetNamespace, targetName, targetImagePullSpec string) (string, error) {
+func GeneratePodTemplate(operatorSpec *operatorv1.StaticPodOperatorSpec, command []string, targetNamespace, targetName, targetImagePullSpec, logFile string) (string, error) {
 	rawStartupMonitorManifest := mustAsset("assets/startup-monitor-pod.yaml")
 
 	var verbosity string
@@ -44,6 +47,13 @@ func GeneratePodTemplate(operatorSpec *operatorv1.StaticPodOperatorSpec, command
 		TargetName:      targetName,
 		OperatorImage:   targetImagePullSpec,
 		Verbosity:       verbosity,
+		LogFilePath:     logFile,
+		LogFileDir: func() string {
+			if len(logFile) == 0 {
+				return ""
+			}
+			return filepath.Dir(logFile)
+		}(),
 	}
 	tmpl, err := template.New("monitor").Parse(string(rawStartupMonitorManifest))
 	if err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -571,6 +571,7 @@ gopkg.in/inf.v0
 ## explicit
 gopkg.in/ldap.v2
 # gopkg.in/natefinch/lumberjack.v2 v2.0.0
+## explicit
 gopkg.in/natefinch/lumberjack.v2
 # gopkg.in/yaml.v2 v2.4.0
 gopkg.in/yaml.v2


### PR DESCRIPTION
since kubelet doesn't respect the restart policy for static pods
we need to store the logs in a file for future troubleshooting

this PR introduces a new flag that allows specifying a log file.
the file will be rotated on a monthly basis and we will retain only the last 3 files.