### PR TITLE
OCPBUGS-2293: pkg/manifest/manifest.go: add option to allow unknown capabilities

### DIFF
--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -119,6 +119,17 @@ func (m *Manifest) UnmarshalJSON(in []byte) error {
 // filter. For example, setting profile non-nil and capabilities nil will return an error if the manifest's
 // profile does not match, but will never return an error about capability issues.
 func (m *Manifest) Include(excludeIdentifier *string, includeTechPreview *bool, profile *string, capabilities *configv1.ClusterVersionCapabilitiesStatus) error {
+	return m.IncludeAllowUnknownCapabilities(excludeIdentifier, includeTechPreview, profile, capabilities, false)
+}
+
+// IncludeAllowUnknownCapabilities returns an error if the manifest fails an inclusion filter and should be excluded from
+// further processing by cluster version operator. Pointer arguments can be set nil to avoid excluding based on that
+// filter. For example, setting profile non-nil and capabilities nil will return an error if the manifest's
+// profile does not match, but will never return an error about capability issues. allowUnknownCapabilities only applies
+// to capabilities filtering. When set to true a manifest will not be excluded simply because it contains an unknown
+// capability. This is necessary to allow updates to an OCP version containing newly defined capabilities.
+func (m *Manifest) IncludeAllowUnknownCapabilities(excludeIdentifier *string, includeTechPreview *bool, profile *string,
+	capabilities *configv1.ClusterVersionCapabilitiesStatus, allowUnknownCapabilities bool) error {
 
 	annotations := m.Obj.GetAnnotations()
 	if annotations == nil {
@@ -155,35 +166,40 @@ func (m *Manifest) Include(excludeIdentifier *string, includeTechPreview *bool, 
 
 	// If there is no capabilities defined in a release then we do not need to check presence of capabilities in the manifest
 	if capabilities != nil {
-		return checkResourceEnablement(annotations, capabilities)
+		return checkResourceEnablement(annotations, capabilities, allowUnknownCapabilities)
 	}
 	return nil
 }
 
 // checkResourceEnablement, given resource annotations and defined cluster capabilities, checks if the capability
-// annotation exists. If so, each capability name is validated against the known set of capabilities. Each valid
-// capability is then checked if it is disabled. If any invalid capabilities are found an error is returned listing
-// all invalid capabilities. Otherwise, if any disabled capabilities are found an error is returned listing all
-// disabled capabilities.
-func checkResourceEnablement(annotations map[string]string, capabilities *configv1.ClusterVersionCapabilitiesStatus) error {
+// annotation exists. If so, each capability name is validated against the known set of capabilities unless
+// allowUnknownCapabilities is true. Each valid capability is then checked if it is disabled. If any invalid
+// capabilities are found an error is returned listing all invalid capabilities. Otherwise, if any disabled
+// capabilities are found an error is returned listing all disabled capabilities.
+func checkResourceEnablement(annotations map[string]string, capabilities *configv1.ClusterVersionCapabilitiesStatus,
+	allowUnknownCapabilities bool) error {
+
 	caps := getManifestCapabilities(annotations)
 	numCaps := len(caps)
 	unknownCaps := make([]string, 0, numCaps)
 	disabledCaps := make([]string, 0, numCaps)
 
 	for _, c := range caps {
-		var isKnownCap bool
-		var isEnabledCap bool
 
-		for _, knownCapability := range capabilities.KnownCapabilities {
-			if c == knownCapability {
-				isKnownCap = true
+		if !allowUnknownCapabilities {
+			var isKnownCap bool
+			for _, knownCapability := range capabilities.KnownCapabilities {
+				if c == knownCapability {
+					isKnownCap = true
+				}
+			}
+			if !isKnownCap {
+				unknownCaps = append(unknownCaps, string(c))
+				continue
 			}
 		}
-		if !isKnownCap {
-			unknownCaps = append(unknownCaps, string(c))
-			continue
-		}
+
+		var isEnabledCap bool
 		for _, enabledCapability := range capabilities.EnabledCapabilities {
 			if c == enabledCapability {
 				isEnabledCap = true

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -776,6 +776,63 @@ func Test_include(t *testing.T) {
 	}
 }
 
+func TestIncludeAllowUnknownCapabilities(t *testing.T) {
+
+	tests := []struct {
+		name         string
+		exclude      *string
+		profile      *string
+		annotations  map[string]interface{}
+		caps         *configv1.ClusterVersionCapabilitiesStatus
+		allowUnknown bool
+
+		expected error
+	}{
+		{
+			name: "multiple capabilities, 1 unknown",
+			annotations: map[string]interface{}{
+				"include.release.openshift.io/self-managed-high-availability": "true",
+				CapabilityAnnotation: "cap1+cap2"},
+			caps: &configv1.ClusterVersionCapabilitiesStatus{
+				KnownCapabilities:   []configv1.ClusterVersionCapability{"cap1", "cap3"},
+				EnabledCapabilities: []configv1.ClusterVersionCapability{"cap1", "cap3"},
+			},
+			allowUnknown: false,
+			expected:     fmt.Errorf("unrecognized capability names: cap2"),
+		},
+		{
+			name: "unknown allowed",
+			annotations: map[string]interface{}{
+				"include.release.openshift.io/self-managed-high-availability": "true",
+				CapabilityAnnotation: "cap1+cap2"},
+			caps: &configv1.ClusterVersionCapabilitiesStatus{
+				KnownCapabilities:   []configv1.ClusterVersionCapability{"cap1", "cap3"},
+				EnabledCapabilities: []configv1.ClusterVersionCapability{"cap1", "cap3"},
+			},
+			allowUnknown: true,
+			expected:     fmt.Errorf("disabled capabilities: cap2"),
+		},
+	}
+
+	for _, tt := range tests {
+		metadata := map[string]interface{}{}
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.annotations != nil {
+				metadata["annotations"] = tt.annotations
+			}
+			m := Manifest{
+				Obj: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": metadata,
+					},
+				},
+			}
+			err := m.IncludeAllowUnknownCapabilities(tt.exclude, nil, tt.profile, tt.caps, tt.allowUnknown)
+			assert.Equal(t, tt.expected, err)
+		})
+	}
+}
+
 func TestGetManifestCapabilities(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
during capabilities filtering. When set to true a manifest will not be excluded simply because it contains an unknown capability. This is necessary to allow updates to an OCP version containing newly defined capabilities.