### PR TITLE
Read featuregates from cluster state

### DIFF
--- a/pkg/operator/configobserver/featuregates/hardcoded_featuregate_reader.go
+++ b/pkg/operator/configobserver/featuregates/hardcoded_featuregate_reader.go
@@ -1,0 +1,59 @@
+package featuregates
+
+import (
+	"context"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+type hardcodedFeatureGateAccess struct {
+	enabled  []configv1.FeatureGateName
+	disabled []configv1.FeatureGateName
+	readErr  error
+
+	initialFeatureGatesObserved               chan struct{}
+	featureGatesHaveChangedSinceFirstObserved chan struct{}
+}
+
+// NewHardcodedFeatureGateAccess is useful for unit testing, potentially in other packages as well.
+func NewHardcodedFeatureGateAccess(enabled, disabled []configv1.FeatureGateName) FeatureGateAccess {
+	initialFeatureGatesObserved := make(chan struct{})
+	close(initialFeatureGatesObserved)
+	c := &hardcodedFeatureGateAccess{
+		enabled:                     enabled,
+		disabled:                    disabled,
+		initialFeatureGatesObserved: initialFeatureGatesObserved,
+		featureGatesHaveChangedSinceFirstObserved: make(chan struct{}),
+	}
+
+	return c
+}
+
+func (c *hardcodedFeatureGateAccess) SetChangeHandler(featureGateChangeHandlerFn FeatureGateChangeHandlerFunc) {
+	// ignore
+}
+
+func (c *hardcodedFeatureGateAccess) Run(ctx context.Context) {
+	// ignore
+}
+
+func (c *hardcodedFeatureGateAccess) InitialFeatureGatesObserved() chan struct{} {
+	return c.initialFeatureGatesObserved
+}
+
+func (c *hardcodedFeatureGateAccess) FeatureGatesHaveChangedSinceFirstObserved() chan struct{} {
+	return c.featureGatesHaveChangedSinceFirstObserved
+}
+
+func (c *hardcodedFeatureGateAccess) AreInitialFeatureGatesObserved() bool {
+	select {
+	case <-c.InitialFeatureGatesObserved():
+		return true
+	default:
+		return false
+	}
+}
+
+func (c *hardcodedFeatureGateAccess) CurrentFeatureGates() ([]configv1.FeatureGateName, []configv1.FeatureGateName, error) {
+	return c.enabled, c.disabled, c.readErr
+}


### PR DESCRIPTION
For https://github.com/openshift/enhancements/pull/1373

Part 2 of a multi-step plan to make individual featuregates observable via the API. This was previously avoided because when featuregates get promoted from TechPreview to Default, during an upgrade, an old operator may try to enable a TechPreview variant of a feature.

This can be addressed by keying the featuregates by version. Let's see how ugly that will be in practice now that we have a decent build-out of library-go.

Unit tests are still owed.  Proof is still owed.  cluster-config-operator controller is still owed.

/hold

This is proving the concept, not to be merged until it shows as working end-to-end.

Other steps include

1. cluster-config-operator (upgrades first) writing the new featuregate
2. enhancements write up describing how it works end to end.

/assign @JoelSpeed 