### PR TITLE
csi: add fbertina and jsafrane as approves

### DIFF
--- a/pkg/operator/csi/OWNERS
+++ b/pkg/operator/csi/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+  - bertinatto
+  - jsafrane
+component: Storage


### PR DESCRIPTION
This would avoid getting the Storage Team blocked.

/assign @mfojtik
