### PR TITLE
Bug 1858760: allow injecting authorizationService URL into Credentials

### DIFF
--- a/pkg/image/registryclient/authorization_service_registry_mapping.go
+++ b/pkg/image/registryclient/authorization_service_registry_mapping.go
@@ -1,0 +1,35 @@
+package registryclient
+
+import (
+	"net/http"
+
+	"github.com/docker/distribution/registry/client/auth"
+)
+
+type AuthorizationServiceRegistryMappingConsumer interface {
+	AcceptAuthorizationServiceRegistryMapping(authorizationService, registry string)
+}
+
+type authorizationServiceHandler struct {
+	credentialStore auth.CredentialStore
+}
+
+func (*authorizationServiceHandler) Scheme() string {
+	return "bearer"
+}
+
+func (bh *authorizationServiceHandler) AuthorizeRequest(_ *http.Request, params map[string]string) error {
+	if consumer, ok := bh.credentialStore.(AuthorizationServiceRegistryMappingConsumer); ok {
+		// look for challenge params
+		realm, ok := params["realm"] // authorizationService
+		if !ok {
+			return nil
+		}
+		service, ok := params["service"] // registry
+		if !ok {
+			return nil
+		}
+		consumer.AcceptAuthorizationServiceRegistryMapping(realm, service)
+	}
+	return nil
+}

--- a/pkg/image/registryclient/authorization_service_registry_mapping_test.go
+++ b/pkg/image/registryclient/authorization_service_registry_mapping_test.go
@@ -1,0 +1,47 @@
+package registryclient
+
+import (
+	"testing"
+)
+
+type consumerStore struct {
+	BasicCredentials
+	authorizationService, registry string
+}
+
+func (c *consumerStore) AcceptAuthorizationServiceRegistryMapping(authorizationService, registry string) {
+	c.authorizationService = authorizationService
+	c.registry = registry
+}
+
+func TestAuthorizationServiceHandler(t *testing.T) {
+	credentialStore := &consumerStore{}
+	handler := &authorizationServiceHandler{credentialStore}
+
+	err := handler.AuthorizeRequest(nil, map[string]string{
+		"realm":   "https://127.0.0.1:3000",
+		"service": "https://127.0.0.1:5000",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if credentialStore.registry != "https://127.0.0.1:5000" {
+		t.Fatalf("unexpected registry: %s", credentialStore.registry)
+	}
+	if credentialStore.authorizationService != "https://127.0.0.1:3000" {
+		t.Fatalf("unexpected authorizationService: %s", credentialStore.authorizationService)
+	}
+}
+
+func TestAuthorizationServiceHandlerLegacyStore(t *testing.T) {
+	// BasicCredentials is not AuthorizationServiceRegistryMappingConsumer
+	handler := &authorizationServiceHandler{credentialStore: NewBasicCredentials()}
+
+	err := handler.AuthorizeRequest(nil, map[string]string{
+		"realm":   "https://127.0.0.1:3000",
+		"service": "https://127.0.0.1:5000",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}

--- a/pkg/image/registryclient/client.go
+++ b/pkg/image/registryclient/client.go
@@ -395,6 +395,8 @@ func (c *Context) cachedTransport(rt http.RoundTripper, host string, scopes []au
 		// TODO: make multiple attempts if the first credential fails
 		auth.NewAuthorizer(
 			c.Challenges,
+			// authorizationServiceHandler has to be first to potentially prepare c.Credentials before NewTokenHandlerWithOptions kicks in
+			&authorizationServiceHandler{c.Credentials},
 			auth.NewTokenHandlerWithOptions(auth.TokenHandlerOptions{
 				Transport:   rt,
 				Credentials: creds,


### PR DESCRIPTION
resolution in registryclient request authorization


- idea behing this: `CredentialStore` will implement `AuthorizationServiceRegistryMappingConsumer` interface to obtain authorizationService URL for mapping it to registry URL

- this is required to prevent hacky alternatives for obtaining authorizationService URL when retrieving tokens ([example](https://github.com/openshift/oc/pull/924/files#diff-592af2d02373e6118684e6622400bc1cf96c4cd51ae91098ad54ba9cf2354431R62))