### PR TITLE
add storage class controller

### DIFF
--- a/pkg/operator/csi/csicontrollerset/csi_controller_set.go
+++ b/pkg/operator/csi/csicontrollerset/csi_controller_set.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/csi/csiconfigobservercontroller"
 	"github.com/openshift/library-go/pkg/operator/csi/csidrivercontrollerservicecontroller"
 	"github.com/openshift/library-go/pkg/operator/csi/csidrivernodeservicecontroller"
+	"github.com/openshift/library-go/pkg/operator/csi/csistorageclasscontroller"
 	"github.com/openshift/library-go/pkg/operator/deploymentcontroller"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/loglevel"
@@ -38,6 +39,7 @@ type CSIControllerSet struct {
 	csiDriverControllerServiceController factory.Controller
 	csiDriverNodeServiceController       factory.Controller
 	serviceMonitorController             factory.Controller
+	csiStorageclassController            factory.Controller
 
 	operatorClient v1helpers.OperatorClientWithFinalizers
 	eventRecorder  events.Recorder
@@ -54,6 +56,7 @@ func (c *CSIControllerSet) Run(ctx context.Context, workers int) {
 		c.csiDriverControllerServiceController,
 		c.csiDriverNodeServiceController,
 		c.serviceMonitorController,
+		c.csiStorageclassController,
 	} {
 		if ctrl == nil {
 			continue
@@ -207,6 +210,25 @@ func (c *CSIControllerSet) WithServiceMonitorController(
 		c.operatorClient,
 		c.eventRecorder,
 	).WithIgnoreNotFoundOnCreate()
+	return c
+}
+
+func (c *CSIControllerSet) WithStorageClassController(
+	name string,
+	assetFunc resourceapply.AssetFunc,
+	file string,
+	kubeClient kubernetes.Interface,
+	namespacedInformerFactory informers.SharedInformerFactory,
+) *CSIControllerSet {
+	c.csiStorageclassController = csistorageclasscontroller.NewCSIStorageClassController(
+		name,
+		assetFunc,
+		file,
+		kubeClient,
+		namespacedInformerFactory,
+		c.operatorClient,
+		c.eventRecorder,
+	)
 	return c
 }
 

--- a/pkg/operator/csi/csistorageclasscontroller/csi_storageclass_controller.go
+++ b/pkg/operator/csi/csistorageclasscontroller/csi_storageclass_controller.go
@@ -1,0 +1,146 @@
+package csistorageclasscontroller
+
+import (
+	"context"
+	operatorapi "github.com/openshift/api/operator/v1"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	v1 "k8s.io/client-go/listers/storage/v1"
+	"k8s.io/klog/v2"
+	"time"
+)
+
+const (
+	defaultScAnnotationKey = "storageclass.kubernetes.io/is-default-class"
+)
+
+// This Controller deploys a StorageClass provided by CSI driver operator
+// and decides if this StorageClass should be applied as default - if requested.
+// If operator wants to request it's StorageClass to be created as default,
+// the asset file provided to this controller must have defaultScAnnotationKey set to "true".
+// Based on the current StorageClasses in the cluster the controller can decide not
+// to deploy given StorageClass as default if there already is any existing default.
+// When the controller detects there already is a StorageClass with a same name it
+// just copies the default StorageClass annotation from the existing one to prevent
+// overwriting value that user might have manually changed.
+// If the asset file does not have defaultScAnnotationKey set at all, controller
+// just skips any checks and modifications and applies the StorageClass as it is.
+// It produces following Conditions:
+// StorageClassControllerDegraded - failed to apply StorageClass provided
+type CSIStorageClassController struct {
+	name               string
+	assetFunc          resourceapply.AssetFunc
+	file               string
+	kubeClient         kubernetes.Interface
+	storageClassLister v1.StorageClassLister
+	operatorClient     v1helpers.OperatorClient
+	eventRecorder      events.Recorder
+}
+
+func NewCSIStorageClassController(
+	name string,
+	assetFunc resourceapply.AssetFunc,
+	file string,
+	kubeClient kubernetes.Interface,
+	informerFactory informers.SharedInformerFactory,
+	operatorClient v1helpers.OperatorClient,
+	eventRecorder events.Recorder) factory.Controller {
+	c := &CSIStorageClassController{
+		name:               name,
+		assetFunc:          assetFunc,
+		file:               file,
+		kubeClient:         kubeClient,
+		storageClassLister: informerFactory.Storage().V1().StorageClasses().Lister(),
+		operatorClient:     operatorClient,
+		eventRecorder:      eventRecorder,
+	}
+
+	return factory.New().WithSync(
+		c.Sync,
+	).ResyncEvery(
+		time.Minute,
+	).WithSyncDegradedOnError(
+		operatorClient,
+	).WithInformers(
+		operatorClient.Informer(),
+		informerFactory.Storage().V1().StorageClasses().Informer(),
+	).ToController(
+		"StorageClassController",
+		eventRecorder,
+	)
+}
+
+func (c *CSIStorageClassController) Sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	klog.V(4).Infof("StorageClassController sync started")
+	defer klog.V(4).Infof("StorageClassController sync finished")
+
+	opSpec, _, _, err := c.operatorClient.GetOperatorState()
+	if err != nil {
+		return err
+	}
+	if opSpec.ManagementState != operatorapi.Managed {
+		return nil
+	}
+
+	syncErr := c.syncStorageClass(ctx)
+
+	return syncErr
+}
+
+func (c *CSIStorageClassController) syncStorageClass(ctx context.Context) error {
+	expectedScBytes, err := c.assetFunc(c.file)
+	if err != nil {
+		return err
+	}
+
+	expectedSC := resourceread.ReadStorageClassV1OrDie(expectedScBytes)
+
+	existingSCs, err := c.storageClassLister.List(labels.Everything())
+	if err != nil {
+		klog.V(2).Infof("could not list StorageClass objects")
+		return err
+	}
+
+	defaultSCCount := 0
+	annotationKeyPresent := false
+	// Skip the default SC annotation check if it's not in the input/expectedSC.
+	if expectedSC.Annotations != nil && expectedSC.Annotations[defaultScAnnotationKey] != "" {
+		for _, sc := range existingSCs {
+			if sc.Annotations[defaultScAnnotationKey] == "true" && sc.Name != expectedSC.Name {
+				defaultSCCount++
+			}
+			if sc.Name == expectedSC.Name && sc.Annotations != nil {
+				// There already is an SC with same name we intend to apply, copy its annotation.
+				if val, ok := sc.Annotations[defaultScAnnotationKey]; ok {
+					expectedSC.Annotations[defaultScAnnotationKey] = val
+					annotationKeyPresent = true // If there is a key, we need to preserve it, whatever the value is.
+				} else {
+					annotationKeyPresent = false
+				}
+			}
+		}
+		// There already is a default, and it's not set on the SC we intend to apply. Also, if there is any value for
+		// defaultScAnnotationKey do not overwrite it (empty string is a correct value).
+		if defaultSCCount > 0 && !annotationKeyPresent {
+			expectedSC.Annotations[defaultScAnnotationKey] = "false"
+		}
+	}
+
+	_, _, err = resourceapply.ApplyStorageClass(ctx, c.kubeClient.StorageV1(), c.eventRecorder, expectedSC)
+
+	return err
+}
+
+// UpdateConditionFunc returns a func to update a condition.
+func removeConditionFn(condType string) v1helpers.UpdateStatusFunc {
+	return func(oldStatus *operatorapi.OperatorStatus) error {
+		v1helpers.RemoveOperatorCondition(&oldStatus.Conditions, condType)
+		return nil
+	}
+}

--- a/pkg/operator/csi/csistorageclasscontroller/csi_storageclass_controller_test.go
+++ b/pkg/operator/csi/csistorageclasscontroller/csi_storageclass_controller_test.go
@@ -1,0 +1,415 @@
+package csistorageclasscontroller
+
+import (
+	"context"
+	"github.com/google/go-cmp/cmp"
+	opv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	coreinformers "k8s.io/client-go/informers"
+	v1 "k8s.io/client-go/informers/storage/v1"
+	"k8s.io/client-go/kubernetes"
+	fakecore "k8s.io/client-go/kubernetes/fake"
+	"testing"
+)
+
+const (
+	controllerName = "TestCSIStorageClassController"
+	operandName    = "test-csi-storage-class-controller"
+)
+
+type testCase struct {
+	name              string
+	initialObjects    testObjects
+	expectedObjects   testObjects
+	appliedAnnotation string
+	expectErr         bool
+}
+
+type testObjects struct {
+	storageClasses []*storagev1.StorageClass
+}
+
+type testContext struct {
+	controller     factory.Controller
+	operatorClient v1helpers.OperatorClient
+	kubeClient     kubernetes.Interface
+	scInformer     v1.StorageClassInformer
+}
+
+// defaultScAnnotation accepts values "true", "false", ""
+func fakeAssetFuncFactory(defaultScAnnotation string) resourceapply.AssetFunc {
+	switch defaultScAnnotation {
+	case "true":
+		return fakeAssetFuncDefaultSc
+	case "false":
+		return fakeAssetFuncNoDefaultSc
+	default:
+		return fakeAssetFuncAnnotationEmpty
+	}
+}
+
+func fakeAssetFuncDefaultSc(filename string) ([]byte, error) {
+	filename = ""
+	storageClass := `
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: "test-apply-sc"
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: test.csi.example.com
+parameters:
+  type: available
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+`
+	return []byte(storageClass), nil
+}
+
+func fakeAssetFuncNoDefaultSc(filename string) ([]byte, error) {
+	filename = ""
+	storageClass := `
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: "test-apply-sc"
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "false"
+provisioner: test.csi.example.com
+parameters:
+  type: available
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+`
+	return []byte(storageClass), nil
+}
+
+func fakeAssetFuncAnnotationEmpty(filename string) ([]byte, error) {
+	filename = ""
+	storageClass := `
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: "test-apply-sc"
+  annotations:
+    storageclass.kubernetes.io/is-default-class: ""
+provisioner: test.csi.example.com
+parameters:
+  type: available
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+`
+	return []byte(storageClass), nil
+}
+
+func fakeAssetFuncToScObject(assetFunc func(string) ([]byte, error)) *storagev1.StorageClass {
+	scBytes, err := assetFunc("filename")
+	if err != nil {
+		return nil
+	}
+	storageClassObject := resourceread.ReadStorageClassV1OrDie(scBytes)
+	return storageClassObject
+}
+
+type driverModifier func(*fakeDriverInstance) *fakeDriverInstance
+
+func makeFakeDriverInstance(modifiers ...driverModifier) *fakeDriverInstance {
+	instance := &fakeDriverInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "cluster",
+			Generation: 0,
+		},
+		Spec: opv1.OperatorSpec{
+			ManagementState: opv1.Managed,
+		},
+		Status: opv1.OperatorStatus{},
+	}
+	for _, modifier := range modifiers {
+		instance = modifier(instance)
+	}
+	return instance
+}
+
+func newTestContext(test testCase, t *testing.T) *testContext {
+	var initialObjects []runtime.Object
+	for _, c := range test.initialObjects.storageClasses {
+		initialObjects = append(initialObjects, c)
+	}
+	kubeClient := fakecore.NewSimpleClientset(initialObjects...)
+	coreInformerFactory := coreinformers.NewSharedInformerFactory(kubeClient, 0 /*no resync */)
+	scInformer := coreInformerFactory.Storage().V1().StorageClasses()
+
+	if initialObjects != nil {
+		for _, obj := range initialObjects {
+			err := scInformer.Informer().GetIndexer().Add(obj)
+			if err != nil {
+				t.Error(err)
+			}
+		}
+	}
+
+	fakeDriver := makeFakeDriverInstance()
+	fakeOperatorClient := v1helpers.NewFakeOperatorClient(&fakeDriver.Spec, &fakeDriver.Status, nil)
+
+	controller := NewCSIStorageClassController(
+		controllerName,
+		fakeAssetFuncFactory(test.appliedAnnotation),
+		"test",
+		kubeClient,
+		coreInformerFactory,
+		fakeOperatorClient,
+		events.NewInMemoryRecorder(operandName),
+	)
+
+	return &testContext{
+		controller:     controller,
+		operatorClient: fakeOperatorClient,
+		kubeClient:     kubeClient,
+		scInformer:     scInformer,
+	}
+}
+
+func makeFakeScInstance(scName string, defaultSCAnnotation string) *storagev1.StorageClass {
+	instance := &storagev1.StorageClass{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "StorageClass",
+			APIVersion: "storage.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        scName,
+			Annotations: map[string]string{"storageclass.kubernetes.io/is-default-class": defaultSCAnnotation},
+		},
+	}
+
+	return instance
+}
+
+func TestSync(t *testing.T) {
+	testCases := []testCase{
+		{
+			name: "test sync non-default sc - prior default is set - applied is not default",
+			initialObjects: testObjects{
+				storageClasses: []*storagev1.StorageClass{
+					makeFakeScInstance("test-sc", "true"),
+					makeFakeScInstance("test-sc-2", "false"),
+				},
+			},
+			appliedAnnotation: "false", //Controls what default annotation value should sync try to apply.
+			expectedObjects: testObjects{
+				storageClasses: []*storagev1.StorageClass{
+					makeFakeScInstance("test-sc", "true"),
+					makeFakeScInstance("test-sc-2", "false"),
+					fakeAssetFuncToScObject(fakeAssetFuncFactory("false")),
+				},
+			},
+		},
+		{
+			name: "test sync non-default sc - prior default is not set - applied is not default",
+			initialObjects: testObjects{
+				storageClasses: []*storagev1.StorageClass{
+					makeFakeScInstance("test-sc", "false"),
+					makeFakeScInstance("test-sc-2", "false"),
+				},
+			},
+			appliedAnnotation: "false",
+			expectedObjects: testObjects{
+				storageClasses: []*storagev1.StorageClass{
+					makeFakeScInstance("test-sc", "false"),
+					makeFakeScInstance("test-sc-2", "false"),
+					fakeAssetFuncToScObject(fakeAssetFuncFactory("false")),
+				},
+			},
+		},
+		{
+			name: "test sync non default sc - prior SC with same name is set - sync must not rewrite existing SC annotation",
+			initialObjects: testObjects{
+				storageClasses: []*storagev1.StorageClass{
+					makeFakeScInstance("test-sc", "false"),
+					makeFakeScInstance("test-sc-2", "false"),
+					fakeAssetFuncToScObject(fakeAssetFuncFactory("true")),
+				},
+			},
+			appliedAnnotation: "false",
+			expectedObjects: testObjects{
+				storageClasses: []*storagev1.StorageClass{
+					makeFakeScInstance("test-sc", "false"),
+					makeFakeScInstance("test-sc-2", "false"),
+					fakeAssetFuncToScObject(fakeAssetFuncFactory("true")),
+				},
+			},
+		},
+		{
+			name: "test sync non default sc - prior SC with same has empty annotation - sync must not rewrite existing SC annotation",
+			initialObjects: testObjects{
+				storageClasses: []*storagev1.StorageClass{
+					makeFakeScInstance("test-sc", "false"),
+					makeFakeScInstance("test-sc-2", "false"),
+					fakeAssetFuncToScObject(fakeAssetFuncFactory("")),
+				},
+			},
+			appliedAnnotation: "false",
+			expectedObjects: testObjects{
+				storageClasses: []*storagev1.StorageClass{
+					makeFakeScInstance("test-sc", "false"),
+					makeFakeScInstance("test-sc-2", "false"),
+					fakeAssetFuncToScObject(fakeAssetFuncFactory("")),
+				},
+			},
+		},
+		{
+			name: "test sync default sc - no prior default set - applied is default",
+			initialObjects: testObjects{
+				storageClasses: []*storagev1.StorageClass{
+					makeFakeScInstance("test-sc", "false"),
+					makeFakeScInstance("test-sc-2", "false"),
+				},
+			},
+			appliedAnnotation: "true",
+			expectedObjects: testObjects{
+				storageClasses: []*storagev1.StorageClass{
+					makeFakeScInstance("test-sc", "false"),
+					makeFakeScInstance("test-sc-2", "false"),
+					fakeAssetFuncToScObject(fakeAssetFuncFactory("true")),
+				},
+			},
+		},
+		{
+			name: "test sync default sc - prior default is set - applied is not default",
+			initialObjects: testObjects{
+				storageClasses: []*storagev1.StorageClass{
+					makeFakeScInstance("test-sc", "true"),
+					makeFakeScInstance("test-sc-2", "false"),
+				},
+			},
+			appliedAnnotation: "true",
+			expectedObjects: testObjects{
+				storageClasses: []*storagev1.StorageClass{
+					makeFakeScInstance("test-sc", "true"),
+					makeFakeScInstance("test-sc-2", "false"),
+					fakeAssetFuncToScObject(fakeAssetFuncFactory("false")),
+				},
+			},
+		},
+		{
+			name: "test sync default sc - no prior sc - applied is default",
+			initialObjects: testObjects{
+				storageClasses: []*storagev1.StorageClass{},
+			},
+			appliedAnnotation: "true",
+			expectedObjects: testObjects{
+				storageClasses: []*storagev1.StorageClass{
+					fakeAssetFuncToScObject(fakeAssetFuncFactory("true")),
+				},
+			},
+		},
+		{
+			name: "test sync default sc - prior SC with same name is non default - sync must not rewrite existing SC annotation",
+			initialObjects: testObjects{
+				storageClasses: []*storagev1.StorageClass{
+					makeFakeScInstance("test-sc", "false"),
+					makeFakeScInstance("test-sc-2", "false"),
+					fakeAssetFuncToScObject(fakeAssetFuncFactory("false")),
+				},
+			},
+			appliedAnnotation: "true",
+			expectedObjects: testObjects{
+				storageClasses: []*storagev1.StorageClass{
+					makeFakeScInstance("test-sc", "false"),
+					makeFakeScInstance("test-sc-2", "false"),
+					fakeAssetFuncToScObject(fakeAssetFuncFactory("false")),
+				},
+			},
+		},
+		{
+			name: "test sync default sc - prior SC with same name has empty annotation - sync must not rewrite existing SC annotation",
+			initialObjects: testObjects{
+				storageClasses: []*storagev1.StorageClass{
+					makeFakeScInstance("test-sc", "false"),
+					makeFakeScInstance("test-sc-2", "false"),
+					fakeAssetFuncToScObject(fakeAssetFuncFactory("")),
+				},
+			},
+			appliedAnnotation: "true",
+			expectedObjects: testObjects{
+				storageClasses: []*storagev1.StorageClass{
+					makeFakeScInstance("test-sc", "false"),
+					makeFakeScInstance("test-sc-2", "false"),
+					fakeAssetFuncToScObject(fakeAssetFuncFactory("")),
+				},
+			},
+		},
+		{
+			name: "test sync default sc - prior SC with same has empty annotation and another SC is default - sync must not rewrite existing SC annotation",
+			initialObjects: testObjects{
+				storageClasses: []*storagev1.StorageClass{
+					makeFakeScInstance("test-sc", "true"),
+					makeFakeScInstance("test-sc-2", "false"),
+					fakeAssetFuncToScObject(fakeAssetFuncFactory("")),
+				},
+			},
+			appliedAnnotation: "true",
+			expectedObjects: testObjects{
+				storageClasses: []*storagev1.StorageClass{
+					makeFakeScInstance("test-sc", "true"),
+					makeFakeScInstance("test-sc-2", "false"),
+					fakeAssetFuncToScObject(fakeAssetFuncFactory("")),
+				},
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			// Initialize
+			ctx := newTestContext(test, t)
+
+			// Act
+			err := ctx.controller.Sync(context.TODO(), factory.NewSyncContext(controllerName, events.NewInMemoryRecorder(operandName)))
+			if err != nil {
+				t.Errorf("Failed to sync StorageClass: %s", err)
+			}
+
+			// Assert
+			actualSCList, _ := ctx.kubeClient.StorageV1().StorageClasses().List(context.TODO(), metav1.ListOptions{})
+			actualSCs := map[string]*storagev1.StorageClass{}
+			for i := range actualSCList.Items {
+				sc := &actualSCList.Items[i]
+				actualSCs[sc.Name] = sc
+			}
+			expectedSCs := map[string]*storagev1.StorageClass{}
+			for _, sc := range test.expectedObjects.storageClasses {
+				expectedSCs[sc.Name] = sc
+			}
+
+			for name, expectedSC := range expectedSCs {
+				actualSC, found := actualSCs[name]
+				if !found {
+					t.Errorf("Expected StorageClass not found: %s", name)
+					continue
+				}
+				if !equality.Semantic.DeepEqual(expectedSC, actualSC) {
+					t.Errorf("Unexpected StorageClass %+v content:\n%s", name, cmp.Diff(expectedSC, actualSC))
+				}
+			}
+
+		})
+	}
+}
+
+// fakeInstance is a fake CSI driver instance that also fullfils the OperatorClient interface
+type fakeDriverInstance struct {
+	metav1.ObjectMeta
+	Spec   opv1.OperatorSpec
+	Status opv1.OperatorStatus
+}


