### PR TITLE
Bug 2108054: Add ReadGenericWithUnstructured

### DIFF
--- a/pkg/operator/resource/resourceapply/generic.go
+++ b/pkg/operator/resource/resourceapply/generic.go
@@ -10,40 +10,19 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/scheme"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	migrationv1alpha1 "sigs.k8s.io/kube-storage-version-migrator/pkg/apis/migration/v1alpha1"
 	migrationclient "sigs.k8s.io/kube-storage-version-migrator/pkg/clients/clientset"
 
-	"github.com/openshift/api"
-
 	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
-
-var (
-	genericScheme = runtime.NewScheme()
-	genericCodecs = serializer.NewCodecFactory(genericScheme)
-	genericCodec  = genericCodecs.UniversalDeserializer()
-)
-
-func init() {
-	utilruntime.Must(api.InstallKube(genericScheme))
-	utilruntime.Must(apiextensionsv1beta1.AddToScheme(genericScheme))
-	utilruntime.Must(apiextensionsv1.AddToScheme(genericScheme))
-	utilruntime.Must(migrationv1alpha1.AddToScheme(genericScheme))
-	utilruntime.Must(admissionregistrationv1.AddToScheme(genericScheme))
-	// TODO: remove once openshift/api/pull/929 is merged
-	utilruntime.Must(policyv1.AddToScheme(genericScheme))
-}
 
 type AssetFunc func(name string) ([]byte, error)
 
@@ -112,7 +91,7 @@ func ApplyDirectly(ctx context.Context, clients *ClientHolder, recorder events.R
 			ret = append(ret, result)
 			continue
 		}
-		requiredObj, err := decode(objBytes)
+		requiredObj, err := resourceread.ReadGenericWithUnstructured(objBytes)
 		if err != nil {
 			result.Error = fmt.Errorf("cannot decode %q: %v", file, err)
 			ret = append(ret, result)
@@ -254,7 +233,7 @@ func DeleteAll(ctx context.Context, clients *ClientHolder, recorder events.Recor
 			ret = append(ret, result)
 			continue
 		}
-		requiredObj, err := decode(objBytes)
+		requiredObj, err := resourceread.ReadGenericWithUnstructured(objBytes)
 		if err != nil {
 			result.Error = fmt.Errorf("cannot decode %q: %v", file, err)
 			ret = append(ret, result)
@@ -389,20 +368,4 @@ func (c *ClientHolder) secretsGetter() corev1client.SecretsGetter {
 		return c.kubeClient.CoreV1()
 	}
 	return v1helpers.CachedSecretGetter(c.kubeClient.CoreV1(), c.kubeInformers)
-}
-
-func decode(objBytes []byte) (runtime.Object, error) {
-	// Try to get a typed object first
-	typedObj, _, decodeErr := genericCodec.Decode(objBytes, nil, nil)
-	if decodeErr == nil {
-		return typedObj, nil
-	}
-
-	// Try unstructured, hoping to recover from "no kind XXX is registered for version YYY"
-	unstructuredObj, _, err := scheme.Codecs.UniversalDecoder().Decode(objBytes, nil, &unstructured.Unstructured{})
-	if err != nil {
-		// Return the original error
-		return nil, decodeErr
-	}
-	return unstructuredObj, nil
 }

--- a/pkg/operator/resource/resourceapply/generic_test.go
+++ b/pkg/operator/resource/resourceapply/generic_test.go
@@ -4,27 +4,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
-
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/openshift/library-go/pkg/operator/events"
 )
