### PR TITLE
Bug 2053582: Track static pod lifecycle

### DIFF
--- a/pkg/operator/staticpod/controller/missingstaticpod/missing_static_pod_controller.go
+++ b/pkg/operator/staticpod/controller/missingstaticpod/missing_static_pod_controller.go
@@ -1,0 +1,268 @@
+package missingstaticpodcontroller
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/informers"
+	corelisterv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/klog/v2"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
+	"github.com/openshift/library-go/pkg/operator/staticpod/internal"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+type missingStaticPodController struct {
+	operatorClient                    v1helpers.StaticPodOperatorClient
+	podListerForTargetNamespace       corelisterv1.PodNamespaceLister
+	configMapListerForTargetNamespace corelisterv1.ConfigMapNamespaceLister
+	targetNamespace                   string
+	operandName                       string
+
+	lastEventEmissionPerNode lastEventEmissionPerNode
+}
+
+type lastEventEmissionPerNode map[string]struct {
+	revision  int
+	timestamp time.Time
+}
+
+// New checks the latest static pods pods and uses the installer to get the
+// latest revision.  If the installer pod was successful, and if it has been
+// longer than the terminationGracePeriodSeconds+120seconds since the installer
+// pod completed successfully, and if the static pod is not at the correct
+// revision, this controller will go degraded.  It will also emit an event for
+// detection in CI.
+func New(
+	operatorClient v1helpers.StaticPodOperatorClient,
+	kubeInformersForTargetNamespace informers.SharedInformerFactory,
+	eventRecorder events.Recorder,
+	targetNamespace string,
+	staticPodName string,
+) factory.Controller {
+	c := &missingStaticPodController{
+		operatorClient:                    operatorClient,
+		podListerForTargetNamespace:       kubeInformersForTargetNamespace.Core().V1().Pods().Lister().Pods(targetNamespace),
+		configMapListerForTargetNamespace: kubeInformersForTargetNamespace.Core().V1().ConfigMaps().Lister().ConfigMaps(targetNamespace),
+		targetNamespace:                   targetNamespace,
+		operandName:                       staticPodName,
+		lastEventEmissionPerNode:          make(lastEventEmissionPerNode),
+	}
+	return factory.New().
+		ResyncEvery(time.Minute).
+		WithInformers(
+			operatorClient.Informer(),
+			kubeInformersForTargetNamespace.Core().V1().Pods().Informer(),
+		).
+		WithBareInformers(
+			kubeInformersForTargetNamespace.Core().V1().ConfigMaps().Informer(),
+		).
+		WithSync(c.sync).
+		WithSyncDegradedOnError(operatorClient).
+		ToController("MissingStaticPodController", eventRecorder)
+}
+
+func (c *missingStaticPodController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	_, originalOperatorStatus, _, err := c.operatorClient.GetStaticPodOperatorState()
+	if err != nil {
+		return err
+	}
+
+	installerPods, err := c.podListerForTargetNamespace.List(labels.SelectorFromSet(labels.Set{"app": "installer"}))
+	if err != nil {
+		return err
+	}
+
+	// get the most recent installer pod for each node
+	latestInstallerPodsByNode, err := getMostRecentInstallerPodByNode(installerPods)
+	if err != nil {
+		return err
+	}
+
+	errors := make([]string, 0, len(latestInstallerPodsByNode))
+	for node, latestInstallerPodOnNode := range latestInstallerPodsByNode {
+		installerPodRevision, err := internal.GetRevisionOfPod(latestInstallerPodOnNode)
+		if err != nil {
+			// we expect every installer pod to have a installerPodRevision in its name, unexpected error here
+			return fmt.Errorf("failed to get installerPodRevision for installer pod %q - %w", latestInstallerPodOnNode.Name, err)
+		}
+
+		finishedAt, ok := installerPodFinishedAt(latestInstallerPodOnNode)
+		if !ok {
+			// either it's in the process of running, or it ran into an error
+			continue
+		}
+
+		gracePeriod, err := c.getStaticPodTerminationGracePeriodSecondsForRevision(installerPodRevision)
+		if err != nil {
+			return err
+		}
+		threshold := gracePeriod + 120*time.Second
+
+		staticPodRevisionOnThisNode := getStaticPodCurrentRevision(node, originalOperatorStatus)
+		if staticPodRevisionOnThisNode == 0 {
+			// skip the bootstraping phase
+			continue
+		}
+
+		if time.Since(finishedAt) > threshold &&
+			staticPodRevisionOnThisNode < installerPodRevision {
+			// if we are here:
+			//  a: the latest installer pod successfully completed at finishedAt
+			//  b: it has been more than 'terminationGracePeriodSeconds' + 120s since the
+			//     installer pod has completed at finishedAt
+			//  c. the static pod is not at correct installerPodRevision yet
+			// then all of the above conditions are true, so we should produce an event
+
+			// only emit an event if for a particular node:
+			// - this is the first time we see a failure
+			// - this is a failure for new revision
+			// - the previously reported event was at least 30 min ago
+			lastEventEmission, found := c.lastEventEmissionPerNode[node]
+			if !found || installerPodRevision != lastEventEmission.revision || time.Since(lastEventEmission.timestamp) > 30*time.Minute {
+				syncCtx.Recorder().Eventf("MissingStaticPod", "static pod lifecycle failure - static pod: %q in namespace: %q for revision: %d on node: %q didn't show up, waited: %v",
+					c.operandName, c.targetNamespace, installerPodRevision, node, threshold)
+
+				lastEventEmission.revision = installerPodRevision
+				lastEventEmission.timestamp = time.Now()
+				c.lastEventEmissionPerNode[node] = lastEventEmission
+			}
+
+			errors = append(errors, fmt.Sprintf("static pod lifecycle failure - static pod: %q in namespace: %q for revision: %d on node: %q didn't show up, waited: %v",
+				c.operandName, c.targetNamespace, installerPodRevision, node, threshold))
+		}
+	}
+
+	if len(errors) > 0 {
+		return fmt.Errorf(strings.Join(errors, "\n"))
+	}
+
+	return nil
+}
+
+// getStaticPodTerminationGracePeriodSecondsForRevision reads the static pod manifest from a configmap
+// in the target namespace and returns the value of terminationGracePeriodSeconds.
+// In case no value was provided for the static pod it returns a default value of 30 seconds.
+func (c *missingStaticPodController) getStaticPodTerminationGracePeriodSecondsForRevision(revision int) (time.Duration, error) {
+	staticPodKeyName := "pod.yaml"
+	staticPodConfigMapName := fmt.Sprintf("%s-pod-%d", c.operandName, revision)
+
+	staticPodConfigMap, err := c.configMapListerForTargetNamespace.Get(staticPodConfigMapName)
+	if err != nil {
+		return 0, err
+	}
+
+	rawStaticPodManifest, hasPodKey := staticPodConfigMap.Data[staticPodKeyName]
+	if !hasPodKey {
+		return 0, fmt.Errorf("didn't find required key %q in cm: %s/%s", staticPodKeyName, staticPodConfigMapName, c.targetNamespace)
+	}
+
+	serializedStaticPod, err := resourceread.ReadPodV1([]byte(rawStaticPodManifest))
+	if err != nil {
+		return 0, err
+	}
+
+	if serializedStaticPod.Spec.TerminationGracePeriodSeconds == nil {
+		klog.V(6).Infof("optional field: %s.spec.terminationGracePeriodSeconds was not specified in cm: %s, returning default value of 30s", staticPodKeyName, staticPodConfigMapName)
+		return 30 * time.Second, nil
+	}
+
+	return time.Duration(*serializedStaticPod.Spec.TerminationGracePeriodSeconds) * time.Second, nil
+}
+
+// TODO: consider the following logic to get the static pods revision:
+// - list all pods
+// - filter only static pods, those with annotation: `kubernetes.io/config.mirror`
+// - there will only be one for each master
+// - determine the node based on .spec.nodeName
+// - get the revision from label: `revision`
+// This would allow reducing the delay and remove the dependency on the node
+// status.
+func getStaticPodCurrentRevision(node string, status *operatorv1.StaticPodOperatorStatus) int {
+	var nodeStatus *operatorv1.NodeStatus
+	for i := range status.NodeStatuses {
+		if status.NodeStatuses[i].NodeName == node {
+			nodeStatus = &status.NodeStatuses[i]
+			break
+		}
+	}
+
+	if nodeStatus == nil {
+		return 0
+	}
+	return int(nodeStatus.CurrentRevision)
+}
+
+func getMostRecentInstallerPodByNode(pods []*corev1.Pod) (map[string]*corev1.Pod, error) {
+	mostRecentInstallerPodByNode := map[string]*corev1.Pod{}
+	byNodes, err := getInstallerPodsByNode(pods)
+	if err != nil {
+		return nil, err
+	}
+
+	for node, installerPodsOnThisNode := range byNodes {
+		if len(installerPodsOnThisNode) == 0 {
+			continue
+		}
+		sort.Sort(internal.ByRevision(installerPodsOnThisNode))
+		mostRecentInstallerPodByNode[node] = installerPodsOnThisNode[len(installerPodsOnThisNode)-1]
+	}
+
+	return mostRecentInstallerPodByNode, nil
+}
+
+func getInstallerPodsByNode(pods []*corev1.Pod) (map[string][]*corev1.Pod, error) {
+	byNodes := map[string][]*corev1.Pod{}
+	for i := range pods {
+		pod := pods[i]
+		if !strings.HasPrefix(pod.Name, "installer-") {
+			continue
+		}
+
+		nodeName := pod.Spec.NodeName
+		if len(nodeName) == 0 {
+			return nil, fmt.Errorf("node name for installer pod %q is empty", pod.Name)
+		}
+		byNodes[nodeName] = append(byNodes[nodeName], pod)
+	}
+
+	return byNodes, nil
+}
+
+// installerPodFinishedAt returns the 'finishedAt' time for an installer
+// pod that has completed successfully
+func installerPodFinishedAt(pod *corev1.Pod) (time.Time, bool) {
+	statuses := pod.Status.ContainerStatuses
+	if len(statuses) == 0 {
+		return time.Time{}, false
+	}
+
+	// we are looking for container name "installer"
+	var installerContainerStatus *corev1.ContainerStatus
+	for i := range statuses {
+		if statuses[i].Name == "installer" {
+			installerContainerStatus = &statuses[i]
+			break
+		}
+	}
+	if installerContainerStatus == nil {
+		return time.Time{}, false
+	}
+
+	terminated := installerContainerStatus.State.Terminated
+	if terminated == nil || terminated.ExitCode != 0 {
+		return time.Time{}, false
+	}
+
+	return terminated.FinishedAt.Time, true
+}

