### PR TITLE
`pkg/route`: Add `ValidateSubdomain`

### DIFF
--- a/pkg/route/routeapihelpers/routeapihelpers.go
+++ b/pkg/route/routeapihelpers/routeapihelpers.go
@@ -47,18 +47,16 @@ func IngressURI(route *routev1.Route, host string) (*url.URL, *routev1.RouteIngr
 
 // ValidateHost checks that a route's host name satisfies DNS requirements, with
 // the assumption that the caller has already checked for an empty host name.
-// Unless the allowNonCompliant annotation is set to true, host name must have
-// at least two labels, with each label no more than 63 characters from the set of
-// alphanumeric characters, '-' or '.', and must start and end with an alphanumeric
-// character. A trailing dot is allowed. The total host name length must be no more
-// than 253 characters.
-// If allowNonCompliant is set to true, it uses a smaller set of conditions from
-// IsDNS1123Subdomain, e.g. character set as described above, and total host name
-// length must be no more than 253 characters.
-func ValidateHost(host string, allowNonCompliant string, hostPath *field.Path) field.ErrorList {
-	result := field.ErrorList{}
-
-	if allowNonCompliant == "true" {
+// Unless allowNonCompliant is true, host name must have at least two labels,
+// with each label no more than 63 characters from the set of alphanumeric
+// characters, '-' or '.', and must start and end with an alphanumeric
+// character. A trailing dot is allowed.  The total host name length must be no
+// more than 253 characters.  If allowNonCompliant is true, it uses a smaller
+// set of conditions from IsDNS1123Subdomain, e.g. character set as described
+// above, and total host name length must be no more than 253 characters.
+func ValidateHost(host string, allowNonCompliant bool, hostPath *field.Path) field.ErrorList {
+	var result field.ErrorList
+	if allowNonCompliant {
 		errs := kvalidation.IsDNS1123Subdomain(host)
 		if len(errs) != 0 {
 			result = append(result, field.Invalid(hostPath, host, fmt.Sprintf("host must conform to DNS naming conventions: %v", errs)))

--- a/pkg/route/routeapihelpers/routeapihelpers_test.go
+++ b/pkg/route/routeapihelpers/routeapihelpers_test.go
@@ -380,3 +380,61 @@ func TestValidateHost(t *testing.T) {
 		}
 	}
 }
+
+// TestValidateSubdomain ensures not specifying a proper subdomain results in
+// error and that a correctly specified subdomain passes successfully.
+func TestValidateSubdomain(t *testing.T) {
+	tests := []struct {
+		name              string
+		subdomain         string
+		allowNonCompliant bool
+		expectedErrors    int
+	}{
+		{
+			name:           "label with >63 chars",
+			subdomain:      "1234567890-1234567890-1234567890-1234567890-1234567890-123456789",
+			expectedErrors: 1,
+		},
+		{
+			name: "subdomain >253 chars",
+			subdomain: "1234567890-1234567890-1234567890-1234567890-1234567890." +
+				"1234567890-1234567890-1234567890-1234567890-1234567890." +
+				"1234567890-1234567890-1234567890-1234567890-1234567890." +
+				"1234567890-1234567890-1234567890-1234567890-1234567890." +
+				"1234567890-1234567890-1234567890-1",
+			expectedErrors: 1,
+		},
+		{
+			name:           "label with invalid char",
+			subdomain:      "foo/bar",
+			expectedErrors: 1,
+		},
+		{
+			name:           "label with wildcard",
+			subdomain:      "*.apps",
+			expectedErrors: 1,
+		},
+		{
+			name:           "empty label",
+			subdomain:      "",
+			expectedErrors: 1,
+		},
+		{
+			name:           "single label",
+			subdomain:      "foo",
+			expectedErrors: 0,
+		},
+		{
+			name:           "multiple labels",
+			subdomain:      "foo.bar.baz",
+			expectedErrors: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		errs := ValidateSubdomain(tc.subdomain, field.NewPath("spec.subdomain"))
+		if len(errs) != tc.expectedErrors {
+			t.Errorf("Test case %q expected %d error(s), got %d: %v", tc.name, tc.expectedErrors, len(errs), errs)
+		}
+	}
+}

--- a/pkg/route/routeapihelpers/routeapihelpers_test.go
+++ b/pkg/route/routeapihelpers/routeapihelpers_test.go
@@ -302,24 +302,24 @@ func TestIngressURI(t *testing.T) {
 }
 
 // TestValidateHost ensures not specifying a proper host name results in error and
-// that a correctly specified host name passes successfully
-func TestValidateRoute(t *testing.T) {
+// that a correctly specified host name passes successfully.
+func TestValidateHost(t *testing.T) {
 	tests := []struct {
 		name              string
 		host              string
-		allowNonCompliant string
+		allowNonCompliant bool
 		expectedErrors    int
 	}{
 		{
 			name:              "Non-DNS-compliant host with non-compliance allowed",
 			host:              "host",
-			allowNonCompliant: "true",
+			allowNonCompliant: true,
 			expectedErrors:    0,
 		},
 		{
 			name:              "Non-DNS-compliant host with non-compliance not allowed",
 			host:              "host",
-			allowNonCompliant: "false",
+			allowNonCompliant: false,
 			expectedErrors:    1,
 		},
 		{
@@ -330,13 +330,13 @@ func TestValidateRoute(t *testing.T) {
 		{
 			name:              "Specified label too long",
 			host:              "1234567890-1234567890-1234567890-1234567890-1234567890-123456789.host.com",
-			allowNonCompliant: "",
+			allowNonCompliant: false,
 			expectedErrors:    1,
 		},
 		{
 			name:              "Specified label too long, is not an error with non-compliance allowed",
 			host:              "1234567890-1234567890-1234567890-1234567890-1234567890-123456789.host.com",
-			allowNonCompliant: "true",
+			allowNonCompliant: true,
 			expectedErrors:    0,
 		},
 		{
@@ -346,7 +346,7 @@ func TestValidateRoute(t *testing.T) {
 				"1234567890-1234567890-1234567890-1234567890-1234567890." +
 				"1234567890-1234567890-1234567890-1234567890-1234567890." +
 				"1234567890-1234567890-1234567890-1",
-			allowNonCompliant: "",
+			allowNonCompliant: false,
 			expectedErrors:    1,
 		},
 		{
@@ -356,19 +356,19 @@ func TestValidateRoute(t *testing.T) {
 				"1234567890-1234567890-1234567890-1234567890-1234567890." +
 				"1234567890-1234567890-1234567890-1234567890-1234567890." +
 				"1234567890-1234567890-1234567890-1",
-			allowNonCompliant: "true",
+			allowNonCompliant: true,
 			expectedErrors:    1,
 		},
 		{
 			name:              "No host",
 			host:              "",
-			allowNonCompliant: "",
+			allowNonCompliant: false,
 			expectedErrors:    1,
 		},
 		{
 			name:              "Invalid DNS 952 host",
 			host:              "**",
-			allowNonCompliant: "",
+			allowNonCompliant: false,
 			expectedErrors:    1,
 		},
 	}


### PR DESCRIPTION
#### `pkg/route`: `ValidateHost`: Use `bool` for parameter

* `pkg/route/routeapihelpers/routeapihelpers.go` (`ValidateHost`): Change the `allowNonCompliant` parameter type from `string` to `bool`.
* `pkg/route/routeapihelpers/routeapihelpers_test.go` (`TestValidateRoute`): Rename...
(`TestValidateHost`): ...to this.  Update argument type.


#### `pkg/route`: Add `ValidateSubdomain`

* `pkg/route/routeapihelpers/routeapihelpers.go` (`ValidateSubdomain`): New function.  Validate that the given value is a valid DNS subdomain per RFC 1123.
* `pkg/route/routeapihelpers/routeapihelpers_test.go` (`TestValidateSubdomain`): Verify that `ValidateSubdomain` behaves as expected.