### PR TITLE
Bugzilla 2063342: audit/manifests: exclude tokenreviews and tokenrequests from audit logs

### DIFF
--- a/pkg/operator/apiserver/audit/manifests/allrequestbodies-rules.yaml
+++ b/pkg/operator/apiserver/audit/manifests/allrequestbodies-rules.yaml
@@ -4,8 +4,8 @@
   - group: "route.openshift.io"
     resources: ["routes"]
   - resources: ["secrets"]
-- level: Metadata
-  resources:
+  - group: "authentication.k8s.io"
+    resources: ["tokenreviews", "tokenrequests"]
   - group: "oauth.openshift.io"
     resources: ["oauthclients"]
 # catch-all rule to log all other requests with request and response payloads

--- a/pkg/operator/apiserver/audit/manifests/writerequestbodies-rules.yaml
+++ b/pkg/operator/apiserver/audit/manifests/writerequestbodies-rules.yaml
@@ -4,8 +4,8 @@
   - group: "route.openshift.io"
     resources: ["routes"]
   - resources: ["secrets"]
-- level: Metadata
-  resources:
+  - group: "authentication.k8s.io"
+    resources: ["tokenreviews", "tokenrequests"]
   - group: "oauth.openshift.io"
     resources: ["oauthclients"]
 # log request and response payloads for all write requests

--- a/pkg/operator/apiserver/audit/testdata/allrequestbodies.yaml
+++ b/pkg/operator/apiserver/audit/testdata/allrequestbodies.yaml
@@ -34,8 +34,8 @@ rules:
   - group: "route.openshift.io"
     resources: ["routes"]
   - resources: ["secrets"]
-- level: Metadata
-  resources:
+  - group: "authentication.k8s.io"
+    resources: ["tokenreviews", "tokenrequests"]
   - group: "oauth.openshift.io"
     resources: ["oauthclients"]
 # catch-all rule to log all other requests with request and response payloads

--- a/pkg/operator/apiserver/audit/testdata/multipleCr.yaml
+++ b/pkg/operator/apiserver/audit/testdata/multipleCr.yaml
@@ -34,10 +34,8 @@ rules:
   - group: "route.openshift.io"
     resources: ["routes"]
   - resources: ["secrets"]
-  userGroups:
-  - system:authenticated:oauth
-- level: Metadata
-  resources:
+  - group: "authentication.k8s.io"
+    resources: ["tokenreviews", "tokenrequests"]
   - group: "oauth.openshift.io"
     resources: ["oauthclients"]
   userGroups:
@@ -66,10 +64,8 @@ rules:
     - group: "route.openshift.io"
       resources: ["routes"]
     - resources: ["secrets"]
-  userGroups:
-    - system:authenticated
-- level: Metadata
-  resources:
+    - group: "authentication.k8s.io"
+      resources: ["tokenreviews", "tokenrequests"]
     - group: "oauth.openshift.io"
       resources: ["oauthclients"]
   userGroups:

--- a/pkg/operator/apiserver/audit/testdata/oauth.yaml
+++ b/pkg/operator/apiserver/audit/testdata/oauth.yaml
@@ -34,10 +34,8 @@ rules:
   - group: "route.openshift.io"
     resources: ["routes"]
   - resources: ["secrets"]
-  userGroups:
-  - system:authenticated:oauth
-- level: Metadata
-  resources:
+  - group: "authentication.k8s.io"
+    resources: ["tokenreviews", "tokenrequests"]
   - group: "oauth.openshift.io"
     resources: ["oauthclients"]
   userGroups:

--- a/pkg/operator/apiserver/audit/testdata/writerequestbodies.yaml
+++ b/pkg/operator/apiserver/audit/testdata/writerequestbodies.yaml
@@ -34,8 +34,8 @@ rules:
   - group: "route.openshift.io"
     resources: ["routes"]
   - resources: ["secrets"]
-- level: Metadata
-  resources:
+  - group: "authentication.k8s.io"
+    resources: ["tokenreviews", "tokenrequests"]
   - group: "oauth.openshift.io"
     resources: ["oauthclients"]
 # log request and response payloads for all write requests


### PR DESCRIPTION
/cc @sttts @tkashem @stlaz 