### PR TITLE
Fix ApplyService to detect new Service spec

### DIFF
--- a/pkg/operator/resource/resourceapply/core.go
+++ b/pkg/operator/resource/resourceapply/core.go
@@ -124,10 +124,17 @@ func ApplyNamespaceImproved(ctx context.Context, client coreclientv1.NamespacesG
 	return actual, true, err
 }
 
-// ApplyService merges objectmeta and requires
-// TODO, since this cannot determine whether changes are due to legitimate actors (api server) or illegitimate ones (users), we cannot update
+// ApplyService merges objectmeta and requires.
+// It detects changes in `required`, i.e. an operator needs .spec changes and overwrites existing .spec with those.
+// TODO, since this cannot determine whether changes in `existing` are due to legitimate actors (api server) or illegitimate ones (users), we cannot update.
 // TODO I've special cased the selector for now
-func ApplyServiceImproved(ctx context.Context, client coreclientv1.ServicesGetter, recorder events.Recorder, required *corev1.Service, cache ResourceCache) (*corev1.Service, bool, error) {
+func ApplyServiceImproved(ctx context.Context, client coreclientv1.ServicesGetter, recorder events.Recorder, requiredOriginal *corev1.Service, cache ResourceCache) (*corev1.Service, bool, error) {
+	required := requiredOriginal.DeepCopy()
+	err := SetSpecHashAnnotation(&required.ObjectMeta, required.Spec)
+	if err != nil {
+		return nil, false, err
+	}
+
 	existing, err := client.Services(required.Namespace).Get(ctx, required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		requiredCopy := required.DeepCopy()
@@ -148,6 +155,8 @@ func ApplyServiceImproved(ctx context.Context, client coreclientv1.ServicesGette
 	modified := resourcemerge.BoolPtr(false)
 	existingCopy := existing.DeepCopy()
 
+	// This will catch also changes between old `required.spec` and current `required.spec`, because
+	// the annotation from SetSpecHashAnnotation will be different.
 	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
 	selectorSame := equality.Semantic.DeepEqual(existingCopy.Spec.Selector, required.Spec.Selector)
 
@@ -163,9 +172,9 @@ func ApplyServiceImproved(ctx context.Context, client coreclientv1.ServicesGette
 		return existingCopy, false, nil
 	}
 
-	existingCopy.Spec.Selector = required.Spec.Selector
-	existingCopy.Spec.Type = required.Spec.Type // if this is different, the update will fail.  Status will indicate it.
-
+	// Either (user changed selector or type) or metadata changed (incl. spec hash). Stomp over
+	// any user *and* Kubernetes changes, hoping that Kubernetes will restore its values.
+	existingCopy.Spec = required.Spec
 	if klog.V(4).Enabled() {
 		klog.Infof("Service %q changes: %v", required.Namespace+"/"+required.Name, JSONPatchNoError(existing, required))
 	}


### PR DESCRIPTION
When an operator needs to update `service.spec`, `ApplyService` should apply it. We detect change of the spec by using an annotation with the old `service.spec` required by the operator and comparing it with the current operator's request.

Keep the existing heuristics of user changes (`spec.type`, `spec.selector`) in place.

This code expects that the API server restores any immutable ``service.spec` fields, like `clusterIP`. My observation is that the API server restores them when processing the update.

This is related to https://bugzilla.redhat.com/show_bug.cgi?id=2076637 - we want to add new `service.spec.ports` to an existing service during cluster update.

cc @deads2k @openshift/storage 