### PR TITLE
Recreate CSIDriver on change

### DIFF
--- a/pkg/operator/resource/resourceapply/storage.go
+++ b/pkg/operator/resource/resourceapply/storage.go
@@ -2,6 +2,7 @@ package resourceapply
 
 import (
 	"context"
+	"fmt"
 
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -57,7 +58,17 @@ func ApplyStorageClass(ctx context.Context, client storageclientv1.StorageClasse
 }
 
 // ApplyCSIDriver merges objectmeta, does not worry about anything else
-func ApplyCSIDriver(ctx context.Context, client storageclientv1.CSIDriversGetter, recorder events.Recorder, required *storagev1.CSIDriver) (*storagev1.CSIDriver, bool, error) {
+func ApplyCSIDriver(ctx context.Context, client storageclientv1.CSIDriversGetter, recorder events.Recorder, requiredOriginal *storagev1.CSIDriver) (*storagev1.CSIDriver, bool, error) {
+
+	required := requiredOriginal.DeepCopy()
+	if required.Annotations == nil {
+		required.Annotations = map[string]string{}
+	}
+	err := SetSpecHashAnnotation(&required.ObjectMeta, required.Spec)
+	if err != nil {
+		return nil, false, err
+	}
+
 	existing, err := client.CSIDrivers().Get(ctx, required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		requiredCopy := required.DeepCopy()
@@ -70,21 +81,46 @@ func ApplyCSIDriver(ctx context.Context, client storageclientv1.CSIDriversGetter
 		return nil, false, err
 	}
 
-	modified := resourcemerge.BoolPtr(false)
+	metadataModified := resourcemerge.BoolPtr(false)
 	existingCopy := existing.DeepCopy()
+	resourcemerge.EnsureObjectMeta(metadataModified, &existingCopy.ObjectMeta, required.ObjectMeta)
 
-	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
-	if !*modified {
-		return existingCopy, false, nil
+	requiredSpecHash := required.Annotations[specHashAnnotation]
+	existingSpecHash := existing.Annotations[specHashAnnotation]
+	sameSpec := requiredSpecHash == existingSpecHash
+	if sameSpec && !*metadataModified {
+		return existing, false, nil
 	}
 
 	if klog.V(4).Enabled() {
 		klog.Infof("CSIDriver %q changes: %v", required.Name, JSONPatchNoError(existing, existingCopy))
 	}
 
-	// TODO: Spec is read-only, so this will fail if user changes it. Should we simply ignore it?
-	actual, err := client.CSIDrivers().Update(ctx, existingCopy, metav1.UpdateOptions{})
-	reportUpdateEvent(recorder, required, err)
+	if sameSpec {
+		// Update metadata by a simple Update call
+		actual, err := client.CSIDrivers().Update(ctx, existingCopy, metav1.UpdateOptions{})
+		reportUpdateEvent(recorder, required, err)
+		return actual, true, err
+	}
+
+	existingCopy.Spec = required.Spec
+	existingCopy.ObjectMeta.ResourceVersion = ""
+	// Spec is read-only after creation. Delete and re-create the object
+	err = client.CSIDrivers().Delete(ctx, existingCopy.Name, metav1.DeleteOptions{})
+	reportDeleteEvent(recorder, existingCopy, err, "Deleting CSIDriver to re-create it with updated parameters")
+	if err != nil && !apierrors.IsNotFound(err) {
+		return existing, false, err
+	}
+	actual, err := client.CSIDrivers().Create(ctx, existingCopy, metav1.CreateOptions{})
+	if err != nil && apierrors.IsAlreadyExists(err) {
+		// Delete() few lines above did not really delete the object,
+		// the API server is probably waiting for a finalizer removal or so.
+		// Report an error, but something else than "Already exists", because
+		// that would be very confusing - Apply failed because the object
+		// already exists???
+		err = fmt.Errorf("failed to re-create CSIDriver object %s, waiting for the original object to be deleted", existingCopy.Name)
+	}
+	reportCreateEvent(recorder, existingCopy, err)
 	return actual, true, err
 }
 

--- a/pkg/operator/resource/resourceapply/storage.go
+++ b/pkg/operator/resource/resourceapply/storage.go
@@ -4,12 +4,10 @@ import (
 	"context"
 
 	storagev1 "k8s.io/api/storage/v1"
-	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	storageclientv1 "k8s.io/client-go/kubernetes/typed/storage/v1"
-	storageclientv1beta1 "k8s.io/client-go/kubernetes/typed/storage/v1beta1"
 	"k8s.io/klog/v2"
 
 	"github.com/openshift/library-go/pkg/operator/events"
@@ -54,37 +52,6 @@ func ApplyStorageClass(ctx context.Context, client storageclientv1.StorageClasse
 
 	// TODO if provisioner, parameters, reclaimpolicy, or volumebindingmode are different, update will fail so delete and recreate
 	actual, err := client.StorageClasses().Update(ctx, requiredCopy, metav1.UpdateOptions{})
-	reportUpdateEvent(recorder, required, err)
-	return actual, true, err
-}
-
-// ApplyCSIDriverV1Beta1 merges objectmeta, does not worry about anything else
-func ApplyCSIDriverV1Beta1(ctx context.Context, client storageclientv1beta1.CSIDriversGetter, recorder events.Recorder, required *storagev1beta1.CSIDriver) (*storagev1beta1.CSIDriver, bool, error) {
-	existing, err := client.CSIDrivers().Get(ctx, required.Name, metav1.GetOptions{})
-	if apierrors.IsNotFound(err) {
-		requiredCopy := required.DeepCopy()
-		actual, err := client.CSIDrivers().Create(
-			ctx, resourcemerge.WithCleanLabelsAndAnnotations(requiredCopy).(*storagev1beta1.CSIDriver), metav1.CreateOptions{})
-		reportCreateEvent(recorder, required, err)
-		return actual, true, err
-	}
-	if err != nil {
-		return nil, false, err
-	}
-
-	modified := resourcemerge.BoolPtr(false)
-	existingCopy := existing.DeepCopy()
-
-	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
-	if !*modified {
-		return existingCopy, false, nil
-	}
-
-	if klog.V(4).Enabled() {
-		klog.Infof("CSIDriver %q changes: %v", required.Name, JSONPatchNoError(existing, existingCopy))
-	}
-
-	actual, err := client.CSIDrivers().Update(ctx, existingCopy, metav1.UpdateOptions{})
 	reportUpdateEvent(recorder, required, err)
 	return actual, true, err
 }

--- a/pkg/operator/resource/resourceapply/storage_test.go
+++ b/pkg/operator/resource/resourceapply/storage_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
 	storagev1 "k8s.io/api/storage/v1"
-	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -154,7 +153,7 @@ func TestApplyStorageClass(t *testing.T) {
 func TestApplyCSIDriver(t *testing.T) {
 	tests := []struct {
 		name     string
-		existing []runtime.Object
+		existing []*storagev1.CSIDriver
 		input    *storagev1.CSIDriver
 
 		expectedModified bool
@@ -177,10 +176,11 @@ func TestApplyCSIDriver(t *testing.T) {
 				if !actions[1].Matches("create", "csidrivers") {
 					t.Error(spew.Sdump(actions))
 				}
-				expected := &storagev1beta1.CSIDriver{
+				expected := &storagev1.CSIDriver{
 					ObjectMeta: metav1.ObjectMeta{Name: "foo", Annotations: map[string]string{"my.csi.driver/foo": "bar"}},
 				}
-				actual := actions[1].(clienttesting.CreateAction).GetObject().(*storagev1beta1.CSIDriver)
+				SetSpecHashAnnotation(&expected.ObjectMeta, expected.Spec)
+				actual := actions[1].(clienttesting.CreateAction).GetObject().(*storagev1.CSIDriver)
 				if !equality.Semantic.DeepEqual(expected, actual) {
 					t.Error(JSONPatchNoError(expected, actual))
 				}
@@ -188,8 +188,8 @@ func TestApplyCSIDriver(t *testing.T) {
 		},
 		{
 			name: "update on missing label",
-			existing: []runtime.Object{
-				&storagev1beta1.CSIDriver{
+			existing: []*storagev1.CSIDriver{
+				{
 					ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 				},
 			},
@@ -207,21 +207,22 @@ func TestApplyCSIDriver(t *testing.T) {
 				if !actions[1].Matches("update", "csidrivers") {
 					t.Error(spew.Sdump(actions))
 				}
-				expected := &storagev1beta1.CSIDriver{
+				expected := &storagev1.CSIDriver{
 					ObjectMeta: metav1.ObjectMeta{Name: "foo", Labels: map[string]string{"new": "merge"}},
 				}
-				actual := actions[1].(clienttesting.CreateAction).GetObject().(*storagev1beta1.CSIDriver)
+				SetSpecHashAnnotation(&expected.ObjectMeta, expected.Spec)
+				actual := actions[1].(clienttesting.CreateAction).GetObject().(*storagev1.CSIDriver)
 				if !equality.Semantic.DeepEqual(expected, actual) {
 					t.Error(JSONPatchNoError(expected, actual))
 				}
 			},
 		},
 		{
-			name: "don't mutate spec",
-			existing: []runtime.Object{
-				&storagev1beta1.CSIDriver{
+			name: "mutated spec",
+			existing: []*storagev1.CSIDriver{
+				{
 					ObjectMeta: metav1.ObjectMeta{Name: "foo"},
-					Spec: storagev1beta1.CSIDriverSpec{
+					Spec: storagev1.CSIDriverSpec{
 						AttachRequired: resourcemerge.BoolPtr(true),
 						PodInfoOnMount: resourcemerge.BoolPtr(true),
 					},
@@ -232,6 +233,40 @@ func TestApplyCSIDriver(t *testing.T) {
 				Spec: storagev1.CSIDriverSpec{
 					AttachRequired: resourcemerge.BoolPtr(false),
 					PodInfoOnMount: resourcemerge.BoolPtr(false),
+				},
+			},
+			expectedModified: true,
+			verifyActions: func(actions []clienttesting.Action, t *testing.T) {
+				if len(actions) != 3 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("get", "csidrivers") || actions[0].(clienttesting.GetAction).GetName() != "foo" {
+					t.Error(spew.Sdump(actions))
+				}
+				if !actions[1].Matches("delete", "csidrivers") {
+					t.Error(spew.Sdump(actions))
+				}
+				if !actions[2].Matches("create", "csidrivers") {
+					t.Error(spew.Sdump(actions))
+				}
+			},
+		},
+		{
+			name: "no change",
+			existing: []*storagev1.CSIDriver{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+					Spec: storagev1.CSIDriverSpec{
+						AttachRequired: resourcemerge.BoolPtr(true),
+						PodInfoOnMount: resourcemerge.BoolPtr(true),
+					},
+				},
+			},
+			input: &storagev1.CSIDriver{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec: storagev1.CSIDriverSpec{
+					AttachRequired: resourcemerge.BoolPtr(true),
+					PodInfoOnMount: resourcemerge.BoolPtr(true),
 				},
 			},
 			expectedModified: false,
@@ -247,7 +282,15 @@ func TestApplyCSIDriver(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			client := fake.NewSimpleClientset(test.existing...)
+			objs := make([]runtime.Object, len(test.existing))
+			for i, csiDriver := range test.existing {
+				// Add spec hash annotation
+				SetSpecHashAnnotation(&csiDriver.ObjectMeta, csiDriver.Spec)
+				// Convert *CSIDriver to *Object
+				objs[i] = csiDriver
+			}
+
+			client := fake.NewSimpleClientset(objs...)
 			_, actualModified, err := ApplyCSIDriver(context.TODO(), client.StorageV1(), events.NewInMemoryRecorder("test"), test.input)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/operator/resource/resourceapply/storage_test.go
+++ b/pkg/operator/resource/resourceapply/storage_test.go
@@ -155,14 +155,14 @@ func TestApplyCSIDriver(t *testing.T) {
 	tests := []struct {
 		name     string
 		existing []runtime.Object
-		input    *storagev1beta1.CSIDriver
+		input    *storagev1.CSIDriver
 
 		expectedModified bool
 		verifyActions    func(actions []clienttesting.Action, t *testing.T)
 	}{
 		{
 			name: "create",
-			input: &storagev1beta1.CSIDriver{
+			input: &storagev1.CSIDriver{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Annotations: map[string]string{"my.csi.driver/foo": "bar"}},
 			},
 
@@ -193,7 +193,7 @@ func TestApplyCSIDriver(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 				},
 			},
-			input: &storagev1beta1.CSIDriver{
+			input: &storagev1.CSIDriver{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Labels: map[string]string{"new": "merge"}},
 			},
 			expectedModified: true,
@@ -227,9 +227,9 @@ func TestApplyCSIDriver(t *testing.T) {
 					},
 				},
 			},
-			input: &storagev1beta1.CSIDriver{
+			input: &storagev1.CSIDriver{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
-				Spec: storagev1beta1.CSIDriverSpec{
+				Spec: storagev1.CSIDriverSpec{
 					AttachRequired: resourcemerge.BoolPtr(false),
 					PodInfoOnMount: resourcemerge.BoolPtr(false),
 				},
@@ -248,7 +248,7 @@ func TestApplyCSIDriver(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			client := fake.NewSimpleClientset(test.existing...)
-			_, actualModified, err := ApplyCSIDriverV1Beta1(context.TODO(), client.StorageV1beta1(), events.NewInMemoryRecorder("test"), test.input)
+			_, actualModified, err := ApplyCSIDriver(context.TODO(), client.StorageV1(), events.NewInMemoryRecorder("test"), test.input)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
`CSIDriver.Spec` is immutable after creation. Some of its fields should not be changed, for example changing `attachRequired` from `true` to `false` when a volume is being attached may result in orphaned VolumeAttachment objects.

But most of its fields can be changed without any issues. We need to change `fsGroupPolicy` from default (empty) to `File` in all CSI drivers that are based on a block file to prevent fsGroup issues like https://bugzilla.redhat.com/show_bug.cgi?id=2058626.

Also, remove support for CSIDriver v1beta1, nobody uses it by now.