### PR TITLE
Add conditional resource synchronization to the resource sync controller

### DIFF
--- a/pkg/operator/apiserver/controllerset/apiservercontrollerset.go
+++ b/pkg/operator/apiserver/controllerset/apiservercontrollerset.go
@@ -24,6 +24,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/loglevel"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
 	"github.com/openshift/library-go/pkg/operator/revisioncontroller"
 	"github.com/openshift/library-go/pkg/operator/secretspruner"
 	"github.com/openshift/library-go/pkg/operator/staticresourcecontroller"
@@ -348,6 +349,7 @@ func (cs *APIServerControllerSet) WithEncryptionControllers(
 	apiServerClient configv1client.APIServerInterface,
 	apiServerInformer configv1informers.APIServerInformer,
 	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
+	resourceSyncer *resourcesynccontroller.ResourceSyncController,
 ) *APIServerControllerSet {
 
 	cs.encryptionControllers = encryptionControllerBuilder{
@@ -362,6 +364,7 @@ func (cs *APIServerControllerSet) WithEncryptionControllers(
 		apiServerInformer:          apiServerInformer,
 		kubeInformersForNamespaces: kubeInformersForNamespaces,
 		secretsClient:              secretsClient,
+		resourceSyncer:             resourceSyncer,
 	}
 
 	return cs
@@ -455,6 +458,7 @@ type encryptionControllerBuilder struct {
 	apiServerClient            configv1client.APIServerInterface
 	apiServerInformer          configv1informers.APIServerInformer
 	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces
+	resourceSyncer             *resourcesynccontroller.ResourceSyncController
 
 	unsupportedConfigPrefix []string
 }
@@ -475,6 +479,7 @@ func (e *encryptionControllerBuilder) build() controllerWrapper {
 		e.kubeInformersForNamespaces,
 		e.secretsClient,
 		e.eventRecorder,
+		e.resourceSyncer,
 	)
 
 	return e.controllerWrapper

--- a/pkg/operator/encryption/controllers/key_controller_test.go
+++ b/pkg/operator/encryption/controllers/key_controller_test.go
@@ -337,7 +337,7 @@ func TestKeyController(t *testing.T) {
 			fakeApiServerClient := fakeConfigClient.ConfigV1().APIServers()
 			fakeApiServerInformer := configv1informers.NewSharedInformerFactory(fakeConfigClient, time.Minute).Config().V1().APIServers()
 
-			deployer, err := encryptiondeployer.NewRevisionLabelPodDeployer("revision", scenario.targetNamespace, kubeInformers, nil, fakePodClient, fakeSecretClient, encryptiondeployer.StaticPodNodeProvider{OperatorClient: fakeOperatorClient})
+			deployer, err := encryptiondeployer.NewRevisionLabelPodDeployer("revision", scenario.targetNamespace, kubeInformers, fakePodClient, fakeSecretClient, encryptiondeployer.StaticPodNodeProvider{OperatorClient: fakeOperatorClient})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/operator/encryption/controllers/migration_controller_test.go
+++ b/pkg/operator/encryption/controllers/migration_controller_test.go
@@ -637,7 +637,7 @@ func TestMigrationController(t *testing.T) {
 				}
 			}
 
-			deployer, err := encryptiondeployer.NewRevisionLabelPodDeployer("revision", scenario.targetNamespace, kubeInformers, nil, fakeKubeClient.CoreV1(), fakeSecretClient, encryptiondeployer.StaticPodNodeProvider{OperatorClient: fakeOperatorClient})
+			deployer, err := encryptiondeployer.NewRevisionLabelPodDeployer("revision", scenario.targetNamespace, kubeInformers, fakeKubeClient.CoreV1(), fakeSecretClient, encryptiondeployer.StaticPodNodeProvider{OperatorClient: fakeOperatorClient})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/operator/encryption/controllers/prune_controller_test.go
+++ b/pkg/operator/encryption/controllers/prune_controller_test.go
@@ -178,7 +178,7 @@ func TestPruneController(t *testing.T) {
 			fakeConfigClient := configv1clientfake.NewSimpleClientset()
 			fakeApiServerInformer := configv1informers.NewSharedInformerFactory(fakeConfigClient, time.Minute).Config().V1().APIServers()
 
-			deployer, err := encryptiondeployer.NewRevisionLabelPodDeployer("revision", scenario.targetNamespace, kubeInformers, nil, fakeKubeClient.CoreV1(), fakeSecretClient, encryptiondeployer.StaticPodNodeProvider{OperatorClient: fakeOperatorClient})
+			deployer, err := encryptiondeployer.NewRevisionLabelPodDeployer("revision", scenario.targetNamespace, kubeInformers, fakeKubeClient.CoreV1(), fakeSecretClient, encryptiondeployer.StaticPodNodeProvider{OperatorClient: fakeOperatorClient})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/operator/encryption/controllers/state_controller_test.go
+++ b/pkg/operator/encryption/controllers/state_controller_test.go
@@ -748,7 +748,7 @@ func TestStateController(t *testing.T) {
 			fakeConfigClient := configv1clientfake.NewSimpleClientset()
 			fakeApiServerInformer := configv1informers.NewSharedInformerFactory(fakeConfigClient, time.Minute).Config().V1().APIServers()
 
-			deployer, err := encryptiondeployer.NewRevisionLabelPodDeployer("revision", scenario.targetNamespace, kubeInformers, nil, fakePodClient, fakeSecretClient, encryptiondeployer.StaticPodNodeProvider{OperatorClient: fakeOperatorClient})
+			deployer, err := encryptiondeployer.NewRevisionLabelPodDeployer("revision", scenario.targetNamespace, kubeInformers, fakePodClient, fakeSecretClient, encryptiondeployer.StaticPodNodeProvider{OperatorClient: fakeOperatorClient})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/operator/resourcesynccontroller/interfaces.go
+++ b/pkg/operator/resourcesynccontroller/interfaces.go
@@ -12,9 +12,16 @@ type ResourceLocation struct {
 	Provider string `json:"provider,omitempty"`
 }
 
+// PreconditionsFulfilled is a function that indicates whether all prerequisites
+// are met and a resource can be synced.
+type preconditionsFulfilled func() (bool, error)
+
+func alwaysFulfilledPreconditions() (bool, error) { return true, nil }
+
 type syncRuleSource struct {
 	ResourceLocation
-	syncedKeys sets.String // defines the set of keys to sync from source to dest
+	syncedKeys               sets.String            // defines the set of keys to sync from source to dest
+	preconditionsFulfilledFn preconditionsFulfilled // preconditions to fulfill before syncing the resource
 }
 
 type syncRules map[ResourceLocation]syncRuleSource

--- a/pkg/operator/resourcesynccontroller/resourcesync_controller.go
+++ b/pkg/operator/resourcesynccontroller/resourcesync_controller.go
@@ -100,10 +100,20 @@ func (c *ResourceSyncController) Name() string {
 }
 
 func (c *ResourceSyncController) SyncConfigMap(destination, source ResourceLocation) error {
-	return c.SyncPartialConfigMap(destination, source)
+	return c.syncConfigMap(destination, source, alwaysFulfilledPreconditions)
 }
 
 func (c *ResourceSyncController) SyncPartialConfigMap(destination ResourceLocation, source ResourceLocation, keys ...string) error {
+	return c.syncConfigMap(destination, source, alwaysFulfilledPreconditions, keys...)
+}
+
+// SyncConfigMapConditionally adds a new configmap that the resource sync
+// controller will synchronise if the given precondition is fulfilled.
+func (c *ResourceSyncController) SyncConfigMapConditionally(destination, source ResourceLocation, preconditionsFulfilledFn preconditionsFulfilled) error {
+	return c.syncConfigMap(destination, source, preconditionsFulfilledFn)
+}
+
+func (c *ResourceSyncController) syncConfigMap(destination ResourceLocation, source ResourceLocation, preconditionsFulfilledFn preconditionsFulfilled, keys ...string) error {
 	if !c.knownNamespaces.Has(destination.Namespace) {
 		return fmt.Errorf("not watching namespace %q", destination.Namespace)
 	}
@@ -114,8 +124,9 @@ func (c *ResourceSyncController) SyncPartialConfigMap(destination ResourceLocati
 	c.syncRuleLock.Lock()
 	defer c.syncRuleLock.Unlock()
 	c.configMapSyncRules[destination] = syncRuleSource{
-		ResourceLocation: source,
-		syncedKeys:       sets.NewString(keys...),
+		ResourceLocation:         source,
+		syncedKeys:               sets.NewString(keys...),
+		preconditionsFulfilledFn: preconditionsFulfilledFn,
 	}
 
 	// make sure the new rule is picked up
@@ -124,10 +135,20 @@ func (c *ResourceSyncController) SyncPartialConfigMap(destination ResourceLocati
 }
 
 func (c *ResourceSyncController) SyncSecret(destination, source ResourceLocation) error {
-	return c.SyncPartialSecret(destination, source)
+	return c.syncSecret(destination, source, alwaysFulfilledPreconditions)
 }
 
 func (c *ResourceSyncController) SyncPartialSecret(destination, source ResourceLocation, keys ...string) error {
+	return c.syncSecret(destination, source, alwaysFulfilledPreconditions, keys...)
+}
+
+// SyncSecretConditionally adds a new secret that the resource sync controller
+// will synchronise if the given precondition is fulfilled.
+func (c *ResourceSyncController) SyncSecretConditionally(destination, source ResourceLocation, preconditionsFulfilledFn preconditionsFulfilled) error {
+	return c.syncSecret(destination, source, preconditionsFulfilledFn)
+}
+
+func (c *ResourceSyncController) syncSecret(destination, source ResourceLocation, preconditionsFulfilledFn preconditionsFulfilled, keys ...string) error {
 	if !c.knownNamespaces.Has(destination.Namespace) {
 		return fmt.Errorf("not watching namespace %q", destination.Namespace)
 	}
@@ -138,8 +159,9 @@ func (c *ResourceSyncController) SyncPartialSecret(destination, source ResourceL
 	c.syncRuleLock.Lock()
 	defer c.syncRuleLock.Unlock()
 	c.secretSyncRules[destination] = syncRuleSource{
-		ResourceLocation: source,
-		syncedKeys:       sets.NewString(keys...),
+		ResourceLocation:         source,
+		syncedKeys:               sets.NewString(keys...),
+		preconditionsFulfilledFn: preconditionsFulfilledFn,
 	}
 
 	// make sure the new rule is picked up
@@ -171,6 +193,14 @@ func (c *ResourceSyncController) Sync(ctx context.Context, syncCtx factory.SyncC
 	errors := []error{}
 
 	for destination, source := range c.configMapSyncRules {
+		// skip the sync if the preconditions aren't fulfilled
+		if fulfilled, err := source.preconditionsFulfilledFn(); !fulfilled || err != nil {
+			if err != nil {
+				errors = append(errors, err)
+			}
+			continue
+		}
+
 		if source.ResourceLocation == emptyResourceLocation {
 			// use the cache to check whether the configmap exists in target namespace, if not skip the extra delete call.
 			if _, err := c.configMapGetter.ConfigMaps(destination.Namespace).Get(ctx, destination.Name, metav1.GetOptions{}); err != nil {
@@ -191,6 +221,14 @@ func (c *ResourceSyncController) Sync(ctx context.Context, syncCtx factory.SyncC
 		}
 	}
 	for destination, source := range c.secretSyncRules {
+		// skip the sync if the preconditions aren't fulfilled
+		if fulfilled, err := source.preconditionsFulfilledFn(); !fulfilled || err != nil {
+			if err != nil {
+				errors = append(errors, err)
+			}
+			continue
+		}
+
 		if source.ResourceLocation == emptyResourceLocation {
 			// use the cache to check whether the secret exists in target namespace, if not skip the extra delete call.
 			if _, err := c.secretGetter.Secrets(destination.Namespace).Get(ctx, destination.Name, metav1.GetOptions{}); err != nil {

--- a/test/e2e-encryption/encryption_test.go
+++ b/test/e2e-encryption/encryption_test.go
@@ -133,6 +133,7 @@ func TestEncryptionIntegration(tt *testing.T) {
 		kubeInformers,
 		deployer, // secret client wrapping kubeClient with encryption-config revision counting
 		eventRecorder,
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("failed to initialize controllers: %v", err)


### PR DESCRIPTION
Controllers behind optional features such as the encryption controller
which is disabled by default for all OpenShift apiservers, have no way
to synchronize secrets/configmaps conditionally. For instance, the
encryption controller tried to synchronize its encryption-config very
often even though encryption is disabled. To mitigate that, some
controllers have some logic to set the SyncResource source
conditionally. An empty source meaning that the sync controller will
skip syncing the object. Since this is very hacky, it would be best to
have preconditions that need to be fulfilled before synchronizing
resources.

To improve that, the ResourceSyncer interface was extended to
add SyncConfigMapCondtionally and SyncSecretConditionally
functions. This allows adding conditional syncs per resource to the
original resource sync controller instead of adding a new controller
dedicated for that.

Related Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1982726
Cause of the bug: the static pod deployer always sync the encryption config secret even when the feature is disabled: https://github.com/openshift/library-go/blob/d429589a7691e57aedcf382d251e6e0ebb4ed0bb/pkg/operator/encryption/deployer/revisionedpod.go#L72-L77
Solution: sync conditionnaly with a controller

Proof: https://github.com/openshift/cluster-kube-apiserver-operator/pull/1250
