### PR TITLE
updates signature of WaitForAPIServerToStabilizeOnTheSameRevision function

### DIFF
--- a/test/library/apiserver/apiserver.go
+++ b/test/library/apiserver/apiserver.go
@@ -1,7 +1,6 @@
 package apiserver
 
 import (
-	"testing"
 	"time"
 
 	"github.com/openshift/library-go/test/library"
@@ -32,6 +31,6 @@ var (
 //  the number of instances is calculated based on the number of running pods in a namespace.
 //  only pods with apiserver=true label are considered
 //  only pods in the given namespace are considered (podClient)
-func WaitForAPIServerToStabilizeOnTheSameRevision(t *testing.T, podClient corev1client.PodInterface) {
-	library.WaitForPodsToStabilizeOnTheSameRevision(t, podClient, "apiserver=true", waitForAPIRevisionSuccessThreshold, waitForAPIRevisionSuccessInterval, waitForAPIRevisionPollInterval, waitForAPIRevisionTimeout)
+func WaitForAPIServerToStabilizeOnTheSameRevision(t library.LoggingT, podClient corev1client.PodInterface) error {
+	return library.WaitForPodsToStabilizeOnTheSameRevision(t, podClient, "apiserver=true", waitForAPIRevisionSuccessThreshold, waitForAPIRevisionSuccessInterval, waitForAPIRevisionPollInterval, waitForAPIRevisionTimeout)
 }

--- a/test/library/library.go
+++ b/test/library/library.go
@@ -18,6 +18,10 @@ var (
 	WaitPollTimeout  = 10 * time.Minute
 )
 
+type LoggingT interface {
+	Logf(format string, args ...interface{})
+}
+
 // GenerateNameForTest generates a name of the form `prefix + test name + random string` that
 // can be used as a resource name. Convert the result to lowercase to use as a dns label.
 func GenerateNameForTest(t *testing.T, prefix string) string {

--- a/test/library/pod_same_revision.go
+++ b/test/library/pod_same_revision.go
@@ -3,7 +3,6 @@ package library
 import (
 	"context"
 	"fmt"
-	"testing"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -21,19 +20,17 @@ import (
 //  the number of instances is calculated based on the number of running pods in a namespace.
 //  only pods with the given label are considered
 //  only pods in the given namespace are considered (podClient)
-func WaitForPodsToStabilizeOnTheSameRevision(t *testing.T, podClient corev1client.PodInterface, podLabelSelector string, waitForRevisionSuccessThreshold int, waitForRevisionSuccessInterval, waitForRevisionPollInterval, waitForRevisionTimeout time.Duration) {
-	if err := wait.Poll(waitForRevisionPollInterval, waitForRevisionTimeout, mustSucceedMultipleTimes(waitForRevisionSuccessThreshold, waitForRevisionSuccessInterval, func() (bool, error) {
+func WaitForPodsToStabilizeOnTheSameRevision(t LoggingT, podClient corev1client.PodInterface, podLabelSelector string, waitForRevisionSuccessThreshold int, waitForRevisionSuccessInterval, waitForRevisionPollInterval, waitForRevisionTimeout time.Duration) error {
+	return wait.Poll(waitForRevisionPollInterval, waitForRevisionTimeout, mustSucceedMultipleTimes(waitForRevisionSuccessThreshold, waitForRevisionSuccessInterval, func() (bool, error) {
 		return arePodsOnTheSameRevision(t, podClient, podLabelSelector)
-	})); err != nil {
-		t.Fatal(err)
-	}
+	}))
 }
 
 // arePodsOnTheSameRevision tries to find the current revision that the pods are running at.
 // The number of instances is calculated based on the number of running pods in a namespace.
 // This should be okay because this function is meant to be used by WaitForPodsToStabilizeOnTheSameRevision which will wait at least waitForRevisionSuccessThreshold * waitForRevisionSuccessInterval
 // The number of pods should stabilize in that period of time.
-func arePodsOnTheSameRevision(t *testing.T, podClient corev1client.PodInterface, podLabelSelector string) (bool, error) {
+func arePodsOnTheSameRevision(t LoggingT, podClient corev1client.PodInterface, podLabelSelector string) (bool, error) {
 	revisionLabel := "revision"
 
 	// do a live list so we never get confused about what revision we are on

--- a/test/library/pod_same_revision_test.go
+++ b/test/library/pod_same_revision_test.go
@@ -16,8 +16,8 @@ func TestArePodsOnTheSameRevision(t *testing.T) {
 		expectSameRevision bool
 	}{
 		{
-			name:           "good pod, same revision",
-			initialObjects: []runtime.Object{newPod(corev1.PodRunning, corev1.ConditionTrue, "3", "node1")},
+			name:               "good pod, same revision",
+			initialObjects:     []runtime.Object{newPod(corev1.PodRunning, corev1.ConditionTrue, "3", "node1")},
 			expectSameRevision: true,
 		},
 	}
@@ -42,7 +42,7 @@ func newPod(phase corev1.PodPhase, ready corev1.ConditionStatus, revision, nodeN
 		ObjectMeta: v1.ObjectMeta{
 			Namespace: "test-ns",
 			Labels: map[string]string{
-				"revision": revision,
+				"revision":  revision,
 				"apiserver": "true",
 			}},
 		Spec: corev1.PodSpec{

--- a/test/library/pod_same_revision_test.go
+++ b/test/library/pod_same_revision_test.go
@@ -1,0 +1,61 @@
+package library
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestArePodsOnTheSameRevision(t *testing.T) {
+	scenarios := []struct {
+		name               string
+		initialObjects     []runtime.Object
+		expectSameRevision bool
+	}{
+		{
+			name:           "good pod, same revision",
+			initialObjects: []runtime.Object{newPod(corev1.PodRunning, corev1.ConditionTrue, "3", "node1")},
+			expectSameRevision: true,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			fakeKubeClient := fake.NewSimpleClientset(scenario.initialObjects...)
+			sameRevision, err := arePodsOnTheSameRevision(t, fakeKubeClient.CoreV1().Pods("test-ns"), "apiserver=true")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if scenario.expectSameRevision != sameRevision {
+				t.Errorf("unexpected result from arePodsOnTheSameRevision, expected = %v, got = %v", scenario.expectSameRevision, sameRevision)
+			}
+		})
+	}
+}
+
+func newPod(phase corev1.PodPhase, ready corev1.ConditionStatus, revision, nodeName string) *corev1.Pod {
+	pod := corev1.Pod{
+		TypeMeta: v1.TypeMeta{Kind: "Pod"},
+		ObjectMeta: v1.ObjectMeta{
+			Namespace: "test-ns",
+			Labels: map[string]string{
+				"revision": revision,
+				"apiserver": "true",
+			}},
+		Spec: corev1.PodSpec{
+			NodeName: nodeName,
+		},
+		Status: corev1.PodStatus{
+			Phase: phase,
+			Conditions: []corev1.PodCondition{{
+				Type:   corev1.PodReady,
+				Status: ready,
+			}},
+		},
+	}
+
+	return &pod
+}


### PR DESCRIPTION
so that it:
 - accepts an object that implements `LoggingT` interface for logging purposes. That allows for using this method from ginkgo and the standard library's testing framework.
 - returns an error, that allows the caller of this method to make a decision on how to log the error or/and end the test.