### PR TITLE
Correct argument order in 'Failed to create installer pod for revision'

### DIFF
--- a/pkg/operator/staticpod/controller/installer/installer_controller.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller.go
@@ -475,7 +475,7 @@ func (c *InstallerController) manageInstallationPods(ctx context.Context, operat
 
 				if err := c.ensureInstallerPod(ctx, operatorSpec, currNodeState); err != nil {
 					c.eventRecorder.Warningf("InstallerPodFailed", "Failed to create installer pod for revision %d count %d on node %q: %v",
-						currNodeState.TargetRevision, currNodeState.NodeName, currNodeState.LastFailedCount, err)
+						currNodeState.TargetRevision, currNodeState.LastFailedCount, currNodeState.NodeName, err)
 					// if a newer revision is pending, continue, so we retry later with the latest available revision
 					if !(operatorStatus.LatestAvailableRevision > currNodeState.TargetRevision) {
 						return true, 0, err


### PR DESCRIPTION
In SNO kube-apiserver operator pog logs, saw many:
```
2021-09-03T02:22:58.369647152Z I0903 02:22:58.369501       1 event.go:282] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-apiserver-operator", Name:"kube-apiserver-operator", UID:"2ed1e3f1-3ea4-407c-b072-b14daeb11140", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'InstallerPodFailed' Failed to create installer pod for revision 11 count %!d(string=xxia0902epic-gqg7k-master-0.c.openshift-qe.internal) on node '\x00': Get "https://172.30.0.1:443/api/v1/namespaces/openshift-kube-apiserver/pods/installer-11-xxia0902epic-gqg7k-master-0.c.openshift-qe.internal": dial tcp 172.30.0.1:443: connect: connection refused
```
Note: Failed to create installer pod for revision 11 count %!d(string=xxia0902epic-gqg7k-master-0.c.openshift-qe.internal) on node '\x00' . Checked the code, found the 2nd and 3rd arguments order is wrong.