### PR TITLE
Adding support for metav1.Condition

### DIFF
--- a/pkg/operator/v1helpers/helper_test.go
+++ b/pkg/operator/v1helpers/helper_test.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/diff"
 )
 
-func newCondition(name, status, reason, message string, lastTransition *metav1.Time) operatorsv1.OperatorCondition {
+func newOperatorCondition(name, status, reason, message string, lastTransition *metav1.Time) operatorsv1.OperatorCondition {
 	ret := operatorsv1.OperatorCondition{
 		Type:    name,
 		Status:  operatorsv1.ConditionStatus(status),
@@ -40,44 +40,44 @@ func TestSetOperatorCondition(t *testing.T) {
 		{
 			name:         "add to empty",
 			starting:     []operatorsv1.OperatorCondition{},
-			newCondition: newCondition("one", "True", "my-reason", "my-message", nil),
+			newCondition: newOperatorCondition("one", "True", "my-reason", "my-message", nil),
 			expected: []operatorsv1.OperatorCondition{
-				newCondition("one", "True", "my-reason", "my-message", nil),
+				newOperatorCondition("one", "True", "my-reason", "my-message", nil),
 			},
 		},
 		{
 			name: "add to non-conflicting",
 			starting: []operatorsv1.OperatorCondition{
-				newCondition("two", "True", "my-reason", "my-message", nil),
+				newOperatorCondition("two", "True", "my-reason", "my-message", nil),
 			},
-			newCondition: newCondition("one", "True", "my-reason", "my-message", nil),
+			newCondition: newOperatorCondition("one", "True", "my-reason", "my-message", nil),
 			expected: []operatorsv1.OperatorCondition{
-				newCondition("two", "True", "my-reason", "my-message", nil),
-				newCondition("one", "True", "my-reason", "my-message", nil),
+				newOperatorCondition("two", "True", "my-reason", "my-message", nil),
+				newOperatorCondition("one", "True", "my-reason", "my-message", nil),
 			},
 		},
 		{
 			name: "change existing status",
 			starting: []operatorsv1.OperatorCondition{
-				newCondition("two", "True", "my-reason", "my-message", nil),
-				newCondition("one", "True", "my-reason", "my-message", nil),
+				newOperatorCondition("two", "True", "my-reason", "my-message", nil),
+				newOperatorCondition("one", "True", "my-reason", "my-message", nil),
 			},
-			newCondition: newCondition("one", "False", "my-different-reason", "my-othermessage", nil),
+			newCondition: newOperatorCondition("one", "False", "my-different-reason", "my-othermessage", nil),
 			expected: []operatorsv1.OperatorCondition{
-				newCondition("two", "True", "my-reason", "my-message", nil),
-				newCondition("one", "False", "my-different-reason", "my-othermessage", nil),
+				newOperatorCondition("two", "True", "my-reason", "my-message", nil),
+				newOperatorCondition("one", "False", "my-different-reason", "my-othermessage", nil),
 			},
 		},
 		{
 			name: "leave existing transition time",
 			starting: []operatorsv1.OperatorCondition{
-				newCondition("two", "True", "my-reason", "my-message", nil),
-				newCondition("one", "True", "my-reason", "my-message", &beforeish),
+				newOperatorCondition("two", "True", "my-reason", "my-message", nil),
+				newOperatorCondition("one", "True", "my-reason", "my-message", &beforeish),
 			},
-			newCondition: newCondition("one", "True", "my-reason", "my-message", &afterish),
+			newCondition: newOperatorCondition("one", "True", "my-reason", "my-message", &afterish),
 			expected: []operatorsv1.OperatorCondition{
-				newCondition("two", "True", "my-reason", "my-message", nil),
-				newCondition("one", "True", "my-reason", "my-message", &beforeish),
+				newOperatorCondition("two", "True", "my-reason", "my-message", nil),
+				newOperatorCondition("one", "True", "my-reason", "my-message", &beforeish),
 			},
 		},
 	}
@@ -119,12 +119,12 @@ func TestRemoveOperatorCondition(t *testing.T) {
 		{
 			name: "remove existing",
 			starting: []operatorsv1.OperatorCondition{
-				newCondition("two", "True", "my-reason", "my-message", nil),
-				newCondition("one", "True", "my-reason", "my-message", nil),
+				newOperatorCondition("two", "True", "my-reason", "my-message", nil),
+				newOperatorCondition("one", "True", "my-reason", "my-message", nil),
 			},
 			removeCondition: "two",
 			expected: []operatorsv1.OperatorCondition{
-				newCondition("one", "True", "my-reason", "my-message", nil),
+				newOperatorCondition("one", "True", "my-reason", "my-message", nil),
 			},
 		},
 	}
@@ -132,6 +132,144 @@ func TestRemoveOperatorCondition(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			RemoveOperatorCondition(&test.starting, test.removeCondition)
+			if len(test.starting) != len(test.expected) {
+				t.Fatal(spew.Sdump(test.starting))
+			}
+
+			for i := range test.expected {
+				expected := test.expected[i]
+				actual := test.starting[i]
+				if expected.LastTransitionTime == (metav1.Time{}) {
+					actual.LastTransitionTime = metav1.Time{}
+				}
+				if !equality.Semantic.DeepEqual(expected, actual) {
+					t.Errorf(diff.ObjectDiff(expected, actual))
+				}
+			}
+		})
+	}
+}
+
+func newCondition(name, status, reason, message string, lastTransition *metav1.Time) metav1.Condition {
+	ret := metav1.Condition{
+		Type:    name,
+		Status:  metav1.ConditionStatus(status),
+		Reason:  reason,
+		Message: message,
+	}
+	if lastTransition != nil {
+		ret.LastTransitionTime = *lastTransition
+	}
+
+	return ret
+}
+
+func TestSetCondition(t *testing.T) {
+	nowish := metav1.Now()
+	beforeish := metav1.Time{Time: nowish.Add(-10 * time.Second)}
+	afterish := metav1.Time{Time: nowish.Add(10 * time.Second)}
+
+	tests := []struct {
+		name         string
+		starting     []metav1.Condition
+		newCondition metav1.Condition
+		expected     []metav1.Condition
+	}{
+		{
+			name:         "add to empty",
+			starting:     []metav1.Condition{},
+			newCondition: newCondition("one", "True", "my-reason", "my-message", nil),
+			expected: []metav1.Condition{
+				newCondition("one", "True", "my-reason", "my-message", nil),
+			},
+		},
+		{
+			name: "add to non-conflicting",
+			starting: []metav1.Condition{
+				newCondition("two", "True", "my-reason", "my-message", nil),
+			},
+			newCondition: newCondition("one", "True", "my-reason", "my-message", nil),
+			expected: []metav1.Condition{
+				newCondition("two", "True", "my-reason", "my-message", nil),
+				newCondition("one", "True", "my-reason", "my-message", nil),
+			},
+		},
+		{
+			name: "change existing status",
+			starting: []metav1.Condition{
+				newCondition("two", "True", "my-reason", "my-message", nil),
+				newCondition("one", "True", "my-reason", "my-message", nil),
+			},
+			newCondition: newCondition("one", "False", "my-different-reason", "my-othermessage", nil),
+			expected: []metav1.Condition{
+				newCondition("two", "True", "my-reason", "my-message", nil),
+				newCondition("one", "False", "my-different-reason", "my-othermessage", nil),
+			},
+		},
+		{
+			name: "leave existing transition time",
+			starting: []metav1.Condition{
+				newCondition("two", "True", "my-reason", "my-message", nil),
+				newCondition("one", "True", "my-reason", "my-message", &beforeish),
+			},
+			newCondition: newCondition("one", "True", "my-reason", "my-message", &afterish),
+			expected: []metav1.Condition{
+				newCondition("two", "True", "my-reason", "my-message", nil),
+				newCondition("one", "True", "my-reason", "my-message", &beforeish),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			SetCondition(&test.starting, test.newCondition)
+			if len(test.starting) != len(test.expected) {
+				t.Fatal(spew.Sdump(test.starting))
+			}
+
+			for i := range test.expected {
+				expected := test.expected[i]
+				actual := test.starting[i]
+				if expected.LastTransitionTime == (metav1.Time{}) {
+					actual.LastTransitionTime = metav1.Time{}
+				}
+				if !equality.Semantic.DeepEqual(expected, actual) {
+					t.Errorf(diff.ObjectDiff(expected, actual))
+				}
+			}
+		})
+	}
+}
+
+func TestRemoveCondition(t *testing.T) {
+	tests := []struct {
+		name            string
+		starting        []metav1.Condition
+		removeCondition string
+		expected        []metav1.Condition
+	}{
+		{
+			name:            "remove missing",
+			starting:        []metav1.Condition{},
+			removeCondition: "one",
+			expected:        []metav1.Condition{},
+		},
+		{
+			name: "remove existing",
+			starting: []metav1.Condition{
+				newCondition("two", "True", "my-reason", "my-message", nil),
+				newCondition("one", "True", "my-reason", "my-message", nil),
+			},
+			removeCondition: "two",
+			expected: []metav1.Condition{
+				newCondition("one", "True", "my-reason", "my-message", nil),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			RemoveCondition(&test.starting, test.removeCondition)
 			if len(test.starting) != len(test.expected) {
 				t.Fatal(spew.Sdump(test.starting))
 			}

--- a/pkg/operator/v1helpers/helpers.go
+++ b/pkg/operator/v1helpers/helpers.go
@@ -422,3 +422,64 @@ func InjectTrustedCAIntoContainers(podSpec *corev1.PodSpec, configMapName string
 
 	return nil
 }
+
+func SetCondition(conditions *[]metav1.Condition, newCondition metav1.Condition) {
+	if conditions == nil {
+		conditions = &[]metav1.Condition{}
+	}
+	existingCondition := FindCondition(*conditions, newCondition.Type)
+	if existingCondition == nil {
+		newCondition.LastTransitionTime = metav1.NewTime(time.Now())
+		*conditions = append(*conditions, newCondition)
+		return
+	}
+
+	if existingCondition.Status != newCondition.Status {
+		existingCondition.Status = newCondition.Status
+		existingCondition.LastTransitionTime = metav1.NewTime(time.Now())
+	}
+
+	existingCondition.Reason = newCondition.Reason
+	existingCondition.Message = newCondition.Message
+}
+
+func RemoveCondition(conditions *[]metav1.Condition, conditionType string) {
+	if conditions == nil {
+		conditions = &[]metav1.Condition{}
+	}
+	newConditions := []metav1.Condition{}
+	for _, condition := range *conditions {
+		if condition.Type != conditionType {
+			newConditions = append(newConditions, condition)
+		}
+	}
+
+	*conditions = newConditions
+}
+
+func FindCondition(conditions []metav1.Condition, conditionType string) *metav1.Condition {
+	for i := range conditions {
+		if conditions[i].Type == conditionType {
+			return &conditions[i]
+		}
+	}
+
+	return nil
+}
+
+func IsConditionTrue(conditions []metav1.Condition, conditionType string) bool {
+	return IsConditionPresentAndEqual(conditions, conditionType, metav1.ConditionTrue)
+}
+
+func IsConditionFalse(conditions []metav1.Condition, conditionType string) bool {
+	return IsConditionPresentAndEqual(conditions, conditionType, metav1.ConditionFalse)
+}
+
+func IsConditionPresentAndEqual(conditions []metav1.Condition, conditionType string, status metav1.ConditionStatus) bool {
+	for _, condition := range conditions {
+		if condition.Type == conditionType {
+			return condition.Status == status
+		}
+	}
+	return false
+}


### PR DESCRIPTION
This PR mirror's the existing logic, for `operatorsv1.OperatorCondition`, to add the same level of support for `metav1.Condition`.  