### PR TITLE
Extend rest mappings with job definition

### DIFF
--- a/pkg/client/openshiftrestmapper/hardcoded_restmapper.go
+++ b/pkg/client/openshiftrestmapper/hardcoded_restmapper.go
@@ -160,6 +160,11 @@ var defaultRESTMappings = []meta.RESTMapping{
 		Scope:            meta.RESTScopeNamespace,
 		Resource:         schema.GroupVersionResource{Group: "monitoring.coreos.com", Version: "v1", Resource: "servicemonitors"},
 	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"},
+		Scope:            meta.RESTScopeNamespace,
+		Resource:         schema.GroupVersionResource{Group: "batch", Version: "v1", Resource: "jobs"},
+	},
 }
 
 func NewOpenShiftHardcodedRESTMapper(delegate meta.RESTMapper) meta.RESTMapper {


### PR DESCRIPTION
It allows properly run jobs when kub-apiserver cannot
reach aggregated APIs. It is related to bz2048801 and bz2054338.