### PR TITLE
Feat: sno leader election config

### DIFF
--- a/pkg/config/clusterstatus/clusterstatus.go
+++ b/pkg/config/clusterstatus/clusterstatus.go
@@ -2,6 +2,7 @@ package clusterstatus
 
 import (
 	"context"
+	"fmt"
 
 	configv1 "github.com/openshift/api/config/v1"
 	openshiftcorev1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
@@ -21,13 +22,8 @@ func GetClusterInfraStatus(ctx context.Context, restClient *rest.Config) (*confi
 	if err != nil {
 		return nil, err
 	}
-	return &infra.Status, nil
-}
-
-func GetClusterInfraStatusOrDie(ctx context.Context, restClient *rest.Config) *configv1.InfrastructureStatus {
-	infra, err := GetClusterInfraStatus(ctx, restClient)
-	if err != nil {
-		panic(err)
+	if infra == nil {
+		return nil, fmt.Errorf("getting resource Infrastructure (name: %s) succeeded but object was nil", infraResourceName)
 	}
-	return infra
+	return &infra.Status, nil
 }

--- a/pkg/config/clusterstatus/clusterstatus.go
+++ b/pkg/config/clusterstatus/clusterstatus.go
@@ -1,0 +1,33 @@
+package clusterstatus
+
+import (
+	"context"
+
+	configv1 "github.com/openshift/api/config/v1"
+	openshiftcorev1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/client-go/rest"
+)
+
+const infraResourceName = "cluster"
+
+func GetClusterInfraStatus(ctx context.Context, restClient *rest.Config) (*configv1.InfrastructureStatus, error) {
+	client, err := openshiftcorev1.NewForConfig(restClient)
+	if err != nil {
+		return nil, err
+	}
+	infra, err := client.Infrastructures().Get(ctx, infraResourceName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return &infra.Status, nil
+}
+
+func GetClusterInfraStatusOrDie(ctx context.Context, restClient *rest.Config) *configv1.InfrastructureStatus {
+	infra, err := GetClusterInfraStatus(ctx, restClient)
+	if err != nil {
+		panic(err)
+	}
+	return infra
+}

--- a/pkg/config/leaderelection/leaderelection_test.go
+++ b/pkg/config/leaderelection/leaderelection_test.go
@@ -1,0 +1,178 @@
+package leaderelection
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestLeaderElectionSNOConfig(t *testing.T) {
+	testCases := []struct {
+		desc           string
+		inputConfig    configv1.LeaderElection
+		expectedConfig configv1.LeaderElection
+	}{
+		{
+			desc: "should not alter disable flag when true",
+			inputConfig: configv1.LeaderElection{
+				Disable: true,
+			},
+			expectedConfig: configv1.LeaderElection{
+				Disable:       true,
+				LeaseDuration: metav1.Duration{Duration: 270 * time.Second},
+				RenewDeadline: metav1.Duration{Duration: 240 * time.Second},
+				RetryPeriod:   metav1.Duration{Duration: 60 * time.Second},
+			},
+		},
+		{
+			desc: "should not alter disable flag when false",
+			inputConfig: configv1.LeaderElection{
+				Disable: false,
+			},
+			expectedConfig: configv1.LeaderElection{
+				Disable:       false,
+				LeaseDuration: metav1.Duration{Duration: 270 * time.Second},
+				RenewDeadline: metav1.Duration{Duration: 240 * time.Second},
+				RetryPeriod:   metav1.Duration{Duration: 60 * time.Second},
+			},
+		},
+		{
+			desc:        "should change durations when none are provided",
+			inputConfig: configv1.LeaderElection{},
+			expectedConfig: configv1.LeaderElection{
+				LeaseDuration: metav1.Duration{Duration: 270 * time.Second},
+				RenewDeadline: metav1.Duration{Duration: 240 * time.Second},
+				RetryPeriod:   metav1.Duration{Duration: 60 * time.Second},
+			},
+		},
+		{
+			desc: "should change durations for sno configs",
+			inputConfig: configv1.LeaderElection{
+				LeaseDuration: metav1.Duration{Duration: 60 * time.Second},
+				RenewDeadline: metav1.Duration{Duration: 40 * time.Second},
+				RetryPeriod:   metav1.Duration{Duration: 20 * time.Second},
+			},
+			expectedConfig: configv1.LeaderElection{
+				LeaseDuration: metav1.Duration{Duration: 270 * time.Second},
+				RenewDeadline: metav1.Duration{Duration: 240 * time.Second},
+				RetryPeriod:   metav1.Duration{Duration: 60 * time.Second},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			resultConfig := LeaderElectionSNOConfig(tc.inputConfig)
+			if !reflect.DeepEqual(tc.expectedConfig, resultConfig) {
+				t.Errorf("expected %#v, got %#v", tc.expectedConfig, resultConfig)
+			}
+		})
+	}
+}
+
+func TestLeaderElectionDefaulting(t *testing.T) {
+	testCases := []struct {
+		desc             string
+		defaultNamespace string
+		defaultName      string
+		inputConfig      configv1.LeaderElection
+		expectedConfig   configv1.LeaderElection
+	}{
+		{
+			desc: "should not alter disable flag when true",
+			inputConfig: configv1.LeaderElection{
+				Disable: true,
+			},
+			expectedConfig: configv1.LeaderElection{
+				Disable:       true,
+				LeaseDuration: metav1.Duration{Duration: 137 * time.Second},
+				RenewDeadline: metav1.Duration{Duration: 107 * time.Second},
+				RetryPeriod:   metav1.Duration{Duration: 26 * time.Second},
+			},
+		},
+		{
+			desc: "should not alter disable flag when false",
+			inputConfig: configv1.LeaderElection{
+				Disable: false,
+			},
+			expectedConfig: configv1.LeaderElection{
+				Disable:       false,
+				LeaseDuration: metav1.Duration{Duration: 137 * time.Second},
+				RenewDeadline: metav1.Duration{Duration: 107 * time.Second},
+				RetryPeriod:   metav1.Duration{Duration: 26 * time.Second},
+			},
+		},
+		{
+			desc:        "should change durations when none are provided",
+			inputConfig: configv1.LeaderElection{},
+			expectedConfig: configv1.LeaderElection{
+				LeaseDuration: metav1.Duration{Duration: 137 * time.Second},
+				RenewDeadline: metav1.Duration{Duration: 107 * time.Second},
+				RetryPeriod:   metav1.Duration{Duration: 26 * time.Second},
+			},
+		},
+		{
+			desc:             "should use default name and namespace when none is provided",
+			inputConfig:      configv1.LeaderElection{},
+			defaultName:      "new-default-name",
+			defaultNamespace: "new-default-namespace",
+			expectedConfig: configv1.LeaderElection{
+				LeaseDuration: metav1.Duration{Duration: 137 * time.Second},
+				RenewDeadline: metav1.Duration{Duration: 107 * time.Second},
+				RetryPeriod:   metav1.Duration{Duration: 26 * time.Second},
+				Name:          "new-default-name",
+				Namespace:     "new-default-namespace",
+			},
+		},
+		{
+			desc: "should not alter durations when values are provided",
+			inputConfig: configv1.LeaderElection{
+				LeaseDuration: metav1.Duration{Duration: 60 * time.Second},
+				RenewDeadline: metav1.Duration{Duration: 40 * time.Second},
+				RetryPeriod:   metav1.Duration{Duration: 20 * time.Second},
+			},
+			expectedConfig: configv1.LeaderElection{
+				LeaseDuration: metav1.Duration{Duration: 60 * time.Second},
+				RenewDeadline: metav1.Duration{Duration: 40 * time.Second},
+				RetryPeriod:   metav1.Duration{Duration: 20 * time.Second},
+			},
+		},
+		{
+			desc:             "should not alter when durations, name and namespace are provided",
+			defaultName:      "new-default-name",
+			defaultNamespace: "new-default-namespace",
+			inputConfig: configv1.LeaderElection{
+				Name:          "original-name",
+				Namespace:     "original-namespace",
+				LeaseDuration: metav1.Duration{Duration: 60 * time.Second},
+				RenewDeadline: metav1.Duration{Duration: 40 * time.Second},
+				RetryPeriod:   metav1.Duration{Duration: 20 * time.Second},
+			},
+			expectedConfig: configv1.LeaderElection{
+				Name:          "original-name",
+				Namespace:     "original-namespace",
+				LeaseDuration: metav1.Duration{Duration: 60 * time.Second},
+				RenewDeadline: metav1.Duration{Duration: 40 * time.Second},
+				RetryPeriod:   metav1.Duration{Duration: 20 * time.Second},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			resultConfig := LeaderElectionDefaulting(tc.inputConfig, tc.defaultNamespace, tc.defaultName)
+
+			// When testing in clusters, namespace is read from /var/run/secrets/kubernetes.io/serviceaccount/namespace in LeaderElectionDefaulting if none is provided.
+			// We configure expectedConfig.Namespace to equal resultConfig.Namespace if no default or input namespace is provided
+			// so we use the dynamic namespace read in from the environment
+			if tc.defaultNamespace == "" && tc.inputConfig.Namespace == "" {
+				tc.expectedConfig.Namespace = resultConfig.Namespace
+			}
+
+			if !reflect.DeepEqual(tc.expectedConfig, resultConfig) {
+				t.Errorf("expected %#v, got %#v", tc.expectedConfig, resultConfig)
+			}
+		})
+	}
+}

--- a/pkg/controller/controllercmd/builder.go
+++ b/pkg/controller/controllercmd/builder.go
@@ -13,6 +13,7 @@ import (
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 	"github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer"
 	"github.com/openshift/library-go/pkg/config/client"
+	"github.com/openshift/library-go/pkg/config/clusterstatus"
 	"github.com/openshift/library-go/pkg/config/configdefaults"
 	leaderelectionconverter "github.com/openshift/library-go/pkg/config/leaderelection"
 	"github.com/openshift/library-go/pkg/config/serving"
@@ -89,6 +90,10 @@ type ControllerBuilder struct {
 	// This stub exists for unit test where we can check if the graceful termination work properly.
 	// Default function will klog.Warning(args) and os.Exit(1).
 	nonZeroExitFn func(args ...interface{})
+
+	// Keep track if we defaulted leader election, used to make sure we don't stomp on the users intent for leader election
+	// We use this flag to determine at runtime if we can alter leader election for SNO configurations
+	userExplicitlySetLeaderElectionValues bool
 }
 
 // NewController returns a builder struct for constructing the command you want to run
@@ -141,6 +146,11 @@ func (b *ControllerBuilder) WithLeaderElection(leaderElection configv1.LeaderEle
 	if leaderElection.Disable {
 		return b
 	}
+
+	// Set flag that SNO leader election configs can be used since user provided no timing configs
+	b.userExplicitlySetLeaderElectionValues = leaderElection.LeaseDuration.Duration != 0 ||
+		leaderElection.RenewDeadline.Duration != 0 ||
+		leaderElection.RetryPeriod.Duration != 0
 
 	defaulted := leaderelectionconverter.LeaderElectionDefaulting(leaderElection, defaultNamespace, defaultName)
 	b.leaderElection = &defaulted
@@ -304,6 +314,17 @@ func (b *ControllerBuilder) Run(ctx context.Context, config *unstructured.Unstru
 		return nil
 	}
 
+	if !b.userExplicitlySetLeaderElectionValues {
+		infraStatus, err := clusterstatus.GetClusterInfraStatus(ctx, clientConfig)
+		if err != nil || infraStatus == nil {
+			eventRecorder.Warningf("ClusterInfrastructureStatus", "unable to get cluster infrastructure status, using HA cluster values for leader election: %v", err)
+			klog.Warningf("unable to get cluster infrastructure status, using HA cluster values for leader election: %v", err)
+		} else {
+			snoLeaderElection := infraStatusTopologyLeaderElection(infraStatus, *b.leaderElection)
+			b.leaderElection = &snoLeaderElection
+		}
+	}
+
 	// ensure blocking TCP connections don't block the leader election
 	leaderConfig := rest.CopyConfig(protoConfig)
 	leaderConfig.Timeout = b.leaderElection.RenewDeadline.Duration
@@ -369,4 +390,18 @@ func (b *ControllerBuilder) getClientConfig() (*rest.Config, error) {
 	}
 
 	return client.GetKubeConfigOrInClusterConfig(kubeconfig, b.clientOverrides)
+}
+
+func infraStatusTopologyLeaderElection(infraStatus *configv1.InfrastructureStatus, original configv1.LeaderElection) configv1.LeaderElection {
+	// if we can't determine the infra toplogy, return original
+	if infraStatus == nil {
+		return original
+	}
+
+	// If we are running in a SingleReplicaTopologyMode and leader election is not disabled, configure leader election for SNO Toplogy
+	if infraStatus.ControlPlaneTopology == configv1.SingleReplicaTopologyMode && !original.Disable {
+		klog.Info("detected SingleReplicaTopologyMode, the original leader election has been altered for the default SingleReplicaToplogy")
+		return leaderelectionconverter.LeaderElectionSNOConfig(original)
+	}
+	return original
 }


### PR DESCRIPTION
Leader election in SNO clusters have limited resources where requests can put un-needed pressure on the `kube-apiserver`. This PR increases the retry period and lease duration on leader election and exposes some helper functions to determine topology and SNO leader election defaults, on operator start up.

