### PR TITLE
bug 2005901: guard controller: create the pdb if it does not exist

### DIFF
--- a/pkg/operator/staticpod/controller/guard/guard_controller.go
+++ b/pkg/operator/staticpod/controller/guard/guard_controller.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/klog/v2"
 
 	configv1 "github.com/openshift/api/config/v1"
-	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
+	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
@@ -48,7 +48,7 @@ type GuardController struct {
 
 	// installerPodImageFn returns the image name for the installer pod
 	installerPodImageFn   func() string
-	createConditionalFunc func() (bool, error)
+	createConditionalFunc func() (bool, bool, error)
 }
 
 func NewGuardController(
@@ -63,7 +63,7 @@ func NewGuardController(
 	podGetter corev1client.PodsGetter,
 	pdbGetter policyclientv1.PodDisruptionBudgetsGetter,
 	eventRecorder events.Recorder,
-	createConditionalFunc func() (bool, error),
+	createConditionalFunc func() (bool, bool, error),
 ) factory.Controller {
 	c := &GuardController{
 		targetNamespace:         targetNamespace,
@@ -112,12 +112,17 @@ func (c *GuardController) sync(ctx context.Context, syncCtx factory.SyncContext)
 	klog.V(5).Info("Syncing guards")
 
 	if c.createConditionalFunc == nil {
-		return fmt.Errorf("create conditional not set")
+		return fmt.Errorf("createConditionalFunc not set")
 	}
 
-	shouldCreate, err := c.createConditionalFunc()
+	shouldCreate, precheckSucceeded, err := c.createConditionalFunc()
 	if err != nil {
-		return fmt.Errorf("create conditional returns an error: %v", err)
+		return fmt.Errorf("createConditionalFunc returns an error: %v", err)
+	}
+
+	if !precheckSucceeded {
+		klog.V(4).Infof("create conditional precheck did not succeed, skipping")
+		return nil
 	}
 
 	errs := []error{}
@@ -280,16 +285,24 @@ func (c *GuardController) sync(ctx context.Context, syncCtx factory.SyncContext)
 	return utilerrors.NewAggregate(errs)
 }
 
-func IsSNOCheckFnc(infraLister configv1listers.InfrastructureLister) func() (bool, error) {
-	return func() (bool, error) {
-		infraData, err := infraLister.Get("cluster")
+// IsSNOCheckFnc creates a function that checks if the topology is SNO
+// In case the err is nil, precheckSucceeded signifies whether the isSNO is valid.
+// If precheckSucceeded is false, the isSNO return value does not reflect the cluster topology
+// and defaults to the bool default value.
+func IsSNOCheckFnc(infraInformer configv1informers.InfrastructureInformer) func() (isSNO, precheckSucceeded bool, err error) {
+	return func() (isSNO, precheckSucceeded bool, err error) {
+		if !infraInformer.Informer().HasSynced() {
+			// Do not return transient error
+			return false, false, nil
+		}
+		infraData, err := infraInformer.Lister().Get("cluster")
 		if err != nil {
-			return false, fmt.Errorf("Unable to list infrastructures.config.openshift.io/cluster object, unable to determine topology mode")
+			return false, true, fmt.Errorf("Unable to list infrastructures.config.openshift.io/cluster object, unable to determine topology mode")
 		}
 		if infraData.Status.ControlPlaneTopology == "" {
-			return false, fmt.Errorf("ControlPlaneTopology was not set, unable to determine topology mode")
+			return false, true, fmt.Errorf("ControlPlaneTopology was not set, unable to determine topology mode")
 		}
 
-		return infraData.Status.ControlPlaneTopology == configv1.SingleReplicaTopologyMode, nil
+		return infraData.Status.ControlPlaneTopology == configv1.SingleReplicaTopologyMode, true, nil
 	}
 }

--- a/pkg/operator/staticpod/controller/guard/guard_controller_test.go
+++ b/pkg/operator/staticpod/controller/guard/guard_controller_test.go
@@ -17,9 +17,25 @@ import (
 	"k8s.io/client-go/util/workqueue"
 
 	configv1 "github.com/openshift/api/config/v1"
+	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
 	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
 	"github.com/openshift/library-go/pkg/operator/events"
 )
+
+type FakeInfrastructureInformer struct {
+	Informer_ cache.SharedIndexInformer
+	Lister_   configlistersv1.InfrastructureLister
+}
+
+func (f FakeInfrastructureInformer) Informer() cache.SharedIndexInformer {
+	return f.Informer_
+}
+
+func (f FakeInfrastructureInformer) Lister() configlistersv1.InfrastructureLister {
+	return f.Lister_
+}
+
+var _ configv1informers.InfrastructureInformer = &FakeInfrastructureInformer{}
 
 type FakeInfrastructureLister struct {
 	InfrastructureLister_ configlistersv1.InfrastructureLister
@@ -33,13 +49,45 @@ func (l FakeInfrastructureLister) List(selector labels.Selector) (ret []*configv
 	return l.InfrastructureLister_.List(selector)
 }
 
+type FakeInfrastructureSharedInformer struct {
+	HasSynced_ bool
+}
+
+func (i FakeInfrastructureSharedInformer) AddIndexers(indexers cache.Indexers) error          { return nil }
+func (i FakeInfrastructureSharedInformer) GetIndexer() cache.Indexer                          { return nil }
+func (i FakeInfrastructureSharedInformer) AddEventHandler(handler cache.ResourceEventHandler) {}
+func (i FakeInfrastructureSharedInformer) AddEventHandlerWithResyncPeriod(handler cache.ResourceEventHandler, resyncPeriod time.Duration) {
+}
+func (i FakeInfrastructureSharedInformer) GetStore() cache.Store           { return nil }
+func (i FakeInfrastructureSharedInformer) GetController() cache.Controller { return nil }
+func (i FakeInfrastructureSharedInformer) Run(stopCh <-chan struct{})      {}
+func (i FakeInfrastructureSharedInformer) HasSynced() bool                 { return i.HasSynced_ }
+func (i FakeInfrastructureSharedInformer) LastSyncResourceVersion() string { return "" }
+func (i FakeInfrastructureSharedInformer) SetWatchErrorHandler(handler cache.WatchErrorHandler) error {
+	return nil
+}
+
 func TestIsSNOCheckFnc(t *testing.T) {
 	tests := []struct {
-		name        string
-		infraObject *configv1.Infrastructure
-		result      bool
-		err         bool
+		name                      string
+		infraObject               *configv1.Infrastructure
+		hasSynced                 bool
+		result, precheckSucceeded bool
+		err                       bool
 	}{
+		{
+			name: "Infrastructure informer has not synced",
+			infraObject: &configv1.Infrastructure{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "cluster",
+				},
+				Status: configv1.InfrastructureStatus{
+					ControlPlaneTopology: configv1.SingleReplicaTopologyMode,
+				},
+			},
+			hasSynced:         false,
+			precheckSucceeded: false,
+		},
 		{
 			name: "Missing Infrastructure status",
 			infraObject: &configv1.Infrastructure{
@@ -48,8 +96,9 @@ func TestIsSNOCheckFnc(t *testing.T) {
 				},
 				Status: configv1.InfrastructureStatus{},
 			},
-			result: false,
-			err:    true,
+			hasSynced:         true,
+			err:               true,
+			precheckSucceeded: true,
 		},
 		{
 			name: "Missing ControlPlaneTopology",
@@ -61,8 +110,9 @@ func TestIsSNOCheckFnc(t *testing.T) {
 					ControlPlaneTopology: "",
 				},
 			},
-			result: false,
-			err:    true,
+			hasSynced:         true,
+			err:               true,
+			precheckSucceeded: true,
 		},
 		{
 			name: "ControlPlaneTopology not SingleReplicaTopologyMode",
@@ -74,7 +124,9 @@ func TestIsSNOCheckFnc(t *testing.T) {
 					ControlPlaneTopology: configv1.HighlyAvailableTopologyMode,
 				},
 			},
-			result: false,
+			hasSynced:         true,
+			result:            false,
+			precheckSucceeded: true,
 		},
 		{
 			name: "ControlPlaneTopology is SingleReplicaTopologyMode",
@@ -86,7 +138,9 @@ func TestIsSNOCheckFnc(t *testing.T) {
 					ControlPlaneTopology: configv1.SingleReplicaTopologyMode,
 				},
 			},
-			result: true,
+			hasSynced:         true,
+			result:            true,
+			precheckSucceeded: true,
 		},
 	}
 
@@ -96,12 +150,18 @@ func TestIsSNOCheckFnc(t *testing.T) {
 			if err := indexer.Add(test.infraObject); err != nil {
 				t.Fatal(err.Error())
 			}
-			lister := FakeInfrastructureLister{
-				InfrastructureLister_: configlistersv1.NewInfrastructureLister(indexer),
+
+			informer := FakeInfrastructureInformer{
+				Informer_: FakeInfrastructureSharedInformer{
+					HasSynced_: test.hasSynced,
+				},
+				Lister_: FakeInfrastructureLister{
+					InfrastructureLister_: configlistersv1.NewInfrastructureLister(indexer),
+				},
 			}
 
-			conditionalFunction := IsSNOCheckFnc(lister)
-			result, err := conditionalFunction()
+			conditionalFunction := IsSNOCheckFnc(informer)
+			result, precheckSucceeded, err := conditionalFunction()
 			if test.err {
 				if err == nil {
 					t.Errorf("%s: expected error, got none", test.name)
@@ -109,8 +169,8 @@ func TestIsSNOCheckFnc(t *testing.T) {
 			} else {
 				if err != nil {
 					t.Errorf("%s: unexpected error: %v", test.name, err)
-				} else if result != test.result {
-					t.Errorf("%s: expected %v, got %v", test.name, test.result, result)
+				} else if result != test.result || precheckSucceeded != test.precheckSucceeded {
+					t.Errorf("%s: expected result %v, got %v, expected precheckSucceeded %v, got %v", test.name, test.result, result, test.precheckSucceeded, precheckSucceeded)
 				}
 			}
 		})
@@ -157,13 +217,14 @@ func (f FakeSyncContext) Recorder() events.Recorder {
 // render a guarding pod
 func TestRenderGuardPod(t *testing.T) {
 	tests := []struct {
-		name        string
-		infraObject *configv1.Infrastructure
-		errString   string
-		err         bool
-		operandPod  *corev1.Pod
-		guardExists bool
-		guardPod    *corev1.Pod
+		name                  string
+		infraObject           *configv1.Infrastructure
+		errString             string
+		err                   bool
+		operandPod            *corev1.Pod
+		guardExists           bool
+		guardPod              *corev1.Pod
+		createConditionalFunc func() (bool, bool, error)
 	}{
 		{
 			name: "Operand pod missing",
@@ -265,6 +326,32 @@ func TestRenderGuardPod(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Conditional return precheckSucceeded is false",
+			infraObject: &configv1.Infrastructure{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "cluster",
+				},
+				Status: configv1.InfrastructureStatus{
+					ControlPlaneTopology: configv1.SingleReplicaTopologyMode,
+				},
+			},
+			createConditionalFunc: func() (bool, bool, error) { return false, false, nil },
+			operandPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "operand1",
+					Namespace: "test",
+					Labels:    map[string]string{"app": "operand"},
+				},
+				Spec: corev1.PodSpec{
+					NodeName: "master1",
+				},
+				Status: corev1.PodStatus{
+					PodIP: "1.1.1.1",
+				},
+			},
+			guardExists: false,
+		},
 	}
 
 	for _, test := range tests {
@@ -272,9 +359,6 @@ func TestRenderGuardPod(t *testing.T) {
 			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
 			if err := indexer.Add(test.infraObject); err != nil {
 				t.Fatal(err.Error())
-			}
-			lister := FakeInfrastructureLister{
-				InfrastructureLister_: configlistersv1.NewInfrastructureLister(indexer),
 			}
 
 			kubeClient := fake.NewSimpleClientset(fakeMasterNode("master1"))
@@ -286,6 +370,20 @@ func TestRenderGuardPod(t *testing.T) {
 			}
 			kubeInformers := informers.NewSharedInformerFactoryWithOptions(kubeClient, 1*time.Minute)
 			eventRecorder := events.NewRecorder(kubeClient.CoreV1().Events("test"), "test-operator", &corev1.ObjectReference{})
+
+			informer := FakeInfrastructureInformer{
+				Informer_: FakeInfrastructureSharedInformer{
+					HasSynced_: true,
+				},
+				Lister_: FakeInfrastructureLister{
+					InfrastructureLister_: configlistersv1.NewInfrastructureLister(indexer),
+				},
+			}
+
+			createConditionalFunc := IsSNOCheckFnc(informer)
+			if test.createConditionalFunc != nil {
+				createConditionalFunc = test.createConditionalFunc
+			}
 
 			ctrl := &GuardController{
 				targetNamespace:         "test",
@@ -299,7 +397,7 @@ func TestRenderGuardPod(t *testing.T) {
 				pdbGetter:               kubeClient.PolicyV1(),
 				pdbLister:               kubeInformers.Policy().V1().PodDisruptionBudgets().Lister(),
 				installerPodImageFn:     getInstallerPodImageFromEnv,
-				createConditionalFunc:   IsSNOCheckFnc(lister),
+				createConditionalFunc:   createConditionalFunc,
 			}
 
 			ctx, cancel := context.WithCancel(context.TODO())
@@ -396,13 +494,19 @@ func TestRenderGuardPodPortChanged(t *testing.T) {
 	if err := indexer.Add(infraObject); err != nil {
 		t.Fatal(err.Error())
 	}
-	lister := FakeInfrastructureLister{
-		InfrastructureLister_: configlistersv1.NewInfrastructureLister(indexer),
-	}
 
 	kubeClient := fake.NewSimpleClientset(fakeMasterNode("master1"), operandPod, guardPod)
 	kubeInformers := informers.NewSharedInformerFactoryWithOptions(kubeClient, 1*time.Minute)
 	eventRecorder := events.NewRecorder(kubeClient.CoreV1().Events("test"), "test-operator", &corev1.ObjectReference{})
+
+	informer := FakeInfrastructureInformer{
+		Informer_: FakeInfrastructureSharedInformer{
+			HasSynced_: true,
+		},
+		Lister_: FakeInfrastructureLister{
+			InfrastructureLister_: configlistersv1.NewInfrastructureLister(indexer),
+		},
+	}
 
 	ctrl := &GuardController{
 		targetNamespace:         "test",
@@ -416,7 +520,7 @@ func TestRenderGuardPodPortChanged(t *testing.T) {
 		pdbGetter:               kubeClient.PolicyV1(),
 		pdbLister:               kubeInformers.Policy().V1().PodDisruptionBudgets().Lister(),
 		installerPodImageFn:     getInstallerPodImageFromEnv,
-		createConditionalFunc:   IsSNOCheckFnc(lister),
+		createConditionalFunc:   IsSNOCheckFnc(informer),
 	}
 
 	ctx, cancel := context.WithCancel(context.TODO())

--- a/pkg/operator/staticpod/controllers.go
+++ b/pkg/operator/staticpod/controllers.go
@@ -68,7 +68,7 @@ type staticPodOperatorControllerBuilder struct {
 	operatorName               string
 	operatorNamespace          string
 	readyzPort                 string
-	guardCreateConditionalFunc func() (bool, error)
+	guardCreateConditionalFunc func() (bool, bool, error)
 }
 
 func NewBuilder(
@@ -99,7 +99,7 @@ type Builder interface {
 	// the installer pod is created for a revision.
 	WithCustomInstaller(command []string, installerPodMutationFunc installer.InstallerPodMutationFunc) Builder
 	WithPruning(command []string, staticPodPrefix string) Builder
-	WithPodDisruptionBudgetGuard(operatorNamespace, operatorName, readyzPort string, createConditionalFunc func() (bool, error)) Builder
+	WithPodDisruptionBudgetGuard(operatorNamespace, operatorName, readyzPort string, createConditionalFunc func() (bool, bool, error)) Builder
 	ToControllers() (manager.ControllerManager, error)
 }
 
@@ -166,7 +166,7 @@ func (b *staticPodOperatorControllerBuilder) WithPruning(command []string, stati
 	return b
 }
 
-func (b *staticPodOperatorControllerBuilder) WithPodDisruptionBudgetGuard(operatorNamespace, operatorName, readyzPort string, createConditionalFunc func() (bool, error)) Builder {
+func (b *staticPodOperatorControllerBuilder) WithPodDisruptionBudgetGuard(operatorNamespace, operatorName, readyzPort string, createConditionalFunc func() (bool, bool, error)) Builder {
 	b.operatorNamespace = operatorNamespace
 	b.operatorName = operatorName
 	b.readyzPort = readyzPort


### PR DESCRIPTION
The guard controller is missing the code that creates a PDB. Also, do not render the guard pod if its underlying node is not schedulable (tainted with `NoSchedule:node.kubernetes.io/unschedulable`).