### PR TITLE
update manifest selection to allow Default and TechPreview for releas…

### DIFF
--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -9,6 +9,8 @@ import (
 	"reflect"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -21,7 +23,20 @@ import (
 const (
 	CapabilityAnnotation  = "capability.openshift.io/name"
 	DefaultClusterProfile = "self-managed-high-availability"
+	featureSetAnnotation  = "release.openshift.io/feature-set"
 )
+
+var knownFeatureSets = sets.String{}
+
+func init() {
+	for featureSet := range configv1.FeatureSets {
+		if len(featureSet) == 0 {
+			knownFeatureSets.Insert("Default")
+			continue
+		}
+		knownFeatureSets.Insert(string(featureSet))
+	}
+}
 
 // resourceId uniquely identifies a Kubernetes resource.
 // It is used to identify any duplicate resources within
@@ -114,11 +129,49 @@ func (m *Manifest) UnmarshalJSON(in []byte) error {
 	return validateResourceId(m.id)
 }
 
+func getFeatureSets(annotations map[string]string) (sets.String, bool, error) {
+	ret := sets.String{}
+	specified := false
+	// We are removing annotations["release.openshift.io/feature-gate"] in 4.12.
+	for _, featureSetAnnotation := range []string{"release.openshift.io/feature-gate", featureSetAnnotation} {
+		featureSetAnnotationValue, featureSetAnnotationExists := annotations[featureSetAnnotation]
+		if featureSetAnnotationExists {
+			specified = true
+			featureSetAnnotationValues := strings.Split(featureSetAnnotationValue, ",")
+			for _, manifestFeatureSet := range featureSetAnnotationValues {
+				if !knownFeatureSets.Has(manifestFeatureSet) {
+					// never include the manifest if the feature-set annotation is outside of known values
+					return nil, specified, fmt.Errorf("unrecognized value %q in %s=%s; known values are: %v", manifestFeatureSet, featureSetAnnotation, featureSetAnnotationValue, strings.Join(knownFeatureSets.List(), ","))
+				}
+			}
+			ret.Insert(featureSetAnnotationValues...)
+		}
+	}
+
+	return ret, specified, nil
+}
+
+func checkFeatureSets(requiredFeatureSet string, annotations map[string]string) error {
+	requiredAnnotationValue := requiredFeatureSet
+	if len(requiredFeatureSet) == 0 {
+		requiredAnnotationValue = "Default" // "" in the FeatureSet API is "Default" in the annotation value
+	}
+	manifestFeatureSets, manifestSpecifiesFeatureSets, err := getFeatureSets(annotations)
+	if err != nil {
+		return err
+	}
+	if manifestSpecifiesFeatureSets && !manifestFeatureSets.Has(requiredAnnotationValue) {
+		return fmt.Errorf("%q is required, and %s=%s", requiredAnnotationValue, featureSetAnnotation, strings.Join(manifestFeatureSets.List(), ","))
+	}
+
+	return nil
+}
+
 // Include returns an error if the manifest fails an inclusion filter and should be excluded from further
 // processing by cluster version operator. Pointer arguments can be set nil to avoid excluding based on that
 // filter. For example, setting profile non-nil and capabilities nil will return an error if the manifest's
 // profile does not match, but will never return an error about capability issues.
-func (m *Manifest) Include(excludeIdentifier *string, includeTechPreview *bool, profile *string, capabilities *configv1.ClusterVersionCapabilitiesStatus) error {
+func (m *Manifest) Include(excludeIdentifier *string, requiredFeatureSet *string, profile *string, capabilities *configv1.ClusterVersionCapabilitiesStatus) error {
 
 	annotations := m.Obj.GetAnnotations()
 	if annotations == nil {
@@ -132,15 +185,10 @@ func (m *Manifest) Include(excludeIdentifier *string, includeTechPreview *bool, 
 		}
 	}
 
-	if includeTechPreview != nil {
-		featureGateAnnotation := "release.openshift.io/feature-gate"
-		featureGateAnnotationValue, featureGateAnnotationExists := annotations[featureGateAnnotation]
-		if featureGateAnnotationValue == string(configv1.TechPreviewNoUpgrade) && !(*includeTechPreview) {
-			return fmt.Errorf("tech-preview excluded, and %s=%s", featureGateAnnotation, featureGateAnnotationValue)
-		}
-		// never include the manifest if the feature-gate annotation is outside of allowed values (only TechPreviewNoUpgrade is currently allowed)
-		if featureGateAnnotationExists && featureGateAnnotationValue != string(configv1.TechPreviewNoUpgrade) {
-			return fmt.Errorf("unrecognized value %s=%s", featureGateAnnotation, featureGateAnnotationValue)
+	if requiredFeatureSet != nil {
+		err := checkFeatureSets(*requiredFeatureSet, annotations)
+		if err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
…e.openshift.io/feature-gate

This will allow us to have manifests that are used in TechPreview and alternative manifests for the same resource to be used for the Default featureset.

You can set .metadata.annotations["release.openshift.io/feature-set"]="Default,LatencySensitive,IPv6DualStackNoUpgrade" and in another manifest .metadata.annotations["release.openshift.io/feature-set"]="TechPreviewNoUpgrade,CustomNoUpgrade" to select which manifests should be active depending on featureset.

This does make it more expensive to add FeatureSets.  This is not a bad thing, FeatureSets should be expensive.

/assign @wking 