### PR TITLE
Bug 2101520: Log right error when initializing delegating authentication

### DIFF
--- a/pkg/config/serving/server.go
+++ b/pkg/config/serving/server.go
@@ -47,7 +47,7 @@ func ToServerConfig(ctx context.Context, servingInfo configv1.HTTPServingInfo, a
 		err := wait.PollImmediateUntil(1*time.Second, func() (done bool, err error) {
 			lastApplyErr = authenticationOptions.ApplyTo(&config.Authentication, config.SecureServing, config.OpenAPIConfig)
 			if lastApplyErr != nil {
-				klog.V(4).Infof("Error initializing delegating authentication (will retry): %v", err)
+				klog.V(4).Infof("Error initializing delegating authentication (will retry): %v", lastApplyErr)
 				return false, nil
 			}
 			return true, nil


### PR DESCRIPTION
This was generating log entries like:

```
I0615 21:46:44.754123       1 server.go:50] Error initializing delegating authentication (will retry): <nil>
I0615 21:46:45.757131       1 server.go:50] Error initializing delegating authentication (will retry): <nil>
I0615 21:46:46.757610       1 server.go:50] Error initializing delegating authentication (will retry): <nil>
I0615 21:46:47.757257       1 server.go:50] Error initializing delegating authentication (will retry): <nil>
I0615 21:46:48.757348       1 server.go:50] Error initializing delegating authentication (will retry): <nil>
I0615 21:46:49.757570       1 server.go:50] Error initializing delegating authentication (will retry): <nil>
I0615 21:46:50.763997       1 server.go:50] Error initializing delegating authentication (will retry): <nil>
(...)
```
Example: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.12-e2e-gcp/1537183611613089792/artifacts/e2e-gcp/gather-extra/artifacts/pods/openshift-cluster-storage-operator_csi-snapshot-controller-operator-8594d57fc8-c8s27_csi-snapshot-controller-operator.log

/assign @deads2k 
CC @openshift/storage
