### PR TITLE
Installer static controller: be more forgiving and consider only recent installer pods

### DIFF
--- a/pkg/operator/staticpod/controller/installerstate/installer_state_controller.go
+++ b/pkg/operator/staticpod/controller/installerstate/installer_state_controller.go
@@ -3,6 +3,7 @@ package installerstate
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -59,6 +60,14 @@ var degradedConditionNames = []string{
 	"InstallerPodNetworkingDegraded",
 }
 
+func installerNameToRevision(name string) (int, error) {
+	parts := strings.Split(name, "-")
+	if len(parts) < 2 {
+		return 0, fmt.Errorf("Installer name %v is invalid, missing revision number", name)
+	}
+	return strconv.Atoi(parts[1])
+}
+
 func (c *InstallerStateController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
 	pods, err := c.podsGetter.Pods(c.targetNamespace).List(ctx, metav1.ListOptions{
 		LabelSelector: labels.SelectorFromSet(labels.Set{"app": "installer"}).String(),
@@ -67,19 +76,41 @@ func (c *InstallerStateController) sync(ctx context.Context, syncCtx factory.Syn
 		return err
 	}
 
+	masterRevisions := make(map[string][]*v1.Pod)
+	installerHighestRunningRevision := make(map[string]int)
+	for _, pod := range pods.Items {
+		p := pod
+		masterRevisions[pod.Spec.NodeName] = append(masterRevisions[pod.Spec.NodeName], &p)
+	}
+	// find the highest revision of a non-pending pod on each master node
+	for masterNode, pods := range masterRevisions {
+		maxRunningRev := 0
+		for _, pod := range pods {
+			if pod.Status.Phase != v1.PodPending || pod.Status.StartTime == nil {
+				rev, err := installerNameToRevision(pod.Name)
+				if err != nil {
+					return err
+				}
+				if rev > maxRunningRev {
+					maxRunningRev = rev
+				}
+			}
+		}
+		installerHighestRunningRevision[masterNode] = maxRunningRev
+	}
+
 	// collect all startingObjects that are in pending state for longer than maxToleratedPodPendingDuration
 	pendingPods := []*v1.Pod{}
 	for _, pod := range pods.Items {
 		if pod.Status.Phase != v1.PodPending || pod.Status.StartTime == nil {
 			continue
 		}
-		if c.timeNowFn().Sub(pod.Status.StartTime.Time) >= maxToleratedPodPendingDuration {
+		if rev, _ := installerNameToRevision(pod.Name); c.timeNowFn().Sub(pod.Status.StartTime.Time) >= maxToleratedPodPendingDuration && rev >= installerHighestRunningRevision[pod.Spec.NodeName] {
 			pendingPods = append(pendingPods, pod.DeepCopy())
 		}
 	}
 
-	// in theory, there should never be two installer startingObjects pending as we don't roll new installer pod
-	// until the previous/existing pod has finished its job.
+	// handle pending installer pods conditions
 	foundConditions := []operatorv1.OperatorCondition{}
 	foundConditions = append(foundConditions, c.handlePendingInstallerPods(syncCtx.Recorder(), pendingPods)...)
 


### PR DESCRIPTION
In case all the latest revision installer pods are running and an older revision installer pod is in Pending state (e.g. the container runtime unable to delete the pod), do not change the InstallerPodContainerWaitingDegraded condition to True.

Based on https://github.com/openshift/library-go/pull/1230 (just rebased master into here - and changed how maps were being declared/assigned)

I think this is already an acceptable solution. Please let me know if a different approach would be better.

Bugs:

https://bugzilla.redhat.com/show_bug.cgi?id=2009646
https://bugzilla.redhat.com/show_bug.cgi?id=1986385