### PR TITLE
staticpodcontroller: refactor ToControllers() method to be less error prone

### DIFF
--- a/pkg/operator/staticpod/controller/guard/guard_controller.go
+++ b/pkg/operator/staticpod/controller/guard/guard_controller.go
@@ -64,7 +64,14 @@ func NewGuardController(
 	pdbGetter policyclientv1.PodDisruptionBudgetsGetter,
 	eventRecorder events.Recorder,
 	createConditionalFunc func() (bool, bool, error),
-) factory.Controller {
+) (factory.Controller, error) {
+	if operandPodLabelSelector == nil {
+		return nil, fmt.Errorf("GuardController: missing required operandPodLabelSelector")
+	}
+	if operandPodLabelSelector.Empty() {
+		return nil, fmt.Errorf("GuardController: operandPodLabelSelector cannot be empty")
+	}
+
 	c := &GuardController{
 		targetNamespace:         targetNamespace,
 		operandPodLabelSelector: operandPodLabelSelector,
@@ -83,7 +90,7 @@ func NewGuardController(
 	return factory.New().WithInformers(
 		kubeInformersForTargetNamespace.Core().V1().Pods().Informer(),
 		kubeInformersClusterScoped.Core().V1().Nodes().Informer(),
-	).WithSync(c.sync).WithSyncDegradedOnError(operatorClient).ToController("GuardController", eventRecorder)
+	).WithSync(c.sync).WithSyncDegradedOnError(operatorClient).ToController("GuardController", eventRecorder), nil
 }
 
 func getInstallerPodImageFromEnv() string {


### PR DESCRIPTION
in particular:
 run the monitor controllers only when explicitly requested
 allow the monitor and the guard controllers to report required parameters