-
-func TestApplyDirectly(t *testing.T) {
-	requiredObj, gvk, err := genericCodec.Decode([]byte(`apiVersion: v1
-kind: Namespace
-metadata:
-  name: openshift-apiserver
-  labels:
-    openshift.io/run-level: "1"
-`), nil, nil)
-	t.Log(spew.Sdump(requiredObj))
-	t.Log(spew.Sdump(gvk))
-	if err != nil {
-		t.Fatal(err)
-	}
-}
 
 func TestApplyDirectlyUnhandledType(t *testing.T) {
 	fakeClient := fake.NewSimpleClientset()

--- a/pkg/operator/resource/resourceread/generic.go
+++ b/pkg/operator/resource/resourceread/generic.go
@@ -1,0 +1,56 @@
+package resourceread
+
+import (
+	"github.com/openshift/api"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	migrationv1alpha1 "sigs.k8s.io/kube-storage-version-migrator/pkg/apis/migration/v1alpha1"
+)
+
+var (
+	genericScheme = runtime.NewScheme()
+	genericCodecs = serializer.NewCodecFactory(genericScheme)
+	genericCodec  = genericCodecs.UniversalDeserializer()
+)
+
+func init() {
+	utilruntime.Must(api.InstallKube(genericScheme))
+	utilruntime.Must(apiextensionsv1beta1.AddToScheme(genericScheme))
+	utilruntime.Must(apiextensionsv1.AddToScheme(genericScheme))
+	utilruntime.Must(migrationv1alpha1.AddToScheme(genericScheme))
+	utilruntime.Must(admissionregistrationv1.AddToScheme(genericScheme))
+}
+
+// ReadGenericWithUnstructured parses given yaml file using known scheme (see genericScheme above).
+// If the object kind is not registered in the scheme, it returns Unstructured as the last resort.
+func ReadGenericWithUnstructured(objBytes []byte) (runtime.Object, error) {
+	// Try to get a typed object first
+	typedObj, _, decodeErr := genericCodec.Decode(objBytes, nil, nil)
+	if decodeErr == nil {
+		return typedObj, nil
+	}
+
+	// Try unstructured, hoping to recover from "no kind XXX is registered for version YYY"
+	unstructuredObj, _, err := scheme.Codecs.UniversalDecoder().Decode(objBytes, nil, &unstructured.Unstructured{})
+	if err != nil {
+		// Return the original error
+		return nil, decodeErr
+	}
+	return unstructuredObj, nil
+}
+
+// ReadGenericWithUnstructuredOrDie parses given yaml file using known scheme (see genericScheme above).
+// If the object kind is not registered in the scheme, it returns Unstructured as the last resort.
+func ReadGenericWithUnstructuredOrDie(objBytes []byte) runtime.Object {
+	obj, err := ReadGenericWithUnstructured(objBytes)
+	if err != nil {
+		panic(err)
+	}
+	return obj
+}

--- a/pkg/operator/resource/resourceread/generic_test.go
+++ b/pkg/operator/resource/resourceread/generic_test.go
@@ -1,0 +1,48 @@
+package resourceread
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestReadGenericKnownObject(t *testing.T) {
+	requiredObj, err := ReadGenericWithUnstructured([]byte(`apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-apiserver
+  labels:
+    openshift.io/run-level: "1"
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := requiredObj.(*v1.Namespace); !ok {
+		t.Fatalf("Expected namespace, got %+v", requiredObj)
+	}
+}
+
+func TestReadGenericUnknownObject(t *testing.T) {
+	requiredObj, err := ReadGenericWithUnstructured([]byte(`apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: foo
+  namespace: bar
+spec:
+  groups:
+    - name: baz
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	u, ok := requiredObj.(*unstructured.Unstructured)
+	if !ok {
+		t.Fatalf("Expected unstructured, got %+v", requiredObj)
+	}
+
+	if u.GetName() != "foo" {
+		t.Errorf("Expected name foo, got %q", u.GetName())
+	}
+}

--- a/pkg/operator/staticresourcecontroller/static_resource_controller.go
+++ b/pkg/operator/staticresourcecontroller/static_resource_controller.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -188,7 +189,7 @@ func (c *StaticResourceController) AddKubeInformers(kubeInformersByNamespace v1h
 				utilruntime.HandleError(fmt.Errorf("missing %q: %v", file, err))
 				continue
 			}
-			requiredObj, _, err := genericCodec.Decode(objBytes, nil, nil)
+			requiredObj, err := resourceread.ReadGenericWithUnstructured(objBytes)
 			if err != nil {
 				utilruntime.HandleError(fmt.Errorf("cannot decode %q: %v", file, err))
 				continue
@@ -397,7 +398,7 @@ func (c *StaticResourceController) RelatedObjects() ([]configv1.ObjectReference,
 				errors = append(errors, err)
 				continue
 			}
-			requiredObj, _, err := genericCodec.Decode(objBytes, nil, nil)
+			requiredObj, err := resourceread.ReadGenericWithUnstructured(objBytes)
 			if err != nil {
 				errors = append(errors, err)
 				continue


### PR DESCRIPTION
And change `ApplyDirectly` + `StaticResourceController` to use it.

This allows `StaticResourceController.RelatedObjects()` to process unknown
types as Unstructured, like `PrometheusRules`.