### PR TITLE
tighten static pod UID until v1.23 to account for kubelet bug fix

### DIFF
--- a/pkg/operator/staticpod/installerpod/cmd.go
+++ b/pkg/operator/staticpod/installerpod/cmd.go
@@ -445,7 +445,12 @@ func (o *InstallOptions) installerPodNeedUUID() bool {
 		return false
 	}
 	// if we run kubelet older than 4.9, installer pods require UID generation
-	return kubeletVersion.LT(semver.MustParse("1.22.0"))
+	// Switching this to 1.23 because there was a fix backported late to 1.22: https://github.com/kubernetes/kubernetes/pull/106394
+	// Once we prove this out in 1.23 after the kube bump, we can consider relaxing the constraint to 1.22.Z, but TRT
+	// suspects that this is failing installs due to
+	//  hyperkube[1371]: I1202 08:50:47.935427    1371 status_manager.go:611] "Pod was deleted and then recreated, skipping status update" pod="openshift-kube-scheduler/openshift-kube-scheduler-ip-10-0-129-204.us-east-2.compute.internal" oldPodUID=f11e314508a00e4ea9bf37d76b82b162 podUID=cce59ead72804895d31dba4208b395aa
+	// in kubelet logs
+	return kubeletVersion.LT(semver.MustParse("1.23.0"))
 }
 
 func (o *InstallOptions) writePod(rawPodBytes []byte, manifestFileName, resourceDir string) error {

--- a/pkg/operator/staticpod/installerpod/cmd_test.go
+++ b/pkg/operator/staticpod/installerpod/cmd_test.go
@@ -248,7 +248,7 @@ func TestCopyContent(t *testing.T) {
 
 func TestKubeletVersion(t *testing.T) {
 	o := &InstallOptions{}
-	o.KubeletVersion = "1.22.1+1b2affc"
+	o.KubeletVersion = "1.23.1+1b2affc"
 	if o.installerPodNeedUUID() {
 		t.Fatalf("kubelet \"v1.22.1+1b2affc\" does not need UID")
 	}


### PR DESCRIPTION
found in https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.10-e2e-aws-serial/1466323246101041152

The kube-scheduler operand pod doesn't appear to be getting updated.  This is only one of a few different problems in the kube-scheduler-operator.