### PR TITLE
pkg/operator/configobserver/etcd: bump owners

### DIFF
--- a/pkg/operator/configobserver/etcd/OWNERS
+++ b/pkg/operator/configobserver/etcd/OWNERS
@@ -1,8 +1,8 @@
 reviewers:
   - ironcladlou
   - hexfusion
-  - retroflexer
+  - hasbro17
 approvers:
   - ironcladlou
   - hexfusion
-  - retroflexer
+  - hasbro17


### PR DESCRIPTION
reflect new team

Signed-off-by: Sam Batschelet <sbatsche@redhat.com>