### PR TITLE
Add utility functions for FeatureGates

### DIFF
--- a/pkg/config/featuregate/featuregate.go
+++ b/pkg/config/featuregate/featuregate.go
@@ -1,0 +1,45 @@
+package featuregate
+
+import (
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+// GetEnabledAndDisabledFeatures returns a list of enabled and disabled features for the given `FeatureGate` instance.
+// Returns an error if the object references an unknown feature set.
+func GetEnabledAndDisabledFeatures(fg *configv1.FeatureGate) ([]string, []string, error) {
+	if fg.Spec.FeatureSet == configv1.CustomNoUpgrade {
+		if fg.Spec.FeatureGateSelection.CustomNoUpgrade != nil {
+			return fg.Spec.FeatureGateSelection.CustomNoUpgrade.Enabled, fg.Spec.FeatureGateSelection.CustomNoUpgrade.Disabled, nil
+		}
+		return []string{}, []string{}, nil
+	}
+
+	featureSet, ok := configv1.FeatureSets[fg.Spec.FeatureSet]
+	if !ok {
+		return []string{}, []string{}, fmt.Errorf("featureSet %q is not a known set of features", featureSet)
+	}
+	return featureSet.Enabled, featureSet.Disabled, nil
+}
+
+// IsFeatureGateEnabled returns true if the provided feature is explicitly enabled by the given `FeatureGate` instance.
+// This returns false if the feature is explicitly disabled or is not enabled by the referenced feature set.
+// Returns an error if the `FeatureGate` references an unknown feature set.
+func IsFeatureGateEnabled(feature string, fg *configv1.FeatureGate) (bool, error) {
+	enabledFeatures, disabledFeatures, err := GetEnabledAndDisabledFeatures(fg)
+	if err != nil {
+		return false, err
+	}
+	for _, disabledFeature := range disabledFeatures {
+		if feature == disabledFeature {
+			return false, nil
+		}
+	}
+	for _, enabledFeature := range enabledFeatures {
+		if feature == enabledFeature {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/pkg/config/featuregate/featuregate_test.go
+++ b/pkg/config/featuregate/featuregate_test.go
@@ -1,0 +1,150 @@
+package featuregate
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+func TestGetEnabledAndDisabledFeatures(t *testing.T) {
+	tests := []struct {
+		name             string
+		configValue      configv1.FeatureSet
+		customNoUpgrade  *configv1.CustomFeatureGates
+		expectError      bool
+		expectedEnabled  []string
+		expectedDisabled []string
+	}{
+		{
+			name:             "default",
+			expectedEnabled:  configv1.FeatureSets[configv1.Default].Enabled,
+			expectedDisabled: configv1.FeatureSets[configv1.Default].Disabled,
+		},
+		{
+			name:             "techpreview",
+			configValue:      configv1.TechPreviewNoUpgrade,
+			expectedEnabled:  configv1.FeatureSets[configv1.TechPreviewNoUpgrade].Enabled,
+			expectedDisabled: configv1.FeatureSets[configv1.TechPreviewNoUpgrade].Disabled,
+		},
+		{
+			name:        "custom no upgrade",
+			configValue: configv1.CustomNoUpgrade,
+			customNoUpgrade: &configv1.CustomFeatureGates{
+				Enabled:  []string{"CustomEnabledFeature"},
+				Disabled: []string{"CustomDisabledFeature"},
+			},
+			expectedEnabled:  []string{"CustomEnabledFeature"},
+			expectedDisabled: []string{"CustomDisabledFeature"},
+		},
+		{
+			name:        "unknown",
+			configValue: configv1.FeatureSet("UnknownDoesntExist"),
+			expectError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fg := &configv1.FeatureGate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster",
+				},
+				Spec: configv1.FeatureGateSpec{
+					FeatureGateSelection: configv1.FeatureGateSelection{
+						FeatureSet:      tc.configValue,
+						CustomNoUpgrade: tc.customNoUpgrade,
+					},
+				},
+			}
+			enabled, disabled, err := GetEnabledAndDisabledFeatures(fg)
+			if err != nil && !tc.expectError {
+				t.Fatalf("unexpected error occurred: %v", err)
+			}
+			if err == nil && tc.expectError {
+				t.Fatal("expected error to occur but got nothing")
+			}
+			if !equality.Semantic.DeepEqual(enabled, tc.expectedEnabled) {
+				t.Errorf("expected enabled list of features\n  %s,\ngot\n  %s", tc.expectedEnabled, enabled)
+			}
+			if !equality.Semantic.DeepEqual(disabled, tc.expectedDisabled) {
+				t.Errorf("expected disabled list of features\n  %s,\ngot\n  %s", tc.expectedDisabled, disabled)
+			}
+		})
+	}
+}
+
+func TestIsFeatureEnabled(t *testing.T) {
+	tests := []struct {
+		name            string
+		configValue     configv1.FeatureSet
+		customNoUpgrade *configv1.CustomFeatureGates
+		testFeature     string
+		expectedResult  bool
+		expectError     bool
+	}{
+		{
+			name: "default - enabled",
+			// Note - GA flag is assumed to always be present in the default feature set.
+			testFeature:    "APIPriorityAndFairness",
+			expectedResult: true,
+		},
+		{
+			name: "default - disabled",
+			// Note - disabled GA flag is assumed to always be present in the default feature set.
+			testFeature:    "LegacyNodeRoleBehavior",
+			expectedResult: false,
+		},
+		{
+			name:           "default - not on list",
+			testFeature:    "UnknownFeatureGate",
+			expectedResult: false,
+		},
+		{
+			name: "techpreview",
+			// Note - tech preview is assumed to be a superset of default features.
+			// Therefore the test feature here may graduate to the default feature set over time.
+			testFeature:    "CSIDriverAzureDisk",
+			configValue:    configv1.TechPreviewNoUpgrade,
+			expectedResult: true,
+		},
+		{
+			name:        "custom - enabled",
+			testFeature: "CustomEnabledFeature",
+			configValue: configv1.CustomNoUpgrade,
+			customNoUpgrade: &configv1.CustomFeatureGates{
+				Enabled:  []string{"CustomEnabledFeature"},
+				Disabled: []string{"CustomDisabledFeature"},
+			},
+			expectedResult: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fg := &configv1.FeatureGate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster",
+				},
+				Spec: configv1.FeatureGateSpec{
+					FeatureGateSelection: configv1.FeatureGateSelection{
+						FeatureSet:      tc.configValue,
+						CustomNoUpgrade: tc.customNoUpgrade,
+					},
+				},
+			}
+			result, err := IsFeatureGateEnabled(tc.testFeature, fg)
+			if err != nil && !tc.expectError {
+				t.Fatalf("unexpected error occurred: %v", err)
+			}
+			if err == nil && tc.expectError {
+				t.Fatal("expected error but got nothing")
+			}
+			if result != tc.expectedResult {
+				t.Errorf("expected feature %s to be enabled=%t, got %t", tc.testFeature, tc.expectedResult, result)
+			}
+		})
+	}
+}

