### PR TITLE
WRKLDS-649: Guard controller: set the readiness probe endpoint explicitly

### DIFF
--- a/pkg/operator/staticpod/controller/guard/guard_controller_test.go
+++ b/pkg/operator/staticpod/controller/guard/guard_controller_test.go
@@ -536,7 +536,8 @@ func TestRenderGuardPodPortChanged(t *testing.T) {
 						ProbeHandler: corev1.ProbeHandler{
 							HTTPGet: &corev1.HTTPGetAction{
 								Host: "1.1.1.1",
-								Port: intstr.FromInt(99999),
+								Port: intstr.FromInt(99998),
+								Path: "readyzpath",
 							},
 						},
 					},
@@ -572,6 +573,7 @@ func TestRenderGuardPodPortChanged(t *testing.T) {
 		operandPodLabelSelector: labels.Set{"app": "operand"}.AsSelector(),
 		operatorName:            "operator",
 		readyzPort:              "99999",
+		readyzEndpoint:          "readyz",
 		nodeLister:              kubeInformers.Core().V1().Nodes().Lister(),
 		podLister:               kubeInformers.Core().V1().Pods().Lister(),
 		podGetter:               kubeClient.CoreV1(),
@@ -598,6 +600,7 @@ func TestRenderGuardPodPortChanged(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	} else {
 		probe := p.Spec.Containers[0].ReadinessProbe.HTTPGet
+		originalProbe := guardPod.Spec.Containers[0].ReadinessProbe.HTTPGet
 		if probe == nil {
 			t.Errorf("missing ReadinessProbe in the guard")
 		}
@@ -605,8 +608,22 @@ func TestRenderGuardPodPortChanged(t *testing.T) {
 			t.Errorf("expected %q host in ReadinessProbe in the guard, got %q instead", operandPod.Status.PodIP, probe.Host)
 		}
 
+		// The port is expected to be set to 99999 by the guard controller
 		if probe.Port.IntValue() != 99999 {
-			t.Errorf("unexpected port in ReadinessProbe in the guard, expected 99999, got %v instead", probe.Port.IntValue())
+			t.Errorf("unexpected port in ReadinessProbe in the guard, expected %q, got %q instead", ctrl.readyzPort, probe.Port.IntValue())
+		}
+		// The port is expected to be different from the one initially set in the guard pod readiness probe
+		if originalProbe.Port.IntValue() == probe.Port.IntValue() {
+			t.Errorf("unexpected port in ReadinessProbe in the guard, expected it to be different from %q, got %q", originalProbe.Port.IntValue(), probe.Port.IntValue())
+		}
+
+		// The path is expected to be set to healthz by the guard controller
+		if probe.Path != ctrl.readyzEndpoint {
+			t.Errorf("unexpected path in ReadinessProbe in the guard, expected %q, got %q instead", ctrl.readyzEndpoint, probe.Path)
+		}
+		// The path is expected to be different from the one initially set in the guard pod readiness probe
+		if probe.Path == originalProbe.Path {
+			t.Errorf("unexpected path in ReadinessProbe in the guard, expected it to be differenf from %q, got %q", originalProbe.Path, probe.Path)
 		}
 	}
 }

--- a/pkg/operator/staticpod/controller/guard/manifests/guard-pod.yaml
+++ b/pkg/operator/staticpod/controller/guard/manifests/guard-pod.yaml
@@ -41,7 +41,7 @@ spec:
         failureThreshold: 3
         httpGet:
           host: # Value set by operator
-          path: healthz
+          path: # Value set by operator
           port: # Value set by operator
           scheme: HTTPS
         periodSeconds: 5

--- a/pkg/operator/staticpod/controllers.go
+++ b/pkg/operator/staticpod/controllers.go
@@ -71,6 +71,7 @@ type staticPodOperatorControllerBuilder struct {
 	operatorName               string
 	operatorNamespace          string
 	readyzPort                 string
+	readyzEndpoint             string
 	guardCreateConditionalFunc func() (bool, bool, error)
 }
 
@@ -103,7 +104,7 @@ type Builder interface {
 	// the installer pod is created for a revision.
 	WithCustomInstaller(command []string, installerPodMutationFunc installer.InstallerPodMutationFunc) Builder
 	WithPruning(command []string, staticPodPrefix string) Builder
-	WithPodDisruptionBudgetGuard(operatorNamespace, operatorName, readyzPort string, createConditionalFunc func() (bool, bool, error)) Builder
+	WithPodDisruptionBudgetGuard(operatorNamespace, operatorName, readyzPort, readyzEndpoint string, createConditionalFunc func() (bool, bool, error)) Builder
 	ToControllers() (manager.ControllerManager, error)
 }
 
@@ -170,10 +171,11 @@ func (b *staticPodOperatorControllerBuilder) WithPruning(command []string, stati
 	return b
 }
 
-func (b *staticPodOperatorControllerBuilder) WithPodDisruptionBudgetGuard(operatorNamespace, operatorName, readyzPort string, createConditionalFunc func() (bool, bool, error)) Builder {
+func (b *staticPodOperatorControllerBuilder) WithPodDisruptionBudgetGuard(operatorNamespace, operatorName, readyzPort, readyzEndpoint string, createConditionalFunc func() (bool, bool, error)) Builder {
 	b.operatorNamespace = operatorNamespace
 	b.operatorName = operatorName
 	b.readyzPort = readyzPort
+	b.readyzEndpoint = readyzEndpoint
 	b.guardCreateConditionalFunc = createConditionalFunc
 	return b
 }
@@ -330,13 +332,14 @@ func (b *staticPodOperatorControllerBuilder) ToControllers() (manager.Controller
 	manager.WithController(unsupportedconfigoverridescontroller.NewUnsupportedConfigOverridesController(b.staticPodOperatorClient, eventRecorder), 1)
 	manager.WithController(loglevel.NewClusterOperatorLoggingController(b.staticPodOperatorClient, eventRecorder), 1)
 
-	if len(b.operatorNamespace) > 0 && len(b.operatorName) > 0 && len(b.readyzPort) > 0 {
+	if len(b.operatorNamespace) > 0 && len(b.operatorName) > 0 && len(b.readyzPort) > 0 && len(b.readyzEndpoint) > 0 {
 		if guardController, err := guard.NewGuardController(
 			b.operandNamespace,
 			b.operandPodLabelSelector,
 			b.staticPodName,
 			b.operatorName,
 			b.readyzPort,
+			b.readyzEndpoint,
 			operandInformers,
 			clusterInformers,
 			b.staticPodOperatorClient,


### PR DESCRIPTION
KS and KCM does not publish /readyz endpoint, only /healthz. On the other hand KA publishes both /healthz and /readyz. The /readyz endpoint is more suitable for checking the readiness.

Thus, the guard controller needs to be allow to explicitly set the readiness probe endpoint.
/hold