### PR TITLE
TRT-623: installer internal loadbalancer

### DIFF
--- a/pkg/operator/staticpod/controllers.go
+++ b/pkg/operator/staticpod/controllers.go
@@ -229,6 +229,7 @@ func (b *staticPodOperatorControllerBuilder) ToControllers() (manager.Controller
 			secretClient,
 			podClient,
 			eventRecorder,
+			infraInformers,
 		).WithCerts(
 			b.certDir,
 			b.certConfigMaps,


### PR DESCRIPTION
Starting as a draft PR to review details.

Originally I set the internal load balancer  for the [Installer Pod Container](https://github.com/neisw/library-go/blob/c471054200f5184bce4a324df75347b15bca325c/pkg/operator/staticpod/controller/installer/installer_controller.go#L927) 

But on review we had been decreasing the timeout in the protoConfig so I set the [Host](https://github.com/neisw/library-go/blob/c471054200f5184bce4a324df75347b15bca325c/pkg/operator/staticpod/installerpod/cmd.go#L178) property and commented out the call for the installer pod containers.



The validation PR I have been working with is for [cluster-kube-apiserver-operator](https://github.com/openshift/cluster-kube-apiserver-operator/pull/1424)  

Commit [8e3373b](https://github.com/openshift/cluster-kube-apiserver-operator/commit/8e3373be43f896f19ab944fabb5edc12a27db990) has the most recent approach targeting protoConfig.

Commits [e064f99](https://github.com/openshift/cluster-kube-apiserver-operator/commit/e064f99007f7669c0d2a33fe488194f3eb8529aa) and [c6a7d15](https://github.com/openshift/cluster-kube-apiserver-operator/commit/c6a7d154a08ad6be32844dbeb174c20380841ea3) had only debugging info and no actual changes.  The other commits all the [Installer Pod Container](https://github.com/neisw/library-go/blob/c471054200f5184bce4a324df75347b15bca325c/pkg/operator/staticpod/controller/installer/installer_controller.go#L927) changes enabled


I specifically targeted the config for the  KubeClient we are using when running the installer command but want to see if **the intention was to have the KUBERNETES_SERVICE_HOST / PORT ENV set for the entire operator?** {cluster-etcd-operator
cluster-kube-apiserver-operator
cluster-kube-controller-manager-operator
cluster-kube-scheduler-operator}