### PR DESCRIPTION
Adding a storage class controller. This controller should be used by CSI driver operators and as a result provide users the possibility of changing their default storage class.

In short the controller can take a storage class asset file which has default StorageClass annotation set to true - this indicates we want to create this specific storage class as default, but only if:

1) there are no other storage classes defined as default
2) there is no storage class with matching name (if there is just copy its annotation)

All other cases should result in applying non-default storage class regardless of the annotation set in asset.

Here is an example of the storage class asset I used for testing:

```
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: gp2-csi
  annotations:
    storageclass.kubernetes.io/is-default-class: "true"
parameters:
  type: gp2
  encrypted: "true"
provisioner: ebs.csi.aws.com
reclaimPolicy: "Delete"
volumeBindingMode: WaitForFirstConsumer
allowVolumeExpansion: true
```

And here is a couple of tests I tried manually:

 1) Setup: no prior default SC
    Action: CSI operator SC is created during sync
    Expected result: operator SC is applied as default

```
    $ oc get sc -o "custom-columns=name:metadata.name,default:metadata.annotations"
    name      default
    gp2       map[storageclass.kubernetes.io/is-default-class:false]
    gp2-csi   map[storageclass.kubernetes.io/is-default-class:false]
    gp3-csi   <none>

    $ oc delete sc/gp2-csi
    storageclass.storage.k8s.io "gp2-csi" deleted

    $ oc get sc -o "custom-columns=name:metadata.name,default:metadata.annotations"
    name      default
    gp2       map[storageclass.kubernetes.io/is-default-class:false]
    gp2-csi   map[storageclass.kubernetes.io/is-default-class:true]
    gp3-csi   <none>
```

