### PR TITLE
Add PowerVS to external CloudProvider

### DIFF
--- a/pkg/cloudprovider/external.go
+++ b/pkg/cloudprovider/external.go
@@ -31,8 +31,7 @@ func IsCloudProviderExternal(platformStatus *configv1.PlatformStatus, featureGat
 			return true, nil
 		}
 		return isExternalFeatureGateEnabled(featureGate)
-	case configv1.IBMCloudPlatformType,
-		configv1.AlibabaCloudPlatformType:
+	case configv1.IBMCloudPlatformType, configv1.AlibabaCloudPlatformType, configv1.PowerVSPlatformType:
 		return true, nil
 	default:
 		// Platforms that do not have external cloud providers implemented

--- a/pkg/cloudprovider/external_test.go
+++ b/pkg/cloudprovider/external_test.go
@@ -170,14 +170,14 @@ func TestIsCloudProviderExternal(t *testing.T) {
 		},
 		featureGate: nil,
 		expected:    true,
-	},{
+	}, {
 		name: "No FeatureGate, Platform: PowerVS",
 		status: &configv1.PlatformStatus{
 			Type: configv1.PowerVSPlatformType,
 		},
 		featureGate: nil,
 		expected:    true,
-	},{
+	}, {
 		name: "FeatureSet: CustomNoUpgrade (With External Feature Gate), Platform: Azure",
 		status: &configv1.PlatformStatus{
 			Type: configv1.AzurePlatformType,

--- a/pkg/cloudprovider/external_test.go
+++ b/pkg/cloudprovider/external_test.go
@@ -170,7 +170,14 @@ func TestIsCloudProviderExternal(t *testing.T) {
 		},
 		featureGate: nil,
 		expected:    true,
-	}, {
+	},{
+		name: "No FeatureGate, Platform: PowerVS",
+		status: &configv1.PlatformStatus{
+			Type: configv1.PowerVSPlatformType,
+		},
+		featureGate: nil,
+		expected:    true,
+	},{
 		name: "FeatureSet: CustomNoUpgrade (With External Feature Gate), Platform: Azure",
 		status: &configv1.PlatformStatus{
 			Type: configv1.AzurePlatformType,

--- a/pkg/operator/configobserver/cloudprovider/observe_cloudprovider.go
+++ b/pkg/operator/configobserver/cloudprovider/observe_cloudprovider.go
@@ -193,6 +193,7 @@ func GetPlatformName(platformType configv1.PlatformType, recorder events.Recorde
 	case configv1.OvirtPlatformType:
 	case configv1.KubevirtPlatformType:
 	case configv1.AlibabaCloudPlatformType:
+	case configv1.PowerVSPlatformType:
 	default:
 		// the new doc on the infrastructure fields requires that we treat an unrecognized thing the same bare metal.
 		// TODO find a way to indicate to the user that we didn't honor their choice

--- a/pkg/operator/configobserver/cloudprovider/observe_cloudprovider_test.go
+++ b/pkg/operator/configobserver/cloudprovider/observe_cloudprovider_test.go
@@ -220,6 +220,16 @@ func TestObserveCloudProviderNames(t *testing.T) {
 		expected:           "external",
 		cloudProviderCount: 1,
 	}, {
+		name: "Power VS platform",
+		infrastructureStatus: configv1.InfrastructureStatus{
+			Platform: configv1.PowerVSPlatformType,
+			PlatformStatus: &configv1.PlatformStatus{
+				Type: configv1.PowerVSPlatformType,
+			},
+		},
+		expected:           "external",
+		cloudProviderCount: 1,
+	}, {
 		name: "None platform",
 		infrastructureStatus: configv1.InfrastructureStatus{
 			Platform: configv1.NonePlatformType,


### PR DESCRIPTION
Adds support for PowerVS as an external cloud provider.

Related to nhancement: https://github.com/openshift/enhancements/pull/736