### PR TITLE
Bug 2096691: Add custom hooks to CSIStorageClassController

### DIFF
--- a/pkg/operator/csi/csicontrollerset/csi_controller_set.go
+++ b/pkg/operator/csi/csicontrollerset/csi_controller_set.go
@@ -222,6 +222,7 @@ func (c *CSIControllerSet) WithStorageClassController(
 	file string,
 	kubeClient kubernetes.Interface,
 	namespacedInformerFactory informers.SharedInformerFactory,
+	hooks ...csistorageclasscontroller.StorageClassHookFunc,
 ) *CSIControllerSet {
 	c.csiStorageclassController = csistorageclasscontroller.NewCSIStorageClassController(
 		name,
@@ -231,6 +232,7 @@ func (c *CSIControllerSet) WithStorageClassController(
 		namespacedInformerFactory,
 		c.operatorClient,
 		c.eventRecorder,
+		hooks...,
 	)
 	return c
 }


### PR DESCRIPTION
An operator now has possibility to modify a StorageClass before it's applied by the SC controller.

Alibaba CSI driver operator will use it to dynamically inject `ResourceGroupID` to the default SC to provision PVs in the same resource group as where are all the other cluster resources like VMs and their root disks.