### PR TITLE
Copy route validation and defaulting bits from openshift-apiserver.

### DIFF
--- a/pkg/route/hostassignment/assignment.go
+++ b/pkg/route/hostassignment/assignment.go
@@ -1,0 +1,197 @@
+package hostassignment
+
+import (
+	"context"
+	"fmt"
+
+	authorizationv1 "k8s.io/api/authorization/v1"
+	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/endpoints/request"
+
+	routev1 "github.com/openshift/api/route/v1"
+	"github.com/openshift/library-go/pkg/authorization/authorizationutil"
+)
+
+// HostGeneratedAnnotationKey is the key for an annotation set to "true" if the route's host was generated
+const HostGeneratedAnnotationKey = "openshift.io/host.generated"
+
+// Registry is an interface for performing subject access reviews
+type SubjectAccessReviewCreator interface {
+	Create(ctx context.Context, sar *authorizationv1.SubjectAccessReview, opts metav1.CreateOptions) (*authorizationv1.SubjectAccessReview, error)
+}
+
+type HostnameGenerator interface {
+	GenerateHostname(*routev1.Route) (string, error)
+}
+
+// AllocateHost allocates a host name ONLY if the route doesn't specify a subdomain wildcard policy and
+// the host name on the route is empty and an allocator is configured.
+// It must first allocate the shard and may return an error if shard allocation fails.
+func AllocateHost(ctx context.Context, route *routev1.Route, sarc SubjectAccessReviewCreator, routeAllocator HostnameGenerator) field.ErrorList {
+	hostSet := len(route.Spec.Host) > 0
+	certSet := route.Spec.TLS != nil && (len(route.Spec.TLS.CACertificate) > 0 || len(route.Spec.TLS.Certificate) > 0 || len(route.Spec.TLS.DestinationCACertificate) > 0 || len(route.Spec.TLS.Key) > 0)
+	if hostSet || certSet {
+		user, ok := request.UserFrom(ctx)
+		if !ok {
+			return field.ErrorList{field.InternalError(field.NewPath("spec", "host"), fmt.Errorf("unable to verify host field can be set"))}
+		}
+		res, err := sarc.Create(
+			ctx,
+			authorizationutil.AddUserToSAR(
+				user,
+				&authorizationv1.SubjectAccessReview{
+					Spec: authorizationv1.SubjectAccessReviewSpec{
+						ResourceAttributes: &authorizationv1.ResourceAttributes{
+							Namespace:   request.NamespaceValue(ctx),
+							Verb:        "create",
+							Group:       routev1.GroupName,
+							Resource:    "routes",
+							Subresource: "custom-host",
+						},
+					},
+				},
+			),
+			metav1.CreateOptions{},
+		)
+		if err != nil {
+			return field.ErrorList{field.InternalError(field.NewPath("spec", "host"), err)}
+		}
+		if !res.Status.Allowed {
+			if hostSet {
+				return field.ErrorList{field.Forbidden(field.NewPath("spec", "host"), "you do not have permission to set the host field of the route")}
+			}
+			return field.ErrorList{field.Forbidden(field.NewPath("spec", "tls"), "you do not have permission to set certificate fields on the route")}
+		}
+	}
+
+	if route.Spec.WildcardPolicy == routev1.WildcardPolicySubdomain {
+		// Don't allocate a host if subdomain wildcard policy.
+		return nil
+	}
+
+	if len(route.Spec.Subdomain) == 0 && len(route.Spec.Host) == 0 && routeAllocator != nil {
+		// TODO: this does not belong here, and should be removed
+		host, err := routeAllocator.GenerateHostname(route)
+		if err != nil {
+			return field.ErrorList{field.InternalError(field.NewPath("spec", "host"), fmt.Errorf("allocation error: %v for route: %#v", err, route))}
+		}
+		route.Spec.Host = host
+		if route.Annotations == nil {
+			route.Annotations = map[string]string{}
+		}
+		route.Annotations[HostGeneratedAnnotationKey] = "true"
+	}
+	return nil
+}
+
+func hasCertificateInfo(tls *routev1.TLSConfig) bool {
+	if tls == nil {
+		return false
+	}
+	return len(tls.Certificate) > 0 ||
+		len(tls.Key) > 0 ||
+		len(tls.CACertificate) > 0 ||
+		len(tls.DestinationCACertificate) > 0
+}
+
+func certificateChangeRequiresAuth(route, older *routev1.Route) bool {
+	switch {
+	case route.Spec.TLS != nil && older.Spec.TLS != nil:
+		a, b := route.Spec.TLS, older.Spec.TLS
+		if !hasCertificateInfo(a) {
+			// removing certificate info is allowed
+			return false
+		}
+		return a.CACertificate != b.CACertificate ||
+			a.Certificate != b.Certificate ||
+			a.DestinationCACertificate != b.DestinationCACertificate ||
+			a.Key != b.Key
+	case route.Spec.TLS != nil:
+		// using any default certificate is allowed
+		return hasCertificateInfo(route.Spec.TLS)
+	default:
+		// all other cases we are not adding additional certificate info
+		return false
+	}
+}
+
+func ValidateHostUpdate(ctx context.Context, route, older *routev1.Route, sarc SubjectAccessReviewCreator) field.ErrorList {
+	hostChanged := route.Spec.Host != older.Spec.Host
+	subdomainChanged := route.Spec.Subdomain != older.Spec.Subdomain
+	certChanged := certificateChangeRequiresAuth(route, older)
+	if !hostChanged && !certChanged && !subdomainChanged {
+		return nil
+	}
+	user, ok := request.UserFrom(ctx)
+	if !ok {
+		return field.ErrorList{field.InternalError(field.NewPath("spec", "host"), fmt.Errorf("unable to verify host field can be changed"))}
+	}
+	res, err := sarc.Create(
+		ctx,
+		authorizationutil.AddUserToSAR(
+			user,
+			&authorizationv1.SubjectAccessReview{
+				Spec: authorizationv1.SubjectAccessReviewSpec{
+					ResourceAttributes: &authorizationv1.ResourceAttributes{
+						Namespace:   request.NamespaceValue(ctx),
+						Verb:        "update",
+						Group:       routev1.GroupName,
+						Resource:    "routes",
+						Subresource: "custom-host",
+					},
+				},
+			},
+		),
+		metav1.CreateOptions{},
+	)
+	if err != nil {
+		if subdomainChanged {
+			return field.ErrorList{field.InternalError(field.NewPath("spec", "subdomain"), err)}
+		}
+		return field.ErrorList{field.InternalError(field.NewPath("spec", "host"), err)}
+	}
+	if !res.Status.Allowed {
+		if hostChanged {
+			return apimachineryvalidation.ValidateImmutableField(route.Spec.Host, older.Spec.Host, field.NewPath("spec", "host"))
+		}
+		if subdomainChanged {
+			return apimachineryvalidation.ValidateImmutableField(route.Spec.Subdomain, older.Spec.Subdomain, field.NewPath("spec", "subdomain"))
+		}
+
+		// if tls is being updated without host being updated, we check if 'create' permission exists on custom-host subresource
+		res, err := sarc.Create(
+			ctx,
+			authorizationutil.AddUserToSAR(
+				user,
+				&authorizationv1.SubjectAccessReview{
+					Spec: authorizationv1.SubjectAccessReviewSpec{
+						ResourceAttributes: &authorizationv1.ResourceAttributes{
+							Namespace:   request.NamespaceValue(ctx),
+							Verb:        "create",
+							Group:       routev1.GroupName,
+							Resource:    "routes",
+							Subresource: "custom-host",
+						},
+					},
+				},
+			),
+			metav1.CreateOptions{},
+		)
+		if err != nil {
+			return field.ErrorList{field.InternalError(field.NewPath("spec", "host"), err)}
+		}
+		if !res.Status.Allowed {
+			if route.Spec.TLS == nil || older.Spec.TLS == nil {
+				return apimachineryvalidation.ValidateImmutableField(route.Spec.TLS, older.Spec.TLS, field.NewPath("spec", "tls"))
+			}
+			errs := apimachineryvalidation.ValidateImmutableField(route.Spec.TLS.CACertificate, older.Spec.TLS.CACertificate, field.NewPath("spec", "tls", "caCertificate"))
+			errs = append(errs, apimachineryvalidation.ValidateImmutableField(route.Spec.TLS.Certificate, older.Spec.TLS.Certificate, field.NewPath("spec", "tls", "certificate"))...)
+			errs = append(errs, apimachineryvalidation.ValidateImmutableField(route.Spec.TLS.DestinationCACertificate, older.Spec.TLS.DestinationCACertificate, field.NewPath("spec", "tls", "destinationCACertificate"))...)
+			errs = append(errs, apimachineryvalidation.ValidateImmutableField(route.Spec.TLS.Key, older.Spec.TLS.Key, field.NewPath("spec", "tls", "key"))...)
+			return errs
+		}
+	}
+	return nil
+}

