### PR TITLE
bug 2026352: staticpod pruner: check if the cert directory exists

### DIFF
--- a/pkg/operator/staticpod/prune/cmd.go
+++ b/pkg/operator/staticpod/prune/cmd.go
@@ -128,6 +128,13 @@ func (o *PruneOptions) Run() error {
 		return nil
 	}
 
+	// If the cert dir does not exist, do nothing.
+	// The dir will get eventually created by an installer pod.
+	if _, err := os.Stat(path.Join(o.ResourceDir, o.CertDir)); os.IsNotExist(err) {
+		klog.Infof("Skipping %s as it does not exist", path.Join(o.ResourceDir, o.CertDir))
+		return nil
+	}
+
 	return filepath.Walk(path.Join(o.ResourceDir, o.CertDir),
 		func(filePath string, info os.FileInfo, err error) error {
 			if err != nil {


### PR DESCRIPTION
When a new master node is provisioned, there's no /etc/kubernetes/static-pod-resources/kube-scheduler-certs directory existing on the node yet. Given there's no sync between when a pruner pod and an installer pod gets to run, it may happen the pruner pod gets to run before the installer pod. In which case the certs directory is missing. Leading to a panic since the pruner expects the certs directory to exists. The directory gets eventually created but the panic is not user friendly.