### PR TITLE
4.10: Re-create StorageClass to change immutable parameters

### DIFF
--- a/pkg/operator/resource/resourceapply/storage.go
+++ b/pkg/operator/resource/resourceapply/storage.go
@@ -2,6 +2,7 @@ package resourceapply
 
 import (
 	"context"
+	"fmt"
 
 	storagev1 "k8s.io/api/storage/v1"
 	storagev1beta1 "k8s.io/api/storage/v1beta1"
@@ -52,10 +53,57 @@ func ApplyStorageClass(ctx context.Context, client storageclientv1.StorageClasse
 		klog.Infof("StorageClass %q changes: %v", required.Name, JSONPatchNoError(existingCopy, requiredCopy))
 	}
 
-	// TODO if provisioner, parameters, reclaimpolicy, or volumebindingmode are different, update will fail so delete and recreate
+	if storageClassNeedsRecreate(existingCopy, requiredCopy) {
+		requiredCopy.ObjectMeta.ResourceVersion = ""
+		err = client.StorageClasses().Delete(ctx, existingCopy.Name, metav1.DeleteOptions{})
+		reportDeleteEvent(recorder, requiredCopy, err, "Deleting StorageClass to re-create it with updated parameters")
+		if err != nil && !apierrors.IsNotFound(err) {
+			return existing, false, err
+		}
+		actual, err := client.StorageClasses().Create(ctx, requiredCopy, metav1.CreateOptions{})
+		if err != nil && apierrors.IsAlreadyExists(err) {
+			// Delete() few lines above did not really delete the object,
+			// the API server is probably waiting for a finalizer removal or so.
+			// Report an error, but something else than "Already exists", because
+			// that would be very confusing - Apply failed because the object
+			// already exists???
+			err = fmt.Errorf("failed to re-create StorageClass %s, waiting for the original object to be deleted", existingCopy.Name)
+		} else if err != nil {
+			err = fmt.Errorf("failed to re-create StorageClass %s: %s", existingCopy.Name, err)
+		}
+		reportCreateEvent(recorder, actual, err)
+		return actual, true, err
+	}
+
+	// Only mutable fields need a change
 	actual, err := client.StorageClasses().Update(ctx, requiredCopy, metav1.UpdateOptions{})
 	reportUpdateEvent(recorder, required, err)
 	return actual, true, err
+}
+
+func storageClassNeedsRecreate(oldSC, newSC *storagev1.StorageClass) bool {
+	// Based on kubernetes/kubernetes/pkg/apis/storage/validation/validation.go,
+	// these fields are immutable.
+	if !equality.Semantic.DeepEqual(oldSC.Parameters, newSC.Parameters) {
+		return true
+	}
+	if oldSC.Provisioner != newSC.Provisioner {
+		return true
+	}
+
+	// In theory, ReclaimPolicy is always set, just in case:
+	if (oldSC.ReclaimPolicy == nil && newSC.ReclaimPolicy != nil) ||
+		(oldSC.ReclaimPolicy != nil && newSC.ReclaimPolicy == nil) {
+		return true
+	}
+	if oldSC.ReclaimPolicy != nil && newSC.ReclaimPolicy != nil && *oldSC.ReclaimPolicy != *newSC.ReclaimPolicy {
+		return true
+	}
+
+	if !equality.Semantic.DeepEqual(oldSC.VolumeBindingMode, newSC.VolumeBindingMode) {
+		return true
+	}
+	return false
 }
 
 // ApplyCSIDriverV1Beta1 merges objectmeta, does not worry about anything else

