### PR TITLE
Bug: 2039256 Validate a hostname the same as openshift-apiserver

### DIFF
--- a/pkg/route/routeapihelpers/routeapihelpers_test.go
+++ b/pkg/route/routeapihelpers/routeapihelpers_test.go
@@ -311,21 +311,20 @@ func TestValidateRoute(t *testing.T) {
 		expectedErrors    int
 	}{
 		{
-			name:              "Non-DNS-compliant host with non-compliance allowed",
-			host:              "host",
-			allowNonCompliant: "true",
-			expectedErrors:    0,
-		},
-		{
-			name:              "Non-DNS-compliant host with non-compliance not allowed",
-			host:              "host",
-			allowNonCompliant: "false",
-			expectedErrors:    1,
+			name:           "Valid host",
+			host:           "host",
+			expectedErrors: 0,
 		},
 		{
 			name:           "Non-DNS-compliant host without non-compliance annotation",
-			host:           "host",
+			host:           "1234567890-1234567890-1234567890-1234567890-1234567890-123456789.host",
 			expectedErrors: 1,
+		},
+		{
+			name:              "Non-DNS-compliant host with non-compliance annotation",
+			host:              "1234567890-1234567890-1234567890-1234567890-1234567890-123456789.host",
+			allowNonCompliant: "true",
+			expectedErrors:    0,
 		},
 		{
 			name:              "Specified label too long",
@@ -363,13 +362,19 @@ func TestValidateRoute(t *testing.T) {
 			name:              "No host",
 			host:              "",
 			allowNonCompliant: "",
-			expectedErrors:    1,
+			expectedErrors:    2,
 		},
 		{
 			name:              "Invalid DNS 952 host",
 			host:              "**",
 			allowNonCompliant: "",
-			expectedErrors:    1,
+			expectedErrors:    2,
+		},
+		{
+			name:              "Invalid host with trailing dot",
+			host:              "hostwithtrailing.",
+			allowNonCompliant: "",
+			expectedErrors:    2,
 		},
 	}
 


### PR DESCRIPTION
 ValidateHost checks that a route's host name satisfies OpenShift DNS requirements,
with the assumption that the caller is not passing in an empty host name.
ValidateHost mimics the host validation in the validateRoute method in the
[openshift-apiserver/pkg/route/apis/route/validation/validation package.](https://github.com/openshift/openshift-apiserver/blob/db22c038b9184b4ae823bba3f57b669526999a2b/pkg/route/apis/route/validation/validation.go#L58-L72)

The host name length must be no more than 253 characters.  The only characters
allowed in host name are alphanumeric characters, '-' or '.', and it must start
and end with an alphanumeric character. A trailing dot is NOT allowed.
If the allowNonCompliant annotation is not set to true, the host name must in
addition consist of one or more labels, with each label no more than 63 characters
from the character set described above, and each label must start and end with an
alphanumeric character.
