### PR TITLE
helpers: prevent panic in status update

### DIFF
--- a/pkg/operator/v1helpers/helpers.go
+++ b/pkg/operator/v1helpers/helpers.go
@@ -165,6 +165,7 @@ func UpdateStatus(ctx context.Context, client OperatorClient, updateFuncs ...Upd
 			return err
 		}
 
+		oldStatus = oldStatus.DeepCopy()
 		newStatus := oldStatus.DeepCopy()
 		for _, update := range updateFuncs {
 			if err := update(newStatus); err != nil {


### PR DESCRIPTION
[I have an example of this code generating a panic](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/release-openshift-ocp-installer-e2e-gcp-serial-4.10/1468032143799095296/artifacts/e2e-gcp-serial/pods/openshift-cluster-storage-operator_cluster-storage-operator-67867cd954-sh44t_cluster-storage-operator_previous.log):

```
Observed a panic: reflect: slice index out of range
[...]
panic({0x1e9ab60, 0x2601af0})
	runtime/panic.go:1047 +0x266
reflect.Value.Index({0x1e1f740, 0xc0015a2f88, 0xc002bb2840}, 0xc0028ef3c8)
	reflect/value.go:1297 +0x178
k8s.io/apimachinery/third_party/forked/golang/reflect.Equalities.deepValueEqual(0x2160340, {0x1e1f740, 0xc0019e5bd0, 0x0}, {0x1e1f740, 0xc0015a2f88, 0x199}, 0x16, 0x2)
	k8s.io/apimachinery@v0.22.1/third_party/forked/golang/reflect/deep_equal.go:172 +0x1185
k8s.io/apimachinery/third_party/forked/golang/reflect.Equalities.deepValueEqual(0x1ff27c0, {0x2160340, 0xc0019e5b98, 0x229ed20}, {0x2160340, 0xc0015a2f50, 0xc002bea000}, 0xe, 0x1)
	k8s.io/apimachinery@v0.22.1/third_party/forked/golang/reflect/deep_equal.go:186 +0x1325
k8s.io/apimachinery/third_party/forked/golang/reflect.Equalities.deepValueEqual(0x1ff27c0, {0x1ff27c0, 0xc0019e5b98, 0x578}, {0x1ff27c0, 0xc0015a2f50, 0x580}, 0xc00073b000, 0x0)
	k8s.io/apimachinery@v0.22.1/third_party/forked/golang/reflect/deep_equal.go:183 +0xe11
k8s.io/apimachinery/third_party/forked/golang/reflect.Equalities.DeepEqual(0xc0019e5b98, {0x1ff27c0, 0xc0019e5b98}, {0x1ff27c0, 0xc0015a2f50})
	k8s.io/apimachinery@v0.22.1/third_party/forked/golang/reflect/deep_equal.go:243 +0x285
github.com/openshift/library-go/pkg/operator/v1helpers.UpdateStatus.func1()
	github.com/openshift/library-go@v0.0.0-20210830145332-4a9873bf5e74/pkg/operator/v1helpers/helpers.go:174 +0x149
[...]
```

While following the trace, deep equal in apimachinery does a length
comparison before accessing v1.Index(i) and v2.Index(i):

  - https://github.com/kubernetes/apimachinery/blame/5f072755815add51938b52f806c555ed8c86a1ce/third_party/forked/golang/reflect/deep_equal.go#L165-L167
  - https://github.com/kubernetes/apimachinery/blame/5f072755815add51938b52f806c555ed8c86a1ce/third_party/forked/golang/reflect/deep_equal.go#L171-L175

If we're hitting a slice index out of range, the only way that I can
imagine this happening is if oldStatus is somehow mutated somewhere else
between the executions of those two sections of code.

This makes a copy of it before doing the comparison.  I'm not entirely certain oldStatus
can actually be modified, but aside from something odd like a cosmic ray bit flip, it's
the only thing I can think of.
