### PR TITLE
bug 2006945: extend hardcoded restmapper for cluster-bootstrap to avoid crashlooping bootstrap kube-apiserver

### DIFF
--- a/pkg/client/openshiftrestmapper/hardcoded_restmapper.go
+++ b/pkg/client/openshiftrestmapper/hardcoded_restmapper.go
@@ -70,6 +70,96 @@ var defaultRESTMappings = []meta.RESTMapping{
 		Scope:            meta.RESTScopeRoot,
 		Resource:         schema.GroupVersionResource{Group: "security.openshift.io", Version: "v1", Resource: "securitycontextconstraints"},
 	},
+	// This is created so that cluster-bootstrap can always map customresourcedefinitions, RBAC, machine resources so that CRDs and
+	// permissions are always created quickly.  We observed discovery not including these on AWS OVN installations and
+	// the lack of CRDs and permissions blocked additional aspects of cluster bootstrapping.
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "apiextensions.k8s.io", Version: "v1", Kind: "CustomResourceDefinition"},
+		Scope:            meta.RESTScopeRoot,
+		Resource:         schema.GroupVersionResource{Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRole"},
+		Scope:            meta.RESTScopeRoot,
+		Resource:         schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterroles"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRoleBinding"},
+		Scope:            meta.RESTScopeRoot,
+		Resource:         schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterrolebindings"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "Role"},
+		Scope:            meta.RESTScopeNamespace,
+		Resource:         schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "roles"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "RoleBinding"},
+		Scope:            meta.RESTScopeNamespace,
+		Resource:         schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "rolebindings"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "machine.openshift.io", Version: "v1beta1", Kind: "Machine"},
+		Scope:            meta.RESTScopeNamespace,
+		Resource:         schema.GroupVersionResource{Group: "machine.openshift.io", Version: "v1beta1", Resource: "machines"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "machine.openshift.io", Version: "v1beta1", Kind: "MachineSet"},
+		Scope:            meta.RESTScopeNamespace,
+		Resource:         schema.GroupVersionResource{Group: "machine.openshift.io", Version: "v1beta1", Resource: "machinesets"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "machineconfiguration.openshift.io", Version: "v1", Kind: "MachineConfig"},
+		Scope:            meta.RESTScopeRoot,
+		Resource:         schema.GroupVersionResource{Group: "machineconfiguration.openshift.io", Version: "v1", Resource: "machineconfigs"},
+	},
+	// This is here so cluster-bootstrap can always create the config instances that are used to drive our operators to avoid the
+	// excessive bootstrap wait that prevents installer from completing on AWS OVN
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "config.openshift.io", Version: "v1", Kind: "DNS"},
+		Scope:            meta.RESTScopeRoot,
+		Resource:         schema.GroupVersionResource{Group: "config.openshift.io", Version: "v1", Resource: "dnses"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "config.openshift.io", Version: "v1", Kind: "Infrastructure"},
+		Scope:            meta.RESTScopeRoot,
+		Resource:         schema.GroupVersionResource{Group: "config.openshift.io", Version: "v1", Resource: "infrastructures"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "config.openshift.io", Version: "v1", Kind: "Network"},
+		Scope:            meta.RESTScopeRoot,
+		Resource:         schema.GroupVersionResource{Group: "config.openshift.io", Version: "v1", Resource: "networks"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "config.openshift.io", Version: "v1", Kind: "Ingress"},
+		Scope:            meta.RESTScopeRoot,
+		Resource:         schema.GroupVersionResource{Group: "config.openshift.io", Version: "v1", Resource: "ingresses"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "config.openshift.io", Version: "v1", Kind: "Proxy"},
+		Scope:            meta.RESTScopeRoot,
+		Resource:         schema.GroupVersionResource{Group: "config.openshift.io", Version: "v1", Resource: "proxies"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "config.openshift.io", Version: "v1", Kind: "Scheduler"},
+		Scope:            meta.RESTScopeRoot,
+		Resource:         schema.GroupVersionResource{Group: "config.openshift.io", Version: "v1", Resource: "schedulers"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "config.openshift.io", Version: "v1", Kind: "ClusterVersion"},
+		Scope:            meta.RESTScopeRoot,
+		Resource:         schema.GroupVersionResource{Group: "config.openshift.io", Version: "v1", Resource: "clusterversions"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "operator.openshift.io", Version: "v1", Kind: "CloudCredential"},
+		Scope:            meta.RESTScopeRoot,
+		Resource:         schema.GroupVersionResource{Group: "operator.openshift.io", Version: "v1", Resource: "cloudcredentials"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "monitoring.coreos.com", Version: "v1", Kind: "ServiceMonitor"},
+		Scope:            meta.RESTScopeNamespace,
+		Resource:         schema.GroupVersionResource{Group: "monitoring.coreos.com", Version: "v1", Resource: "servicemonitors"},
+	},
 }
 
 func NewOpenShiftHardcodedRESTMapper(delegate meta.RESTMapper) meta.RESTMapper {


### PR DESCRIPTION
found on aws-ovn, 4.9 installation

1. bootstrap-kube-apiserver starts, readyz=false
2. cluster-bootstrap starts creating resources, but discovery does not return a full list
3. without a mapping for CRD, the rolebindingrestriction resource isn't created
4. without rolebindingrestrictions defined, the bootstrap-kube-apiserver poststarthook for initial rolebindings cannot create (blocked by admission)
5. the poststarthook fails, preventing initial rolebindings from being created causing a crashloop
6. additionally, permissions granted in our rendered artifacts are not added, this includes permissions for CSR creation for nodes
6. kubelets trying to join the cluster lack RBAC permissions for the initial CSR and anything before the kubelet client
7. pods trying to start may lack RBAC bound SCC permissions
8. operator pods that rely on visibility to config CRDs and CRs are delayed significantly by the lack of both

This avoids those conditions by hardcoding the RESTMappings that appeared to be missing and hopefully breaking the racy loop