### PR TITLE
[OCPCLOUD-1818] Migrate vSphere to out of tree cloudprovider

### DIFF
--- a/pkg/cloudprovider/external.go
+++ b/pkg/cloudprovider/external.go
@@ -23,8 +23,7 @@ func IsCloudProviderExternal(platformStatus *configv1.PlatformStatus, featureGat
 	}
 	switch platformStatus.Type {
 	case configv1.AWSPlatformType,
-		configv1.GCPPlatformType,
-		configv1.VSpherePlatformType:
+		configv1.GCPPlatformType:
 		// Platforms that are external based on feature gate presence
 		return isExternalFeatureGateEnabled(featureGate)
 	case configv1.AzurePlatformType:
@@ -34,10 +33,11 @@ func IsCloudProviderExternal(platformStatus *configv1.PlatformStatus, featureGat
 		return isExternalFeatureGateEnabled(featureGate)
 	case configv1.AlibabaCloudPlatformType,
 		configv1.IBMCloudPlatformType,
+		configv1.KubevirtPlatformType,
+		configv1.NutanixPlatformType,
 		configv1.OpenStackPlatformType,
 		configv1.PowerVSPlatformType,
-		configv1.KubevirtPlatformType,
-		configv1.NutanixPlatformType:
+		configv1.VSpherePlatformType:
 		return true, nil
 	default:
 		// Platforms that do not have external cloud providers implemented

--- a/pkg/cloudprovider/external_test.go
+++ b/pkg/cloudprovider/external_test.go
@@ -306,7 +306,7 @@ func TestIsCloudProviderExternal(t *testing.T) {
 			Type: configv1.VSpherePlatformType,
 		},
 		featureGate: nil,
-		expected:    false,
+		expected:    true,
 	}, {
 		name: "FeatureSet: CustomNoUpgrade (With External Feature Gate), Platform: vSphere",
 		status: &configv1.PlatformStatus{


### PR DESCRIPTION
This PR migrates the vSphere cloud provider from in-tree to out-of-tree. It must be merged in tandem with the PR for KCMO and CCMO to avoid a build that contains one or the other operator PRs without the other. If either merges without the other, it will either lead to no cloud controllers or duplicate cloud controllers, either of which will not work well.

* [KCMO PR](https://github.com/openshift/cluster-kube-controller-manager-operator/pull/687)
* [CCMO PR](https://github.com/openshift/cluster-cloud-controller-manager-operator/pull/214)
* [Cluster Bot demonstration of above PRs](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-origin-installer-launch-vsphere-modern/1612407690103885824)
* [Updating origin external CCM test](https://github.com/openshift/origin/pull/27638)