--- a/pkg/route/hostassignment/assignment_test.go
+++ b/pkg/route/hostassignment/assignment_test.go
@@ -1,0 +1,387 @@
+package hostassignment
+
+import (
+	"context"
+	"testing"
+
+	authorizationv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/endpoints/request"
+
+	routev1 "github.com/openshift/api/route/v1"
+)
+
+type testAllocator struct {
+}
+
+func (t testAllocator) GenerateHostname(*routev1.Route) (string, error) {
+	return "mygeneratedhost.com", nil
+}
+
+type testSAR struct {
+	allow bool
+	err   error
+	sar   *authorizationv1.SubjectAccessReview
+}
+
+func (t *testSAR) Create(_ context.Context, subjectAccessReview *authorizationv1.SubjectAccessReview, _ metav1.CreateOptions) (*authorizationv1.SubjectAccessReview, error) {
+	t.sar = subjectAccessReview
+	return &authorizationv1.SubjectAccessReview{
+		Status: authorizationv1.SubjectAccessReviewStatus{
+			Allowed: t.allow,
+		},
+	}, t.err
+}
+
+func TestHostWithWildcardPolicies(t *testing.T) {
+	ctx := request.NewContext()
+	ctx = request.WithUser(ctx, &user.DefaultInfo{Name: "bob"})
+
+	tests := []struct {
+		name          string
+		host, oldHost string
+
+		subdomain, oldSubdomain string
+
+		wildcardPolicy routev1.WildcardPolicyType
+		tls, oldTLS    *routev1.TLSConfig
+
+		expected          string
+		expectedSubdomain string
+
+		errs  int
+		allow bool
+	}{
+		{
+			name:     "no-host-empty-policy",
+			expected: "mygeneratedhost.com",
+			allow:    true,
+		},
+		{
+			name:           "no-host-nopolicy",
+			wildcardPolicy: routev1.WildcardPolicyNone,
+			expected:       "mygeneratedhost.com",
+			allow:          true,
+		},
+		{
+			name:           "no-host-wildcard-subdomain",
+			wildcardPolicy: routev1.WildcardPolicySubdomain,
+			expected:       "",
+			allow:          true,
+			errs:           0,
+		},
+		{
+			name:     "host-empty-policy",
+			host:     "empty.policy.test",
+			expected: "empty.policy.test",
+			allow:    true,
+		},
+		{
+			name:           "host-no-policy",
+			host:           "no.policy.test",
+			wildcardPolicy: routev1.WildcardPolicyNone,
+			expected:       "no.policy.test",
+			allow:          true,
+		},
+		{
+			name:           "host-wildcard-subdomain",
+			host:           "wildcard.policy.test",
+			wildcardPolicy: routev1.WildcardPolicySubdomain,
+			expected:       "wildcard.policy.test",
+			allow:          true,
+		},
+		{
+			name:           "custom-host-permission-denied",
+			host:           "another.test",
+			expected:       "another.test",
+			wildcardPolicy: routev1.WildcardPolicyNone,
+			allow:          false,
+			errs:           1,
+		},
+		{
+			name:           "tls-permission-denied-destination",
+			tls:            &routev1.TLSConfig{Termination: routev1.TLSTerminationReencrypt, DestinationCACertificate: "a"},
+			wildcardPolicy: routev1.WildcardPolicyNone,
+			allow:          false,
+			errs:           1,
+		},
+		{
+			name:           "tls-permission-denied-cert",
+			tls:            &routev1.TLSConfig{Termination: routev1.TLSTerminationEdge, Certificate: "a"},
+			wildcardPolicy: routev1.WildcardPolicyNone,
+			allow:          false,
+			errs:           1,
+		},
+		{
+			name:           "tls-permission-denied-ca-cert",
+			tls:            &routev1.TLSConfig{Termination: routev1.TLSTerminationEdge, CACertificate: "a"},
+			wildcardPolicy: routev1.WildcardPolicyNone,
+			allow:          false,
+			errs:           1,
+		},
+		{
+			name:           "tls-permission-denied-key",
+			tls:            &routev1.TLSConfig{Termination: routev1.TLSTerminationEdge, Key: "a"},
+			wildcardPolicy: routev1.WildcardPolicyNone,
+			allow:          false,
+			errs:           1,
+		},
+		{
+			name:           "no-host-but-allowed",
+			expected:       "mygeneratedhost.com",
+			wildcardPolicy: routev1.WildcardPolicyNone,
+			allow:          false,
+		},
+		{
+			name:           "update-changed-host-denied",
+			host:           "new.host",
+			expected:       "new.host",
+			oldHost:        "original.host",
+			wildcardPolicy: routev1.WildcardPolicyNone,
+			allow:          false,
+			errs:           1,
+		},
+		{
+			name:           "update-changed-host-allowed",
+			host:           "new.host",
+			expected:       "new.host",
+			oldHost:        "original.host",
+			wildcardPolicy: routev1.WildcardPolicyNone,
+			allow:          true,
+			errs:           0,
+		},
+		{
+			name:              "update-changed-subdomain-denied",
+			subdomain:         "new.host",
+			expectedSubdomain: "new.host",
+			oldSubdomain:      "original.host",
+			wildcardPolicy:    routev1.WildcardPolicyNone,
+			allow:             false,
+			errs:              1,
+		},
+		{
+			name:              "update-changed-subdomain-allowed",
+			subdomain:         "new.host",
+			expectedSubdomain: "new.host",
+			oldSubdomain:      "original.host",
+			wildcardPolicy:    routev1.WildcardPolicyNone,
+			allow:             true,
+			errs:              0,
+		},
+		{
+			name:           "key-unchanged",
+			host:           "host",
+			expected:       "host",
+			oldHost:        "host",
+			tls:            &routev1.TLSConfig{Termination: routev1.TLSTerminationEdge, Key: "a"},
+			oldTLS:         &routev1.TLSConfig{Termination: routev1.TLSTerminationEdge, Key: "a"},
+			wildcardPolicy: routev1.WildcardPolicyNone,
+			allow:          false,
+			errs:           0,
+		},
+		{
+			name:           "key-changed",
+			host:           "host",
+			expected:       "host",
+			oldHost:        "host",
+			tls:            &routev1.TLSConfig{Termination: routev1.TLSTerminationEdge, Key: "a"},
+			oldTLS:         &routev1.TLSConfig{Termination: routev1.TLSTerminationEdge, Key: "b"},
+			wildcardPolicy: routev1.WildcardPolicyNone,
+			allow:          false,
+			errs:           1,
+		},
+		{
+			name:           "certificate-unchanged",
+			host:           "host",
+			expected:       "host",
+			oldHost:        "host",
+			tls:            &routev1.TLSConfig{Termination: routev1.TLSTerminationEdge, Certificate: "a"},
+			oldTLS:         &routev1.TLSConfig{Termination: routev1.TLSTerminationEdge, Certificate: "a"},
+			wildcardPolicy: routev1.WildcardPolicyNone,
+			allow:          false,
+			errs:           0,
+		},
+		{
+			name:           "certificate-changed",
+			host:           "host",
+			expected:       "host",
+			oldHost:        "host",
+			tls:            &routev1.TLSConfig{Termination: routev1.TLSTerminationEdge, Certificate: "a"},
+			oldTLS:         &routev1.TLSConfig{Termination: routev1.TLSTerminationEdge, Certificate: "b"},
+			wildcardPolicy: routev1.WildcardPolicyNone,
+			allow:          false,
+			errs:           1,
+		},
+		{
+			name:           "ca-certificate-unchanged",
+			host:           "host",
+			expected:       "host",
+			oldHost:        "host",
+			tls:            &routev1.TLSConfig{Termination: routev1.TLSTerminationEdge, CACertificate: "a"},
+			oldTLS:         &routev1.TLSConfig{Termination: routev1.TLSTerminationEdge, CACertificate: "a"},
+			wildcardPolicy: routev1.WildcardPolicyNone,
+			allow:          false,
+			errs:           0,
+		},
+		{
+			name:           "ca-certificate-changed",
+			host:           "host",
+			expected:       "host",
+			oldHost:        "host",
+			tls:            &routev1.TLSConfig{Termination: routev1.TLSTerminationEdge, CACertificate: "a"},
+			oldTLS:         &routev1.TLSConfig{Termination: routev1.TLSTerminationEdge, CACertificate: "b"},
+			wildcardPolicy: routev1.WildcardPolicyNone,
+			allow:          false,
+			errs:           1,
+		},
+		{
+			name:           "key-unchanged",
+			host:           "host",
+			expected:       "host",
+			oldHost:        "host",
+			tls:            &routev1.TLSConfig{Termination: routev1.TLSTerminationEdge, Key: "a"},
+			oldTLS:         &routev1.TLSConfig{Termination: routev1.TLSTerminationEdge, Key: "a"},
+			wildcardPolicy: routev1.WildcardPolicyNone,
+			allow:          false,
+			errs:           0,
+		},
+		{
+			name:           "key-changed",
+			host:           "host",
+			expected:       "host",
+			oldHost:        "host",
+			tls:            &routev1.TLSConfig{Termination: routev1.TLSTerminationEdge, Key: "a"},
+			oldTLS:         &routev1.TLSConfig{Termination: routev1.TLSTerminationEdge, Key: "b"},
+			wildcardPolicy: routev1.WildcardPolicyNone,
+			allow:          false,
+			errs:           1,
+		},
+		{
+			name:           "destination-ca-certificate-unchanged",
+			host:           "host",
+			expected:       "host",
+			oldHost:        "host",
+			tls:            &routev1.TLSConfig{Termination: routev1.TLSTerminationReencrypt, DestinationCACertificate: "a"},
+			oldTLS:         &routev1.TLSConfig{Termination: routev1.TLSTerminationReencrypt, DestinationCACertificate: "a"},
+			wildcardPolicy: routev1.WildcardPolicyNone,
+			allow:          false,
+			errs:           0,
+		},
+		{
+			name:           "destination-ca-certificate-changed",
+			host:           "host",
+			expected:       "host",
+			oldHost:        "host",
+			tls:            &routev1.TLSConfig{Termination: routev1.TLSTerminationReencrypt, DestinationCACertificate: "a"},
+			oldTLS:         &routev1.TLSConfig{Termination: routev1.TLSTerminationReencrypt, DestinationCACertificate: "b"},
+			wildcardPolicy: routev1.WildcardPolicyNone,
+			allow:          false,
+			errs:           1,
+		},
+		{
+			name:           "set-to-edge-changed",
+			host:           "host",
+			expected:       "host",
+			oldHost:        "host",
+			tls:            &routev1.TLSConfig{Termination: routev1.TLSTerminationEdge},
+			oldTLS:         nil,
+			wildcardPolicy: routev1.WildcardPolicyNone,
+			allow:          false,
+			errs:           0,
+		},
+		{
+			name:           "cleared-edge",
+			host:           "host",
+			expected:       "host",
+			oldHost:        "host",
+			tls:            nil,
+			oldTLS:         &routev1.TLSConfig{Termination: routev1.TLSTerminationEdge},
+			wildcardPolicy: routev1.WildcardPolicyNone,
+			allow:          false,
+			errs:           0,
+		},
+		{
+			name:           "removed-certificate",
+			host:           "host",
+			expected:       "host",
+			oldHost:        "host",
+			tls:            &routev1.TLSConfig{Termination: routev1.TLSTerminationReencrypt},
+			oldTLS:         &routev1.TLSConfig{Termination: routev1.TLSTerminationReencrypt, Certificate: "a"},
+			wildcardPolicy: routev1.WildcardPolicyNone,
+			allow:          false,
+			errs:           0,
+		},
+		{
+			name:           "added-certificate-and-fails",
+			host:           "host",
+			expected:       "host",
+			oldHost:        "host",
+			tls:            &routev1.TLSConfig{Termination: routev1.TLSTerminationReencrypt, Certificate: "a"},
+			oldTLS:         nil,
+			wildcardPolicy: routev1.WildcardPolicyNone,
+			allow:          false,
+			errs:           1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			route := &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:       "wildcard",
+					Name:            tc.name,
+					UID:             types.UID("wild"),
+					ResourceVersion: "1",
+				},
+				Spec: routev1.RouteSpec{
+					Host:           tc.host,
+					Subdomain:      tc.subdomain,
+					WildcardPolicy: tc.wildcardPolicy,
+					TLS:            tc.tls,
+					To: routev1.RouteTargetReference{
+						Name: "test",
+						Kind: "Service",
+					},
+				},
+			}
+
+			var errs field.ErrorList
+			if len(tc.oldHost) > 0 || len(tc.oldSubdomain) > 0 || tc.oldTLS != nil {
+				oldRoute := &routev1.Route{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:       "wildcard",
+						Name:            tc.name,
+						UID:             types.UID("wild"),
+						ResourceVersion: "1",
+					},
+					Spec: routev1.RouteSpec{
+						Host:           tc.oldHost,
+						Subdomain:      tc.oldSubdomain,
+						WildcardPolicy: tc.wildcardPolicy,
+						TLS:            tc.oldTLS,
+						To: routev1.RouteTargetReference{
+							Name: "test",
+							Kind: "Service",
+						},
+					},
+				}
+				errs = ValidateHostUpdate(ctx, route, oldRoute, &testSAR{allow: tc.allow})
+			} else {
+				errs = AllocateHost(ctx, route, &testSAR{allow: tc.allow}, testAllocator{})
+			}
+
+			if route.Spec.Host != tc.expected {
+				t.Fatalf("expected host %s, got %s", tc.expected, route.Spec.Host)
+			}
+			if route.Spec.Subdomain != tc.expectedSubdomain {
+				t.Fatalf("expected subdomain %s, got %s", tc.expectedSubdomain, route.Spec.Subdomain)
+			}
+			if len(errs) != tc.errs {
+				t.Fatalf("expected %d errors, got %d: %v", tc.errs, len(errs), errs)
+			}
+		})
+	}
+}

