### PR TITLE
Bug 2049234: Fix handling namespaces with dots in registry client

### DIFF
--- a/pkg/image/registryclient/client.go
+++ b/pkg/image/registryclient/client.go
@@ -237,11 +237,18 @@ func (c *Context) Repository(ctx context.Context, registry *url.URL, repoName st
 	if err != nil {
 		return nil, err
 	}
-	ref, err := imagereference.Parse(repoName)
+
+	registryName := registry.Host
+	if registryName == "registry-1.docker.io" {
+		registryName = "docker.io"
+	}
+	fullReference := fmt.Sprintf("%s/%s", registryName, repoName)
+
+	ref, err := imagereference.Parse(fullReference)
 	if err != nil {
 		return nil, err
 	}
-	ref.Registry = registry.Host
+
 	locator := repositoryLocator{
 		named: named,
 		ref:   ref,

--- a/pkg/image/registryclient/client_mirrored.go
+++ b/pkg/image/registryclient/client_mirrored.go
@@ -64,6 +64,7 @@ type blobMirroredRepoRetriever interface {
 
 // repositoryLocator caches the components necessary to connect to a single image repository.
 type repositoryLocator struct {
+	// ref is the full image reference as it is provided by the client.
 	ref reference.DockerImageReference
 	// url may specify a default protocol (http) instead of (https), but is otherwise calculated
 	// by taking ref.Registry and applying it to url.Host

--- a/pkg/image/registryclient/client_test.go
+++ b/pkg/image/registryclient/client_test.go
@@ -860,8 +860,22 @@ type fakeAlternateBlobStrategy struct {
 func (s *fakeAlternateBlobStrategy) FirstRequest(ctx context.Context, locator imagereference.DockerImageReference) (alternateRepositories []imagereference.DockerImageReference, err error) {
 	return s.FirstAlternates, s.FirstErr
 }
+
 func (s *fakeAlternateBlobStrategy) OnFailure(ctx context.Context, locator imagereference.DockerImageReference) (alternateRepositories []imagereference.DockerImageReference, err error) {
 	return s.FailureAlternates, s.FailureErr
+}
+
+type fakeAlternateBlobStrategyFuncs struct {
+	FirstRequestFunc func(ctx context.Context, locator imagereference.DockerImageReference) (alternateRepositories []imagereference.DockerImageReference, err error)
+	OnFailureFunc    func(ctx context.Context, locator imagereference.DockerImageReference) (alternateRepositories []imagereference.DockerImageReference, err error)
+}
+
+func (s *fakeAlternateBlobStrategyFuncs) FirstRequest(ctx context.Context, locator imagereference.DockerImageReference) (alternateRepositories []imagereference.DockerImageReference, err error) {
+	return s.FirstRequestFunc(ctx, locator)
+}
+
+func (s *fakeAlternateBlobStrategyFuncs) OnFailure(ctx context.Context, locator imagereference.DockerImageReference) (alternateRepositories []imagereference.DockerImageReference, err error) {
+	return s.OnFailureFunc(ctx, locator)
 }
 
 func TestMirroredRegistry_BlobGet(t *testing.T) {
@@ -892,14 +906,18 @@ func TestMirroredRegistry_BlobGet(t *testing.T) {
 		t.Fatal("Expected data to be present")
 	}
 
-	c.Alternates = &fakeAlternateBlobStrategy{
-		FirstAlternates: []imagereference.DockerImageReference{
-			{Registry: "quay.io", Namespace: "library", Name: "postgres"},
-			{Registry: "docker.io", Namespace: "library", Name: "postgres"},
+	c.Alternates = &fakeAlternateBlobStrategyFuncs{
+		FirstRequestFunc: func(ctx context.Context, locator imagereference.DockerImageReference) (alternateRepositories []imagereference.DockerImageReference, err error) {
+			if locator.Exact() != "quay.io/test.me/other" {
+				t.Errorf("unexpected locator: %#+v", locator)
+			}
+			return []imagereference.DockerImageReference{
+				{Registry: "quay.io", Namespace: "library", Name: "postgres"},
+				{Registry: "docker.io", Namespace: "library", Name: "postgres"},
+			}, nil
 		},
-		FirstErr: nil,
 	}
-	r, err = c.Repository(context.Background(), &url.URL{Host: "quay.io"}, "test/other", false)
+	r, err = c.Repository(context.Background(), &url.URL{Host: "quay.io"}, "test.me/other", false)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The registry client incorrectly parsed the repository name as a full image
reference, and because of this, it could interpret a namespace with a
dot as a host name and eventually loose it.