2)  Setup: prior default SC exists
    Action: CSI operator SC is created during sync
    Expected result: operator SC is applied as non default

```
    $ oc patch sc gp2 -p '{"metadata":{"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
    storageclass.storage.k8s.io/gp2 patched

    $ oc get sc -o "custom-columns=name:metadata.name,default:metadata.annotations"
    name      default
    gp2       map[storageclass.kubernetes.io/is-default-class:true]
    gp2-csi   map[storageclass.kubernetes.io/is-default-class:false]
    gp3-csi   <none>

    $ oc delete sc/gp2-csi
    storageclass.storage.k8s.io "gp2-csi" deleted

    $ oc get sc -o "custom-columns=name:metadata.name,default:metadata.annotations"
    name      default
    gp2       map[storageclass.kubernetes.io/is-default-class:true]
    gp2-csi   map[storageclass.kubernetes.io/is-default-class:false]
    gp3-csi   <none>
```

3)  Setup: prior non default SC exists and matches csi operator SC name
    Action: operator SC is reapplied during sync
    Expected result: reapplying does not override default SC annotation to "true"

```
    $ oc patch sc gp2-csi -p '{"metadata":{"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
storageclass.storage.k8s.io/gp2-csi patched

    # Wait for sync and check the gp2-csi is still non-default
    $ sleep 70 && oc get sc -o "custom-columns=name:metadata.name,default:metadata.annotations"
    name      default
    gp2       map[storageclass.kubernetes.io/is-default-class:false]
    gp2-csi   map[storageclass.kubernetes.io/is-default-class:false]
    gp3-csi   <none>
```


