### PR TITLE
moves `IsSNOCheckFnc` to a common place

### DIFF
--- a/pkg/operator/staticpod/controller/common/helpers.go
+++ b/pkg/operator/staticpod/controller/common/helpers.go
@@ -7,11 +7,14 @@ import (
 	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
 )
 
-// IsSNOCheckFnc creates a function that checks if the topology is SNO
-// In case the err is nil, precheckSucceeded signifies whether the isSNO is valid.
-// If precheckSucceeded is false, the isSNO return value does not reflect the cluster topology
-// and defaults to the bool default value.
-func IsSNOCheckFnc(infraInformer configv1informers.InfrastructureInformer) func() (isSNO, precheckSucceeded bool, err error) {
+// NewIsSingleNodePlatformFn returns a function that checks if the cluster topology is single node (aka. SNO)
+// In case the err is nil, preconditionFulfilled indicates whether the isSNO is valid.
+// If preconditionFulfilled is false, the isSNO return value does not reflect the cluster topology and defaults to the bool default value.
+//
+// Note:
+// usually when preconditionFulfilled is false you should gate your controller as this means we were not able to
+// check the current topology
+func NewIsSingleNodePlatformFn(infraInformer configv1informers.InfrastructureInformer) func() (isSNO, preconditionFulfilled bool, err error) {
 	return func() (isSNO, precheckSucceeded bool, err error) {
 		if !infraInformer.Informer().HasSynced() {
 			// Do not return transient error

--- a/pkg/operator/staticpod/controller/common/helpers.go
+++ b/pkg/operator/staticpod/controller/common/helpers.go
@@ -1,0 +1,30 @@
+package common
+
+import (
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
+)
+
+// IsSNOCheckFnc creates a function that checks if the topology is SNO
+// In case the err is nil, precheckSucceeded signifies whether the isSNO is valid.
+// If precheckSucceeded is false, the isSNO return value does not reflect the cluster topology
+// and defaults to the bool default value.
+func IsSNOCheckFnc(infraInformer configv1informers.InfrastructureInformer) func() (isSNO, precheckSucceeded bool, err error) {
+	return func() (isSNO, precheckSucceeded bool, err error) {
+		if !infraInformer.Informer().HasSynced() {
+			// Do not return transient error
+			return false, false, nil
+		}
+		infraData, err := infraInformer.Lister().Get("cluster")
+		if err != nil {
+			return false, true, fmt.Errorf("Unable to list infrastructures.config.openshift.io/cluster object, unable to determine topology mode")
+		}
+		if infraData.Status.ControlPlaneTopology == "" {
+			return false, true, fmt.Errorf("ControlPlaneTopology was not set, unable to determine topology mode")
+		}
+
+		return infraData.Status.ControlPlaneTopology == configv1.SingleReplicaTopologyMode, true, nil
+	}
+}

--- a/pkg/operator/staticpod/controller/guard/guard_controller.go
+++ b/pkg/operator/staticpod/controller/guard/guard_controller.go
@@ -22,8 +22,6 @@ import (
 	policylisterv1 "k8s.io/client-go/listers/policy/v1"
 	"k8s.io/klog/v2"
 
-	configv1 "github.com/openshift/api/config/v1"
-	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
@@ -310,26 +308,4 @@ func (c *GuardController) sync(ctx context.Context, syncCtx factory.SyncContext)
 	}
 
 	return utilerrors.NewAggregate(errs)
-}
-
-// IsSNOCheckFnc creates a function that checks if the topology is SNO
-// In case the err is nil, precheckSucceeded signifies whether the isSNO is valid.
-// If precheckSucceeded is false, the isSNO return value does not reflect the cluster topology
-// and defaults to the bool default value.
-func IsSNOCheckFnc(infraInformer configv1informers.InfrastructureInformer) func() (isSNO, precheckSucceeded bool, err error) {
-	return func() (isSNO, precheckSucceeded bool, err error) {
-		if !infraInformer.Informer().HasSynced() {
-			// Do not return transient error
-			return false, false, nil
-		}
-		infraData, err := infraInformer.Lister().Get("cluster")
-		if err != nil {
-			return false, true, fmt.Errorf("Unable to list infrastructures.config.openshift.io/cluster object, unable to determine topology mode")
-		}
-		if infraData.Status.ControlPlaneTopology == "" {
-			return false, true, fmt.Errorf("ControlPlaneTopology was not set, unable to determine topology mode")
-		}
-
-		return infraData.Status.ControlPlaneTopology == configv1.SingleReplicaTopologyMode, true, nil
-	}
 }

--- a/pkg/operator/staticpod/controller/guard/guard_controller_test.go
+++ b/pkg/operator/staticpod/controller/guard/guard_controller_test.go
@@ -161,7 +161,7 @@ func TestIsSNOCheckFnc(t *testing.T) {
 				},
 			}
 
-			conditionalFunction := staticcontrollercommon.IsSNOCheckFnc(informer)
+			conditionalFunction := staticcontrollercommon.NewIsSingleNodePlatformFn(informer)
 			result, precheckSucceeded, err := conditionalFunction()
 			if test.err {
 				if err == nil {
@@ -420,7 +420,7 @@ func TestRenderGuardPod(t *testing.T) {
 				},
 			}
 
-			createConditionalFunc := staticcontrollercommon.IsSNOCheckFnc(informer)
+			createConditionalFunc := staticcontrollercommon.NewIsSingleNodePlatformFn(informer)
 			if test.createConditionalFunc != nil {
 				createConditionalFunc = test.createConditionalFunc
 			}
@@ -560,7 +560,7 @@ func TestRenderGuardPodPortChanged(t *testing.T) {
 		pdbGetter:               kubeClient.PolicyV1(),
 		pdbLister:               kubeInformers.Policy().V1().PodDisruptionBudgets().Lister(),
 		installerPodImageFn:     getInstallerPodImageFromEnv,
-		createConditionalFunc:   staticcontrollercommon.IsSNOCheckFnc(informer),
+		createConditionalFunc:   staticcontrollercommon.NewIsSingleNodePlatformFn(informer),
 	}
 
 	ctx, cancel := context.WithCancel(context.TODO())

--- a/pkg/operator/staticpod/controller/guard/guard_controller_test.go
+++ b/pkg/operator/staticpod/controller/guard/guard_controller_test.go
@@ -20,6 +20,7 @@ import (
 	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
 	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
 	"github.com/openshift/library-go/pkg/operator/events"
+	staticcontrollercommon "github.com/openshift/library-go/pkg/operator/staticpod/controller/common"
 )
 
 type FakeInfrastructureInformer struct {
@@ -160,7 +161,7 @@ func TestIsSNOCheckFnc(t *testing.T) {
 				},
 			}
 
-			conditionalFunction := IsSNOCheckFnc(informer)
+			conditionalFunction := staticcontrollercommon.IsSNOCheckFnc(informer)
 			result, precheckSucceeded, err := conditionalFunction()
 			if test.err {
 				if err == nil {
@@ -419,7 +420,7 @@ func TestRenderGuardPod(t *testing.T) {
 				},
 			}
 
-			createConditionalFunc := IsSNOCheckFnc(informer)
+			createConditionalFunc := staticcontrollercommon.IsSNOCheckFnc(informer)
 			if test.createConditionalFunc != nil {
 				createConditionalFunc = test.createConditionalFunc
 			}
@@ -559,7 +560,7 @@ func TestRenderGuardPodPortChanged(t *testing.T) {
 		pdbGetter:               kubeClient.PolicyV1(),
 		pdbLister:               kubeInformers.Policy().V1().PodDisruptionBudgets().Lister(),
 		installerPodImageFn:     getInstallerPodImageFromEnv,
-		createConditionalFunc:   IsSNOCheckFnc(informer),
+		createConditionalFunc:   staticcontrollercommon.IsSNOCheckFnc(informer),
 	}
 
 	ctx, cancel := context.WithCancel(context.TODO())


### PR DESCRIPTION
the function will be used by multiple controllers. This PR also renames the function to `NewIsSingleNodePlatformFn`

instructions on update:

 import `staticcontrollercommon "github.com/openshift/library-go/pkg/operator/staticpod/controller/common"`
 use `staticcontrollercommon.NewIsSingleNodePlatformFn`


will be used by https://github.com/openshift/library-go/pull/1347