### PR TITLE
OWNERS_ALIASES: Update approvers: add David, remove Jack, and earlier

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,10 +2,7 @@
 
 aliases:
   update-approvers:
-    - abhinavdahiya
-    - jottofar
+    - Davoska
     - LalatenduMohanty
-    - sdodson
-    - smarterclayton
-    - vrutkovs
+    - petr-muller
     - wking


### PR DESCRIPTION
Catching up with openshift/cluster-version-operator@f921431cca (openshift/cluster-version-operator#891).