### PR TITLE
Bug 2037274: pkg/security/ldapclient: add configuration for connection verification

### DIFF
--- a/pkg/security/OWNERS
+++ b/pkg/security/OWNERS
@@ -1,0 +1,7 @@
+reviewers:
+  - ibihim
+  - s-urbaniak
+  - slaskawi
+  - stlaz
+approvers:
+  - stlaz

--- a/pkg/security/ldapclient/client.go
+++ b/pkg/security/ldapclient/client.go
@@ -13,6 +13,11 @@ import (
 
 // NewLDAPClientConfig returns a new LDAP client config
 func NewLDAPClientConfig(URL, bindDN, bindPassword, CA string, insecure bool) (Config, error) {
+	return NewLDAPClientConfigWithTLSConnectionVerification(URL, bindDN, bindPassword, CA, insecure, nil)
+}
+
+// NewLDAPClientConfig returns a new LDAP client config
+func NewLDAPClientConfigWithTLSConnectionVerification(URL, bindDN, bindPassword, CA string, insecure bool, verifyFn func(tls.ConnectionState) error) (Config, error) {
 	url, err := ldaputil.ParseURL(URL)
 	if err != nil {
 		return nil, fmt.Errorf("Error parsing URL: %v", err)
@@ -26,6 +31,8 @@ func NewLDAPClientConfig(URL, bindDN, bindPassword, CA string, insecure bool) (C
 		}
 		tlsConfig.RootCAs = roots
 	}
+
+	tlsConfig.VerifyConnection = verifyFn
 
 	return &ldapClientConfig{
 		scheme:       url.Scheme,


### PR DESCRIPTION
This adds the possibility to add connection verification in the ldap client configuration.

See https://github.com/openshift/enhancements/pull/980 for context.