### PR TITLE
BZ_2065028: remove P=f on degrading operator

### DIFF
--- a/pkg/operator/apiserver/controller/workload/workload.go
+++ b/pkg/operator/apiserver/controller/workload/workload.go
@@ -272,9 +272,6 @@ func (c *Controller) updateOperatorStatus(ctx context.Context, previousStatus *o
 		deploymentProgressingCondition.Message = fmt.Sprintf("deployment/%s.%s: observed generation is %d, desired generation is %d.", workload.Name, c.targetNamespace, workload.Status.ObservedGeneration, workload.ObjectMeta.Generation)
 	} else if workloadIsBeingUpdated {
 		deploymentProgressingCondition.Status = operatorv1.ConditionTrue
-		if workloadIsBeingUpdatedTooLong {
-			deploymentProgressingCondition.Status = operatorv1.ConditionFalse
-		}
 		deploymentProgressingCondition.Reason = "PodsUpdating"
 		deploymentProgressingCondition.Message = fmt.Sprintf("deployment/%s.%s: %d/%d pods have been updated to the latest generation", workload.Name, c.targetNamespace, workload.Status.UpdatedReplicas, desiredReplicas)
 	} else {

--- a/pkg/operator/apiserver/controller/workload/workload_test.go
+++ b/pkg/operator/apiserver/controller/workload/workload_test.go
@@ -188,7 +188,7 @@ func TestUpdateOperatorStatus(t *testing.T) {
 					},
 					{
 						Type:    fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
-						Status:  operatorv1.ConditionFalse,
+						Status:  operatorv1.ConditionTrue,
 						Reason:  "PodsUpdating",
 						Message: "deployment/apiserver.openshift-apiserver: 0/3 pods have been updated to the latest generation",
 					},


### PR DESCRIPTION
## What

An operator that is `progressing=true` for a long time should stay in progressing state (on top of getting `degraded=true`).

## Why

```
Progressing Timeline in Minutes
[--------|--------]
0   ^   15   ^  45  ^
     A         B        C

A is progressing=true, degraded=false
B is progressing=false, degraded=false
C is progressing=false, degraded=true (inertia logic set to 30 minutes for CAO)
```

## Ref

[Request Header IDP Flaky Test](https://bugzilla.redhat.com/show_bug.cgi?id=2065028)
[30 minutes](https://github.com/openshift/library-go/blob/master/pkg/operator/apiserver/controllerset/apiservercontrollerset.go#L160-L165=)

Signed-off-by: Krzysztof Ostrowski <kostrows@redhat.com>