### PR TITLE
bug 2005901: staticpod builder: initialize operand label selector separately

### DIFF
--- a/pkg/operator/staticpod/controller/guard/guard_controller_test.go
+++ b/pkg/operator/staticpod/controller/guard/guard_controller_test.go
@@ -288,17 +288,18 @@ func TestRenderGuardPod(t *testing.T) {
 			eventRecorder := events.NewRecorder(kubeClient.CoreV1().Events("test"), "test-operator", &corev1.ObjectReference{})
 
 			ctrl := &GuardController{
-				targetNamespace:       "test",
-				podResourcePrefix:     "operand",
-				operatorName:          "operator",
-				readyzPort:            "99999",
-				nodeLister:            kubeInformers.Core().V1().Nodes().Lister(),
-				podLister:             kubeInformers.Core().V1().Pods().Lister(),
-				podGetter:             kubeClient.CoreV1(),
-				pdbGetter:             kubeClient.PolicyV1(),
-				pdbLister:             kubeInformers.Policy().V1().PodDisruptionBudgets().Lister(),
-				installerPodImageFn:   getInstallerPodImageFromEnv,
-				createConditionalFunc: IsSNOCheckFnc(lister),
+				targetNamespace:         "test",
+				podResourcePrefix:       "operand",
+				operatorName:            "operator",
+				operandPodLabelSelector: labels.Set{"app": "operand"}.AsSelector(),
+				readyzPort:              "99999",
+				nodeLister:              kubeInformers.Core().V1().Nodes().Lister(),
+				podLister:               kubeInformers.Core().V1().Pods().Lister(),
+				podGetter:               kubeClient.CoreV1(),
+				pdbGetter:               kubeClient.PolicyV1(),
+				pdbLister:               kubeInformers.Policy().V1().PodDisruptionBudgets().Lister(),
+				installerPodImageFn:     getInstallerPodImageFromEnv,
+				createConditionalFunc:   IsSNOCheckFnc(lister),
 			}
 
 			ctx, cancel := context.WithCancel(context.TODO())
@@ -404,17 +405,18 @@ func TestRenderGuardPodPortChanged(t *testing.T) {
 	eventRecorder := events.NewRecorder(kubeClient.CoreV1().Events("test"), "test-operator", &corev1.ObjectReference{})
 
 	ctrl := &GuardController{
-		targetNamespace:       "test",
-		podResourcePrefix:     "operand",
-		operatorName:          "operator",
-		readyzPort:            "99999",
-		nodeLister:            kubeInformers.Core().V1().Nodes().Lister(),
-		podLister:             kubeInformers.Core().V1().Pods().Lister(),
-		podGetter:             kubeClient.CoreV1(),
-		pdbGetter:             kubeClient.PolicyV1(),
-		pdbLister:             kubeInformers.Policy().V1().PodDisruptionBudgets().Lister(),
-		installerPodImageFn:   getInstallerPodImageFromEnv,
-		createConditionalFunc: IsSNOCheckFnc(lister),
+		targetNamespace:         "test",
+		podResourcePrefix:       "operand",
+		operandPodLabelSelector: labels.Set{"app": "operand"}.AsSelector(),
+		operatorName:            "operator",
+		readyzPort:              "99999",
+		nodeLister:              kubeInformers.Core().V1().Nodes().Lister(),
+		podLister:               kubeInformers.Core().V1().Pods().Lister(),
+		podGetter:               kubeClient.CoreV1(),
+		pdbGetter:               kubeClient.PolicyV1(),
+		pdbLister:               kubeInformers.Policy().V1().PodDisruptionBudgets().Lister(),
+		installerPodImageFn:     getInstallerPodImageFromEnv,
+		createConditionalFunc:   IsSNOCheckFnc(lister),
 	}
 
 	ctx, cancel := context.WithCancel(context.TODO())


### PR DESCRIPTION
Not every controller consumes operand pod label selector when the StartMonitor is enabled.
Also, the operand pod label selector is now required by the guard
controller since not every operator has the static pod name
equal to the app label. E.g.

| operand | label | static pod name |
| ------- | ----- | --------------- |
| kube-scheduler | app=openshift-kube-scheduler | openshift-kube-scheduler |
| kube-controller-manager | app=kube-controller-manager | kube-controller-manager |
| kube-apiserver | app=openshift-kube-apiserver | kube-apiserver |

In case of KS and KCM both app label and the static pod name are equal.
Whereas in the case of KA, the app label differs from the static pod
name. Thus, it is more practical to provide the operand pod label selector rather than rely on a specific label.

Required by https://github.com/openshift/cluster-kube-apiserver-operator/pull/1275.