### PR TITLE
USHIFT-606: Remove validity period warnings for certs and CA certs

### DIFF
--- a/pkg/crypto/crypto.go
+++ b/pkg/crypto/crypto.go
@@ -639,10 +639,6 @@ func MakeSelfSignedCAConfigForSubject(subject pkix.Name, expireDays int) (*TLSCe
 		caLifetimeInDays = expireDays
 	}
 
-	if caLifetimeInDays > DefaultCACertificateLifetimeInDays {
-		warnAboutCertificateLifeTime(subject.CommonName, DefaultCACertificateLifetimeInDays)
-	}
-
 	caLifetime := time.Duration(caLifetimeInDays) * 24 * time.Hour
 	return makeSelfSignedCAConfigForSubjectAndDuration(subject, caLifetime)
 }
@@ -1023,10 +1019,6 @@ func newServerCertificateTemplate(subject pkix.Name, hosts []string, expireDays 
 		lifetimeInDays = expireDays
 	}
 
-	if lifetimeInDays > DefaultCertificateLifetimeInDays {
-		warnAboutCertificateLifeTime(subject.CommonName, DefaultCertificateLifetimeInDays)
-	}
-
 	lifetime := time.Duration(lifetimeInDays) * 24 * time.Hour
 
 	return newServerCertificateTemplateForDuration(subject, hosts, lifetime, currentTime, authorityKeyId, subjectKeyId)
@@ -1112,10 +1104,6 @@ func newClientCertificateTemplate(subject pkix.Name, expireDays int, currentTime
 		lifetimeInDays = expireDays
 	}
 
-	if lifetimeInDays > DefaultCertificateLifetimeInDays {
-		warnAboutCertificateLifeTime(subject.CommonName, DefaultCertificateLifetimeInDays)
-	}
-
 	lifetime := time.Duration(lifetimeInDays) * 24 * time.Hour
 
 	return newClientCertificateTemplateForDuration(subject, lifetime, currentTime)
@@ -1136,12 +1124,6 @@ func newClientCertificateTemplateForDuration(subject pkix.Name, lifetime time.Du
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 		BasicConstraintsValid: true,
 	}
-}
-
-func warnAboutCertificateLifeTime(name string, defaultLifetimeInDays int) {
-	defaultLifetimeInYears := defaultLifetimeInDays / 365
-	fmt.Fprintf(os.Stderr, "WARNING: Validity period of the certificate for %q is greater than %d years!\n", name, defaultLifetimeInYears)
-	fmt.Fprintln(os.Stderr, "WARNING: By security reasons it is strongly recommended to change this period and make it smaller!")
 }
 
 func signCertificate(template *x509.Certificate, requestKey crypto.PublicKey, issuer *x509.Certificate, issuerKey crypto.PrivateKey) (*x509.Certificate, error) {

--- a/pkg/crypto/crypto_test.go
+++ b/pkg/crypto/crypto_test.go
@@ -159,10 +159,6 @@ func newSigningCertificateTemplate(subject pkix.Name, expireDays int, currentTim
 		caLifetimeInDays = expireDays
 	}
 
-	if caLifetimeInDays > DefaultCACertificateLifetimeInDays {
-		warnAboutCertificateLifeTime(subject.CommonName, DefaultCACertificateLifetimeInDays)
-	}
-
 	caLifetime := time.Duration(caLifetimeInDays) * 24 * time.Hour
 
 	return newSigningCertificateTemplateForDuration(subject, caLifetime, currentTime, nil, nil)


### PR DESCRIPTION
Warnings are based on hardcoded values to 5y for CA and 2y for certificates. Some of the components in OpenShift/MicroShift are using validity periods exceeding those values.
For example, in cluster-kube-apiserver-operator we may find:
- [Localhost serving](https://github.com/openshift/cluster-kube-apiserver-operator/blob/master/pkg/operator/certrotationcontroller/certrotationcontroller.go#L216) using 10y.
- [Service network serving](https://github.com/openshift/cluster-kube-apiserver-operator/blob/master/pkg/operator/certrotationcontroller/certrotationcontroller.go#L256) using 10y.
- [External LB serving](https://github.com/openshift/cluster-kube-apiserver-operator/blob/master/pkg/operator/certrotationcontroller/certrotationcontroller.go#L297) using 10y.
- [Node system admin client](https://github.com/openshift/cluster-kube-apiserver-operator/blob/master/pkg/operator/certrotationcontroller/certrotationcontroller.go#L577) using 1y.
- Many others using 60d.

A static default value will generate this kind of warnings:
```
Nov 16 06:33:54 release-ci-ci-op-wl16xyg3-4db11 microshift[62391]: WARNING: Validity period of the certificate for "admin-kubeconfig-signer" is greater than 5 years!
Nov 16 06:33:54 release-ci-ci-op-wl16xyg3-4db11 microshift[62391]: WARNING: By security reasons it is strongly recommended to change this period and make it smaller!
Nov 16 06:33:55 release-ci-ci-op-wl16xyg3-4db11 microshift[62391]: WARNING: Validity period of the certificate for "system:admin" is greater than 2 years!
Nov 16 06:33:55 release-ci-ci-op-wl16xyg3-4db11 microshift[62391]: WARNING: By security reasons it is strongly recommended to change this period and make it smaller!
Nov 16 06:33:56 release-ci-ci-op-wl16xyg3-4db11 microshift[62391]: WARNING: Validity period of the certificate for "service-ca" is greater than 5 years!
Nov 16 06:33:56 release-ci-ci-op-wl16xyg3-4db11 microshift[62391]: WARNING: By security reasons it is strongly recommended to change this period and make it smaller!
```

Which are not actionable unless you check logs and then change something in the code that manages certificates, typically.