--- a/pkg/operator/staticpod/controller/missingstaticpod/missing_static_pod_controller_test.go
+++ b/pkg/operator/staticpod/controller/missingstaticpod/missing_static_pod_controller_test.go
@@ -1,0 +1,633 @@
+package missingstaticpodcontroller
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes/fake"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/google/go-cmp/cmp"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+var emptyStaticPodPayloadYaml = ``
+
+var validStaticPodPayloadYaml = `
+apiVersion: v1
+kind: Pod
+spec:
+  terminationGracePeriodSeconds: 194
+`
+
+var staticPodPayloadInvalidTypeYaml = `
+apiVersion: v1
+kind: Pod
+spec:
+  terminationGracePeriodSeconds: "194"
+`
+
+var staticPodPayloadNoTerminationGracePeriodYaml = `
+apiVersion: v1
+kind: Pod
+spec:
+  priorityClassName: system-node-critical
+`
+
+func TestMissingStaticPodControllerSync(t *testing.T) {
+	var (
+		// we need to use metav1.Now as the base for all the times since the sync loop
+		// compare the termination timestamp with the threshold based on the elapsed
+		// time.
+		now = metav1.Now()
+
+		targetNamespace = "test"
+		operandName     = "test-operand"
+	)
+
+	testCases := []struct {
+		name           string
+		operatorStatus *operatorv1.StaticPodOperatorStatus
+		pods           []*corev1.Pod
+		cms            []*corev1.ConfigMap
+		expectSyncErr  bool
+		expectedEvents int
+	}{
+		{
+			name: "two terminated installer pods per node with correct revision",
+			operatorStatus: &operatorv1.StaticPodOperatorStatus{
+				NodeStatuses: []operatorv1.NodeStatus{
+					{NodeName: "node-1", CurrentRevision: 2},
+					{NodeName: "node-2", CurrentRevision: 2},
+				},
+			},
+			pods: []*corev1.Pod{
+				makeTerminatedInstallerPod(1, "node-1", 0, metav1.NewTime(now.Add(-2*time.Hour))),
+				makeTerminatedInstallerPod(2, "node-1", 0, metav1.NewTime(now.Add(-time.Hour))),
+				makeTerminatedInstallerPod(1, "node-2", 0, metav1.NewTime(now.Add(-2*time.Hour))),
+				makeTerminatedInstallerPod(2, "node-2", 0, metav1.NewTime(now.Add(-time.Hour))),
+			},
+			cms: []*corev1.ConfigMap{
+				makeOperandConfigMap(targetNamespace, operandName, 2, validStaticPodPayloadYaml),
+			},
+			expectSyncErr:  false,
+			expectedEvents: 0,
+		},
+		{
+			name: "current revision older than the latest installer revision",
+			operatorStatus: &operatorv1.StaticPodOperatorStatus{
+				NodeStatuses: []operatorv1.NodeStatus{
+					{NodeName: "node-1", CurrentRevision: 2},
+				},
+			},
+			pods: []*corev1.Pod{
+				makeTerminatedInstallerPod(1, "node-1", 0, metav1.NewTime(now.Add(-3*time.Hour))),
+				makeTerminatedInstallerPod(2, "node-1", 0, metav1.NewTime(now.Add(-2*time.Hour))),
+				makeTerminatedInstallerPod(3, "node-1", 0, metav1.NewTime(now.Add(-time.Hour))),
+			},
+			cms: []*corev1.ConfigMap{
+				makeOperandConfigMap(targetNamespace, operandName, 3, validStaticPodPayloadYaml),
+			},
+			expectSyncErr:  true,
+			expectedEvents: 1,
+		},
+		{
+			name: "current revision older then the latest installer revision but termination time within threshold",
+			operatorStatus: &operatorv1.StaticPodOperatorStatus{
+				NodeStatuses: []operatorv1.NodeStatus{
+					{NodeName: "node-1", CurrentRevision: 2},
+				},
+			},
+			pods: []*corev1.Pod{
+				makeTerminatedInstallerPod(1, "node-1", 0, metav1.NewTime(now.Add(-2*time.Hour))),
+				makeTerminatedInstallerPod(2, "node-1", 0, metav1.NewTime(now.Add(-time.Hour))),
+				makeTerminatedInstallerPod(3, "node-1", 0, now),
+			},
+			cms: []*corev1.ConfigMap{
+				makeOperandConfigMap(targetNamespace, operandName, 3, validStaticPodPayloadYaml),
+			},
+			expectSyncErr:  false,
+			expectedEvents: 0,
+		},
+		{
+			name: "only one node has a missing pod",
+			operatorStatus: &operatorv1.StaticPodOperatorStatus{
+				NodeStatuses: []operatorv1.NodeStatus{
+					{NodeName: "node-1", CurrentRevision: 2},
+					{NodeName: "node-2", CurrentRevision: 3},
+				},
+			},
+			pods: []*corev1.Pod{
+				makeTerminatedInstallerPod(1, "node-1", 0, metav1.NewTime(now.Add(-3*time.Hour))),
+				makeTerminatedInstallerPod(2, "node-1", 0, metav1.NewTime(now.Add(-2*time.Hour))),
+				makeTerminatedInstallerPod(3, "node-1", 0, metav1.NewTime(now.Add(-time.Hour))),
+				makeTerminatedInstallerPod(1, "node-2", 0, metav1.NewTime(now.Add(-3*time.Hour))),
+				makeTerminatedInstallerPod(2, "node-2", 0, metav1.NewTime(now.Add(-2*time.Hour))),
+				makeTerminatedInstallerPod(3, "node-2", 0, metav1.NewTime(now.Add(-time.Hour))),
+			},
+			cms: []*corev1.ConfigMap{
+				makeOperandConfigMap(targetNamespace, operandName, 2, validStaticPodPayloadYaml),
+				makeOperandConfigMap(targetNamespace, operandName, 3, validStaticPodPayloadYaml),
+			},
+			expectSyncErr:  true,
+			expectedEvents: 1,
+		},
+		{
+			name: "multiple missing pods for the same revision but on different nodes should produce multiple events",
+			operatorStatus: &operatorv1.StaticPodOperatorStatus{
+				NodeStatuses: []operatorv1.NodeStatus{
+					{NodeName: "node-1", CurrentRevision: 2},
+					{NodeName: "node-2", CurrentRevision: 2},
+				},
+			},
+			pods: []*corev1.Pod{
+				makeTerminatedInstallerPod(1, "node-1", 0, metav1.NewTime(now.Add(-3*time.Hour))),
+				makeTerminatedInstallerPod(2, "node-1", 0, metav1.NewTime(now.Add(-2*time.Hour))),
+				makeTerminatedInstallerPod(3, "node-1", 0, metav1.NewTime(now.Add(-time.Hour))),
+				makeTerminatedInstallerPod(1, "node-2", 0, metav1.NewTime(now.Add(-3*time.Hour))),
+				makeTerminatedInstallerPod(2, "node-2", 0, metav1.NewTime(now.Add(-2*time.Hour))),
+				makeTerminatedInstallerPod(3, "node-2", 0, metav1.NewTime(now.Add(-time.Hour))),
+			},
+			cms: []*corev1.ConfigMap{
+				makeOperandConfigMap(targetNamespace, operandName, 3, validStaticPodPayloadYaml),
+			},
+			expectSyncErr:  true,
+			expectedEvents: 2,
+		},
+		{
+			name: "installer pod is still running",
+			operatorStatus: &operatorv1.StaticPodOperatorStatus{
+				NodeStatuses: []operatorv1.NodeStatus{
+					{NodeName: "node-1", CurrentRevision: 0},
+				},
+			},
+			pods: []*corev1.Pod{
+				makeInstallerPod(1, "node-1"),
+			},
+			cms: []*corev1.ConfigMap{
+				makeOperandConfigMap(targetNamespace, operandName, 1, validStaticPodPayloadYaml),
+			},
+			expectSyncErr:  false,
+			expectedEvents: 0,
+		},
+		{
+			name: "installer pod ran into an error",
+			operatorStatus: &operatorv1.StaticPodOperatorStatus{
+				NodeStatuses: []operatorv1.NodeStatus{
+					{NodeName: "node-1", CurrentRevision: 0},
+				},
+			},
+			pods: []*corev1.Pod{
+				makeTerminatedInstallerPod(1, "node-1", 1, now),
+			},
+			cms: []*corev1.ConfigMap{
+				makeOperandConfigMap(targetNamespace, operandName, 1, validStaticPodPayloadYaml),
+			},
+			expectSyncErr:  false,
+			expectedEvents: 0,
+		},
+		{
+			name: "operand configmap with payload without termination grace period",
+			operatorStatus: &operatorv1.StaticPodOperatorStatus{
+				NodeStatuses: []operatorv1.NodeStatus{
+					{NodeName: "node-1", CurrentRevision: 2},
+				},
+			},
+			pods: []*corev1.Pod{
+				makeTerminatedInstallerPod(1, "node-1", 0, metav1.NewTime(now.Add(-2*time.Hour))),
+				makeTerminatedInstallerPod(2, "node-1", 0, metav1.NewTime(now.Add(-time.Hour))),
+			},
+			cms: []*corev1.ConfigMap{
+				makeOperandConfigMap(targetNamespace, operandName, 2, staticPodPayloadNoTerminationGracePeriodYaml),
+			},
+			expectSyncErr:  false,
+			expectedEvents: 0,
+		},
+		{
+			name: "operand configmap with invalid payload",
+			operatorStatus: &operatorv1.StaticPodOperatorStatus{
+				NodeStatuses: []operatorv1.NodeStatus{
+					{NodeName: "node-1", CurrentRevision: 2},
+				},
+			},
+			pods: []*corev1.Pod{
+				makeTerminatedInstallerPod(1, "node-1", 0, metav1.NewTime(now.Add(-2*time.Hour))),
+				makeTerminatedInstallerPod(2, "node-1", 0, metav1.NewTime(now.Add(-time.Hour))),
+			},
+			cms: []*corev1.ConfigMap{
+				makeOperandConfigMap(targetNamespace, operandName, 2, staticPodPayloadInvalidTypeYaml),
+			},
+			expectSyncErr:  true,
+			expectedEvents: 0,
+		},
+		{
+			name: "operand configmap with empty payload",
+			operatorStatus: &operatorv1.StaticPodOperatorStatus{
+				NodeStatuses: []operatorv1.NodeStatus{
+					{NodeName: "node-1", CurrentRevision: 2},
+				},
+			},
+			pods: []*corev1.Pod{
+				makeTerminatedInstallerPod(1, "node-1", 0, metav1.NewTime(now.Add(-2*time.Hour))),
+				makeTerminatedInstallerPod(2, "node-1", 0, metav1.NewTime(now.Add(-time.Hour))),
+			},
+			cms: []*corev1.ConfigMap{
+				makeOperandConfigMap(targetNamespace, operandName, 2, emptyStaticPodPayloadYaml),
+			},
+			expectSyncErr:  true,
+			expectedEvents: 0,
+		},
+		{
+			name: "operand configmap without pod.yaml key",
+			operatorStatus: &operatorv1.StaticPodOperatorStatus{
+				NodeStatuses: []operatorv1.NodeStatus{
+					{NodeName: "node-1", CurrentRevision: 2},
+				},
+			},
+			pods: []*corev1.Pod{
+				makeTerminatedInstallerPod(1, "node-1", 0, metav1.NewTime(now.Add(-2*time.Hour))),
+				makeTerminatedInstallerPod(2, "node-1", 0, metav1.NewTime(now.Add(-time.Hour))),
+			},
+			cms: []*corev1.ConfigMap{
+				{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-pod-%d", operandName, 2), Namespace: targetNamespace}},
+			},
+			expectSyncErr:  true,
+			expectedEvents: 0,
+		},
+		{
+			name: "the controller should take into account the latest graceful termination period of the static pod",
+			operatorStatus: &operatorv1.StaticPodOperatorStatus{
+				NodeStatuses: []operatorv1.NodeStatus{
+					{NodeName: "node-1", CurrentRevision: 1},
+				},
+			},
+			pods: []*corev1.Pod{
+				makeTerminatedInstallerPod(1, "node-1", 0, metav1.NewTime(now.Add(-2*time.Hour))),
+				makeTerminatedInstallerPod(2, "node-1", 0, metav1.NewTime(now.Add(-time.Minute))),
+			},
+			cms: []*corev1.ConfigMap{
+				makeOperandConfigMap(targetNamespace, operandName, 1, makeValidPayloadWithGracefulTerminationPeriod(30)),
+				makeOperandConfigMap(targetNamespace, operandName, 2, makeValidPayloadWithGracefulTerminationPeriod(300)),
+			},
+			expectSyncErr:  false,
+			expectedEvents: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(
+				nil,
+				tc.operatorStatus,
+				nil,
+				nil,
+			)
+			kubeClient := fake.NewSimpleClientset()
+			eventRecorder := events.NewRecorder(kubeClient.CoreV1().Events("test"), "missing-static-pod-controller", &corev1.ObjectReference{})
+			syncCtx := factory.NewSyncContext("MissingStaticPodController", eventRecorder)
+			controller := missingStaticPodController{
+				operatorClient:                    fakeOperatorClient,
+				podListerForTargetNamespace:       &fakePodNamespaceLister{pods: tc.pods},
+				configMapListerForTargetNamespace: &fakeConfigMapNamespaceLister{cms: tc.cms},
+				targetNamespace:                   targetNamespace,
+				operandName:                       operandName,
+				lastEventEmissionPerNode:          make(lastEventEmissionPerNode),
+			}
+
+			err := controller.sync(context.TODO(), syncCtx)
+			if err != nil != tc.expectSyncErr {
+				t.Fatalf("expected sync error to have occured to be %t, got: %t, err: %v", tc.expectSyncErr, err != nil, err)
+			}
+
+			if err == nil {
+				return
+			}
+
+			events, err := kubeClient.CoreV1().Events("test").List(context.TODO(), metav1.ListOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if len(events.Items) != tc.expectedEvents {
+				t.Fatalf("expected %d events to have been emitted, got: %d", tc.expectedEvents, len(events.Items))
+			}
+
+			for _, ev := range events.Items {
+				if ev.Reason != "MissingStaticPod" {
+					t.Fatalf("expected all events to have a MissingStartingPod reason, found: %s", ev.Reason)
+				}
+			}
+		})
+	}
+}
+
+type fakePodNamespaceLister struct {
+	pods []*corev1.Pod
+}
+
+func (f *fakePodNamespaceLister) List(selector labels.Selector) ([]*corev1.Pod, error) {
+	return f.pods, nil
+}
+
+func (f *fakePodNamespaceLister) Get(name string) (*corev1.Pod, error) {
+	for _, pod := range f.pods {
+		if pod.ObjectMeta.Name == name {
+			return pod, nil
+		}
+	}
+	return nil, fmt.Errorf("pod %q not found", name)
+}
+
+type fakeConfigMapNamespaceLister struct {
+	cms []*corev1.ConfigMap
+}
+
+func (f *fakeConfigMapNamespaceLister) List(selector labels.Selector) ([]*corev1.ConfigMap, error) {
+	return f.cms, nil
+}
+
+func (f *fakeConfigMapNamespaceLister) Get(name string) (*corev1.ConfigMap, error) {
+	for _, cm := range f.cms {
+		if cm.ObjectMeta.Name == name {
+			return cm, nil
+		}
+	}
+	return nil, fmt.Errorf("configmap %q not found", name)
+}
+
+func makeTerminatedInstallerPod(revision int, node string, exitCode int32, terminatedAt metav1.Time) *corev1.Pod {
+	pod := makeInstallerPod(revision, node)
+	pod.Status = corev1.PodStatus{
+		ContainerStatuses: []corev1.ContainerStatus{
+			{Name: "installer", State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: exitCode, FinishedAt: terminatedAt}}},
+		},
+	}
+	return pod
+}
+
+func makeInstallerPod(revision int, node string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   fmt.Sprintf("installer-%d-%s", revision, node),
+			Labels: map[string]string{"app": "installer"},
+		},
+		Spec: corev1.PodSpec{NodeName: node},
+	}
+}
+
+func makeOperandConfigMap(targetNamespace string, operandName string, revision int, payload string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-pod-%d", operandName, revision), Namespace: targetNamespace},
+		Data:       map[string]string{"pod.yaml": payload},
+	}
+}
+
+func makeValidPayloadWithGracefulTerminationPeriod(period int) string {
+	return fmt.Sprintf(`
+apiVersion: v1
+kind: Pod
+spec:
+  terminationGracePeriodSeconds: %d
+`, period)
+}
+
+func TestGetStaticPodTerminationGracePeriodSecondsForRevision(t *testing.T) {
+	scenarios := []struct {
+		name                           string
+		staticPodPayload               string
+		targetRevision                 int
+		expectedTerminationGracePeriod time.Duration
+		expectedError                  error
+	}{
+		// scenario 1
+		{
+			name:                           "happy path, found terminationGracePeriodSeconds in pod.yaml.spec.terminationGracePeriodSeconds field",
+			staticPodPayload:               validStaticPodPayloadYaml,
+			expectedTerminationGracePeriod: 194 * time.Second,
+		},
+
+		// scenario 2
+		{
+			name:             "invalid type for terminationGracePeriodSeconds in pod.yaml.spec.terminationGracePeriodSeconds field",
+			staticPodPayload: staticPodPayloadInvalidTypeYaml,
+			expectedError:    fmt.Errorf("json: cannot unmarshal string into Go struct field PodSpec.spec.terminationGracePeriodSeconds of type int64"),
+		},
+
+		// scenario 3
+		{
+			name:                           "default value for terminationGracePeriodSeconds is returned if pod.yaml.spec.terminationGracePeriodSeconds wasn't specified",
+			staticPodPayload:               staticPodPayloadNoTerminationGracePeriodYaml,
+			expectedTerminationGracePeriod: 30 * time.Second,
+		},
+
+		// scenario 4
+		{
+			name:             "pod.yaml.spec is required",
+			staticPodPayload: emptyStaticPodPayloadYaml,
+			expectedError:    fmt.Errorf("didn't find required key \"pod.yaml\" in cm: operand-name-pod-0/target-namespace"),
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			// test data
+			configMapIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			targetConfigMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("operand-name-pod-%d", scenario.targetRevision), Namespace: "target-namespace"},
+			}
+			if len(scenario.staticPodPayload) > 0 {
+				targetConfigMap.Data = map[string]string{"pod.yaml": scenario.staticPodPayload}
+			}
+			configMapIndexer.Add(targetConfigMap)
+			configMapLister := corev1listers.NewConfigMapLister(configMapIndexer).ConfigMaps("target-namespace")
+
+			// act
+			c := &missingStaticPodController{
+				operatorClient:                    nil,
+				podListerForTargetNamespace:       nil,
+				configMapListerForTargetNamespace: configMapLister,
+				targetNamespace:                   "target-namespace",
+				operandName:                       "operand-name",
+			}
+			actualTerminationGracePeriod, err := c.getStaticPodTerminationGracePeriodSecondsForRevision(scenario.targetRevision)
+
+			// validate
+			if err == nil && scenario.expectedError != nil {
+				t.Fatal("expected to get an error from getStaticPodTerminationGracePeriodSecondsForRevision function")
+			}
+			if err != nil && scenario.expectedError == nil {
+				t.Fatal(err)
+			}
+			if err != nil && scenario.expectedError != nil && err.Error() != scenario.expectedError.Error() {
+				t.Fatalf("unexpected error returned = %v, expected = %v", err, scenario.expectedError)
+			}
+			if actualTerminationGracePeriod != scenario.expectedTerminationGracePeriod {
+				t.Fatalf("unexpected termination grace period for: %v, expected: %v", actualTerminationGracePeriod, scenario.expectedTerminationGracePeriod)
+			}
+		})
+	}
+}
+
+func TestGetStaticPodCurrentRevision(t *testing.T) {
+	testCases := []struct {
+		name             string
+		node             string
+		status           *operatorv1.StaticPodOperatorStatus
+		expectedRevision int
+	}{
+		{
+			name: "node status was reported by the status pod controller",
+			node: "node-1",
+			status: &operatorv1.StaticPodOperatorStatus{
+				NodeStatuses: []operatorv1.NodeStatus{{NodeName: "node-1", CurrentRevision: 1}},
+			},
+			expectedRevision: 1,
+		},
+		{
+			name: "node status wasn't reported by the status pod controller",
+			node: "node-1",
+			status: &operatorv1.StaticPodOperatorStatus{
+				NodeStatuses: []operatorv1.NodeStatus{},
+			},
+			expectedRevision: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			revision := getStaticPodCurrentRevision(tc.node, tc.status)
+			if revision != tc.expectedRevision {
+				t.Fatalf("expected revision to be %d, got: %d", tc.expectedRevision, revision)
+			}
+		})
+	}
+}
+
+func TestGetMostRecentInstallerPodByNode(t *testing.T) {
+	testCases := []struct {
+		name              string
+		pods              []*corev1.Pod
+		expectedPodByNode map[string]*corev1.Pod
+	}{
+		{
+			name: "two installer pods per node",
+			pods: []*corev1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Name: "installer-1-node-1"}, Spec: corev1.PodSpec{NodeName: "node-1"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "installer-2-node-1"}, Spec: corev1.PodSpec{NodeName: "node-1"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "installer-1-node-2"}, Spec: corev1.PodSpec{NodeName: "node-2"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "installer-2-node-2"}, Spec: corev1.PodSpec{NodeName: "node-2"}},
+			},
+			expectedPodByNode: map[string]*corev1.Pod{
+				"node-1": {ObjectMeta: metav1.ObjectMeta{Name: "installer-2-node-1"}, Spec: corev1.PodSpec{NodeName: "node-1"}},
+				"node-2": {ObjectMeta: metav1.ObjectMeta{Name: "installer-2-node-2"}, Spec: corev1.PodSpec{NodeName: "node-2"}},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			podByNode, err := getMostRecentInstallerPodByNode(tc.pods)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !cmp.Equal(podByNode, tc.expectedPodByNode) {
+				t.Fatalf("unexpected most recent installer pod by node:\n%s", cmp.Diff(podByNode, tc.expectedPodByNode))
+			}
+		})
+	}
+}
+
+func TestGetInstallerPodsByNode(t *testing.T) {
+	testCases := []struct {
+		name               string
+		pods               []*corev1.Pod
+		expectedPodsByNode map[string][]*corev1.Pod
+	}{
+		{
+			name: "two installer pods per node",
+			pods: []*corev1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Name: "installer-1-node-1"}, Spec: corev1.PodSpec{NodeName: "node-1"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "installer-2-node-1"}, Spec: corev1.PodSpec{NodeName: "node-1"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "installer-1-node-2"}, Spec: corev1.PodSpec{NodeName: "node-2"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "installer-2-node-2"}, Spec: corev1.PodSpec{NodeName: "node-2"}},
+			},
+			expectedPodsByNode: map[string][]*corev1.Pod{
+				"node-1": {
+					{ObjectMeta: metav1.ObjectMeta{Name: "installer-1-node-1"}, Spec: corev1.PodSpec{NodeName: "node-1"}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "installer-2-node-1"}, Spec: corev1.PodSpec{NodeName: "node-1"}},
+				},
+				"node-2": {
+					{ObjectMeta: metav1.ObjectMeta{Name: "installer-1-node-2"}, Spec: corev1.PodSpec{NodeName: "node-2"}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "installer-2-node-2"}, Spec: corev1.PodSpec{NodeName: "node-2"}},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			podsByNode, err := getInstallerPodsByNode(tc.pods)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !cmp.Equal(podsByNode, tc.expectedPodsByNode) {
+				t.Fatalf("unexpected pods by node seperation:\n%s", cmp.Diff(podsByNode, tc.expectedPodsByNode))
+			}
+		})
+	}
+}
+
+func TestInstallerPodFinishedAt(t *testing.T) {
+	expectedTime := metav1.Unix(1644579221, 0)
+
+	testCases := []struct {
+		name           string
+		pod            *corev1.Pod
+		expectFinished bool
+	}{
+		{
+			name: "installer pod finished",
+			pod: &corev1.Pod{Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "container", State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 0, FinishedAt: metav1.Time{}}}},
+				{Name: "installer", State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 0, FinishedAt: expectedTime}}},
+			}}},
+			expectFinished: true,
+		},
+		{
+			name: "installer pod not finished",
+			pod: &corev1.Pod{Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "installer", State: corev1.ContainerState{}},
+			}}},
+			expectFinished: false,
+		},
+		{
+			name: "installer pod without installer container status reported",
+			pod: &corev1.Pod{Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "installer"},
+			}}},
+			expectFinished: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			time, finished := installerPodFinishedAt(tc.pod)
+			if finished != tc.expectFinished {
+				t.Fatalf("expected installer container finished to be %t, got: %t", tc.expectFinished, finished)
+			}
+			if finished && !time.Equal(expectedTime.Time) {
+				t.Fatalf("expected installer container to be finished at %s, got: %s", expectedTime, time)
+			}
+		})
+	}
+}

