### PR TITLE
startup-monitor: reduce the log file size

### DIFF
--- a/pkg/operator/staticpod/startupmonitor/cmd.go
+++ b/pkg/operator/staticpod/startupmonitor/cmd.go
@@ -179,8 +179,8 @@ func setupLogger(logFilePath string) {
 	}
 	klog.SetOutput(&lumberjack.Logger{
 		Filename:   logFilePath,
-		MaxSize:    100, // large files break some editors
-		MaxBackups: 3,
+		MaxSize:    5, // keep it small since we added the logs to the must-gather bundle
+		MaxBackups: 2,
 		MaxAge:     28, // if something goes wrong we will be called out early, retain logs for ~ a month, just in case
 		Compress:   false,
 	})


### PR DESCRIPTION
since we decided to add the logs to the must-gather bundle and due to the fact that these logs will be small (we do collect logs only for 5 min on each rollout SNO) reducing the size to 5 MB is enough