--- a/pkg/route/hostassignment/plugin.go
+++ b/pkg/route/hostassignment/plugin.go
@@ -1,0 +1,46 @@
+package hostassignment
+
+import (
+	"fmt"
+	"strings"
+
+	kvalidation "k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/klog/v2"
+
+	routev1 "github.com/openshift/api/route/v1"
+)
+
+// Default DNS suffix to use if no configuration is passed to this plugin.
+const defaultDNSSuffix = "router.default.svc.cluster.local"
+
+// SimpleAllocationPlugin implements the route.AllocationPlugin interface
+// to provide a simple unsharded (or single sharded) allocation plugin.
+type SimpleAllocationPlugin struct {
+	DNSSuffix string
+}
+
+// NewSimpleAllocationPlugin creates a new SimpleAllocationPlugin.
+func NewSimpleAllocationPlugin(suffix string) (*SimpleAllocationPlugin, error) {
+	if len(suffix) == 0 {
+		suffix = defaultDNSSuffix
+	}
+
+	klog.V(4).Infof("Route plugin initialized with suffix=%s", suffix)
+
+	// Check that the DNS suffix is valid.
+	if len(kvalidation.IsDNS1123Subdomain(suffix)) != 0 {
+		return nil, fmt.Errorf("invalid DNS suffix: %s", suffix)
+	}
+
+	return &SimpleAllocationPlugin{DNSSuffix: suffix}, nil
+}
+
+// GenerateHostname generates a host name for a route - using the service name,
+// namespace (if provided) and the router shard dns suffix.
+// TODO: move to router code, and have the routers set this back on the route status.
+func (p *SimpleAllocationPlugin) GenerateHostname(route *routev1.Route) (string, error) {
+	if len(route.Name) == 0 || len(route.Namespace) == 0 {
+		return "", nil
+	}
+	return fmt.Sprintf("%s-%s.%s", strings.Replace(route.Name, ".", "-", -1), route.Namespace, p.DNSSuffix), nil
+}

--- a/pkg/route/hostassignment/plugin_test.go
+++ b/pkg/route/hostassignment/plugin_test.go
@@ -1,0 +1,249 @@
+package hostassignment
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
+
+	routev1 "github.com/openshift/api/route/v1"
+)
+
+func TestNewSimpleAllocationPlugin(t *testing.T) {
+	tests := []struct {
+		Name             string
+		ErrorExpectation bool
+	}{
+		{
+			Name:             "www.example.org",
+			ErrorExpectation: false,
+		},
+		{
+			Name:             "www^acme^org",
+			ErrorExpectation: true,
+		},
+		{
+			Name:             "bad wolf.whoswho",
+			ErrorExpectation: true,
+		},
+		{
+			Name:             "tardis#1.watch",
+			ErrorExpectation: true,
+		},
+		{
+			Name:             "こんにちはopenshift.com",
+			ErrorExpectation: true,
+		},
+		{
+			Name:             "yo!yo!@#$%%$%^&*(0){[]}:;',<>?/1.test",
+			ErrorExpectation: true,
+		},
+		{
+			Name:             "",
+			ErrorExpectation: false,
+		},
+	}
+
+	for _, tc := range tests {
+		sap, err := NewSimpleAllocationPlugin(tc.Name)
+		if err != nil && !tc.ErrorExpectation {
+			t.Errorf("Test case for %s got an error where none was expected", tc.Name)
+		}
+		if len(tc.Name) > 0 {
+			continue
+		}
+		dap := &SimpleAllocationPlugin{DNSSuffix: defaultDNSSuffix}
+		if sap.DNSSuffix != dap.DNSSuffix {
+			t.Errorf("Expected function to use defaultDNSSuffix for empty name argument.")
+		}
+	}
+}
+
+func TestSimpleAllocationPlugin(t *testing.T) {
+	tests := []struct {
+		name  string
+		route *routev1.Route
+		empty bool
+	}{
+		{
+			name: "No Name",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "namespace",
+				},
+				Spec: routev1.RouteSpec{
+					To: routev1.RouteTargetReference{
+						Name: "service",
+					},
+				},
+			},
+			empty: true,
+		},
+		{
+			name: "No namespace",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "name",
+				},
+				Spec: routev1.RouteSpec{
+					To: routev1.RouteTargetReference{
+						Name: "nonamespace",
+					},
+				},
+			},
+			empty: true,
+		},
+		{
+			name: "No service name",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+			},
+		},
+		{
+			name: "Valid route",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+				Spec: routev1.RouteSpec{
+					Host: "www.example.com",
+					To: routev1.RouteTargetReference{
+						Name: "myservice",
+					},
+				},
+			},
+		},
+		{
+			name: "No host",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+				Spec: routev1.RouteSpec{
+					Host: "www.example.com",
+					To: routev1.RouteTargetReference{
+						Name: "myservice",
+					},
+				},
+			},
+		},
+	}
+
+	plugin, err := NewSimpleAllocationPlugin("www.example.org")
+	if err != nil {
+		t.Errorf("Error creating SimpleAllocationPlugin got %s", err)
+		return
+	}
+
+	for _, tc := range tests {
+		name, _ := plugin.GenerateHostname(tc.route)
+		switch {
+		case len(name) == 0 && !tc.empty, len(name) != 0 && tc.empty:
+			t.Errorf("Test case %s got %d length name.", tc.name, len(name))
+		case tc.empty:
+			continue
+		}
+		if len(validation.IsDNS1123Subdomain(name)) != 0 {
+			t.Errorf("Test case %s got %s - invalid DNS name.", tc.name, name)
+		}
+	}
+}
+
+func TestSimpleAllocationPluginViaController(t *testing.T) {
+	tests := []struct {
+		name  string
+		route *routev1.Route
+		empty bool
+	}{
+		{
+			name: "No Name",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "namespace",
+				},
+				Spec: routev1.RouteSpec{
+					To: routev1.RouteTargetReference{
+						Name: "service",
+					},
+				},
+			},
+			empty: true,
+		},
+		{
+			name: "Host but no name",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "namespace",
+				},
+				Spec: routev1.RouteSpec{
+					Host: "foo.com",
+				},
+			},
+			empty: true,
+		},
+		{
+			name: "No namespace",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "name",
+				},
+				Spec: routev1.RouteSpec{
+					To: routev1.RouteTargetReference{
+						Name: "nonamespace",
+					},
+				},
+			},
+			empty: true,
+		},
+		{
+			name: "No service name",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+			},
+		},
+		{
+			name: "Valid route",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+				Spec: routev1.RouteSpec{
+					Host: "www.example.com",
+					To: routev1.RouteTargetReference{
+						Name: "s3",
+					},
+				},
+			},
+		},
+	}
+
+	plugin, err := NewSimpleAllocationPlugin("www.example.org")
+	if err != nil {
+		t.Fatalf("unexpected error")
+	}
+
+	for _, tc := range tests {
+		name, err := plugin.GenerateHostname(tc.route)
+		if err != nil {
+			t.Errorf("Test case %s got an error %s", tc.name, err)
+		}
+		switch {
+		case len(name) == 0 && !tc.empty, len(name) != 0 && tc.empty:
+			t.Errorf("Test case %s got %d length name.", tc.name, len(name))
+		case tc.empty:
+			continue
+		}
+		if len(validation.IsDNS1123Subdomain(name)) != 0 {
+			t.Errorf("Test case %s got %s - invalid DNS name.", tc.name, name)
+		}
+	}
+}

