### PR TITLE
OCPBUGS-1904: add new ConditionalStaticResourcesController

### DIFF
--- a/pkg/operator/staticresourcecontroller/static_resource_controller.go
+++ b/pkg/operator/staticresourcecontroller/static_resource_controller.go
@@ -368,7 +368,7 @@ func (c *StaticResourceController) Sync(ctx context.Context, syncContext factory
 }
 
 func (c *StaticResourceController) Name() string {
-	return "StaticResourceController"
+	return c.name
 }
 
 func (c *StaticResourceController) RelatedObjects() ([]configv1.ObjectReference, error) {


### PR DESCRIPTION
This controller can be used to conditionally to deploy resources that depend on a runtime check. With this we can check if the a `VolumeSnapshotClass` CRD exists before deploying the CR.

While at it, fix the `StaticResourceController.Name()` method to return the controller name that was provided by the user. With this patch log entries will show the correct controller name.

CC @openshift/storage 