### PR TITLE
resourceapply: don't require generation for applying *WebhookConfiguration resources

### DIFF
--- a/pkg/operator/resource/resourceapply/admissionregistration.go
+++ b/pkg/operator/resource/resourceapply/admissionregistration.go
@@ -21,7 +21,7 @@ import (
 // and an update performed if the mutatingwebhookconfiguration spec and metadata differ from
 // the previously required spec and metadata based on generation change.
 func ApplyMutatingWebhookConfiguration(ctx context.Context, client admissionregistrationclientv1.MutatingWebhookConfigurationsGetter, recorder events.Recorder,
-	requiredOriginal *admissionregistrationv1.MutatingWebhookConfiguration, expectedGeneration int64) (*admissionregistrationv1.MutatingWebhookConfiguration, bool, error) {
+	requiredOriginal *admissionregistrationv1.MutatingWebhookConfiguration) (*admissionregistrationv1.MutatingWebhookConfiguration, bool, error) {
 
 	if requiredOriginal == nil {
 		return nil, false, fmt.Errorf("Unexpected nil instead of an object")
@@ -45,7 +45,7 @@ func ApplyMutatingWebhookConfiguration(ctx context.Context, client admissionregi
 	existingCopy := existing.DeepCopy()
 
 	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
-	if !*modified && existingCopy.GetGeneration() == expectedGeneration {
+	if !*modified {
 		return existingCopy, false, nil
 	}
 	// at this point we know that we're going to perform a write.  We're just trying to get the object correct
@@ -85,7 +85,7 @@ func copyMutatingWebhookCABundle(from, to *admissionregistrationv1.MutatingWebho
 // and an update performed if the validatingwebhookconfiguration spec and metadata differ from
 // the previously required spec and metadata based on generation change.
 func ApplyValidatingWebhookConfiguration(ctx context.Context, client admissionregistrationclientv1.ValidatingWebhookConfigurationsGetter, recorder events.Recorder,
-	requiredOriginal *admissionregistrationv1.ValidatingWebhookConfiguration, expectedGeneration int64) (*admissionregistrationv1.ValidatingWebhookConfiguration, bool, error) {
+	requiredOriginal *admissionregistrationv1.ValidatingWebhookConfiguration) (*admissionregistrationv1.ValidatingWebhookConfiguration, bool, error) {
 	if requiredOriginal == nil {
 		return nil, false, fmt.Errorf("Unexpected nil instead of an object")
 	}
@@ -108,7 +108,7 @@ func ApplyValidatingWebhookConfiguration(ctx context.Context, client admissionre
 	existingCopy := existing.DeepCopy()
 
 	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
-	if !*modified && existingCopy.GetGeneration() == expectedGeneration {
+	if !*modified {
 		return existingCopy, false, nil
 	}
 	// at this point we know that we're going to perform a write.  We're just trying to get the object correct

--- a/pkg/operator/resource/resourceapply/generic.go
+++ b/pkg/operator/resource/resourceapply/generic.go
@@ -206,13 +206,13 @@ func ApplyDirectly(ctx context.Context, clients *ClientHolder, recorder events.R
 			if clients.kubeClient == nil {
 				result.Error = fmt.Errorf("missing kubeClient")
 			} else {
-				result.Result, result.Changed, result.Error = ApplyValidatingWebhookConfiguration(ctx, clients.kubeClient.AdmissionregistrationV1(), recorder, t, -1)
+				result.Result, result.Changed, result.Error = ApplyValidatingWebhookConfiguration(ctx, clients.kubeClient.AdmissionregistrationV1(), recorder, t)
 			}
 		case *admissionregistrationv1.MutatingWebhookConfiguration:
 			if clients.kubeClient == nil {
 				result.Error = fmt.Errorf("missing kubeClient")
 			} else {
-				result.Result, result.Changed, result.Error = ApplyMutatingWebhookConfiguration(ctx, clients.kubeClient.AdmissionregistrationV1(), recorder, t, -1)
+				result.Result, result.Changed, result.Error = ApplyMutatingWebhookConfiguration(ctx, clients.kubeClient.AdmissionregistrationV1(), recorder, t)
 			}
 		case *storagev1.CSIDriver:
 			if clients.kubeClient == nil {


### PR DESCRIPTION
Currently, whoever uses the `staticresourcecontroller` to roll out webhook configuration objects will get this test failure in CI:

```
[sig-arch] events should not repeat pathologically 

1 events happened too frequently  event happened 585 times, something is wrong: ns/openshift-cluster-csi-drivers deployment/vmware-vsphere-csi-driver-operator - reason/ValidatingWebhookConfigurationUpdated Updated ValidatingWebhookConfiguration.admissionregistration.k8s.io/validation.csi.vsphere.vmware.com because it changed
```

I see 2 ways of fixing this:

1. Special-case negative values for the expected generation, so that [this](https://github.com/openshift/library-go/blob/c58f31ee6d3a5b97360175fa073a7eec6ccd1b79/pkg/operator/resource/resourceapply/generic.go#L215) won't constantly update the object.

2. Remove the expected generation argument altogether from the `Apply[Validating,Mutating]WebhookConfiguration()` functions. This might break some users ([here](https://github.com/openshift/cluster-baremetal-operator/blob/91c6c71b6f8219be8a7bd431d71a43afbfe16dfb/provisioning/baremetal_webhook.go#L42) and [here](https://github.com/openshift/machine-api-operator/blob/8525494f83c66da81c96bdf635f168bd7f3ff086/pkg/operator/sync.go#L196-L224)).

Edit: we chose option 2 above (see https://github.com/openshift/library-go/pull/1256#issuecomment-984581830).
