### PR TITLE
Fix key migration never completing in encryption tests

### DIFF
--- a/test/library/encryption/helpers.go
+++ b/test/library/encryption/helpers.go
@@ -174,7 +174,8 @@ func WaitForNextMigratedKey(t testing.TB, kubeClient kubernetes.Interface, prevK
 		}
 
 		if currentKeyMeta.Name == nextKeyName {
-			if len(prevKeyMeta.Migrated) == len(currentKeyMeta.Migrated) {
+			if (len(prevKeyMeta.Migrated) == len(currentKeyMeta.Migrated)) ||
+				(len(prevKeyMeta.Name) == 0 && len(currentKeyMeta.Migrated) > 0) {
 				for _, expectedGR := range prevKeyMeta.Migrated {
 					if !hasResource(expectedGR, prevKeyMeta.Migrated) {
 						return false, nil


### PR DESCRIPTION
There is a bug in the TestEncryptionTypeAESCBC test where the first
migration will never be counted as completed.
This is because the test checks the completion of the migration based on
the fact that the migrated resources for the previous key are the same
as the migrated resources of the current (desired) key. However, when
going from no key to aescbc for example, the first key doesn't have any
migrated resources since it didn't encrypt anything and as such the test
becomes stuck until a new migration is requested which in most test
cases never happens.