--- a/pkg/route/validation/validation.go
+++ b/pkg/route/validation/validation.go
@@ -1,0 +1,393 @@
+package validation
+
+import (
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
+	kvalidation "k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	routev1 "github.com/openshift/api/route/v1"
+)
+
+var validateRouteName = apimachineryvalidation.NameIsDNSSubdomain
+
+func ValidateRoute(route *routev1.Route) field.ErrorList {
+	return validateRoute(route, true)
+}
+
+// validLabels - used in the ValidateRouteUpdate function to check if "older" routes conform to DNS1123Labels or not
+func validLabels(host string) bool {
+	if len(host) == 0 {
+		return true
+	}
+	return checkLabelSegments(host)
+}
+
+// checkLabelSegments - function that checks if hostname labels conform to DNS1123Labels
+func checkLabelSegments(host string) bool {
+	segments := strings.Split(host, ".")
+	for _, s := range segments {
+		errs := kvalidation.IsDNS1123Label(s)
+		if len(errs) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// validateRoute - private function to validate route
+func validateRoute(route *routev1.Route, checkHostname bool) field.ErrorList {
+	//ensure meta is set properly
+	result := validateObjectMeta(&route.ObjectMeta, true, validateRouteName, field.NewPath("metadata"))
+
+	specPath := field.NewPath("spec")
+
+	//host is not required but if it is set ensure it meets DNS requirements
+	if len(route.Spec.Host) > 0 {
+		if len(kvalidation.IsDNS1123Subdomain(route.Spec.Host)) != 0 {
+			result = append(result, field.Invalid(specPath.Child("host"), route.Spec.Host, "host must conform to DNS 952 subdomain conventions"))
+		}
+
+		// Check the hostname only if the old route did not have an invalid DNS1123Label
+		// and the new route cares about DNS compliant labels.
+		if checkHostname && route.Annotations[routev1.AllowNonDNSCompliantHostAnnotation] != "true" {
+			segments := strings.Split(route.Spec.Host, ".")
+			for _, s := range segments {
+				errs := kvalidation.IsDNS1123Label(s)
+				for _, e := range errs {
+					result = append(result, field.Invalid(specPath.Child("host"), route.Spec.Host, e))
+				}
+			}
+		}
+	}
+
+	if len(route.Spec.Subdomain) > 0 {
+		// Subdomain is not lenient because it was never used outside of
+		// routes.
+		//
+		// TODO: Use ValidateSubdomain from library-go.
+		if len(route.Spec.Subdomain) > kvalidation.DNS1123SubdomainMaxLength {
+			result = append(result, field.Invalid(field.NewPath("spec.subdomain"), route.Spec.Subdomain, kvalidation.MaxLenError(kvalidation.DNS1123SubdomainMaxLength)))
+		}
+		for _, label := range strings.Split(route.Spec.Subdomain, ".") {
+			if errs := kvalidation.IsDNS1123Label(label); len(errs) > 0 {
+				result = append(result, field.Invalid(field.NewPath("spec.subdomain"), label, strings.Join(errs, ", ")))
+			}
+		}
+	}
+
+	if err := validateWildcardPolicy(route.Spec.Host, route.Spec.WildcardPolicy, specPath.Child("wildcardPolicy")); err != nil {
+		result = append(result, err)
+	}
+
+	if len(route.Spec.Path) > 0 && !strings.HasPrefix(route.Spec.Path, "/") {
+		result = append(result, field.Invalid(specPath.Child("path"), route.Spec.Path, "path must begin with /"))
+	}
+
+	if len(route.Spec.Path) > 0 && route.Spec.TLS != nil &&
+		route.Spec.TLS.Termination == routev1.TLSTerminationPassthrough {
+		result = append(result, field.Invalid(specPath.Child("path"), route.Spec.Path, "passthrough termination does not support paths"))
+	}
+
+	if len(route.Spec.To.Name) == 0 {
+		result = append(result, field.Required(specPath.Child("to", "name"), ""))
+	}
+	if route.Spec.To.Kind != "Service" {
+		result = append(result, field.Invalid(specPath.Child("to", "kind"), route.Spec.To.Kind, "must reference a Service"))
+	}
+	if route.Spec.To.Weight != nil && (*route.Spec.To.Weight < 0 || *route.Spec.To.Weight > 256) {
+		result = append(result, field.Invalid(specPath.Child("to", "weight"), route.Spec.To.Weight, "weight must be an integer between 0 and 256"))
+	}
+
+	backendPath := specPath.Child("alternateBackends")
+	if len(route.Spec.AlternateBackends) > 3 {
+		result = append(result, field.Required(backendPath, "cannot specify more than 3 alternate backends"))
+	}
+	for i, svc := range route.Spec.AlternateBackends {
+		if len(svc.Name) == 0 {
+			result = append(result, field.Required(backendPath.Index(i).Child("name"), ""))
+		}
+		if svc.Kind != "Service" {
+			result = append(result, field.Invalid(backendPath.Index(i).Child("kind"), svc.Kind, "must reference a Service"))
+		}
+		if svc.Weight != nil && (*svc.Weight < 0 || *svc.Weight > 256) {
+			result = append(result, field.Invalid(backendPath.Index(i).Child("weight"), svc.Weight, "weight must be an integer between 0 and 256"))
+		}
+	}
+
+	if route.Spec.Port != nil {
+		switch target := route.Spec.Port.TargetPort; {
+		case target.Type == intstr.Int && target.IntVal == 0,
+			target.Type == intstr.String && len(target.StrVal) == 0:
+			result = append(result, field.Required(specPath.Child("port", "targetPort"), ""))
+		}
+	}
+
+	if errs := validateTLS(route, specPath.Child("tls")); len(errs) != 0 {
+		result = append(result, errs...)
+	}
+
+	return result
+}
+
+func ValidateRouteUpdate(route *routev1.Route, older *routev1.Route) field.ErrorList {
+	allErrs := validateObjectMetaUpdate(&route.ObjectMeta, &older.ObjectMeta, field.NewPath("metadata"))
+	allErrs = append(allErrs, apimachineryvalidation.ValidateImmutableField(route.Spec.WildcardPolicy, older.Spec.WildcardPolicy, field.NewPath("spec", "wildcardPolicy"))...)
+	hostnameUpdated := route.Spec.Host != older.Spec.Host
+	allErrs = append(allErrs, validateRoute(route, hostnameUpdated && validLabels(older.Spec.Host))...)
+	return allErrs
+}
+
+// ValidateRouteStatusUpdate validates status updates for routes.
+//
+// Note that this function shouldn't call ValidateRouteUpdate, otherwise
+// we are risking to break existing routes.
+func ValidateRouteStatusUpdate(route *routev1.Route, older *routev1.Route) field.ErrorList {
+	allErrs := validateObjectMetaUpdate(&route.ObjectMeta, &older.ObjectMeta, field.NewPath("metadata"))
+
+	// TODO: validate route status
+	return allErrs
+}
+
+type blockVerifierFunc func(block *pem.Block) (*pem.Block, error)
+
+func publicKeyBlockVerifier(block *pem.Block) (*pem.Block, error) {
+	key, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	block = &pem.Block{
+		Type: "PUBLIC KEY",
+	}
+	if block.Bytes, err = x509.MarshalPKIXPublicKey(key); err != nil {
+		return nil, err
+	}
+	return block, nil
+}
+
+func certificateBlockVerifier(block *pem.Block) (*pem.Block, error) {
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	block = &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: cert.Raw,
+	}
+	return block, nil
+}
+
+func privateKeyBlockVerifier(block *pem.Block) (*pem.Block, error) {
+	key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		key, err = x509.ParsePKCS1PrivateKey(block.Bytes)
+		if err != nil {
+			key, err = x509.ParseECPrivateKey(block.Bytes)
+			if err != nil {
+				return nil, fmt.Errorf("block %s is not valid", block.Type)
+			}
+		}
+	}
+	switch t := key.(type) {
+	case *rsa.PrivateKey:
+		block = &pem.Block{
+			Type:  "RSA PRIVATE KEY",
+			Bytes: x509.MarshalPKCS1PrivateKey(t),
+		}
+	case *ecdsa.PrivateKey:
+		block = &pem.Block{
+			Type: "ECDSA PRIVATE KEY",
+		}
+		if block.Bytes, err = x509.MarshalECPrivateKey(t); err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("block private key %T is not valid", key)
+	}
+	return block, nil
+}
+
+func ignoreBlockVerifier(block *pem.Block) (*pem.Block, error) {
+	return nil, nil
+}
+
+var knownBlockDecoders = map[string]blockVerifierFunc{
+	"RSA PRIVATE KEY":   privateKeyBlockVerifier,
+	"ECDSA PRIVATE KEY": privateKeyBlockVerifier,
+	"PRIVATE KEY":       privateKeyBlockVerifier,
+	"PUBLIC KEY":        publicKeyBlockVerifier,
+	// Potential "in the wild" PEM encoded blocks that can be normalized
+	"RSA PUBLIC KEY":   publicKeyBlockVerifier,
+	"DSA PUBLIC KEY":   publicKeyBlockVerifier,
+	"ECDSA PUBLIC KEY": publicKeyBlockVerifier,
+	"CERTIFICATE":      certificateBlockVerifier,
+	// Blocks that should be dropped
+	"EC PARAMETERS": ignoreBlockVerifier,
+}
+
+// validateTLS tests fields for different types of TLS combinations are set.  Called
+// by ValidateRoute.
+func validateTLS(route *routev1.Route, fldPath *field.Path) field.ErrorList {
+	result := field.ErrorList{}
+	tls := route.Spec.TLS
+
+	// no tls config present, no need for validation
+	if tls == nil {
+		return nil
+	}
+
+	switch tls.Termination {
+	// reencrypt may specify destination ca cert
+	// cert, key, cacert may not be specified because the route may be a wildcard
+	case routev1.TLSTerminationReencrypt:
+	//passthrough term should not specify any cert
+	case routev1.TLSTerminationPassthrough:
+		if len(tls.Certificate) > 0 {
+			result = append(result, field.Invalid(fldPath.Child("certificate"), "redacted certificate data", "passthrough termination does not support certificates"))
+		}
+
+		if len(tls.Key) > 0 {
+			result = append(result, field.Invalid(fldPath.Child("key"), "redacted key data", "passthrough termination does not support certificates"))
+		}
+
+		if len(tls.CACertificate) > 0 {
+			result = append(result, field.Invalid(fldPath.Child("caCertificate"), "redacted ca certificate data", "passthrough termination does not support certificates"))
+		}
+
+		if len(tls.DestinationCACertificate) > 0 {
+			result = append(result, field.Invalid(fldPath.Child("destinationCACertificate"), "redacted destination ca certificate data", "passthrough termination does not support certificates"))
+		}
+	// edge cert should only specify cert, key, and cacert but those certs
+	// may not be specified if the route is a wildcard route
+	case routev1.TLSTerminationEdge:
+		if len(tls.DestinationCACertificate) > 0 {
+			result = append(result, field.Invalid(fldPath.Child("destinationCACertificate"), "redacted destination ca certificate data", "edge termination does not support destination certificates"))
+		}
+	default:
+		validValues := []string{string(routev1.TLSTerminationEdge), string(routev1.TLSTerminationPassthrough), string(routev1.TLSTerminationReencrypt)}
+		result = append(result, field.NotSupported(fldPath.Child("termination"), tls.Termination, validValues))
+	}
+
+	if err := validateInsecureEdgeTerminationPolicy(tls, fldPath.Child("insecureEdgeTerminationPolicy")); err != nil {
+		result = append(result, err)
+	}
+
+	return result
+}
+
+// validateInsecureEdgeTerminationPolicy tests fields for different types of
+// insecure options. Called by validateTLS.
+func validateInsecureEdgeTerminationPolicy(tls *routev1.TLSConfig, fldPath *field.Path) *field.Error {
+	// Check insecure option value if specified (empty is ok).
+	if len(tls.InsecureEdgeTerminationPolicy) == 0 {
+		return nil
+	}
+
+	// It is an edge-terminated or reencrypt route, check insecure option value is
+	// one of None(for disable), Allow or Redirect.
+	allowedValues := map[routev1.InsecureEdgeTerminationPolicyType]struct{}{
+		routev1.InsecureEdgeTerminationPolicyNone:     {},
+		routev1.InsecureEdgeTerminationPolicyAllow:    {},
+		routev1.InsecureEdgeTerminationPolicyRedirect: {},
+	}
+
+	switch tls.Termination {
+	case routev1.TLSTerminationReencrypt:
+		fallthrough
+	case routev1.TLSTerminationEdge:
+		if _, ok := allowedValues[tls.InsecureEdgeTerminationPolicy]; !ok {
+			msg := fmt.Sprintf("invalid value for InsecureEdgeTerminationPolicy option, acceptable values are %s, %s, %s, or empty", routev1.InsecureEdgeTerminationPolicyNone, routev1.InsecureEdgeTerminationPolicyAllow, routev1.InsecureEdgeTerminationPolicyRedirect)
+			return field.Invalid(fldPath, tls.InsecureEdgeTerminationPolicy, msg)
+		}
+	case routev1.TLSTerminationPassthrough:
+		if routev1.InsecureEdgeTerminationPolicyNone != tls.InsecureEdgeTerminationPolicy && routev1.InsecureEdgeTerminationPolicyRedirect != tls.InsecureEdgeTerminationPolicy {
+			msg := fmt.Sprintf("invalid value for InsecureEdgeTerminationPolicy option, acceptable values are %s, %s, or empty", routev1.InsecureEdgeTerminationPolicyNone, routev1.InsecureEdgeTerminationPolicyRedirect)
+			return field.Invalid(fldPath, tls.InsecureEdgeTerminationPolicy, msg)
+		}
+	}
+
+	return nil
+}
+
+var (
+	allowedWildcardPolicies    = []string{string(routev1.WildcardPolicyNone), string(routev1.WildcardPolicySubdomain)}
+	allowedWildcardPoliciesSet = sets.NewString(allowedWildcardPolicies...)
+)
+
+// validateWildcardPolicy tests that the wildcard policy is either empty or one of the supported types.
+func validateWildcardPolicy(host string, policy routev1.WildcardPolicyType, fldPath *field.Path) *field.Error {
+	if len(policy) == 0 {
+		return nil
+	}
+
+	// Check if policy is one of None or Subdomain.
+	if !allowedWildcardPoliciesSet.Has(string(policy)) {
+		return field.NotSupported(fldPath, policy, allowedWildcardPolicies)
+	}
+
+	if policy == routev1.WildcardPolicySubdomain && len(host) == 0 {
+		return field.Invalid(fldPath, policy, "host name not specified for wildcard policy")
+	}
+
+	return nil
+}
+
+// The special finalizer name validations were copied from k8s.io/kubernetes to eliminate that
+// dependency and preserve the existing behavior.
+
+// k8s.io/kubernetes/pkg/apis/core/validation.ValidateObjectMeta
+func validateObjectMeta(meta *metav1.ObjectMeta, requiresNamespace bool, nameFn apimachineryvalidation.ValidateNameFunc, fldPath *field.Path) field.ErrorList {
+	allErrs := apimachineryvalidation.ValidateObjectMeta(meta, requiresNamespace, apimachineryvalidation.ValidateNameFunc(nameFn), fldPath)
+	// run additional checks for the finalizer name
+	for i := range meta.Finalizers {
+		allErrs = append(allErrs, validateKubeFinalizerName(string(meta.Finalizers[i]), fldPath.Child("finalizers").Index(i))...)
+	}
+	return allErrs
+}
+
+// k8s.io/kubernetes/pkg/apis/core/validation.ValidateObjectMetaUpdate
+func validateObjectMetaUpdate(newMeta, oldMeta *metav1.ObjectMeta, fldPath *field.Path) field.ErrorList {
+	allErrs := apimachineryvalidation.ValidateObjectMetaUpdate(newMeta, oldMeta, fldPath)
+	// run additional checks for the finalizer name
+	for i := range newMeta.Finalizers {
+		allErrs = append(allErrs, validateKubeFinalizerName(string(newMeta.Finalizers[i]), fldPath.Child("finalizers").Index(i))...)
+	}
+
+	return allErrs
+}
+
+var standardFinalizers = sets.NewString(
+	string(corev1.FinalizerKubernetes),
+	metav1.FinalizerOrphanDependents,
+	metav1.FinalizerDeleteDependents,
+)
+
+func validateKubeFinalizerName(stringValue string, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if len(strings.Split(stringValue, "/")) == 1 {
+		if !standardFinalizers.Has(stringValue) {
+			return append(allErrs, field.Invalid(fldPath, stringValue, "name is neither a standard finalizer name nor is it fully qualified"))
+		}
+	}
+
+	return allErrs
+}
+
+func Warnings(route *routev1.Route) []string {
+	if len(route.Spec.Host) != 0 && len(route.Spec.Subdomain) != 0 {
+		var warnings []string
+		warnings = append(warnings, "spec.host is set; spec.subdomain may be ignored")
+		return warnings
+	}
+	return nil
+}

