### PR TITLE
[wip] make the static resource controller handle featureset annotations

### DIFF
--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -9,6 +9,8 @@ import (
 	"reflect"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -114,11 +116,46 @@ func (m *Manifest) UnmarshalJSON(in []byte) error {
 	return validateResourceId(m.id)
 }
 
+const featureSetAnnotation = "release.openshift.io/feature-set"
+
+var knownFeatureSets = sets.String{}
+
+func init() {
+	for featureSet := range configv1.FeatureSets {
+		if len(featureSet) == 0 {
+			knownFeatureSets.Insert("Default")
+			continue
+		}
+		knownFeatureSets.Insert(string(featureSet))
+	}
+}
+
+func getFeatureSets(annotations map[string]string) (sets.String, bool, error) {
+	ret := sets.String{}
+	specified := false
+	for _, featureSetAnnotation := range []string{"release.openshift.io/feature-gate", featureSetAnnotation} {
+		featureSetAnnotationValue, featureSetAnnotationExists := annotations[featureSetAnnotation]
+		if featureSetAnnotationExists {
+			specified = true
+			featureSetAnnotationValues := strings.Split(featureSetAnnotationValue, ",")
+			for _, manifestFeatureSet := range featureSetAnnotationValues {
+				if !knownFeatureSets.Has(manifestFeatureSet) {
+					// never include the manifest if the feature-set annotation is outside of known values
+					return nil, specified, fmt.Errorf("unrecognized value %q in %s=%s; known values are: %v", manifestFeatureSet, featureSetAnnotation, featureSetAnnotationValue, strings.Join(knownFeatureSets.List(), ","))
+				}
+			}
+			ret.Insert(featureSetAnnotationValues...)
+		}
+	}
+
+	return ret, specified, nil
+}
+
 // Include returns an error if the manifest fails an inclusion filter and should be excluded from further
 // processing by cluster version operator. Pointer arguments can be set nil to avoid excluding based on that
 // filter. For example, setting profile non-nil and capabilities nil will return an error if the manifest's
 // profile does not match, but will never return an error about capability issues.
-func (m *Manifest) Include(excludeIdentifier *string, includeTechPreview *bool, profile *string, capabilities *configv1.ClusterVersionCapabilitiesStatus) error {
+func (m *Manifest) Include(excludeIdentifier *string, requiredFeatureSet *string, profile *string, capabilities *configv1.ClusterVersionCapabilitiesStatus) error {
 
 	annotations := m.Obj.GetAnnotations()
 	if annotations == nil {
@@ -132,15 +169,17 @@ func (m *Manifest) Include(excludeIdentifier *string, includeTechPreview *bool, 
 		}
 	}
 
-	if includeTechPreview != nil {
-		featureGateAnnotation := "release.openshift.io/feature-gate"
-		featureGateAnnotationValue, featureGateAnnotationExists := annotations[featureGateAnnotation]
-		if featureGateAnnotationValue == string(configv1.TechPreviewNoUpgrade) && !(*includeTechPreview) {
-			return fmt.Errorf("tech-preview excluded, and %s=%s", featureGateAnnotation, featureGateAnnotationValue)
+	if requiredFeatureSet != nil {
+		requiredAnnotationValue := *requiredFeatureSet
+		if len(*requiredFeatureSet) == 0 {
+			requiredAnnotationValue = "Default" // "" in the FeatureSet API is "Default" in the annotation value
 		}
-		// never include the manifest if the feature-gate annotation is outside of allowed values (only TechPreviewNoUpgrade is currently allowed)
-		if featureGateAnnotationExists && featureGateAnnotationValue != string(configv1.TechPreviewNoUpgrade) {
-			return fmt.Errorf("unrecognized value %s=%s", featureGateAnnotation, featureGateAnnotationValue)
+		manifestFeatureSets, manifestSpecifiesFeatureSets, err := getFeatureSets(annotations)
+		if err != nil {
+			return err
+		}
+		if manifestSpecifiesFeatureSets && !manifestFeatureSets.Has(requiredAnnotationValue) {
+			return fmt.Errorf("%q is required, and %s=%s", requiredAnnotationValue, featureSetAnnotation, strings.Join(manifestFeatureSets.List(), ","))
 		}
 	}
 

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 
+	utilpointer "k8s.io/utils/pointer"
+
 	"github.com/davecgh/go-spew/spew"
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/stretchr/testify/assert"
@@ -590,13 +592,11 @@ func Test_include(t *testing.T) {
 	identifier := "identifier"
 	defaultClusterProfile := "self-managed-high-availability"
 	singleNodeProfile := "single-node"
-	trueBol := true
-	falseBol := false
 
 	tests := []struct {
 		name               string
 		exclude            *string
-		includeTechPreview *bool
+		requiredFeatureSet *string
 		profile            *string
 		annotations        map[string]interface{}
 		caps               *configv1.ClusterVersionCapabilitiesStatus
@@ -640,18 +640,34 @@ func Test_include(t *testing.T) {
 			annotations: map[string]interface{}{"include.release.openshift.io/self-managed-high-availability": "true"},
 		},
 		{
+			name:               "unspecified manifest included if techpreview off",
+			requiredFeatureSet: utilpointer.String(""),
+			profile:            &defaultClusterProfile,
+			annotations: map[string]interface{}{
+				"include.release.openshift.io/self-managed-high-availability": "true",
+			},
+		},
+		{
+			name:               "unspecified manifest included if techpreview on",
+			requiredFeatureSet: utilpointer.String("TechPreviewNoUpgrade"),
+			profile:            &defaultClusterProfile,
+			annotations: map[string]interface{}{
+				"include.release.openshift.io/self-managed-high-availability": "true",
+			},
+		},
+		{
 			name:               "correct techpreview value is excluded if techpreview off",
-			includeTechPreview: &falseBol,
+			requiredFeatureSet: utilpointer.String(""),
 			profile:            &defaultClusterProfile,
 			annotations: map[string]interface{}{
 				"include.release.openshift.io/self-managed-high-availability": "true",
 				"release.openshift.io/feature-gate":                           "TechPreviewNoUpgrade",
 			},
-			expected: fmt.Errorf("tech-preview excluded, and release.openshift.io/feature-gate=TechPreviewNoUpgrade"),
+			expected: fmt.Errorf("\"Default\" is required, and release.openshift.io/feature-set=TechPreviewNoUpgrade"),
 		},
 		{
 			name:               "correct techpreview value is included if techpreview on",
-			includeTechPreview: &trueBol,
+			requiredFeatureSet: utilpointer.String("TechPreviewNoUpgrade"),
 			profile:            &defaultClusterProfile,
 			annotations: map[string]interface{}{
 				"include.release.openshift.io/self-managed-high-availability": "true",
@@ -660,23 +676,62 @@ func Test_include(t *testing.T) {
 		},
 		{
 			name:               "incorrect techpreview value is not excluded if techpreview off",
-			includeTechPreview: &falseBol,
+			requiredFeatureSet: utilpointer.String(""),
 			profile:            &defaultClusterProfile,
 			annotations: map[string]interface{}{
 				"include.release.openshift.io/self-managed-high-availability": "true",
 				"release.openshift.io/feature-gate":                           "Other",
 			},
-			expected: fmt.Errorf("unrecognized value release.openshift.io/feature-gate=Other"),
+			expected: fmt.Errorf("unrecognized value \"Other\" in release.openshift.io/feature-gate=Other; known values are: CustomNoUpgrade,Default,IPv6DualStackNoUpgrade,LatencySensitive,TechPreviewNoUpgrade"),
 		},
 		{
 			name:               "incorrect techpreview value is not excluded if techpreview on",
-			includeTechPreview: &trueBol,
+			requiredFeatureSet: utilpointer.String("TechPreviewNoUpgrade"),
 			profile:            &defaultClusterProfile,
 			annotations: map[string]interface{}{
 				"include.release.openshift.io/self-managed-high-availability": "true",
 				"release.openshift.io/feature-gate":                           "Other",
 			},
-			expected: fmt.Errorf("unrecognized value release.openshift.io/feature-gate=Other"),
+			expected: fmt.Errorf("unrecognized value \"Other\" in release.openshift.io/feature-gate=Other; known values are: CustomNoUpgrade,Default,IPv6DualStackNoUpgrade,LatencySensitive,TechPreviewNoUpgrade"),
+		},
+		{
+			name:               "correct techpreview value is excluded if techpreview off using feature-set",
+			requiredFeatureSet: utilpointer.String(""),
+			profile:            &defaultClusterProfile,
+			annotations: map[string]interface{}{
+				"include.release.openshift.io/self-managed-high-availability": "true",
+				"release.openshift.io/feature-set":                            "TechPreviewNoUpgrade",
+			},
+			expected: fmt.Errorf("\"Default\" is required, and release.openshift.io/feature-set=TechPreviewNoUpgrade"),
+		},
+		{
+			name:               "correct techpreview value is included if techpreview on using feature-set",
+			requiredFeatureSet: utilpointer.String("TechPreviewNoUpgrade"),
+			profile:            &defaultClusterProfile,
+			annotations: map[string]interface{}{
+				"include.release.openshift.io/self-managed-high-availability": "true",
+				"release.openshift.io/feature-set":                            "TechPreviewNoUpgrade",
+			},
+		},
+		{
+			name:               "incorrect techpreview value is not excluded if techpreview off using feature-set",
+			requiredFeatureSet: utilpointer.String(""),
+			profile:            &defaultClusterProfile,
+			annotations: map[string]interface{}{
+				"include.release.openshift.io/self-managed-high-availability": "true",
+				"release.openshift.io/feature-set":                            "Other",
+			},
+			expected: fmt.Errorf("unrecognized value \"Other\" in release.openshift.io/feature-set=Other; known values are: CustomNoUpgrade,Default,IPv6DualStackNoUpgrade,LatencySensitive,TechPreviewNoUpgrade"),
+		},
+		{
+			name:               "incorrect techpreview value is not excluded if techpreview on using feature-set",
+			requiredFeatureSet: utilpointer.String("TechPreviewNoUpgrade"),
+			profile:            &defaultClusterProfile,
+			annotations: map[string]interface{}{
+				"include.release.openshift.io/self-managed-high-availability": "true",
+				"release.openshift.io/feature-set":                            "Other",
+			},
+			expected: fmt.Errorf("unrecognized value \"Other\" in release.openshift.io/feature-set=Other; known values are: CustomNoUpgrade,Default,IPv6DualStackNoUpgrade,LatencySensitive,TechPreviewNoUpgrade"),
 		},
 		{
 			name:        "default profile selection excludes without annotation",
@@ -770,7 +825,7 @@ func Test_include(t *testing.T) {
 					},
 				},
 			}
-			err := m.Include(tt.exclude, tt.includeTechPreview, tt.profile, tt.caps)
+			err := m.Include(tt.exclude, tt.requiredFeatureSet, tt.profile, tt.caps)
 			assert.Equal(t, tt.expected, err)
 		})
 	}

--- a/pkg/operator/resource/resourceapply/common_conditions.go
+++ b/pkg/operator/resource/resourceapply/common_conditions.go
@@ -1,0 +1,41 @@
+package resourceapply
+
+import (
+	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
+	"github.com/openshift/library-go/pkg/manifest"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type manifestFeatureSetChecker struct {
+	featureGateLister configv1listers.FeatureGateLister
+}
+
+func NewManifestFeatureSetChecker(featureGateLister configv1listers.FeatureGateLister) ManifestConditionalFunction {
+	return manifestFeatureSetChecker{featureGateLister: featureGateLister}.DoesManifestHaveRequiredFeatureSet
+}
+
+func (c manifestFeatureSetChecker) DoesManifestHaveRequiredFeatureSet(obj runtime.Object) (bool, error) {
+	requiredFeatureSet := ""
+	featureGate, err := c.featureGateLister.Get("cluster")
+	switch {
+	case apierrors.IsNotFound(err):
+		// do nothing, if there's no featureset, this is correct
+	case err != nil:
+		return false, err
+	default:
+		requiredFeatureSet = string(featureGate.Spec.FeatureSet)
+	}
+
+	metadata, err := meta.Accessor(obj)
+	if err != nil {
+		return false, err // this will mean something else will likely fail and report a better message.
+	}
+	matches, err := manifest.ResourceSatisfiesFeatureSetRequirement(requiredFeatureSet, metadata.GetAnnotations())
+	if err != nil {
+		return false, err
+	}
+
+	return matches, nil
+}


### PR DESCRIPTION
This allows static resources to be labelled the same way as CVO resources.

/hold

holding until I add tests