### PR TITLE
MULTIARCH-3212: Add region mapping config for PowerVS cloud

### DIFF
--- a/pkg/config/cloud/powervs/powervs_regions.go
+++ b/pkg/config/cloud/powervs/powervs_regions.go
@@ -1,0 +1,102 @@
+package powervs
+
+import (
+	"fmt"
+)
+
+// Since there is no API to query these, we have to hard-code them here.
+
+// Region describes resources associated with a region in Power VS.
+// We're using a few items from the IBM Cloud VPC offering. The region names
+// for VPC are different so another function of this is to correlate those.
+type Region struct {
+	Description string
+	VPCRegion   string
+	Zones       []string
+}
+
+// Regions provides a mapping between Power VS and IBM Cloud VPC regions.
+var Regions = map[string]Region{
+	"dal": {
+		Description: "Dallas, USA",
+		VPCRegion:   "us-south",
+		Zones:       []string{"dal12"},
+	},
+	"eu-de": {
+		Description: "Frankfurt, Germany",
+		VPCRegion:   "eu-de",
+		Zones: []string{
+			"eu-de-1",
+			"eu-de-2",
+		},
+	},
+	"lon": {
+		Description: "London, UK.",
+		VPCRegion:   "eu-gb",
+		Zones: []string{
+			"lon04",
+			"lon06",
+		},
+	},
+	"mon": {
+		Description: "Montreal, Canada",
+		VPCRegion:   "ca-tor",
+		Zones:       []string{"mon01"},
+	},
+	"osa": {
+		Description: "Osaka, Japan",
+		VPCRegion:   "jp-osa",
+		Zones:       []string{"osa21"},
+	},
+	"syd": {
+		Description: "Sydney, Australia",
+		VPCRegion:   "au-syd",
+		Zones: []string{
+			"syd04",
+			"syd05",
+		},
+	},
+	"sao": {
+		Description: "São Paulo, Brazil",
+		VPCRegion:   "br-sao",
+		Zones:       []string{"sao01"},
+	},
+	"tok": {
+		Description: "Tokyo, Japan",
+		VPCRegion:   "jp-tok",
+		Zones:       []string{"tok04"},
+	},
+	"us-east": {
+		Description: "Washington DC, USA",
+		VPCRegion:   "us-east",
+		Zones:       []string{"us-east"},
+	},
+}
+
+// VPCRegionForPowerVSRegion returns the VPC region for the specified PowerVS region.
+func VPCRegionForPowerVSRegion(region string) (string, error) {
+	if r, ok := Regions[region]; ok {
+		return r.VPCRegion, nil
+	}
+
+	return "", fmt.Errorf("VPC region corresponding to a PowerVS region %s not found ", region)
+}
+
+// RegionShortNames returns the list of region names
+func RegionShortNames() []string {
+	keys := []string{}
+	for r := range Regions {
+		keys = append(keys, r)
+	}
+	return keys
+}
+
+// ValidateVPCRegion validates that given VPC region is known/tested.
+func ValidateVPCRegion(region string) bool {
+	for r := range Regions {
+		if region == Regions[r].VPCRegion {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
This is to keep the region mapping of PowerVS in common package, so all the components can access.

Region mapping is required to derive the location for VPC or COS from PowerVS region, since PowerVS follows different location notation, this mapping is required. With this mapping, user need to pass PowerVS region alone and other resource like VPC's region can be derived from this mapping.

As per @JoelSpeed's suggestion [here](https://github.com/openshift/api/pull/1383#issuecomment-1377039920) raised this PR.

Fixes https://issues.redhat.com/browse/MULTIARCH-3212