4)  Setup: prior default SC exists and matches csi operator SC name
    Action: operator SC is reapplied during sync
    Expected result: reapplying does not override existing SC annotation back to false - two SCs are kept as default
     
     *This is not a supported configuration but we have to allow this in order to keep behavior consistent with other resource controllers.*
    
```
    $ oc get sc -o "custom-columns=name:metadata.name,default:metadata.annotations"
    name      default
    gp2       map[storageclass.kubernetes.io/is-default-class:true]
    gp2-csi   map[storageclass.kubernetes.io/is-default-class:false]
    gp3-csi   <none>
    
    $ oc patch sc gp2-csi -p '{"metadata":{"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
    storageclass.storage.k8s.io/gp2-csi patched
    
    $ oc get sc -o "custom-columns=name:metadata.name,default:metadata.annotations"
    name      default
    gp2       map[storageclass.kubernetes.io/is-default-class:true]
    gp2-csi   map[storageclass.kubernetes.io/is-default-class:true]
    gp3-csi   <none>
```

5)  Setup: prior default SC exists and matches csi operator SC name and has empty value
    Action: operator SC is reapplied during sync
    Expected result: reapplying does not override existing SC annotation
    
```
    $ oc get sc -o "custom-columns=name:metadata.name,default:metadata.annotations"
    name      default
    gp2       map[storageclass.kubernetes.io/is-default-class:true]
    gp2-csi   map[storageclass.kubernetes.io/is-default-class:false]
    gp3-csi   map[storageclass.kubernetes.io/is-default-class:false]
    
    $ oc patch sc gp2-csi -p '{"metadata":{"annotations":{"storageclass.kubernetes.io/is-default-class":""}}}'
    storageclass.storage.k8s.io/gp2-csi patched
    
    $ oc get sc -o "custom-columns=name:metadata.name,default:metadata.annotations"
    name      default
    gp2       map[storageclass.kubernetes.io/is-default-class:true]
    gp2-csi   map[storageclass.kubernetes.io/is-default-class:]
    gp3-csi   map[storageclass.kubernetes.io/is-default-class:false]

```