### PR TITLE
USHIFT-573 Regenerate client certificate on subject change

### DIFF
--- a/pkg/crypto/crypto.go
+++ b/pkg/crypto/crypto.go
@@ -19,6 +19,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strconv"
 	"sync"
@@ -828,13 +829,35 @@ func (ca *CA) MakeServerCertForDuration(hostnames sets.String, lifetime time.Dur
 }
 
 func (ca *CA) EnsureClientCertificate(certFile, keyFile string, u user.Info, expireDays int) (*TLSCertificateConfig, bool, error) {
-	certConfig, err := GetTLSCertificateConfig(certFile, keyFile)
+	certConfig, err := GetClientCertificate(certFile, keyFile, u)
 	if err != nil {
 		certConfig, err = ca.MakeClientCertificate(certFile, keyFile, u, expireDays)
 		return certConfig, true, err // true indicates we wrote the files.
 	}
-
 	return certConfig, false, nil
+}
+
+func GetClientCertificate(certFile, keyFile string, u user.Info) (*TLSCertificateConfig, error) {
+	certConfig, err := GetTLSCertificateConfig(certFile, keyFile)
+	if err != nil {
+		return nil, err
+	}
+
+	if subject := certConfig.Certs[0].Subject; subjectChanged(subject, userToSubject(u)) {
+		return nil, fmt.Errorf("existing client certificate in %s was issued for a different Subject (%s)",
+			certFile, subject)
+	}
+
+	return certConfig, nil
+}
+
+func subjectChanged(existing, expected pkix.Name) bool {
+	sort.Strings(existing.Organization)
+	sort.Strings(expected.Organization)
+
+	return existing.CommonName != expected.CommonName ||
+		existing.SerialNumber != expected.SerialNumber ||
+		!reflect.DeepEqual(existing.Organization, expected.Organization)
 }
 
 func (ca *CA) MakeClientCertificate(certFile, keyFile string, u user.Info, expireDays int) (*TLSCertificateConfig, error) {


### PR DESCRIPTION
MicroShift uses this library to generate certificates, including the kubelet
certificates.

The subject part of the certificate is used to authenticate the kubelet and
limit the permissions on what can access. On a host name, the client
certificate was not being regenerated, so the kubelet could not create a
new entry for the new hostname, and blocked on a loop.

This commit forces the regeneration of the client certificate when the
subject field on the disk file differs.

https://issues.redhat.com/browse/USHIFT-573
