### PR TITLE
workload controller: fix nil panic on precondition not ready w/o an error

### DIFF
--- a/pkg/operator/apiserver/controller/workload/workload.go
+++ b/pkg/operator/apiserver/controller/workload/workload.go
@@ -123,8 +123,10 @@ func (c *Controller) sync(ctx context.Context, controllerContext factory.SyncCon
 		return err
 	}
 
-	if fulfilled, err := c.delegate.PreconditionFulfilled(ctx); !fulfilled || err != nil {
+	if fulfilled, err := c.delegate.PreconditionFulfilled(ctx); err != nil {
 		return c.updateOperatorStatus(ctx, operatorStatus, nil, false, false, []error{err})
+	} else if !fulfilled {
+		return c.updateOperatorStatus(ctx, operatorStatus, nil, false, false, nil)
 	}
 
 	workload, operatorConfigAtHighestGeneration, errs := c.delegate.Sync(ctx, controllerContext)


### PR DESCRIPTION
The workload controller throws panics if the sync Delegate returns
(not-ready, nil error) because the error returned is put into a slice
without checking its nil value. A generic processing of the slice
then tries to call Error() on the nil.

------

as observed in https://github.com/openshift/cluster-authentication-operator/pull/532

/assign @p0lyn0mial 
/cc @s-urbaniak 