### PR TITLE
Bug 2031839: metricscontroller: handle empty vector query result

### DIFF
--- a/pkg/operator/metricscontroller/legacy_cn_certs_sync.go
+++ b/pkg/operator/metricscontroller/legacy_cn_certs_sync.go
@@ -30,7 +30,11 @@ func NewLegacyCNCertsMetricsSyncFunc(query string, operatorClient v1helpers.Oper
 		var value model.SampleValue
 		switch result.Type() {
 		case model.ValVector:
-			value = result.(model.Vector)[0].Value
+			vec := result.(model.Vector)
+			if len(vec) == 0 {
+				return fmt.Errorf("empty vector result from query: %q", query)
+			}
+			value = vec[0].Value
 		case model.ValScalar:
 			value = result.(*model.Scalar).Value
 		default:

--- a/pkg/operator/metricscontroller/legacy_cn_certs_sync_test.go
+++ b/pkg/operator/metricscontroller/legacy_cn_certs_sync_test.go
@@ -42,6 +42,11 @@ func TestLegacyCNCertsController(t *testing.T) {
 		wantConditions []operatorv1.OperatorCondition
 	}{
 		{
+			name:          "vector - empty result",
+			queryResult:   prometheusmodel.Vector([]*prometheusmodel.Sample{}),
+			wantSyncError: `empty vector result from query: ""`,
+		},
+		{
 			name: "vector - valid certs",
 			queryResult: prometheusmodel.Vector([]*prometheusmodel.Sample{
 				{


### PR DESCRIPTION
This fixes an empty vector result which can happy during early bootstrap phases, recognized during proof PR https://github.com/openshift/cluster-kube-apiserver-operator/pull/1274.

/cc @stlaz