--- a/pkg/operator/configobserver/featuregates/observe_featuregates.go
+++ b/pkg/operator/configobserver/featuregates/observe_featuregates.go
@@ -11,6 +11,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+	"github.com/openshift/library-go/pkg/config/featuregate"
 	"github.com/openshift/library-go/pkg/operator/configobserver"
 	"github.com/openshift/library-go/pkg/operator/events"
 )
@@ -98,7 +99,7 @@ func (f *featureFlags) getWhitelistedFeatureNames(fg *configv1.FeatureGate) ([]s
 		return fmt.Sprintf("%s=false", fs)
 	}
 
-	enabledFeatures, disabledFeatures, err = getFeaturesFromTheSpec(fg)
+	enabledFeatures, disabledFeatures, err = featuregate.GetEnabledAndDisabledFeatures(fg)
 	if err != nil {
 		return nil, err
 	}
@@ -125,19 +126,4 @@ func (f *featureFlags) getWhitelistedFeatureNames(fg *configv1.FeatureGate) ([]s
 	}
 
 	return newConfigValue, nil
-}
-
-func getFeaturesFromTheSpec(fg *configv1.FeatureGate) ([]string, []string, error) {
-	if fg.Spec.FeatureSet == configv1.CustomNoUpgrade {
-		if fg.Spec.FeatureGateSelection.CustomNoUpgrade != nil {
-			return fg.Spec.FeatureGateSelection.CustomNoUpgrade.Enabled, fg.Spec.FeatureGateSelection.CustomNoUpgrade.Disabled, nil
-		}
-		return []string{}, []string{}, nil
-	}
-
-	featureSet, ok := configv1.FeatureSets[fg.Spec.FeatureSet]
-	if !ok {
-		return []string{}, []string{}, fmt.Errorf(".spec.featureSet %q not found", featureSet)
-	}
-	return featureSet.Enabled, featureSet.Disabled, nil
 }


### PR DESCRIPTION
- Export the `getFeaturesFromTheSpec` function, renaming it
  `GetEnabledAndDisabledFeatures` and adding appropriate godoc. This
  will let library-go users determine the list of enabled and disabled
  features independently of the `ObserveFeatureFlags` function.
- Add a general purpose function for checking if a feature gate has been
  enabled.
- Implement unit tests for the new library functions.