### PR TITLE
Add Nutanix as an external cloud provider platform

### DIFF
--- a/pkg/cloudprovider/external.go
+++ b/pkg/cloudprovider/external.go
@@ -36,7 +36,8 @@ func IsCloudProviderExternal(platformStatus *configv1.PlatformStatus, featureGat
 		configv1.IBMCloudPlatformType,
 		configv1.OpenStackPlatformType,
 		configv1.PowerVSPlatformType,
-		configv1.KubevirtPlatformType:
+		configv1.KubevirtPlatformType,
+		configv1.NutanixPlatformType:
 		return true, nil
 	default:
 		// Platforms that do not have external cloud providers implemented

--- a/pkg/cloudprovider/external_test.go
+++ b/pkg/cloudprovider/external_test.go
@@ -155,6 +155,45 @@ func TestIsCloudProviderExternal(t *testing.T) {
 		featureGate: nil,
 		expected:    true,
 	}, {
+		name: "No FeatureGate, Platform: Nutanix",
+		status: &configv1.PlatformStatus{
+			Type: configv1.NutanixPlatformType,
+		},
+		featureGate: nil,
+		expected:    true,
+	}, {
+		name: "FeatureSet: CustomNoUpgrade (With External Feature Gate Enabled), Platform: Nutanix",
+		status: &configv1.PlatformStatus{
+			Type: configv1.NutanixPlatformType,
+		},
+		featureGate: &configv1.FeatureGate{
+			Spec: configv1.FeatureGateSpec{
+				FeatureGateSelection: configv1.FeatureGateSelection{
+					FeatureSet: configv1.CustomNoUpgrade,
+					CustomNoUpgrade: &configv1.CustomFeatureGates{
+						Enabled: []string{ExternalCloudProviderFeature},
+					},
+				},
+			},
+		},
+		expected: true,
+	}, {
+		name: "FeatureSet: CustomNoUpgrade (With External Feature Gate Disabled), Platform: Nutanix",
+		status: &configv1.PlatformStatus{
+			Type: configv1.NutanixPlatformType,
+		},
+		featureGate: &configv1.FeatureGate{
+			Spec: configv1.FeatureGateSpec{
+				FeatureGateSelection: configv1.FeatureGateSelection{
+					FeatureSet: configv1.CustomNoUpgrade,
+					CustomNoUpgrade: &configv1.CustomFeatureGates{
+						Disabled: []string{ExternalCloudProviderFeature},
+					},
+				},
+			},
+		},
+		expected: true,
+	}, {
 		name: "No FeatureGate, Platform: PowerVS",
 		status: &configv1.PlatformStatus{
 			Type: configv1.PowerVSPlatformType,

--- a/pkg/operator/configobserver/cloudprovider/observe_cloudprovider_test.go
+++ b/pkg/operator/configobserver/cloudprovider/observe_cloudprovider_test.go
@@ -117,6 +117,16 @@ func TestObserveCloudProviderNames(t *testing.T) {
 		expected:           "external",
 		cloudProviderCount: 1,
 	}, {
+		name: "Nutanix Platform",
+		infrastructureStatus: configv1.InfrastructureStatus{
+			Platform: configv1.NutanixPlatformType,
+			PlatformStatus: &configv1.PlatformStatus{
+				Type: configv1.NutanixPlatformType,
+			},
+		},
+		expected:           "external",
+		cloudProviderCount: 1,
+	}, {
 		name: "Azure platform",
 		infrastructureStatus: configv1.InfrastructureStatus{
 			Platform: configv1.AzurePlatformType,


### PR DESCRIPTION
Add Nutanix as an external cloud provider platform, in order to integrate the nutanix-ccm to openshift.