### PR TITLE
Bug 2053582: Track static pod lifecycle

### DIFF
--- a/pkg/operator/staticpod/controllers.go
+++ b/pkg/operator/staticpod/controllers.go
@@ -351,6 +351,7 @@ func (b *staticPodOperatorControllerBuilder) ToControllers() (manager.Controller
 		b.kubeInformers.InformersFor(b.operandNamespace),
 		b.eventRecorder,
 		b.operandNamespace,
+		b.staticPodName,
 		b.operandName,
 	), 1)
 


### PR DESCRIPTION
Improves MissingStaticPod controller to read a static pod revision from the mirror pod.
This approach has the advantage over the previous one because is able to detect potential issues during the bootstrap phase. Previously all failures would be ignored because we skipped CurrentRevision == 0