### PR TITLE
Bug 1977730: change write storage chmod

### DIFF
--- a/pkg/operator/staticpod/certsyncpod/certsync_controller.go
+++ b/pkg/operator/staticpod/certsyncpod/certsync_controller.go
@@ -264,7 +264,7 @@ func (c *CertSyncController) sync(ctx context.Context, syncCtx factory.SyncConte
 			}
 
 			klog.Infof("Writing secret manifest %q ...", fullFilename)
-			if err := staticpod.WriteFileAtomic(content, 0644, fullFilename); err != nil {
+			if err := staticpod.WriteFileAtomic(content, 0600, fullFilename); err != nil {
 				c.eventRecorder.Warningf("CertificateUpdateFailed", "Failed writing file for secret: %s/%s: %v", secret.Namespace, secret.Name, err)
 				errors = append(errors, err)
 				continue


### PR DESCRIPTION
This is for a Bug 1977730. Cert were being given 600 here, but Kubernetes prefers 644.
https://kubernetes.io/docs/concepts/configuration/secret/#secret-files-permissions