### PR TITLE
Fix test-e2e-encryption rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,10 @@ verify-podnetworkconnectivitychecks:
 	$(MAKE) -C pkg/operator/connectivitycheckcontroller verify
 
 test-e2e-encryption: GO_TEST_PACKAGES :=./test/e2e-encryption/...
+test-e2e-encryption: GO_TEST_FLAGS += -v
+test-e2e-encryption: GO_TEST_FLAGS += -timeout 4h
+test-e2e-encryption: GO_TEST_FLAGS += -p 1
+test-e2e-encryption: test-unit
 .PHONY: test-e2e-encryption
 
 test-e2e-monitoring:

--- a/test/e2e-encryption/encryption_test.go
+++ b/test/e2e-encryption/encryption_test.go
@@ -382,7 +382,7 @@ func TestEncryptionIntegration(tt *testing.T) {
 }
 
 const encryptionTestOperatorCRD = `
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: encryptiontests.operator.openshift.io

--- a/test/e2e-encryption/encryption_test.go
+++ b/test/e2e-encryption/encryption_test.go
@@ -26,12 +26,14 @@ import (
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/utils/clock"
 	"sigs.k8s.io/yaml"
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	configv1clientfake "github.com/openshift/client-go/config/clientset/versioned/fake"
 	configv1informers "github.com/openshift/client-go/config/informers/externalversions"
+	applyoperatorv1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
 
 	"github.com/openshift/library-go/pkg/operator/encryption"
 	"github.com/openshift/library-go/pkg/operator/encryption/controllers"
@@ -82,7 +84,14 @@ func TestEncryptionIntegration(tt *testing.T) {
 	// create operator client and create instance with ManagementState="Managed"
 	operatorGVR := schema.GroupVersionResource{Group: operatorCRD.Spec.Group, Version: "v1", Resource: operatorCRD.Spec.Names.Plural}
 	operatorv1.GroupVersion.WithResource("encryptiontests")
-	operatorClient, operatorInformer, err := genericoperatorclient.NewClusterScopedOperatorClient(kubeConfig, operatorGVR)
+	operatorClient, operatorInformer, err := genericoperatorclient.NewClusterScopedOperatorClient(
+		clock.RealClock{},
+		kubeConfig,
+		operatorGVR,
+		operatorv1.GroupVersion.WithKind("EncryptionTest"),
+		extractOperatorSpec,
+		extractOperatorStatus,
+	)
 	dynamicClient, err := dynamic.NewForConfig(kubeConfig)
 	require.NoError(t, err)
 	err = wait.PollImmediate(time.Second, wait.ForeverTestTimeout, func() (bool, error) {
@@ -627,4 +636,12 @@ func (p *provider) EncryptedGRs() []schema.GroupResource {
 
 func (p *provider) ShouldRunEncryptionControllers() (bool, error) {
 	return true, nil
+}
+
+func extractOperatorSpec(obj *unstructured.Unstructured, fieldManager string) (*applyoperatorv1.OperatorSpecApplyConfiguration, error) {
+	return applyoperatorv1.OperatorSpec(), nil
+}
+
+func extractOperatorStatus(obj *unstructured.Unstructured, fieldManager string) (*applyoperatorv1.OperatorStatusApplyConfiguration, error) {
+	return applyoperatorv1.OperatorStatus(), nil
 }


### PR DESCRIPTION
The test-e2e-encryption rule was broken which caused the `e2e-aws-encryption` CI job to not do anything. For instance, if we look at the [job logs](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_library-go/1469/pull-ci-openshift-library-go-master-e2e-aws-encryption/1626266910360342528/artifacts/e2e-aws-encryption/test/build-log.txt), the `make test-e2e-encryption` invocation is yielding the following error:
```
make: Nothing to be done for 'test-e2e-encryption'.
```

The intended way to run these test seem to call the `test-unit` rule from build-machinery: https://github.com/openshift/build-machinery-go/blob/bd58a901bbfeb5f63f027cfaa35de4863bb535fb/make/targets/golang/test-unit.mk#L5-L13. And that is what we are doing today in cluster-kube-apiserver-operator: https://github.com/openshift/cluster-kube-apiserver-operator/blob/master/Makefile#L39-L60.

Alongside this fix, I also added the flags that we are setting in the kas-operator repo as they seem to be a good fit for this test aswell.