### PR TITLE
Suppress 'No Recognised Cloud Provider' warning for Nutanix

### DIFF
--- a/pkg/operator/configobserver/cloudprovider/observe_cloudprovider.go
+++ b/pkg/operator/configobserver/cloudprovider/observe_cloudprovider.go
@@ -190,6 +190,7 @@ func GetPlatformName(platformType configv1.PlatformType, recorder events.Recorde
 		cloudProvider = "openstack"
 	case configv1.IBMCloudPlatformType:
 	case configv1.NonePlatformType:
+	case configv1.NutanixPlatformType:
 	case configv1.OvirtPlatformType:
 	case configv1.KubevirtPlatformType:
 	case configv1.AlibabaCloudPlatformType:


### PR DESCRIPTION
Add a case statement for Nutanix so the warning does not get issued
for OCP clusters on Nutanix platform.