### PR TITLE
Always enable external cloud provider on OpenStack

### DIFF
--- a/pkg/cloudprovider/external.go
+++ b/pkg/cloudprovider/external.go
@@ -24,8 +24,7 @@ func IsCloudProviderExternal(platformStatus *configv1.PlatformStatus, featureGat
 	switch platformStatus.Type {
 	case configv1.AWSPlatformType,
 		configv1.GCPPlatformType,
-		configv1.VSpherePlatformType,
-		configv1.OpenStackPlatformType:
+		configv1.VSpherePlatformType:
 		// Platforms that are external based on feature gate presence
 		return isExternalFeatureGateEnabled(featureGate)
 	case configv1.AzurePlatformType:
@@ -33,7 +32,10 @@ func IsCloudProviderExternal(platformStatus *configv1.PlatformStatus, featureGat
 			return true, nil
 		}
 		return isExternalFeatureGateEnabled(featureGate)
-	case configv1.IBMCloudPlatformType, configv1.AlibabaCloudPlatformType, configv1.PowerVSPlatformType:
+	case configv1.AlibabaCloudPlatformType,
+		configv1.IBMCloudPlatformType,
+		configv1.OpenStackPlatformType,
+		configv1.PowerVSPlatformType:
 		return true, nil
 	default:
 		// Platforms that do not have external cloud providers implemented

--- a/pkg/cloudprovider/external_test.go
+++ b/pkg/cloudprovider/external_test.go
@@ -19,9 +19,7 @@ func TestIsCloudProviderExternal(t *testing.T) {
 		status: &configv1.PlatformStatus{
 			Type: configv1.OpenStackPlatformType,
 		},
-		featureGate: nil,
-		expected:    false,
-		expectedErr: nil,
+		expected: true,
 	}, {
 		name: "FeatureSet: Unknown, Platform: OpenStack",
 		status: &configv1.PlatformStatus{
@@ -34,8 +32,7 @@ func TestIsCloudProviderExternal(t *testing.T) {
 				},
 			},
 		},
-		expected:    false,
-		expectedErr: fmt.Errorf(".spec.featureSet \"Unknown\" not found"),
+		expected: true,
 	}, {
 		name: "FeatureSet: TechPreviewNoUpgrade, Platform: OpenStack",
 		status: &configv1.PlatformStatus{
@@ -61,7 +58,7 @@ func TestIsCloudProviderExternal(t *testing.T) {
 				},
 			},
 		},
-		expected: false,
+		expected: true,
 	}, {
 		name: "FeatureSet: IPv6DualStackNoUpgrade, Platform: OpenStack",
 		status: &configv1.PlatformStatus{
@@ -74,7 +71,7 @@ func TestIsCloudProviderExternal(t *testing.T) {
 				},
 			},
 		},
-		expected: false,
+		expected: true,
 	}, {
 		name: "FeatureSet: CustomNoUpgrade (No External Feature Gate), Platform: OpenStack",
 		status: &configv1.PlatformStatus{
@@ -90,7 +87,7 @@ func TestIsCloudProviderExternal(t *testing.T) {
 				},
 			},
 		},
-		expected: false,
+		expected: true,
 	}, {
 		name: "FeatureSet: CustomNoUpgrade (With External Feature Gate Enabled), Platform: OpenStack",
 		status: &configv1.PlatformStatus{
@@ -123,7 +120,7 @@ func TestIsCloudProviderExternal(t *testing.T) {
 				},
 			},
 		},
-		expected: false,
+		expected: true,
 	}, {
 		name: "FeatureSet: CustomNoUpgrade (With External Feature Gate Disabled), Platform: OpenStack",
 		status: &configv1.PlatformStatus{
@@ -139,7 +136,7 @@ func TestIsCloudProviderExternal(t *testing.T) {
 				},
 			},
 		},
-		expected: false,
+		expected: true,
 	}, {
 		name: "FeatureSet: CustomNoUpgrade (With External Feature Gate), Platform: AWS",
 		status: &configv1.PlatformStatus{

--- a/pkg/operator/configobserver/cloudprovider/observe_cloudprovider_test.go
+++ b/pkg/operator/configobserver/cloudprovider/observe_cloudprovider_test.go
@@ -181,7 +181,7 @@ func TestObserveCloudProviderNames(t *testing.T) {
 				Type: configv1.OpenStackPlatformType,
 			},
 		},
-		expected:           "openstack",
+		expected:           "external",
 		cloudProviderCount: 1,
 	}, {
 		name: "OpenStack platform set for external configuration",


### PR DESCRIPTION
The OpenStack team want to enable the OpenStack CCM on all clusters from 4.12 onwards. This changes the decision logic of the `IsCloudProviderExternal` function so that no matter the scenario, the OpenStack CCM will be external.

This will need to be paired with PRs to update KCMO, CCCMO, MCO and KASO.
The KCMO and CCCMO PRs are time sensitive and must be merged simultaneously.
The other two PRs can be merged later without any ill effect to the CI or new installs/debug builds for developers.

I used cluster bot to test this with the respective CCCMO and KCMO PRs, with two results:
* [First attempt - failed](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-origin-installer-launch-openstack/1551878461327413248)
* [Second attempt - passed](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-origin-installer-launch-openstack/1551942225204613120)

This test vendored the commit 3431d9d80fd17d34a3b92f538e8c32bfd332ed05 from my branch (parent commit is current master of openshift/library-go ca167a8bd3428e4f22a59efba8b3f2277c34adc7), and should therefore contain all of the latest changes to library-go.