### PR TITLE
CertsFromPEM: avoid mutating the input byte slice

### DIFF
--- a/pkg/crypto/crypto.go
+++ b/pkg/crypto/crypto.go
@@ -1010,9 +1010,10 @@ func IPAddressesDNSNames(hosts []string) ([]net.IP, []string) {
 func CertsFromPEM(pemCerts []byte) ([]*x509.Certificate, error) {
 	ok := false
 	certs := []*x509.Certificate{}
-	for len(pemCerts) > 0 {
-		var block *pem.Block
-		block, pemCerts = pem.Decode(pemCerts)
+	pemCertsCopy := make([]byte, len(pemCerts))
+	copy(pemCertsCopy, pemCerts)
+
+	for block, pemCertsCopy := pem.Decode(pemCertsCopy); len(pemCertsCopy) > 0; block, pemCertsCopy = pem.Decode(pemCertsCopy) {
 		if block == nil {
 			break
 		}
@@ -1030,7 +1031,7 @@ func CertsFromPEM(pemCerts []byte) ([]*x509.Certificate, error) {
 	}
 
 	if !ok {
-		return certs, errors.New("Could not read any certificates")
+		return certs, errors.New("could not read any certificates")
 	}
 	return certs, nil
 }


### PR DESCRIPTION
CertsFromPEM might have possibly been causing mutations of its
input when using pem.Decode. Avoid that by deep-copying.

---

Currently, this is the only spot which CAO uses that seems suspicious with regards to https://bugzilla.redhat.com/show_bug.cgi?id=1935654.

cc @s-urbaniak @sttts 