### PR TITLE
Remove AdmissionTimeout and use context timeout

### DIFF
--- a/pkg/apiserver/admission/admissiontimeout/decorator.go
+++ b/pkg/apiserver/admission/admissiontimeout/decorator.go
@@ -1,12 +1,18 @@
 package admissiontimeout
 
 import (
+	"time"
+
 	"k8s.io/apiserver/pkg/admission"
 )
 
+const defaultAdmissionTimeout = 13 * time.Second
+
+// WithTimeout decorates admission plugin with timeout
 func WithTimeout(admissionPlugin admission.Interface, name string) admission.Interface {
 	return pluginHandlerWithTimeout{
-		name:            name,
-		admissionPlugin: admissionPlugin,
+		name:             name,
+		admissionPlugin:  admissionPlugin,
+		admissionTimeout: defaultAdmissionTimeout,
 	}
 }

--- a/pkg/apiserver/admission/admissiontimeout/decorator.go
+++ b/pkg/apiserver/admission/admissiontimeout/decorator.go
@@ -1,22 +1,12 @@
 package admissiontimeout
 
 import (
-	"time"
-
 	"k8s.io/apiserver/pkg/admission"
 )
 
-// AdmissionTimeout provides a decorator that will fail an admission plugin after a certain amount of time
-//
-// DEPRECATED: use the context of the admission handler instead.
-type AdmissionTimeout struct {
-	Timeout time.Duration
-}
-
-func (d AdmissionTimeout) WithTimeout(admissionPlugin admission.Interface, name string) admission.Interface {
+func WithTimeout(admissionPlugin admission.Interface, name string) admission.Interface {
 	return pluginHandlerWithTimeout{
 		name:            name,
 		admissionPlugin: admissionPlugin,
-		timeout:         d.Timeout,
 	}
 }

--- a/pkg/apiserver/admission/admissiontimeout/timeoutadmission_test.go
+++ b/pkg/apiserver/admission/admissiontimeout/timeoutadmission_test.go
@@ -40,6 +40,16 @@ func TestTimeoutAdmission(t *testing.T) {
 		expectedError   string
 	}{
 		{
+			name:    "succeed",
+			timeout: 50 * time.Millisecond,
+			admissionPlugin: func() (admitFunc, chan struct{}) {
+				stopCh := make(chan struct{})
+				return func(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) error {
+					return nil
+				}, stopCh
+			},
+		},
+		{
 			name:    "stops on time",
 			timeout: 50 * time.Millisecond,
 			admissionPlugin: func() (admitFunc, chan struct{}) {


### PR DESCRIPTION
This PR removes deprecated AdmissionTimeout struct and uses context timeout
in pluginHandlerWithTimeout.

Thanks to that, consumers can get admission plugin whose timeout value
is wrapped in context via `admissiontimeout.WithTimeout`.