### PR TITLE
pkg: fix apiservice discovery context panic

### DIFF
--- a/pkg/operator/apiserver/controller/apiservice/apigroup.go
+++ b/pkg/operator/apiserver/controller/apiservice/apigroup.go
@@ -101,7 +101,7 @@ func checkDiscoveryForAPIService(ctx context.Context, restclient rest.Interface,
 			defer wg.Done()
 			defer utilruntime.HandleCrash()
 
-			discoveryCtx, ctxCancelFn = context.WithTimeout(discoveryCtx, 25*time.Second)
+			discoveryCtx, ctxCancelFn = context.WithTimeout(ctx, 25*time.Second)
 			defer ctxCancelFn()
 
 			result := restclient.Get().AbsPath("/apis/" + apiService.Spec.Group + "/" + apiService.Spec.Version).Do(discoveryCtx).StatusCode(&statusCode)


### PR DESCRIPTION
Fix panic seen in https://github.com/openshift/cluster-openshift-apiserver-operator/pull/483#issuecomment-970532608, after pulling the changes from https://github.com/openshift/library-go/pull/1142.