### PR TITLE
[release-4.12]  OCPBUGS-4478: guard controller: set an explicit hostname to avoid name collisions

### DIFF
--- a/pkg/operator/staticpod/controller/guard/guard_controller.go
+++ b/pkg/operator/staticpod/controller/guard/guard_controller.go
@@ -2,6 +2,7 @@ package guard
 
 import (
 	"context"
+	"crypto/sha1"
 	_ "embed"
 	"fmt"
 	"os"
@@ -99,7 +100,7 @@ func getGuardPodName(prefix, nodeName string) string {
 	return fmt.Sprintf("%s-guard-%s", prefix, nodeName)
 }
 
-func getGuardPodHostname(nodeName string) string {
+func getGuardPodHostname(namespace, nodeName string) string {
 	// The hostname is not used by the controller and not expected to be used at all.
 	// Generate the shorted but unique hostname so the hostname length is always
 	// under 63 characters as specified by hostnameMaxLen so the kubelet does not
@@ -108,7 +109,9 @@ func getGuardPodHostname(nodeName string) string {
 	//
 	// The controller creates exactly one guard pod per each node.
 	// Making the nodename a unique identifier for each guard pod.
-	hostname := fmt.Sprintf("guard-%s", nodeName)
+	// Adding the namespace to make the input for the generated hash longer
+	hash := sha1.Sum([]byte(fmt.Sprintf("%s-%s", namespace, nodeName)))
+	hostname := "guard-" + fmt.Sprintf("%x", string(hash[:])) + "-end" //6 + 40 + 4 = 50 chars
 	// a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character
 	return strings.Replace(hostname, ".", "-", -1)
 }
@@ -279,7 +282,7 @@ func (c *GuardController) sync(ctx context.Context, syncCtx factory.SyncContext)
 
 			pod.ObjectMeta.Name = getGuardPodName(c.podResourcePrefix, node.Name)
 			pod.ObjectMeta.Namespace = c.targetNamespace
-			pod.Spec.Hostname = getGuardPodHostname(node.Name)
+			pod.Spec.Hostname = getGuardPodHostname(c.targetNamespace, node.Name)
 			pod.Spec.NodeName = node.Name
 			pod.Spec.Containers[0].Image = c.installerPodImageFn()
 			pod.Spec.Containers[0].ReadinessProbe.HTTPGet.Host = operands[node.Name].Status.PodIP

--- a/pkg/operator/staticpod/controller/guard/guard_controller.go
+++ b/pkg/operator/staticpod/controller/guard/guard_controller.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -96,6 +97,20 @@ func getInstallerPodImageFromEnv() string {
 
 func getGuardPodName(prefix, nodeName string) string {
 	return fmt.Sprintf("%s-guard-%s", prefix, nodeName)
+}
+
+func getGuardPodHostname(nodeName string) string {
+	// The hostname is not used by the controller and not expected to be used at all.
+	// Generate the shorted but unique hostname so the hostname length is always
+	// under 63 characters as specified by hostnameMaxLen so the kubelet does not
+	// truncate the name to avoid conflicting hostnames.
+	// See OCPBUGS-3041 for more details.
+	//
+	// The controller creates exactly one guard pod per each node.
+	// Making the nodename a unique identifier for each guard pod.
+	hostname := fmt.Sprintf("guard-%s", nodeName)
+	// a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character
+	return strings.Replace(hostname, ".", "-", -1)
 }
 
 func getGuardPDBName(prefix string) string {
@@ -264,6 +279,7 @@ func (c *GuardController) sync(ctx context.Context, syncCtx factory.SyncContext)
 
 			pod.ObjectMeta.Name = getGuardPodName(c.podResourcePrefix, node.Name)
 			pod.ObjectMeta.Namespace = c.targetNamespace
+			pod.Spec.Hostname = getGuardPodHostname(node.Name)
 			pod.Spec.NodeName = node.Name
 			pod.Spec.Containers[0].Image = c.installerPodImageFn()
 			pod.Spec.Containers[0].ReadinessProbe.HTTPGet.Host = operands[node.Name].Status.PodIP
@@ -284,6 +300,10 @@ func (c *GuardController) sync(ctx context.Context, syncCtx factory.SyncContext)
 				}
 				if actual.Spec.Containers[0].ReadinessProbe.HTTPGet.Host != pod.Spec.Containers[0].ReadinessProbe.HTTPGet.Host {
 					klog.V(5).Infof("Operand PodIP changed, deleting %v so the guard can be re-created", pod.Name)
+					delete = true
+				}
+				if actual.Spec.Hostname != pod.Spec.Hostname {
+					klog.V(5).Infof("Guard Hostname changed, deleting %v so the guard can be re-created", pod.Name)
 					delete = true
 				}
 				if delete {

--- a/pkg/operator/staticpod/controller/guard/guard_controller_test.go
+++ b/pkg/operator/staticpod/controller/guard/guard_controller_test.go
@@ -360,6 +360,7 @@ func TestRenderGuardPod(t *testing.T) {
 					Labels:    map[string]string{"app": "guard"},
 				},
 				Spec: corev1.PodSpec{
+					Hostname: "guard-master1",
 					NodeName: "master1",
 				},
 				Status: corev1.PodStatus{
@@ -513,6 +514,7 @@ func TestRenderGuardPodPortChanged(t *testing.T) {
 			Labels:    map[string]string{"app": "guard"},
 		},
 		Spec: corev1.PodSpec{
+			Hostname: "guard-master1",
 			NodeName: "master1",
 			Containers: []corev1.Container{
 				{


### PR DESCRIPTION
Backporting this one https://github.com/openshift/library-go/pull/1427