--- a/pkg/operator/resource/resourceapply/storage_test.go
+++ b/pkg/operator/resource/resourceapply/storage_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
+	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -18,6 +19,11 @@ import (
 )
 
 func TestApplyStorageClass(t *testing.T) {
+	retain := v1.PersistentVolumeReclaimRetain
+	delete := v1.PersistentVolumeReclaimDelete
+	immediate := storagev1.VolumeBindingImmediate
+	wait := storagev1.VolumeBindingWaitForFirstConsumer
+
 	tests := []struct {
 		name     string
 		existing []runtime.Object
@@ -132,6 +138,216 @@ func TestApplyStorageClass(t *testing.T) {
 				}
 				if !actions[0].Matches("get", "storageclasses") || actions[0].(clienttesting.GetAction).GetName() != "foo" {
 					t.Error(spew.Sdump(actions))
+				}
+			},
+		},
+		{
+			name: "update of mutable AllowVolumeExpansion",
+			existing: []runtime.Object{
+				&storagev1.StorageClass{
+					ObjectMeta:        metav1.ObjectMeta{Name: "foo"},
+					Provisioner:       "foo",
+					ReclaimPolicy:     &retain,
+					VolumeBindingMode: &immediate,
+					Parameters: map[string]string{
+						"foo": "bar",
+					},
+					AllowVolumeExpansion: resourcemerge.BoolPtr(true),
+				},
+			},
+			input: &storagev1.StorageClass{
+				ObjectMeta:        metav1.ObjectMeta{Name: "foo"},
+				Provisioner:       "foo",
+				ReclaimPolicy:     &retain,
+				VolumeBindingMode: &immediate,
+				Parameters: map[string]string{
+					"foo": "bar",
+				},
+				AllowVolumeExpansion: resourcemerge.BoolPtr(false),
+			},
+			expectedModified: true,
+			verifyActions: func(actions []clienttesting.Action, t *testing.T) {
+				if len(actions) != 2 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("get", "storageclasses") || actions[0].(clienttesting.GetAction).GetName() != "foo" {
+					t.Error(spew.Sdump(actions))
+				}
+				if !actions[1].Matches("update", "storageclasses") {
+					t.Error(spew.Sdump(actions))
+				}
+				expected := &storagev1.StorageClass{
+					ObjectMeta:        metav1.ObjectMeta{Name: "foo"},
+					Provisioner:       "foo",
+					ReclaimPolicy:     &retain,
+					VolumeBindingMode: &immediate,
+					Parameters: map[string]string{
+						"foo": "bar",
+					},
+					AllowVolumeExpansion: resourcemerge.BoolPtr(false),
+				}
+				actual := actions[1].(clienttesting.UpdateAction).GetObject().(*storagev1.StorageClass)
+				if !equality.Semantic.DeepEqual(expected, actual) {
+					t.Error(JSONPatchNoError(expected, actual))
+				}
+			},
+		},
+		{
+			name: "update of immutable Provisioner",
+			existing: []runtime.Object{
+				&storagev1.StorageClass{
+					ObjectMeta:  metav1.ObjectMeta{Name: "foo"},
+					Provisioner: "foo",
+				},
+			},
+			input: &storagev1.StorageClass{
+				ObjectMeta:  metav1.ObjectMeta{Name: "foo"},
+				Provisioner: "bar",
+			},
+			expectedModified: true,
+			verifyActions: func(actions []clienttesting.Action, t *testing.T) {
+				if len(actions) != 3 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("get", "storageclasses") || actions[0].(clienttesting.GetAction).GetName() != "foo" {
+					t.Error(spew.Sdump(actions))
+				}
+				if !actions[1].Matches("delete", "storageclasses") {
+					t.Error(spew.Sdump(actions))
+				}
+				if !actions[2].Matches("create", "storageclasses") {
+					t.Error(spew.Sdump(actions))
+				}
+				expected := &storagev1.StorageClass{
+					ObjectMeta:  metav1.ObjectMeta{Name: "foo"},
+					Provisioner: "bar",
+				}
+				actual := actions[2].(clienttesting.CreateAction).GetObject().(*storagev1.StorageClass)
+				if !equality.Semantic.DeepEqual(expected, actual) {
+					t.Error(JSONPatchNoError(expected, actual))
+				}
+			},
+		},
+		{
+			name: "update of immutable ReclaimPolicy",
+			existing: []runtime.Object{
+				&storagev1.StorageClass{
+					ObjectMeta:    metav1.ObjectMeta{Name: "foo"},
+					Provisioner:   "foo",
+					ReclaimPolicy: &retain,
+				},
+			},
+			input: &storagev1.StorageClass{
+				ObjectMeta:    metav1.ObjectMeta{Name: "foo"},
+				Provisioner:   "foo",
+				ReclaimPolicy: &delete,
+			},
+			expectedModified: true,
+			verifyActions: func(actions []clienttesting.Action, t *testing.T) {
+				if len(actions) != 3 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("get", "storageclasses") || actions[0].(clienttesting.GetAction).GetName() != "foo" {
+					t.Error(spew.Sdump(actions))
+				}
+				if !actions[1].Matches("delete", "storageclasses") {
+					t.Error(spew.Sdump(actions))
+				}
+				if !actions[2].Matches("create", "storageclasses") {
+					t.Error(spew.Sdump(actions))
+				}
+				expected := &storagev1.StorageClass{
+					ObjectMeta:    metav1.ObjectMeta{Name: "foo"},
+					Provisioner:   "foo",
+					ReclaimPolicy: &delete,
+				}
+				actual := actions[2].(clienttesting.CreateAction).GetObject().(*storagev1.StorageClass)
+				if !equality.Semantic.DeepEqual(expected, actual) {
+					t.Error(JSONPatchNoError(expected, actual))
+				}
+			},
+		},
+		{
+			name: "update of immutable VolumeBindingMode",
+			existing: []runtime.Object{
+				&storagev1.StorageClass{
+					ObjectMeta:        metav1.ObjectMeta{Name: "foo"},
+					Provisioner:       "foo",
+					VolumeBindingMode: &immediate,
+				},
+			},
+			input: &storagev1.StorageClass{
+				ObjectMeta:        metav1.ObjectMeta{Name: "foo"},
+				Provisioner:       "foo",
+				VolumeBindingMode: &wait,
+			},
+			expectedModified: true,
+			verifyActions: func(actions []clienttesting.Action, t *testing.T) {
+				if len(actions) != 3 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("get", "storageclasses") || actions[0].(clienttesting.GetAction).GetName() != "foo" {
+					t.Error(spew.Sdump(actions))
+				}
+				if !actions[1].Matches("delete", "storageclasses") {
+					t.Error(spew.Sdump(actions))
+				}
+				if !actions[2].Matches("create", "storageclasses") {
+					t.Error(spew.Sdump(actions))
+				}
+				expected := &storagev1.StorageClass{
+					ObjectMeta:        metav1.ObjectMeta{Name: "foo"},
+					Provisioner:       "foo",
+					VolumeBindingMode: &wait,
+				}
+				actual := actions[2].(clienttesting.CreateAction).GetObject().(*storagev1.StorageClass)
+				if !equality.Semantic.DeepEqual(expected, actual) {
+					t.Error(JSONPatchNoError(expected, actual))
+				}
+			},
+		},
+		{
+			name: "update of immutable Parameters",
+			existing: []runtime.Object{
+				&storagev1.StorageClass{
+					ObjectMeta:  metav1.ObjectMeta{Name: "foo"},
+					Provisioner: "foo",
+					Parameters: map[string]string{
+						"foo": "bar",
+					},
+				},
+			},
+			input: &storagev1.StorageClass{
+				ObjectMeta:  metav1.ObjectMeta{Name: "foo"},
+				Provisioner: "foo",
+				Parameters: map[string]string{
+					"foo": "baz",
+				},
+			},
+			expectedModified: true,
+			verifyActions: func(actions []clienttesting.Action, t *testing.T) {
+				if len(actions) != 3 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("get", "storageclasses") || actions[0].(clienttesting.GetAction).GetName() != "foo" {
+					t.Error(spew.Sdump(actions))
+				}
+				if !actions[1].Matches("delete", "storageclasses") {
+					t.Error(spew.Sdump(actions))
+				}
+				if !actions[2].Matches("create", "storageclasses") {
+					t.Error(spew.Sdump(actions))
+				}
+				expected := &storagev1.StorageClass{
+					ObjectMeta:  metav1.ObjectMeta{Name: "foo"},
+					Provisioner: "foo",
+					Parameters: map[string]string{
+						"foo": "baz",
+					},
+				}
+				actual := actions[2].(clienttesting.CreateAction).GetObject().(*storagev1.StorageClass)
+				if !equality.Semantic.DeepEqual(expected, actual) {
+					t.Error(JSONPatchNoError(expected, actual))
 				}
 			},
 		},


### PR DESCRIPTION
Backporting https://github.com/openshift/library-go/pull/1348 to 4.10.

Some StorageClass fields are immutable after creation, therefore we need to delete and re-create the StorageClass if an operator needs to change these fields.

In 4.10 we need to fix StorageClass for Alibaba CSI driver.