### PR TITLE
Revert "Make request using correct namespace"

### DIFF
--- a/pkg/template/templateprocessingclient/dynamic_process.go
+++ b/pkg/template/templateprocessingclient/dynamic_process.go
@@ -40,7 +40,7 @@ func (c *dynamicTemplateProcessor) ProcessToList(template *templatev1.Template) 
 
 func (c *dynamicTemplateProcessor) ProcessToListFromUnstructured(unstructuredTemplate *unstructured.Unstructured) (*unstructured.UnstructuredList, error) {
 	processedTemplate, err := c.client.Resource(templatev1.GroupVersion.WithResource("processedtemplates")).
-		Namespace(unstructuredTemplate.GetNamespace()).Create(context.TODO(), unstructuredTemplate, metav1.CreateOptions{})
+		Namespace("default").Create(context.TODO(), unstructuredTemplate, metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Reverts openshift/library-go#1402

This change seems to break several template tests. https://github.com/openshift/origin/pull/27548 is pulling in new change and gcp-ovn and aws-ovn-fips fail on

> [sig-devex][Feature:Templates] template-api TestTemplate [apigroup:template.openshift.io] [Suite:openshift/conformance/parallel]
> [sig-devex][Feature:Templates] template-api TestTemplateTransformationFromConfig [apigroup:template.openshift.io] [Suite:openshift/conformance/parallel]

https://github.com/openshift/origin/pull/27565 is bringing in kube bump but with openshift/library-go#1402 reverted - tests pass