--- a/pkg/operator/staticpod/controllers.go
+++ b/pkg/operator/staticpod/controllers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/staticpod/controller/guard"
 	"github.com/openshift/library-go/pkg/operator/staticpod/controller/installer"
 	"github.com/openshift/library-go/pkg/operator/staticpod/controller/installerstate"
+	missingstaticpodcontroller "github.com/openshift/library-go/pkg/operator/staticpod/controller/missingstaticpod"
 	"github.com/openshift/library-go/pkg/operator/staticpod/controller/node"
 	"github.com/openshift/library-go/pkg/operator/staticpod/controller/prune"
 	"github.com/openshift/library-go/pkg/operator/staticpod/controller/startupmonitorcondition"
@@ -344,6 +345,14 @@ func (b *staticPodOperatorControllerBuilder) ToControllers() (manager.Controller
 			errs = append(errs, err)
 		}
 	}
+
+	manager.WithController(missingstaticpodcontroller.New(
+		b.staticPodOperatorClient,
+		b.kubeInformers.InformersFor(b.operandNamespace),
+		b.eventRecorder,
+		b.operandNamespace,
+		b.operandName,
+	), 1)
 
 	return manager, errors.NewAggregate(errs)
 }


### PR DESCRIPTION
Effort based on https://github.com/openshift/cluster-kube-apiserver-operator/pull/1317 and including the following gists written by @p0lyn0mial to address a comment regarding the termination grace period:
- https://gist.github.com/p0lyn0mial/363f5f1c04c1ff6b607d8358a123dc53
- https://gist.github.com/p0lyn0mial/abd14f30fe1f83b849e5f7f9f9811275