### PR TITLE
Add DialContext configuration override

### DIFF
--- a/pkg/network/dialer.go
+++ b/pkg/network/dialer.go
@@ -7,7 +7,7 @@ import (
 
 type DialContext func(ctx context.Context, network, address string) (net.Conn, error)
 
-// DefaultDialContext returns a DialContext function from a network dialer with default options sets.
+// DefaultClientDialContext returns a DialContext function from a network dialer with default options sets.
 func DefaultClientDialContext() DialContext {
 	return dialerWithDefaultOptions()
 }


### PR DESCRIPTION
library-go GetClientConfig&GetKubeConfigOrInClusterConfig functions do not
support customizing DialContext settings like Timeout, KeepAlive, etc. Due to that reason
some other repositories use their own GetClientConfig function,
ie. https://github.com/openshift/origin/blob/a9f946043f69428491745ab517d0c23a5b4c2cdd/test/extended/util/client.go#L862

This PR provides a way to customize DialContext settings to unify
GetClientConfig implementation spread across multiple repositories.