### PR TITLE
Allow resource deletion based on a certain condition

### DIFF
--- a/pkg/operator/resource/resourceapply/apiextensions.go
+++ b/pkg/operator/resource/resourceapply/apiextensions.go
@@ -42,3 +42,15 @@ func ApplyCustomResourceDefinitionV1(ctx context.Context, client apiextclientv1.
 
 	return actual, true, err
 }
+
+func DeleteCustomResourceDefinitionV1(ctx context.Context, client apiextclientv1.CustomResourceDefinitionsGetter, recorder events.Recorder, required *apiextensionsv1.CustomResourceDefinition) (*apiextensionsv1.CustomResourceDefinition, bool, error) {
+	err := client.CustomResourceDefinitions().Delete(ctx, required.Name, metav1.DeleteOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	reportDeleteEvent(recorder, required, err)
+	return nil, true, nil
+}

--- a/pkg/operator/resource/resourceapply/core.go
+++ b/pkg/operator/resource/resourceapply/core.go
@@ -455,3 +455,75 @@ func deleteSecretSyncTarget(ctx context.Context, client coreclientv1.SecretsGett
 	}
 	return false, err
 }
+
+func DeleteNamespace(ctx context.Context, client coreclientv1.NamespacesGetter, recorder events.Recorder, required *corev1.Namespace) (*corev1.Namespace, bool, error) {
+	err := client.Namespaces().Delete(ctx, required.Name, metav1.DeleteOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	reportDeleteEvent(recorder, required, err)
+	return nil, true, nil
+}
+
+func DeleteService(ctx context.Context, client coreclientv1.ServicesGetter, recorder events.Recorder, required *corev1.Service) (*corev1.Service, bool, error) {
+	err := client.Services(required.Namespace).Delete(ctx, required.Name, metav1.DeleteOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	reportDeleteEvent(recorder, required, err)
+	return nil, true, nil
+}
+
+func DeletePod(ctx context.Context, client coreclientv1.PodsGetter, recorder events.Recorder, required *corev1.Pod) (*corev1.Pod, bool, error) {
+	err := client.Pods(required.Namespace).Delete(ctx, required.Name, metav1.DeleteOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	reportDeleteEvent(recorder, required, err)
+	return nil, true, nil
+}
+
+func DeleteServiceAccount(ctx context.Context, client coreclientv1.ServiceAccountsGetter, recorder events.Recorder, required *corev1.ServiceAccount) (*corev1.ServiceAccount, bool, error) {
+	err := client.ServiceAccounts(required.Namespace).Delete(ctx, required.Name, metav1.DeleteOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	reportDeleteEvent(recorder, required, err)
+	return nil, true, nil
+}
+
+func DeleteConfigMap(ctx context.Context, client coreclientv1.ConfigMapsGetter, recorder events.Recorder, required *corev1.ConfigMap) (*corev1.ConfigMap, bool, error) {
+	err := client.ConfigMaps(required.Namespace).Delete(ctx, required.Name, metav1.DeleteOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	reportDeleteEvent(recorder, required, err)
+	return nil, true, nil
+}
+
+func DeleteSecret(ctx context.Context, client coreclientv1.SecretsGetter, recorder events.Recorder, required *corev1.Secret) (*corev1.Secret, bool, error) {
+	err := client.Secrets(required.Namespace).Delete(ctx, required.Name, metav1.DeleteOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	reportDeleteEvent(recorder, required, err)
+	return nil, true, nil
+}

--- a/pkg/operator/resource/resourceapply/generic.go
+++ b/pkg/operator/resource/resourceapply/generic.go
@@ -55,6 +55,10 @@ type ApplyResult struct {
 	Error   error
 }
 
+// ConditionalFunction provides needed dependency for a resource on another condition instead of blindly creating
+// a resource. This conditional function can also be used to delete the resource when not needed
+type ConditionalFunction func() bool
+
 type ClientHolder struct {
 	kubeClient          kubernetes.Interface
 	apiExtensionsClient apiextensionsclient.Interface
@@ -227,6 +231,135 @@ func ApplyDirectly(ctx context.Context, clients *ClientHolder, recorder events.R
 				result.Error = fmt.Errorf("missing dynamicClient")
 			} else {
 				result.Result, result.Changed, result.Error = ApplyKnownUnstructured(ctx, clients.dynamicClient, recorder, t)
+			}
+		default:
+			result.Error = fmt.Errorf("unhandled type %T", requiredObj)
+		}
+
+		ret = append(ret, result)
+	}
+
+	return ret
+}
+
+func DeleteAll(ctx context.Context, clients *ClientHolder, recorder events.Recorder, manifests AssetFunc,
+	files ...string) []ApplyResult {
+	ret := []ApplyResult{}
+
+	for _, file := range files {
+		result := ApplyResult{File: file}
+		objBytes, err := manifests(file)
+		if err != nil {
+			result.Error = fmt.Errorf("missing %q: %v", file, err)
+			ret = append(ret, result)
+			continue
+		}
+		requiredObj, err := decode(objBytes)
+		if err != nil {
+			result.Error = fmt.Errorf("cannot decode %q: %v", file, err)
+			ret = append(ret, result)
+			continue
+		}
+		result.Type = fmt.Sprintf("%T", requiredObj)
+		// NOTE: Do not add CR resources into this switch otherwise the protobuf client can cause problems.
+		switch t := requiredObj.(type) {
+		case *corev1.Namespace:
+			if clients.kubeClient == nil {
+				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				_, result.Changed, result.Error = DeleteNamespace(ctx, clients.kubeClient.CoreV1(), recorder, t)
+			}
+		case *corev1.Service:
+			if clients.kubeClient == nil {
+				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				_, result.Changed, result.Error = DeleteService(ctx, clients.kubeClient.CoreV1(), recorder, t)
+			}
+		case *corev1.Pod:
+			if clients.kubeClient == nil {
+				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				_, result.Changed, result.Error = DeletePod(ctx, clients.kubeClient.CoreV1(), recorder, t)
+			}
+		case *corev1.ServiceAccount:
+			if clients.kubeClient == nil {
+				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				_, result.Changed, result.Error = DeleteServiceAccount(ctx, clients.kubeClient.CoreV1(), recorder, t)
+			}
+		case *corev1.ConfigMap:
+			client := clients.configMapsGetter()
+			if client == nil {
+				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				_, result.Changed, result.Error = DeleteConfigMap(ctx, client, recorder, t)
+			}
+		case *corev1.Secret:
+			client := clients.secretsGetter()
+			if client == nil {
+				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				_, result.Changed, result.Error = DeleteSecret(ctx, client, recorder, t)
+			}
+		case *rbacv1.ClusterRole:
+			if clients.kubeClient == nil {
+				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				_, result.Changed, result.Error = DeleteClusterRole(ctx, clients.kubeClient.RbacV1(), recorder, t)
+			}
+		case *rbacv1.ClusterRoleBinding:
+			if clients.kubeClient == nil {
+				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				_, result.Changed, result.Error = DeleteClusterRoleBinding(ctx, clients.kubeClient.RbacV1(), recorder, t)
+			}
+		case *rbacv1.Role:
+			if clients.kubeClient == nil {
+				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				_, result.Changed, result.Error = DeleteRole(ctx, clients.kubeClient.RbacV1(), recorder, t)
+			}
+		case *rbacv1.RoleBinding:
+			if clients.kubeClient == nil {
+				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				_, result.Changed, result.Error = DeleteRoleBinding(ctx, clients.kubeClient.RbacV1(), recorder, t)
+			}
+		case *policyv1.PodDisruptionBudget:
+			if clients.kubeClient == nil {
+				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				_, result.Changed, result.Error = DeletePodDisruptionBudget(ctx, clients.kubeClient.PolicyV1(), recorder, t)
+			}
+		case *apiextensionsv1.CustomResourceDefinition:
+			if clients.apiExtensionsClient == nil {
+				result.Error = fmt.Errorf("missing apiExtensionsClient")
+			} else {
+				_, result.Changed, result.Error = DeleteCustomResourceDefinitionV1(ctx, clients.apiExtensionsClient.ApiextensionsV1(), recorder, t)
+			}
+		case *storagev1.StorageClass:
+			if clients.kubeClient == nil {
+				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				_, result.Changed, result.Error = DeleteStorageClass(ctx, clients.kubeClient.StorageV1(), recorder, t)
+			}
+		case *storagev1.CSIDriver:
+			if clients.kubeClient == nil {
+				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				_, result.Changed, result.Error = DeleteCSIDriver(ctx, clients.kubeClient.StorageV1(), recorder, t)
+			}
+		case *migrationv1alpha1.StorageVersionMigration:
+			if clients.migrationClient == nil {
+				result.Error = fmt.Errorf("missing migrationClient")
+			} else {
+				_, result.Changed, result.Error = DeleteStorageVersionMigration(ctx, clients.migrationClient, recorder, t)
+			}
+		case *unstructured.Unstructured:
+			if clients.dynamicClient == nil {
+				result.Error = fmt.Errorf("missing dynamicClient")
+			} else {
+				_, result.Changed, result.Error = DeleteKnownUnstructured(ctx, clients.dynamicClient, recorder, t)
 			}
 		default:
 			result.Error = fmt.Errorf("unhandled type %T", requiredObj)

--- a/pkg/operator/resource/resourceapply/migration.go
+++ b/pkg/operator/resource/resourceapply/migration.go
@@ -44,3 +44,16 @@ func ApplyStorageVersionMigration(ctx context.Context, client migrationclientv1a
 	reportUpdateEvent(recorder, required, err)
 	return actual, true, err
 }
+
+func DeleteStorageVersionMigration(ctx context.Context, client migrationclientv1alpha1.Interface, recorder events.Recorder, required *migrationv1alpha1.StorageVersionMigration) (*migrationv1alpha1.StorageVersionMigration, bool, error) {
+	clientInterface := client.MigrationV1alpha1().StorageVersionMigrations()
+	err := clientInterface.Delete(ctx, required.Name, metav1.DeleteOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	reportDeleteEvent(recorder, required, err)
+	return nil, true, nil
+}

--- a/pkg/operator/resource/resourceapply/policy.go
+++ b/pkg/operator/resource/resourceapply/policy.go
@@ -4,12 +4,11 @@ import (
 	"context"
 
 	policyv1 "k8s.io/api/policy/v1"
-	"k8s.io/klog/v2"
-
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	policyclientv1 "k8s.io/client-go/kubernetes/typed/policy/v1"
+	"k8s.io/klog/v2"
 
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
@@ -46,4 +45,16 @@ func ApplyPodDisruptionBudget(ctx context.Context, client policyclientv1.PodDisr
 	actual, err := client.PodDisruptionBudgets(required.Namespace).Update(ctx, existingCopy, metav1.UpdateOptions{})
 	reportUpdateEvent(recorder, required, err)
 	return actual, true, err
+}
+
+func DeletePodDisruptionBudget(ctx context.Context, client policyclientv1.PodDisruptionBudgetsGetter, recorder events.Recorder, required *policyv1.PodDisruptionBudget) (*policyv1.PodDisruptionBudget, bool, error) {
+	err := client.PodDisruptionBudgets(required.Namespace).Delete(ctx, required.Name, metav1.DeleteOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	reportDeleteEvent(recorder, required, err)
+	return nil, true, nil
 }

--- a/pkg/operator/resource/resourceapply/rbac.go
+++ b/pkg/operator/resource/resourceapply/rbac.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"fmt"
 
-	"k8s.io/klog/v2"
-
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	rbacclientv1 "k8s.io/client-go/kubernetes/typed/rbac/v1"
+	"k8s.io/klog/v2"
 
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
@@ -196,4 +195,52 @@ func ApplyRoleBinding(ctx context.Context, client rbacclientv1.RoleBindingsGette
 	actual, err := client.RoleBindings(requiredCopy.Namespace).Update(ctx, existingCopy, metav1.UpdateOptions{})
 	reportUpdateEvent(recorder, requiredCopy, err)
 	return actual, true, err
+}
+
+func DeleteClusterRole(ctx context.Context, client rbacclientv1.ClusterRolesGetter, recorder events.Recorder, required *rbacv1.ClusterRole) (*rbacv1.ClusterRole, bool, error) {
+	err := client.ClusterRoles().Delete(ctx, required.Name, metav1.DeleteOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	reportDeleteEvent(recorder, required, err)
+	return nil, true, nil
+}
+
+func DeleteClusterRoleBinding(ctx context.Context, client rbacclientv1.ClusterRoleBindingsGetter, recorder events.Recorder, required *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, bool, error) {
+	err := client.ClusterRoleBindings().Delete(ctx, required.Name, metav1.DeleteOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	reportDeleteEvent(recorder, required, err)
+	return nil, true, nil
+}
+
+func DeleteRole(ctx context.Context, client rbacclientv1.RolesGetter, recorder events.Recorder, required *rbacv1.Role) (*rbacv1.Role, bool, error) {
+	err := client.Roles(required.Namespace).Delete(ctx, required.Name, metav1.DeleteOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	reportDeleteEvent(recorder, required, err)
+	return nil, true, nil
+}
+
+func DeleteRoleBinding(ctx context.Context, client rbacclientv1.RoleBindingsGetter, recorder events.Recorder, required *rbacv1.RoleBinding) (*rbacv1.RoleBinding, bool, error) {
+	err := client.RoleBindings(required.Namespace).Delete(ctx, required.Name, metav1.DeleteOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	reportDeleteEvent(recorder, required, err)
+	return nil, true, nil
 }

--- a/pkg/operator/resource/resourceapply/storage.go
+++ b/pkg/operator/resource/resourceapply/storage.go
@@ -3,8 +3,6 @@ package resourceapply
 import (
 	"context"
 
-	"k8s.io/klog/v2"
-
 	storagev1 "k8s.io/api/storage/v1"
 	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -12,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	storageclientv1 "k8s.io/client-go/kubernetes/typed/storage/v1"
 	storageclientv1beta1 "k8s.io/client-go/kubernetes/typed/storage/v1beta1"
+	"k8s.io/klog/v2"
 
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
@@ -120,4 +119,29 @@ func ApplyCSIDriver(ctx context.Context, client storageclientv1.CSIDriversGetter
 	actual, err := client.CSIDrivers().Update(ctx, existingCopy, metav1.UpdateOptions{})
 	reportUpdateEvent(recorder, required, err)
 	return actual, true, err
+}
+
+func DeleteStorageClass(ctx context.Context, client storageclientv1.StorageClassesGetter, recorder events.Recorder, required *storagev1.StorageClass) (*storagev1.StorageClass, bool,
+	error) {
+	err := client.StorageClasses().Delete(ctx, required.Name, metav1.DeleteOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	reportDeleteEvent(recorder, required, err)
+	return nil, true, nil
+}
+
+func DeleteCSIDriver(ctx context.Context, client storageclientv1.CSIDriversGetter, recorder events.Recorder, required *storagev1.CSIDriver) (*storagev1.CSIDriver, bool, error) {
+	err := client.CSIDrivers().Delete(ctx, required.Name, metav1.DeleteOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	reportDeleteEvent(recorder, required, err)
+	return nil, true, nil
 }

--- a/pkg/operator/resource/resourceapply/unstructured.go
+++ b/pkg/operator/resource/resourceapply/unstructured.go
@@ -25,3 +25,18 @@ func ApplyKnownUnstructured(ctx context.Context, client dynamic.Interface, recor
 
 	return nil, false, fmt.Errorf("unsupported object type: %s", obj.GetKind())
 }
+
+// DeleteKnownUnstructured deletes few selected Unstructured types
+func DeleteKnownUnstructured(ctx context.Context, client dynamic.Interface, recorder events.Recorder, obj *unstructured.Unstructured) (*unstructured.Unstructured, bool, error) {
+	switch obj.GetObjectKind().GroupVersionKind().GroupKind() {
+	case schema.GroupKind{Group: "monitoring.coreos.com", Kind: "ServiceMonitor"}:
+		return DeleteServiceMonitor(ctx, client, recorder, obj)
+	case schema.GroupKind{Group: "monitoring.coreos.com", Kind: "PrometheusRule"}:
+		return DeletePrometheusRule(ctx, client, recorder, obj)
+	case schema.GroupKind{Group: "snapshot.storage.k8s.io", Kind: "VolumeSnapshotClass"}:
+		return DeleteVolumeSnapshotClass(ctx, client, recorder, obj)
+
+	}
+
+	return nil, false, fmt.Errorf("unsupported object type: %s", obj.GetKind())
+}

--- a/pkg/operator/resource/resourceapply/volumesnapshotclass.go
+++ b/pkg/operator/resource/resourceapply/volumesnapshotclass.go
@@ -114,3 +114,16 @@ func ApplyVolumeSnapshotClass(ctx context.Context, client dynamic.Interface, rec
 	recorder.Eventf("VolumeSnapshotClassUpdated", "Updated VolumeSnapshotClass.snapshot.storage.k8s.io/v1 because it changed")
 	return newObj, true, err
 }
+
+func DeleteVolumeSnapshotClass(ctx context.Context, client dynamic.Interface, recorder events.Recorder, required *unstructured.Unstructured) (*unstructured.Unstructured, bool, error) {
+	namespace := required.GetNamespace()
+	err := client.Resource(volumeSnapshotClassResourceGVR).Namespace(namespace).Delete(ctx, required.GetName(), metav1.DeleteOptions{})
+	if err != nil && errors.IsNotFound(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	reportDeleteEvent(recorder, required, err)
+	return nil, true, nil
+}


### PR DESCRIPTION
With introduction of various topologies, some resources such as PDBs
have no use in single node installations. Other resources may lose
their purpose when certain condition holds. E.g. AWS machine controller
in absence of all nodes provisioned in AWS in a hybrid installation.

This PR adds Delete functions for various resources an defines a ConditionalFunction which can be used by controllers to conditionally delete/create a resource.