### PR TITLE
OCPBUGS-2125: pkg/manifest/manifest.go: add option to allow unknown capabilities

### DIFF
--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -172,6 +172,17 @@ func checkFeatureSets(requiredFeatureSet string, annotations map[string]string) 
 // filter. For example, setting profile non-nil and capabilities nil will return an error if the manifest's
 // profile does not match, but will never return an error about capability issues.
 func (m *Manifest) Include(excludeIdentifier *string, requiredFeatureSet *string, profile *string, capabilities *configv1.ClusterVersionCapabilitiesStatus) error {
+	return m.IncludeAllowUnknownCapabilities(excludeIdentifier, requiredFeatureSet, profile, capabilities, false)
+}
+
+// IncludeAllowUnknownCapabilities returns an error if the manifest fails an inclusion filter and should be excluded from
+// further processing by cluster version operator. Pointer arguments can be set nil to avoid excluding based on that
+// filter. For example, setting profile non-nil and capabilities nil will return an error if the manifest's
+// profile does not match, but will never return an error about capability issues. allowUnknownCapabilities only applies
+// to capabilities filtering. When set to true a manifest will not be excluded simply because it contains an unknown
+// capability. This is necessary to allow updates to an OCP version containing newly defined capabilities.
+func (m *Manifest) IncludeAllowUnknownCapabilities(excludeIdentifier *string, requiredFeatureSet *string, profile *string,
+	capabilities *configv1.ClusterVersionCapabilitiesStatus, allowUnknownCapabilities bool) error {
 
 	annotations := m.Obj.GetAnnotations()
 	if annotations == nil {
@@ -203,35 +214,40 @@ func (m *Manifest) Include(excludeIdentifier *string, requiredFeatureSet *string
 
 	// If there is no capabilities defined in a release then we do not need to check presence of capabilities in the manifest
 	if capabilities != nil {
-		return checkResourceEnablement(annotations, capabilities)
+		return checkResourceEnablement(annotations, capabilities, allowUnknownCapabilities)
 	}
 	return nil
 }
 
 // checkResourceEnablement, given resource annotations and defined cluster capabilities, checks if the capability
-// annotation exists. If so, each capability name is validated against the known set of capabilities. Each valid
-// capability is then checked if it is disabled. If any invalid capabilities are found an error is returned listing
-// all invalid capabilities. Otherwise, if any disabled capabilities are found an error is returned listing all
-// disabled capabilities.
-func checkResourceEnablement(annotations map[string]string, capabilities *configv1.ClusterVersionCapabilitiesStatus) error {
+// annotation exists. If so, each capability name is validated against the known set of capabilities unless
+// allowUnknownCapabilities is true. Each valid capability is then checked if it is disabled. If any invalid
+// capabilities are found an error is returned listing all invalid capabilities. Otherwise, if any disabled
+// capabilities are found an error is returned listing all disabled capabilities.
+func checkResourceEnablement(annotations map[string]string, capabilities *configv1.ClusterVersionCapabilitiesStatus,
+	allowUnknownCapabilities bool) error {
+
 	caps := getManifestCapabilities(annotations)
 	numCaps := len(caps)
 	unknownCaps := make([]string, 0, numCaps)
 	disabledCaps := make([]string, 0, numCaps)
 
 	for _, c := range caps {
-		var isKnownCap bool
-		var isEnabledCap bool
 
-		for _, knownCapability := range capabilities.KnownCapabilities {
-			if c == knownCapability {
-				isKnownCap = true
+		if !allowUnknownCapabilities {
+			var isKnownCap bool
+			for _, knownCapability := range capabilities.KnownCapabilities {
+				if c == knownCapability {
+					isKnownCap = true
+				}
+			}
+			if !isKnownCap {
+				unknownCaps = append(unknownCaps, string(c))
+				continue
 			}
 		}
-		if !isKnownCap {
-			unknownCaps = append(unknownCaps, string(c))
-			continue
-		}
+
+		var isEnabledCap bool
 		for _, enabledCapability := range capabilities.EnabledCapabilities {
 			if c == enabledCapability {
 				isEnabledCap = true


### PR DESCRIPTION
during capabilities filtering. When set to true a manifest will not be excluded simply because it contains an unknown capability. This is necessary to allow updates to an OCP version containing newly defined capabilities.