--- a/pkg/route/validation/validation_test.go
+++ b/pkg/route/validation/validation_test.go
@@ -1,0 +1,1362 @@
+package validation
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	routev1 "github.com/openshift/api/route/v1"
+)
+
+const (
+	testCACertificate = `-----BEGIN CERTIFICATE-----
+MIIClDCCAf2gAwIBAgIJAPU57OGhuqJtMA0GCSqGSIb3DQEBCwUAMGMxCzAJBgNV
+BAYTAlVTMQswCQYDVQQIDAJDQTERMA8GA1UECgwIU2VjdXJpdHkxGzAZBgNVBAsM
+Ek9wZW5TaGlmdDMgdGVzdCBDQTEXMBUGA1UEAwwOaGVhZGVyLnRlc3QgQ0EwHhcN
+MTYwMzEyMDQyMTAzWhcNMzYwMzEyMDQyMTAzWjBjMQswCQYDVQQGEwJVUzELMAkG
+A1UECAwCQ0ExETAPBgNVBAoMCFNlY3VyaXR5MRswGQYDVQQLDBJPcGVuU2hpZnQz
+IHRlc3QgQ0ExFzAVBgNVBAMMDmhlYWRlci50ZXN0IENBMIGfMA0GCSqGSIb3DQEB
+AQUAA4GNADCBiQKBgQCsdVIJ6GSrkFdE9LzsMItYGE4q3qqSqIbs/uwMoVsMT+33
+pLeyzeecPuoQsdO6SEuqhUM1ivUN4GyXIR1+aW2baMwMXpjX9VIJu5d4FqtGi6SD
+RfV+tbERWwifPJlN+ryuvqbbDxrjQeXhemeo7yrJdgJ1oyDmoM5pTiSUUmltvQID
+AQABo1AwTjAdBgNVHQ4EFgQUOVuieqGfp2wnKo7lX2fQt+Yk1C4wHwYDVR0jBBgw
+FoAUOVuieqGfp2wnKo7lX2fQt+Yk1C4wDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0B
+AQsFAAOBgQA8VhmNeicRnKgXInVyYZDjL0P4WRbKJY7DkJxRMRWxikbEVHdySki6
+jegpqgJqYbzU6EiuTS2sl2bAjIK9nGUtTDt1PJIC1Evn5Q6v5ylNflpv6GxtUbCt
+bGvtpjWA4r9WASIDPFsxk/cDEEEO6iPxgMOf5MdpQC2y2MU0rzF/Gg==
+-----END CERTIFICATE-----`
+
+	testDestinationCACertificate = testCACertificate
+)
+
+func createRouteSpecTo(name string, kind string) routev1.RouteTargetReference {
+	svc := routev1.RouteTargetReference{
+		Name: name,
+		Kind: kind,
+	}
+	return svc
+}
+
+// Context around testing hostname validation.
+// Currently the host name validation checks along these lines
+//
+// DNS 1123 subdomain
+// - host name ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+// - and not greater than 253 characters
+//
+// The additional test (which now aligns with the router hostname validation) is
+// DNS 1123 label
+// - host name label ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+// - and not greater than 63 characters
+//
+// The above check can be bypassed by setting the annotation for backwards compatibility
+// - route.openshift.io/allow-non-dns-compliant-host: "true"
+
+// N.B. For tests that have the AllowNonDNSCompliantHostAnnotation annotation set to true
+// - All tests return the expected behavior of the current api-server
+// - The ONLY exception is the test for labels greater than 63 i.e -> name: "Valid host (64 chars label annotation override)"
+// - The behavior is as follows
+//   - annotation set to false (default) test name: "Valid host (64 chars label annotation override)" has expectedErrors > 0
+//   - annotation set to true            test name: "Valid host (64 chars label annotation override)" has expectedErrors == 0
+//
+// As mentioned this allows for the edge case where customers were using DNS labels greater than 64 chars and were not using the openshift router.
+
+// TestValidateRoute ensures not specifying a required field results in error and a fully specified
+// route passes successfully
+func TestValidateRoute(t *testing.T) {
+	tests := []struct {
+		name           string
+		route          *routev1.Route
+		expectedErrors int
+	}{
+		{
+			name: "No Name",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+				},
+				Spec: routev1.RouteSpec{
+					Host: "host",
+					To:   createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 1,
+		},
+		{
+			name: "No namespace",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "name",
+				},
+				Spec: routev1.RouteSpec{
+					Host: "host",
+					To:   createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 1,
+		},
+		{
+			name: "No host",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+				Spec: routev1.RouteSpec{
+					To: createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 0,
+		},
+		{
+			name: "Invalid host",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+					Annotations: map[string]string{
+						routev1.AllowNonDNSCompliantHostAnnotation: "true",
+					},
+				},
+				Spec: routev1.RouteSpec{
+					Host: "**",
+					To:   createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 1,
+		},
+		{
+			name: "Valid single label host",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+					Annotations: map[string]string{
+						routev1.AllowNonDNSCompliantHostAnnotation: "true",
+					},
+				},
+				Spec: routev1.RouteSpec{
+					Host: "test",
+					To:   createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 0,
+		},
+		{
+			name: "Valid host (start & end alpha)",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+					Annotations: map[string]string{
+						routev1.AllowNonDNSCompliantHostAnnotation: "true",
+					},
+				},
+				Spec: routev1.RouteSpec{
+					Host: "abc.test.com",
+					To:   createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 0,
+		},
+		{
+			name: "Valid host (start & end numeric)",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+				Spec: routev1.RouteSpec{
+					Host: "1.test.com.2",
+					To:   createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 0,
+		},
+		{
+			name: "Invalid host (trailing '.')",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+					Annotations: map[string]string{
+						routev1.AllowNonDNSCompliantHostAnnotation: "true",
+					},
+				},
+				Spec: routev1.RouteSpec{
+					Host: "abc.test.com.",
+					To:   createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 1,
+		},
+		{
+			name: "Invalid host ('*' not allowed)",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+					Annotations: map[string]string{
+						routev1.AllowNonDNSCompliantHostAnnotation: "true",
+					},
+				},
+				Spec: routev1.RouteSpec{
+					Host: "abc.*.test.com",
+					To:   createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 1,
+		},
+		{
+			name: "Invalid host ('%!&#@$^' not allowed)",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+					Annotations: map[string]string{
+						routev1.AllowNonDNSCompliantHostAnnotation: "true",
+					},
+				},
+				Spec: routev1.RouteSpec{
+					Host: "abc.%!&#@$^.test.com",
+					To:   createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 1,
+		},
+		{
+			name: "Invalid host ('A-Z' not allowed)",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+					Annotations: map[string]string{
+						routev1.AllowNonDNSCompliantHostAnnotation: "true",
+					},
+				},
+				Spec: routev1.RouteSpec{
+					Host: "A.test.com",
+					To:   createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 1,
+		},
+		{
+			name: "Invalid host (trailing '-' not allowed)",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+					Annotations: map[string]string{
+						routev1.AllowNonDNSCompliantHostAnnotation: "true",
+					},
+				},
+				Spec: routev1.RouteSpec{
+					Host: "abc.test.com.-",
+					To:   createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 1,
+		},
+		{
+			name: "Valid host (many segements/labels allowed)",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+				Spec: routev1.RouteSpec{
+					Host: "x.abc.y.test.com",
+					To:   createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 0,
+		},
+		{
+			name: "Valid host 63 chars label",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+					Annotations: map[string]string{
+						routev1.AllowNonDNSCompliantHostAnnotation: "true",
+					},
+				},
+				Spec: routev1.RouteSpec{
+					Host: "name-namespace-1234567890-1234567890-1234567890-1234567890-1234.test.com",
+					To:   createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 0,
+		},
+		{
+			name: "Valid host (64 chars label annotation override)",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+					Annotations: map[string]string{
+						routev1.AllowNonDNSCompliantHostAnnotation: "true",
+					},
+				},
+				Spec: routev1.RouteSpec{
+					Host: "name-namespace-1234567890-1234567890-1234567890-1234567890-12345.test.com",
+					To:   createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 0,
+		},
+		{
+			name: "Valid host (253 chars)",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+				Spec: routev1.RouteSpec{
+					Host: "name-namespace.a1234567890.b1234567890.c1234567890.d1234567890.e1234567890.f1234567890.g1234567890.h1234567890.i1234567890.j1234567890.k1234567890.l1234567890.m1234567890.n1234567890.o1234567890.p1234567890.q1234567890.r1234567890.s12345678.test.com",
+					To:   createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 0,
+		},
+		{
+			name: "Invalid host (279 chars)",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+				Spec: routev1.RouteSpec{
+					Host: "name-namespace.a1234567890.b1234567890.c1234567890.d1234567890.e1234567890.f1234567890.g1234567890.h1234567890.i1234567890.j1234567890.k1234567890.l1234567890.m1234567890.n1234567890.o1234567890.p1234567890.q1234567890.r1234567890.s1234567890.t1234567890.u1234567890.test.com",
+					To:   createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 1,
+		},
+		{
+			name: "Invalid host (does not conform DNS host name)",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+				Spec: routev1.RouteSpec{
+					Host: "**",
+					To:   createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 2,
+		},
+		{
+			name: "Valid single label host (conform DNS host name)",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+				Spec: routev1.RouteSpec{
+					Host: "test",
+					To:   createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 0,
+		},
+		{
+			name: "Valid host (conform DNS host name start & end alpha)",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+				Spec: routev1.RouteSpec{
+					Host: "abc.test.com",
+					To:   createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 0,
+		},
+		{
+			name: "Valid host (conform DNS host name - start & end numeric)",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+				Spec: routev1.RouteSpec{
+					Host: "1.abc.test.com.2",
+					To:   createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 0,
+		},
+		{
+			name: "Invalid host (does not conform DNS host name - trailing '.')",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+				Spec: routev1.RouteSpec{
+					Host: "abc.test.com.",
+					To:   createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 2,
+		},
+		{
+			name: "Invalid host (does not conform DNS host name - '*' not allowed)",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+				Spec: routev1.RouteSpec{
+					Host: "abc.*.test.com",
+					To:   createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 2,
+		},
+		{
+			name: "Invalid host (does not conform DNS host name - '%!&#@$^' not allowed)",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+				Spec: routev1.RouteSpec{
+					Host: "abc.%!&#@$^.test.com",
+					To:   createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 2,
+		},
+		{
+			name: "Invalid host (does not conform DNS host name - 'A-Z' not allowed)",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+				Spec: routev1.RouteSpec{
+					Host: "A.test.com",
+					To:   createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 2,
+		},
+		{
+			name: "Invalid host (does not conform DNS host name - trailing '-' not allowed)",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+				Spec: routev1.RouteSpec{
+					Host: "abc.test.com.-",
+					To:   createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 2,
+		},
+		{
+			name: "Valid host (conform DNS host name - many segments/labels allowed)",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+				Spec: routev1.RouteSpec{
+					Host: "x.abc.y.test.com",
+					To:   createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 0,
+		},
+		{
+			name: "Valid host (conform DNS host name - 63 chars label)",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+				Spec: routev1.RouteSpec{
+					Host: "name-namespace-1234567890-1234567890-1234567890-1234567890-1234.test.com",
+					To:   createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 0,
+		},
+		{
+			name: "Invalid host (does not conform  DNS host name - 64 chars label)",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+				Spec: routev1.RouteSpec{
+					Host: "name-namespace-1234567890-1234567890-1234567890-1234567890-12345.test.com",
+					To:   createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 1,
+		},
+		{
+			name: "Valid host (conform DNS host name - 253 chars)",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+				Spec: routev1.RouteSpec{
+					Host: "name-namespace.a1234567890.b1234567890.c1234567890.d1234567890.e1234567890.f1234567890.g1234567890.h1234567890.i1234567890.j1234567890.k1234567890.l1234567890.m1234567890.n1234567890.o1234567890.p1234567890.q1234567890.r1234567890.s123456789.t1.test.com",
+					To:   createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 0,
+		},
+		{
+			name: "Invalid host (does conform DNS host name - 254 chars)",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+					Annotations: map[string]string{
+						routev1.AllowNonDNSCompliantHostAnnotation: "false",
+					},
+				},
+				Spec: routev1.RouteSpec{
+					Host: "name-namespace.a1234567890.b1234567890.c1234567890.d1234567890.e1234567890.f1234567890.g1234567890.h1234567890.i1234567890.j1234567890.k1234567890.l1234567890.m1234567890.n1234567890.o1234567890.p1234567890.q1234567890.r1234567890.s1234567890.t12.test.com",
+					To:   createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 1,
+		},
+		{
+			name: "Valid subdomain",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+				Spec: routev1.RouteSpec{
+					Subdomain: "api.ci",
+					To:        createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 0,
+		},
+		{
+			name: "Valid subdomain (253 chars)",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+				Spec: routev1.RouteSpec{
+					Subdomain: "name-namespace.a1234567890.b1234567890.c1234567890.d1234567890.e1234567890.f1234567890.g1234567890.h1234567890.i1234567890.j1234567890.k1234567890.l1234567890.m1234567890.n1234567890.o1234567890.p1234567890.q1234567890.r1234567890.s12345678.test.com",
+					To:        createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 0,
+		},
+		{
+			name: "Invalid subdomain (279 chars)",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+				Spec: routev1.RouteSpec{
+					Subdomain: "name-namespace.a1234567890.b1234567890.c1234567890.d1234567890.e1234567890.f1234567890.g1234567890.h1234567890.i1234567890.j1234567890.k1234567890.l1234567890.m1234567890.n1234567890.o1234567890.p1234567890.q1234567890.r1234567890.s1234567890.t1234567890.u1234567890.test.com",
+					To:        createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 1,
+		},
+		{
+			name: "Invalid DNS 952 subdomain",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+				Spec: routev1.RouteSpec{
+					Subdomain: "**",
+					To:        createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 1,
+		},
+		{
+			name: "Valid subdomain (conform DNS host name - 253 chars)",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+				Spec: routev1.RouteSpec{
+					Subdomain: "name-namespace.a1234567890.b1234567890.c1234567890.d1234567890.e1234567890.f1234567890.g1234567890.h1234567890.i1234567890.j1234567890.k1234567890.l1234567890.m1234567890.n1234567890.o1234567890.p1234567890.q1234567890.r1234567890.s123456789.t1.test.com",
+					To:        createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 0,
+		},
+		{
+			name: "Invalid subdomain (does conform DNS host name - 254 chars)",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+					Annotations: map[string]string{
+						routev1.AllowNonDNSCompliantHostAnnotation: "false",
+					},
+				},
+				Spec: routev1.RouteSpec{
+					Subdomain: "name-namespace.a1234567890.b1234567890.c1234567890.d1234567890.e1234567890.f1234567890.g1234567890.h1234567890.i1234567890.j1234567890.k1234567890.l1234567890.m1234567890.n1234567890.o1234567890.p1234567890.q1234567890.r1234567890.s1234567890.t12.test.com",
+					To:        createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 1,
+		},
+		{
+			name: "No service name",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+				Spec: routev1.RouteSpec{
+					Host: "host",
+					To:   createRouteSpecTo("", "Service"),
+				},
+			},
+			expectedErrors: 1,
+		},
+		{
+			name: "No service kind",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+				Spec: routev1.RouteSpec{
+					Host: "host",
+					To:   createRouteSpecTo("serviceName", ""),
+				},
+			},
+			expectedErrors: 1,
+		},
+		{
+			name: "Zero port",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+				Spec: routev1.RouteSpec{
+					Host: "www.example.com",
+					To:   createRouteSpecTo("serviceName", "Service"),
+					Port: &routev1.RoutePort{
+						TargetPort: intstr.FromInt(0),
+					},
+				},
+			},
+			expectedErrors: 1,
+		},
+		{
+			name: "Empty string port",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+				Spec: routev1.RouteSpec{
+					Host: "www.example.com",
+					To:   createRouteSpecTo("serviceName", "Service"),
+					Port: &routev1.RoutePort{
+						TargetPort: intstr.FromString(""),
+					},
+				},
+			},
+			expectedErrors: 1,
+		},
+		{
+			name: "Valid route",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+				Spec: routev1.RouteSpec{
+					Host: "www.example.com",
+					To:   createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 0,
+		},
+		{
+			name: "Valid route with path",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+				Spec: routev1.RouteSpec{
+					Host: "www.example.com",
+					To:   createRouteSpecTo("serviceName", "Service"),
+					Path: "/test",
+				},
+			},
+			expectedErrors: 0,
+		},
+		{
+			name: "Invalid route with path",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+				Spec: routev1.RouteSpec{
+					Host: "www.example.com",
+					To:   createRouteSpecTo("serviceName", "Service"),
+					Path: "test",
+				},
+			},
+			expectedErrors: 1,
+		},
+		{
+			name: "Passthrough route with path",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+				Spec: routev1.RouteSpec{
+					Host: "www.example.com",
+					Path: "/test",
+					To:   createRouteSpecTo("serviceName", "Service"),
+					TLS: &routev1.TLSConfig{
+						Termination: routev1.TLSTerminationPassthrough,
+					},
+				},
+			},
+			expectedErrors: 1,
+		},
+		{
+			name: "No wildcard policy",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nowildcard",
+					Namespace: "foo",
+				},
+				Spec: routev1.RouteSpec{
+					Host: "no.wildcard.test",
+					To:   createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 0,
+		},
+		{
+			name: "wildcard policy none",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nowildcard2",
+					Namespace: "foo",
+				},
+				Spec: routev1.RouteSpec{
+					Host:           "none.wildcard.test",
+					To:             createRouteSpecTo("serviceName", "Service"),
+					WildcardPolicy: routev1.WildcardPolicyNone,
+				},
+			},
+			expectedErrors: 0,
+		},
+		{
+			name: "wildcard policy subdomain",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "wildcardpolicy",
+					Namespace: "foo",
+				},
+				Spec: routev1.RouteSpec{
+					Host:           "subdomain.wildcard.test",
+					To:             createRouteSpecTo("serviceName", "Service"),
+					WildcardPolicy: routev1.WildcardPolicySubdomain,
+				},
+			},
+			expectedErrors: 0,
+		},
+		{
+			name: "Invalid wildcard policy",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "badwildcard",
+					Namespace: "foo",
+				},
+				Spec: routev1.RouteSpec{
+					Host:           "bad.wildcard.test",
+					To:             createRouteSpecTo("serviceName", "Service"),
+					WildcardPolicy: "bad-wolf",
+				},
+			},
+			expectedErrors: 1,
+		},
+		{
+			name: "Invalid host for wildcard policy",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "badhost",
+					Namespace: "foo",
+				},
+				Spec: routev1.RouteSpec{
+					To:             createRouteSpecTo("serviceName", "Service"),
+					WildcardPolicy: routev1.WildcardPolicySubdomain,
+				},
+			},
+			expectedErrors: 1,
+		},
+		{
+			name: "Empty host for wildcard policy",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "emptyhost",
+					Namespace: "foo",
+				},
+				Spec: routev1.RouteSpec{
+					Host:           "",
+					To:             createRouteSpecTo("serviceName", "Service"),
+					WildcardPolicy: routev1.WildcardPolicySubdomain,
+				},
+			},
+			expectedErrors: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		errs := ValidateRoute(tc.route)
+		if len(errs) != tc.expectedErrors {
+			t.Errorf("Test case %s expected %d error(s), got %d. %v", tc.name, tc.expectedErrors, len(errs), errs)
+		}
+	}
+}
+
+func TestValidateTLS(t *testing.T) {
+	tests := []struct {
+		name           string
+		route          *routev1.Route
+		expectedErrors int
+	}{
+		{
+			name: "No TLS Termination",
+			route: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					TLS: &routev1.TLSConfig{
+						Termination: "",
+					},
+				},
+			},
+			expectedErrors: 1,
+		},
+		{
+			name: "Passthrough termination OK",
+			route: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					TLS: &routev1.TLSConfig{
+						Termination: routev1.TLSTerminationPassthrough,
+					},
+				},
+			},
+			expectedErrors: 0,
+		},
+		{
+			name: "Reencrypt termination OK with certs",
+			route: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					TLS: &routev1.TLSConfig{
+						Termination:              routev1.TLSTerminationReencrypt,
+						Certificate:              "def",
+						Key:                      "ghi",
+						CACertificate:            "jkl",
+						DestinationCACertificate: "abc",
+					},
+				},
+			},
+			expectedErrors: 0,
+		},
+		{
+			name: "Reencrypt termination OK without certs",
+			route: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					TLS: &routev1.TLSConfig{
+						Termination:              routev1.TLSTerminationReencrypt,
+						DestinationCACertificate: "abc",
+					},
+				},
+			},
+			expectedErrors: 0,
+		},
+		{
+			name: "Reencrypt termination no dest cert",
+			route: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					TLS: &routev1.TLSConfig{
+						Termination:   routev1.TLSTerminationReencrypt,
+						Certificate:   "def",
+						Key:           "ghi",
+						CACertificate: "jkl",
+					},
+				},
+			},
+			expectedErrors: 0,
+		},
+		{
+			name: "Edge termination OK with certs",
+			route: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					TLS: &routev1.TLSConfig{
+						Termination:   routev1.TLSTerminationEdge,
+						Certificate:   "abc",
+						Key:           "abc",
+						CACertificate: "abc",
+					},
+				},
+			},
+			expectedErrors: 0,
+		},
+		{
+			name: "Edge termination OK without certs",
+			route: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					TLS: &routev1.TLSConfig{
+						Termination: routev1.TLSTerminationEdge,
+					},
+				},
+			},
+			expectedErrors: 0,
+		},
+		{
+			name: "Edge termination, dest cert",
+			route: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					TLS: &routev1.TLSConfig{
+						Termination:              routev1.TLSTerminationEdge,
+						DestinationCACertificate: "abc",
+					},
+				},
+			},
+			expectedErrors: 1,
+		},
+		{
+			name: "Passthrough termination, cert",
+			route: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					TLS: &routev1.TLSConfig{Termination: routev1.TLSTerminationPassthrough, Certificate: "test"},
+				},
+			},
+			expectedErrors: 1,
+		},
+		{
+			name: "Passthrough termination, key",
+			route: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					TLS: &routev1.TLSConfig{Termination: routev1.TLSTerminationPassthrough, Key: "test"},
+				},
+			},
+			expectedErrors: 1,
+		},
+		{
+			name: "Passthrough termination, ca cert",
+			route: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					TLS: &routev1.TLSConfig{Termination: routev1.TLSTerminationPassthrough, CACertificate: "test"},
+				},
+			},
+			expectedErrors: 1,
+		},
+		{
+			name: "Passthrough termination, dest ca cert",
+			route: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					TLS: &routev1.TLSConfig{Termination: routev1.TLSTerminationPassthrough, DestinationCACertificate: "test"},
+				},
+			},
+			expectedErrors: 1,
+		},
+		{
+			name: "Invalid termination type",
+			route: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					TLS: &routev1.TLSConfig{
+						Termination: "invalid",
+					},
+				},
+			},
+			expectedErrors: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		errs := validateTLS(tc.route, nil)
+
+		if len(errs) != tc.expectedErrors {
+			t.Errorf("Test case %s expected %d error(s), got %d. %v", tc.name, tc.expectedErrors, len(errs), errs)
+		}
+	}
+}
+
+func TestValidatePassthroughInsecureEdgeTerminationPolicy(t *testing.T) {
+
+	insecureTypes := map[routev1.InsecureEdgeTerminationPolicyType]bool{
+		"": false,
+		routev1.InsecureEdgeTerminationPolicyNone:     false,
+		routev1.InsecureEdgeTerminationPolicyAllow:    true,
+		routev1.InsecureEdgeTerminationPolicyRedirect: false,
+		"support HTTPsec": true,
+		"or maybe HSTS":   true,
+	}
+
+	for key, expected := range insecureTypes {
+		route := &routev1.Route{
+			Spec: routev1.RouteSpec{
+				TLS: &routev1.TLSConfig{
+					Termination:                   routev1.TLSTerminationPassthrough,
+					InsecureEdgeTerminationPolicy: key,
+				},
+			},
+		}
+		route.Spec.TLS.InsecureEdgeTerminationPolicy = key
+		errs := validateTLS(route, nil)
+		if !expected && len(errs) != 0 {
+			t.Errorf("Test case for Passthrough termination with insecure=%s got %d errors where none where expected. %v",
+				key, len(errs), errs)
+		}
+		if expected && len(errs) == 0 {
+			t.Errorf("Test case for Passthrough termination with insecure=%s got no errors where some where expected.", key)
+		}
+	}
+}
+
+// TestValidateRouteBad ensures not specifying a required field results in error and a fully specified
+// route passes successfully
+func TestValidateRouteUpdate(t *testing.T) {
+	tests := []struct {
+		name           string
+		route          *routev1.Route
+		change         func(route *routev1.Route)
+		expectedErrors int
+	}{
+		{
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "bar",
+					Namespace:       "foo",
+					ResourceVersion: "1",
+				},
+				Spec: routev1.RouteSpec{
+					Host: "host",
+					To: routev1.RouteTargetReference{
+						Name: "serviceName",
+						Kind: "Service",
+					},
+				},
+			},
+			change:         func(route *routev1.Route) { route.Spec.Host = "" },
+			expectedErrors: 0, // now controlled by rbac
+		},
+		{
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "bar",
+					Namespace:       "foo",
+					ResourceVersion: "1",
+				},
+				Spec: routev1.RouteSpec{
+					Host: "host",
+					To: routev1.RouteTargetReference{
+						Name: "serviceName",
+						Kind: "Service",
+					},
+				},
+			},
+			change:         func(route *routev1.Route) { route.Spec.Host = "other" },
+			expectedErrors: 0, // now controlled by rbac
+		},
+		{
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "bar",
+					Namespace:       "foo",
+					ResourceVersion: "1",
+				},
+				Spec: routev1.RouteSpec{
+					Host: "host",
+					To: routev1.RouteTargetReference{
+						Name: "serviceName",
+						Kind: "Service",
+					},
+				},
+			},
+			change:         func(route *routev1.Route) { route.Name = "baz" },
+			expectedErrors: 1,
+		},
+		{
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "bar",
+					Namespace:       "foo",
+					ResourceVersion: "1",
+				},
+				Spec: routev1.RouteSpec{
+					Host: "name-namespace-1234567890-1234567890-1234567890-1234567890-12345.test.com",
+					To: routev1.RouteTargetReference{
+						Name: "serviceName",
+						Kind: "Service",
+					},
+				},
+			},
+			change: func(route *routev1.Route) {
+				route.Spec.Host = "abc.test.com"
+			}, // old route was invalid - ignore validation check
+			expectedErrors: 0,
+		},
+		{
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "bar",
+					Namespace:       "foo",
+					ResourceVersion: "1",
+					Annotations: map[string]string{
+						routev1.AllowNonDNSCompliantHostAnnotation: "true",
+					},
+				},
+				Spec: routev1.RouteSpec{
+					Host: "name-namespace-1234567890-1234567890-1234567890-1234567890-12345.test.com",
+					To: routev1.RouteTargetReference{
+						Name: "serviceName",
+						Kind: "Service",
+					},
+				},
+			},
+			change: func(route *routev1.Route) {
+				route.Spec.Host = "abc.test.com"
+			}, // old route was invalid - ignore validation check even if annoatation is set
+			expectedErrors: 0,
+		},
+		{
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "bar",
+					Namespace:       "foo",
+					ResourceVersion: "1",
+					Annotations: map[string]string{
+						routev1.AllowNonDNSCompliantHostAnnotation: "true",
+					},
+				},
+				Spec: routev1.RouteSpec{
+					Host: "abc.test.com",
+					To: routev1.RouteTargetReference{
+						Name: "serviceName",
+						Kind: "Service",
+					},
+				},
+			},
+			change: func(route *routev1.Route) {
+				route.Spec.Host = "name-namespace-1234567890-1234567890-1234567890-1234567890-12345.test.com"
+			}, // new route is invalid - skip check as annotation is set
+			expectedErrors: 0,
+		},
+		{
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "bar",
+					Namespace:       "foo",
+					ResourceVersion: "1",
+				},
+				Spec: routev1.RouteSpec{
+					Host: "abc.test.com",
+					To: routev1.RouteTargetReference{
+						Name: "serviceName",
+						Kind: "Service",
+					},
+				},
+			},
+			change: func(route *routev1.Route) {
+				route.Spec.Host = "name-namespace-1234567890-1234567890-1234567890-1234567890-12345.test.com"
+			}, // new route is invalid - do labels check
+			expectedErrors: 1,
+		},
+	}
+
+	for i, tc := range tests {
+		newRoute := tc.route.DeepCopy()
+		tc.change(newRoute)
+		errs := ValidateRouteUpdate(newRoute, tc.route)
+		if len(errs) != tc.expectedErrors {
+			t.Errorf("%d: expected %d error(s), got %d. %v", i, tc.expectedErrors, len(errs), errs)
+		}
+	}
+}
+
+func TestValidateInsecureEdgeTerminationPolicy(t *testing.T) {
+	tests := []struct {
+		name           string
+		insecure       routev1.InsecureEdgeTerminationPolicyType
+		expectedErrors int
+	}{
+		{
+			name:           "empty insecure option",
+			insecure:       "",
+			expectedErrors: 0,
+		},
+		{
+			name:           "foobar insecure option",
+			insecure:       "foobar",
+			expectedErrors: 1,
+		},
+		{
+			name:           "insecure option none",
+			insecure:       routev1.InsecureEdgeTerminationPolicyNone,
+			expectedErrors: 0,
+		},
+		{
+			name:           "insecure option allow",
+			insecure:       routev1.InsecureEdgeTerminationPolicyAllow,
+			expectedErrors: 0,
+		},
+		{
+			name:           "insecure option redirect",
+			insecure:       routev1.InsecureEdgeTerminationPolicyRedirect,
+			expectedErrors: 0,
+		},
+		{
+			name:           "insecure option other",
+			insecure:       "something else",
+			expectedErrors: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		route := &routev1.Route{
+			Spec: routev1.RouteSpec{
+				TLS: &routev1.TLSConfig{
+					Termination:                   routev1.TLSTerminationEdge,
+					InsecureEdgeTerminationPolicy: tc.insecure,
+				},
+			},
+		}
+		errs := validateTLS(route, nil)
+
+		if len(errs) != tc.expectedErrors {
+			t.Errorf("Test case %s expected %d error(s), got %d. %v", tc.name, tc.expectedErrors, len(errs), errs)
+		}
+	}
+}
+
+func TestValidateEdgeReencryptInsecureEdgeTerminationPolicy(t *testing.T) {
+	tests := []struct {
+		name  string
+		route *routev1.Route
+	}{
+		{
+			name: "Reencrypt termination",
+			route: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					TLS: &routev1.TLSConfig{
+						Termination:              routev1.TLSTerminationReencrypt,
+						DestinationCACertificate: "dca",
+					},
+				},
+			},
+		},
+		{
+			name: "Reencrypt termination DestCACert",
+			route: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					TLS: &routev1.TLSConfig{
+						Termination:              routev1.TLSTerminationReencrypt,
+						DestinationCACertificate: testDestinationCACertificate,
+					},
+				},
+			},
+		},
+		{
+			name: "Edge termination",
+			route: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					TLS: &routev1.TLSConfig{
+						Termination: routev1.TLSTerminationEdge,
+					},
+				},
+			},
+		},
+	}
+
+	insecureTypes := map[routev1.InsecureEdgeTerminationPolicyType]bool{
+		routev1.InsecureEdgeTerminationPolicyNone:     false,
+		routev1.InsecureEdgeTerminationPolicyAllow:    false,
+		routev1.InsecureEdgeTerminationPolicyRedirect: false,
+		"support HTTPsec": true,
+		"or maybe HSTS":   true,
+	}
+
+	for _, tc := range tests {
+		for key, expected := range insecureTypes {
+			tc.route.Spec.TLS.InsecureEdgeTerminationPolicy = key
+			errs := validateTLS(tc.route, nil)
+			if !expected && len(errs) != 0 {
+				t.Errorf("Test case %s with insecure=%s got %d errors where none were expected. %v",
+					tc.name, key, len(errs), errs)
+			}
+			if expected && len(errs) == 0 {
+				t.Errorf("Test case %s  with insecure=%s got no errors where some were expected.", tc.name, key)
+			}
+		}
+	}
+}
+
+func TestWarnings(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		host      string
+		subdomain string
+		expected  []string
+	}{
+		{
+			name:      "both host and subdomain set",
+			host:      "foo",
+			subdomain: "bar",
+			expected:  []string{"spec.host is set; spec.subdomain may be ignored"},
+		},
+		{
+			name: "only host set",
+			host: "foo",
+		},
+		{
+			name:      "only subdomain set",
+			subdomain: "bar",
+		},
+		{
+			name: "both host and subdomain unset",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := Warnings(&routev1.Route{
+				Spec: routev1.RouteSpec{
+					Host:      tc.host,
+					Subdomain: tc.subdomain,
+				},
+			})
+			if len(actual) != len(tc.expected) {
+				t.Fatalf("expected %#v, got %#v", tc.expected, actual)
+			}
+			for i := range actual {
+				if actual[i] != tc.expected[i] {
+					t.Fatalf("expected %#v, got %#v", tc.expected, actual)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is an almost-direct copy of the route validation and hostname assignment logic from openshift-apiserver, which has been refactored to operate on the v1 types from openshift/api instead of the internal types from openshift/openshift-apiserver. From library-go, one implementation will be sharable between openshift-apiserver and kube-apiserver to support OpenShift variants that serve the route API via CRD.