### PR TITLE
[OCPCLOUD-1186] Handle DisableCloudProviders feature gate as cloud-provider=external

### DIFF
--- a/pkg/cloudprovider/external.go
+++ b/pkg/cloudprovider/external.go
@@ -12,6 +12,11 @@ const (
 	// This is used to flag to operators that the cluster should be using the external cloud-controller-manager
 	// rather than the in-tree cloud controller loops.
 	ExternalCloudProviderFeature = "ExternalCloudProvider"
+
+	// DisableCloudProviders is an upstream feature gate that disables cloud initialization within
+	// KCM, KAS and Kubelet.
+	// https://github.com/kubernetes/kubernetes/blob/4615578137f42cb69c2e193723a2366ce7eb73c3/pkg/features/kube_features.go#L569-L570
+	DisableCloudProvidersFeature = "DisableCloudProviders"
 )
 
 // IsCloudProviderExternal is used to check whether external cloud provider settings should be used in a component.
@@ -63,5 +68,6 @@ func isExternalFeatureGateEnabled(featureGate *configv1.FeatureGate) (bool, erro
 		disabledFeatureGates = sets.NewString(featureGate.Spec.CustomNoUpgrade.Disabled...)
 	}
 
-	return !disabledFeatureGates.Has(ExternalCloudProviderFeature) && enabledFeatureGates.Has(ExternalCloudProviderFeature), nil
+	return !disabledFeatureGates.Has(ExternalCloudProviderFeature) && enabledFeatureGates.Has(ExternalCloudProviderFeature) ||
+		!disabledFeatureGates.Has(DisableCloudProvidersFeature) && enabledFeatureGates.Has(DisableCloudProvidersFeature), nil
 }

--- a/pkg/cloudprovider/external_test.go
+++ b/pkg/cloudprovider/external_test.go
@@ -267,6 +267,56 @@ func TestIsCloudProviderExternal(t *testing.T) {
 		},
 		expected:    false,
 		expectedErr: fmt.Errorf("platformStatus is required"),
+	}, {
+		name: "FeatureSet: CustomNoUpgrade (With Disable Cloud Providers Feature Gate), Platform: AWS",
+		status: &configv1.PlatformStatus{
+			Type: configv1.AWSPlatformType,
+		},
+		featureGate: &configv1.FeatureGate{
+			Spec: configv1.FeatureGateSpec{
+				FeatureGateSelection: configv1.FeatureGateSelection{
+					FeatureSet: configv1.CustomNoUpgrade,
+					CustomNoUpgrade: &configv1.CustomFeatureGates{
+						Enabled: []string{DisableCloudProvidersFeature},
+					},
+				},
+			},
+		},
+		expected: true,
+	}, {
+		name: "FeatureSet: CustomNoUpgrade (With External Enabled, DisableCloudProviders Disabled), Platform: AWS",
+		status: &configv1.PlatformStatus{
+			Type: configv1.AWSPlatformType,
+		},
+		featureGate: &configv1.FeatureGate{
+			Spec: configv1.FeatureGateSpec{
+				FeatureGateSelection: configv1.FeatureGateSelection{
+					FeatureSet: configv1.CustomNoUpgrade,
+					CustomNoUpgrade: &configv1.CustomFeatureGates{
+						Enabled:  []string{ExternalCloudProviderFeature},
+						Disabled: []string{DisableCloudProvidersFeature},
+					},
+				},
+			},
+		},
+		expected: true,
+	}, {
+		name: "FeatureSet: CustomNoUpgrade (With DisableCloudProviders Enabled, External Disabled), Platform: AWS",
+		status: &configv1.PlatformStatus{
+			Type: configv1.AWSPlatformType,
+		},
+		featureGate: &configv1.FeatureGate{
+			Spec: configv1.FeatureGateSpec{
+				FeatureGateSelection: configv1.FeatureGateSelection{
+					FeatureSet: configv1.CustomNoUpgrade,
+					CustomNoUpgrade: &configv1.CustomFeatureGates{
+						Enabled:  []string{DisableCloudProvidersFeature},
+						Disabled: []string{ExternalCloudProviderFeature},
+					},
+				},
+			},
+		},
+		expected: true,
 	}}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {


### PR DESCRIPTION
Kube 1.22 introduced a feature gate `DisableCloudProviders`. If a user creates a `CustomNoUpgrade` FeatureGate with this feature gate enabled, it will break their cluster today as the fg disables cloud provider initialisation, they will get errors such as:
```
I0907 16:33:57.363162       1 plugins.go:110] INFO: Please make sure you are running external cloud controller manager binary for provider "aws".In-tree cloud providers are currently disabled. Refer to https://github.com/kubernetes/kubernetes/tree/master/staging/src/k8s.io/cloud-provider/samplefor example implementation.
W0907 16:33:57.363183       1 plugins.go:114] WARNING: "aws" built-in cloud provider is now disabled. Please reach to sig-cloud-provider and use 'external' cloud provider for "aws": The AWS provider is deprecated and will be removed in a future release. Please use https://github.com/kubernetes/cloud-provider-aws
F0907 16:33:57.363193       1 controllermanager.go:246] error building controller context: cloud provider "aws" was specified, but built-in cloud providers are disabled. Please set --cloud-provider=external and migrate to an external cloud provider
```

To prevent this error, we can handle the upstream feature gate in the same was as we handle our own `ExternalCloudProvider` feature gate.

This should also allow teams within OpenShift to test what happens when the providers are disabled in tree (which is not necessarily the same as just setting `cloud-provider=external` ) to make sure we are ready for that change when it comes.