### PR TITLE
[release-4.10] OCPBUGS-5345: routes/status resources can leak sensitive data

### DIFF
--- a/pkg/operator/apiserver/audit/bindata/bindata.go
+++ b/pkg/operator/apiserver/audit/bindata/bindata.go
@@ -62,7 +62,7 @@ var _pkgOperatorApiserverAuditManifestsAllrequestbodiesRulesYaml = []byte(`# exc
 - level: Metadata
   resources:
   - group: "route.openshift.io"
-    resources: ["routes"]
+    resources: ["routes", "routes/status"]
   - resources: ["secrets"]
 - level: Metadata
   resources:
@@ -184,7 +184,7 @@ var _pkgOperatorApiserverAuditManifestsWriterequestbodiesRulesYaml = []byte(`# e
 - level: Metadata
   resources:
   - group: "route.openshift.io"
-    resources: ["routes"]
+    resources: ["routes", "routes/status"]
   - resources: ["secrets"]
 - level: Metadata
   resources:

--- a/pkg/operator/apiserver/audit/manifests/allrequestbodies-rules.yaml
+++ b/pkg/operator/apiserver/audit/manifests/allrequestbodies-rules.yaml
@@ -2,7 +2,7 @@
 - level: Metadata
   resources:
   - group: "route.openshift.io"
-    resources: ["routes"]
+    resources: ["routes", "routes/status"]
   - resources: ["secrets"]
 - level: Metadata
   resources:

--- a/pkg/operator/apiserver/audit/manifests/writerequestbodies-rules.yaml
+++ b/pkg/operator/apiserver/audit/manifests/writerequestbodies-rules.yaml
@@ -2,7 +2,7 @@
 - level: Metadata
   resources:
   - group: "route.openshift.io"
-    resources: ["routes"]
+    resources: ["routes", "routes/status"]
   - resources: ["secrets"]
 - level: Metadata
   resources:

--- a/pkg/operator/apiserver/audit/testdata/allrequestbodies.yaml
+++ b/pkg/operator/apiserver/audit/testdata/allrequestbodies.yaml
@@ -32,7 +32,7 @@ rules:
 - level: Metadata
   resources:
   - group: "route.openshift.io"
-    resources: ["routes"]
+    resources: ["routes", "routes/status"]
   - resources: ["secrets"]
 - level: Metadata
   resources:

--- a/pkg/operator/apiserver/audit/testdata/audit-policies-cm-scenario-1.yaml
+++ b/pkg/operator/apiserver/audit/testdata/audit-policies-cm-scenario-1.yaml
@@ -72,7 +72,7 @@ data:
     - level: Metadata
       resources:
       - group: "route.openshift.io"
-        resources: ["routes"]
+        resources: ["routes", "routes/status"]
       - resources: ["secrets"]
     - level: Metadata
       resources:
@@ -121,7 +121,7 @@ data:
     - level: Metadata
       resources:
       - group: "route.openshift.io"
-        resources: ["routes"]
+        resources: ["routes", "routes/status"]
       - resources: ["secrets"]
     - level: Metadata
       resources:

--- a/pkg/operator/apiserver/audit/testdata/multipleCr.yaml
+++ b/pkg/operator/apiserver/audit/testdata/multipleCr.yaml
@@ -32,7 +32,7 @@ rules:
 - level: Metadata
   resources:
   - group: "route.openshift.io"
-    resources: ["routes"]
+    resources: ["routes", "routes/status"]
   - resources: ["secrets"]
   userGroups:
   - system:authenticated:oauth
@@ -64,7 +64,7 @@ rules:
 - level: Metadata
   resources:
     - group: "route.openshift.io"
-      resources: ["routes"]
+      resources: ["routes", "routes/status"]
     - resources: ["secrets"]
   userGroups:
     - system:authenticated

--- a/pkg/operator/apiserver/audit/testdata/oauth.yaml
+++ b/pkg/operator/apiserver/audit/testdata/oauth.yaml
@@ -32,7 +32,7 @@ rules:
 - level: Metadata
   resources:
   - group: "route.openshift.io"
-    resources: ["routes"]
+    resources: ["routes", "routes/status"]
   - resources: ["secrets"]
   userGroups:
   - system:authenticated:oauth

--- a/pkg/operator/apiserver/audit/testdata/writerequestbodies.yaml
+++ b/pkg/operator/apiserver/audit/testdata/writerequestbodies.yaml
@@ -32,7 +32,7 @@ rules:
 - level: Metadata
   resources:
   - group: "route.openshift.io"
-    resources: ["routes"]
+    resources: ["routes", "routes/status"]
   - resources: ["secrets"]
 - level: Metadata
   resources:


### PR DESCRIPTION
cherry-pick of https://github.com/openshift/library-go/pull/1394 (manually done)