### PR TITLE
Bug 2049671: resourcesynccontroller: avoid requests to non-existent target

### DIFF
--- a/pkg/operator/resourcesynccontroller/resourcesync_controller.go
+++ b/pkg/operator/resourcesynccontroller/resourcesync_controller.go
@@ -68,8 +68,8 @@ func NewResourceSyncController(
 		kubeInformersForNamespaces: kubeInformersForNamespaces,
 		knownNamespaces:            kubeInformersForNamespaces.Namespaces(),
 
-		configMapGetter: configMapsGetter,
-		secretGetter:    secretsGetter,
+		configMapGetter: v1helpers.CachedConfigMapGetter(configMapsGetter, kubeInformersForNamespaces),
+		secretGetter:    v1helpers.CachedSecretGetter(secretsGetter, kubeInformersForNamespaces),
 		syncCtx:         factory.NewSyncContext("ResourceSyncController", eventRecorder.WithComponentSuffix("resource-sync-controller")),
 	}
 


### PR DESCRIPTION
This PR reduces the amount of requests made by the `resourcesynccontroller` when a target ConfigMap doesn't exist.

1. To avoid unnecessary GET requests, we use cached clients in `resourcesynccontroller`.
2. To avoid unnecessary DELETE requests, we first verify if the target exists in `SyncPartialConfigMap`.

Before this patch, on a fresh-installed cluster, without user workloads, we can see that the amount of requests keep growing:

```
$ oc dev_tool audit -f must-gather.local.6142475801866269614/quay-io-openshift-release-dev-ocp-v4-0-art-dev-sha256-de53ed4750def9ed611ca460c780cc78eece525162747213cfdbb4c26687460c/audit_logs/kube-apiserver/ -otop --by=verb --user="system:serviceaccount:openshift-cluster-csi-drivers:aws-ebs-csi-driver-operator"  --resource="configmaps" --failed-only
had 5547 line read failures
count: 206, first: 2022-03-12T08:44:24-03:00, last: 2022-03-12T09:04:49-03:00, duration: 20m24.691542s

Top 10 "DELETE" (of 103 total hits):
    103x [ 11.668456ms] [404-102] /api/v1/namespaces/openshift-cluster-csi-drivers/configmaps/kube-cloud-config [system:serviceaccount:openshift-cluster-csi-drivers:aws-ebs-csi-driver-operator]

Top 10 "GET" (of 103 total hits):
    103x [  9.466233ms] [404-102] /api/v1/namespaces/openshift-config-managed/configmaps/kube-cloud-config [system:serviceaccount:openshift-cluster-csi-drivers:aws-ebs-csi-driver-operator]
```

After 3 minutes we have 20 more requests:

```
$  oc dev_tool audit -f must-gather.local.4791791518547958434/quay-io-openshift-release-dev-ocp-v4-0-art-dev-sha256-de53ed4750def9ed611ca460c780cc78eece525162747213cfdbb4c26687460c/audit_logs/kube-apiserver/ -otop --by=verb --user="system:serviceaccount:openshift-cluster-csi-drivers:aws-ebs-csi-driver-operator"  --resource="configmaps" --failed-only
had 5547 line read failures
count: 226, first: 2022-03-12T08:44:24-03:00, last: 2022-03-12T09:07:51-03:00, duration: 23m26.899552s

Top 10 "DELETE" (of 113 total hits):
    113x [ 10.925663ms] [404-112] /api/v1/namespaces/openshift-cluster-csi-drivers/configmaps/kube-cloud-config [system:serviceaccount:openshift-cluster-csi-drivers:aws-ebs-csi-driver-operator]

Top 10 "GET" (of 113 total hits):
    113x [  9.023026ms] [404-112] /api/v1/namespaces/openshift-config-managed/configmaps/kube-cloud-config [system:serviceaccount:openshift-cluster-csi-drivers:aws-ebs-csi-driver-operator]
$ oc adm must-gather -- /usr/bin/gather_audit_logs; sleep 180; oc adm must-gather -- /usr/bin/gather_audit_logs
```

With this patch, the count stays the same:

```
$ oc dev_tool audit -f must-gather.local.386413735759890088/registry-build01-ci-openshift-org-ci-ln-m19lrrb-stable-sha256-d8bd3c25f0974f2ceec780f10166cab12b7d73ebb557d0d4a3839575e2cbc6e7/audit_logs/kube-apiserver/ -otop --by=verb --user="system:serviceaccount:openshift-cluster-csi-drivers:aws-ebs-csi-driver-operator"  --resource="configmaps" --failed-only
had 2868 line read failures

$ oc dev_tool audit -f must-gather.local.4759162092148356031/registry-build01-ci-openshift-org-ci-ln-m19lrrb-stable-sha256-d8bd3c25f0974f2ceec780f10166cab12b7d73ebb557d0d4a3839575e2cbc6e7/audit_logs/kube-apiserver/ -otop --by=verb --user="system:serviceaccount:openshift-cluster-csi-drivers:aws-ebs-csi-driver-operator"  --resource="configmaps" --failed-only
had 2868 line read failures
```

CC @openshift/storage
