### PR TITLE
Bug 2067804: Restore Apply*WebhookConfiguration functions

### DIFF
--- a/pkg/operator/resource/resourceapply/admissionregistration.go
+++ b/pkg/operator/resource/resourceapply/admissionregistration.go
@@ -75,6 +75,11 @@ func ApplyMutatingWebhookConfigurationImproved(ctx context.Context, client admis
 	return actual, true, nil
 }
 
+func ApplyMutatingWebhookConfiguration(ctx context.Context, client admissionregistrationclientv1.MutatingWebhookConfigurationsGetter, recorder events.Recorder,
+	requiredOriginal *admissionregistrationv1.MutatingWebhookConfiguration) (*admissionregistrationv1.MutatingWebhookConfiguration, bool, error) {
+	return ApplyMutatingWebhookConfigurationImproved(ctx, client, recorder, requiredOriginal, noCache)
+}
+
 // copyMutatingWebhookCABundle populates webhooks[].clientConfig.caBundle fields from existing resource if it was set before
 // and is not set in present. This provides upgrade compatibility with service-ca-bundle operator.
 func copyMutatingWebhookCABundle(from, to *admissionregistrationv1.MutatingWebhookConfiguration) {
@@ -148,6 +153,11 @@ func ApplyValidatingWebhookConfigurationImproved(ctx context.Context, client adm
 	// need to store the original so that the early comparison of hashes is done based on the original, not a mutated copy
 	cache.UpdateCachedResourceMetadata(requiredOriginal, actual)
 	return actual, true, nil
+}
+
+func ApplyValidatingWebhookConfiguration(ctx context.Context, client admissionregistrationclientv1.ValidatingWebhookConfigurationsGetter, recorder events.Recorder,
+	requiredOriginal *admissionregistrationv1.ValidatingWebhookConfiguration, cache ResourceCache) (*admissionregistrationv1.ValidatingWebhookConfiguration, bool, error) {
+	return ApplyValidatingWebhookConfigurationImproved(ctx, client, recorder, requiredOriginal, noCache)
 }
 
 // copyValidatingWebhookCABundle populates webhooks[].clientConfig.caBundle fields from existing resource if it was set before


### PR DESCRIPTION
Consumers of library-go cannot create an instance of noCache as it is a
private type; these functions were previously removed in
99821bd429ba0c4ed18fc18d3394511fa240d6c3

cc #1294 
cc @deads2k 

This is currently blocking CVE mitigation in the CBO.