### PR TITLE
Notice the notFound err

### DIFF
--- a/pkg/operator/resourcesynccontroller/core.go
+++ b/pkg/operator/resourcesynccontroller/core.go
@@ -18,9 +18,6 @@ func CombineCABundleConfigMaps(destinationConfigMap ResourceLocation, lister cor
 	certificates := []*x509.Certificate{}
 	for _, input := range inputConfigMaps {
 		inputConfigMap, err := lister.ConfigMaps(input.Namespace).Get(input.Name)
-		if apierrors.IsNotFound(err) {
-			continue
-		}
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**1 bug description**
when resourcesynccontroller miss key configmap in CombineCABundleConfigMaps, and err is notFound, it will continue and ignore this failure, this will cause the caller func generate wrong configurations

**2 related issues**:

**more information, please read the following issues**
[# issue 702 openshift/cluster-kube-controller-manager-operator kube-controller-manager rootCA miss key conf](https://github.com/openshift/cluster-kube-controller-manager-operator/issues/702)

[# issue 1472 github.com/openshift/library-go  missing key configmap](https://github.com/openshift/library-go/issues/1472)