### PR TITLE
pkg/security/OWNERS: add auth team

### DIFF
--- a/pkg/security/OWNERS
+++ b/pkg/security/OWNERS
@@ -1,0 +1,7 @@
+reviewers:
+  - ibihim
+  - s-urbaniak
+  - slaskawi
+  - stlaz
+approvers:
+  - stlaz


### PR DESCRIPTION
This updates the auth team to be owners of the security package which mostly includes ldap helpers.

/cc @sttts 