### PR TITLE
[release-4.10] OCPBUGS-8235: Guard controller: set the readiness probe endpoint explicitly

### DIFF
--- a/pkg/operator/staticpod/controller/guard/bindata/bindata.go
+++ b/pkg/operator/staticpod/controller/guard/bindata/bindata.go
@@ -98,7 +98,7 @@ spec:
         failureThreshold: 3
         httpGet:
           host: # Value set by operator
-          path: healthz
+          path: # Value set by operator
           port: # Value set by operator
           scheme: HTTPS
         periodSeconds: 5

--- a/pkg/operator/staticpod/controller/guard/guard_controller.go
+++ b/pkg/operator/staticpod/controller/guard/guard_controller.go
@@ -41,6 +41,7 @@ type GuardController struct {
 	targetNamespace, podResourcePrefix string
 	operatorName                       string
 	readyzPort                         string
+	readyzEndpoint                     string
 	operandPodLabelSelector            labels.Selector
 
 	nodeLister corelisterv1.NodeLister
@@ -60,6 +61,7 @@ func NewGuardController(
 	podResourcePrefix string,
 	operatorName string,
 	readyzPort string,
+	readyzEndpoint string,
 	kubeInformersForTargetNamespace informers.SharedInformerFactory,
 	kubeInformersClusterScoped informers.SharedInformerFactory,
 	operatorClient operatorv1helpers.StaticPodOperatorClient,
@@ -81,6 +83,7 @@ func NewGuardController(
 		podResourcePrefix:       podResourcePrefix,
 		operatorName:            operatorName,
 		readyzPort:              readyzPort,
+		readyzEndpoint:          readyzEndpoint,
 		nodeLister:              kubeInformersClusterScoped.Core().V1().Nodes().Lister(),
 		podLister:               kubeInformersForTargetNamespace.Core().V1().Pods().Lister(),
 		podGetter:               podGetter,
@@ -290,6 +293,7 @@ func (c *GuardController) sync(ctx context.Context, syncCtx factory.SyncContext)
 				panic(err)
 			}
 			pod.Spec.Containers[0].ReadinessProbe.HTTPGet.Port = intstr.FromInt(readyzPort)
+			pod.Spec.Containers[0].ReadinessProbe.HTTPGet.Path = c.readyzEndpoint
 
 			actual, err := c.podGetter.Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
 			if err == nil {
@@ -301,6 +305,14 @@ func (c *GuardController) sync(ctx context.Context, syncCtx factory.SyncContext)
 				}
 				if actual.Spec.Containers[0].ReadinessProbe.HTTPGet.Host != pod.Spec.Containers[0].ReadinessProbe.HTTPGet.Host {
 					klog.V(5).Infof("Operand PodIP changed, deleting %v so the guard can be re-created", pod.Name)
+					delete = true
+				}
+				if actual.Spec.Containers[0].ReadinessProbe.HTTPGet.Port.String() != pod.Spec.Containers[0].ReadinessProbe.HTTPGet.Port.String() {
+					klog.V(5).Infof("Guard readinessProbe port changed, deleting %v so the guard can be re-created", pod.Name)
+					delete = true
+				}
+				if actual.Spec.Containers[0].ReadinessProbe.HTTPGet.Path != pod.Spec.Containers[0].ReadinessProbe.HTTPGet.Path {
+					klog.V(5).Infof("Guard readinessProbe path changed, deleting %v so the guard can be re-created", pod.Name)
 					delete = true
 				}
 				if actual.Spec.Hostname != pod.Spec.Hostname {

--- a/pkg/operator/staticpod/controller/guard/manifests/guard-pod.yaml
+++ b/pkg/operator/staticpod/controller/guard/manifests/guard-pod.yaml
@@ -41,7 +41,7 @@ spec:
         failureThreshold: 3
         httpGet:
           host: # Value set by operator
-          path: healthz
+          path: # Value set by operator
           port: # Value set by operator
           scheme: HTTPS
         periodSeconds: 5

--- a/pkg/operator/staticpod/controllers.go
+++ b/pkg/operator/staticpod/controllers.go
@@ -69,6 +69,7 @@ type staticPodOperatorControllerBuilder struct {
 	operatorName               string
 	operatorNamespace          string
 	readyzPort                 string
+	readyzEndpoint             string
 	guardCreateConditionalFunc func() (bool, bool, error)
 }
 
@@ -99,7 +100,7 @@ type Builder interface {
 	// the installer pod is created for a revision.
 	WithCustomInstaller(command []string, installerPodMutationFunc installer.InstallerPodMutationFunc) Builder
 	WithPruning(command []string, staticPodPrefix string) Builder
-	WithPodDisruptionBudgetGuard(operatorNamespace, operatorName, readyzPort string, createConditionalFunc func() (bool, bool, error)) Builder
+	WithPodDisruptionBudgetGuard(operatorNamespace, operatorName, readyzPort, readyzEndpoint string, createConditionalFunc func() (bool, bool, error)) Builder
 	ToControllers() (manager.ControllerManager, error)
 }
 
@@ -166,10 +167,11 @@ func (b *staticPodOperatorControllerBuilder) WithPruning(command []string, stati
 	return b
 }
 
-func (b *staticPodOperatorControllerBuilder) WithPodDisruptionBudgetGuard(operatorNamespace, operatorName, readyzPort string, createConditionalFunc func() (bool, bool, error)) Builder {
+func (b *staticPodOperatorControllerBuilder) WithPodDisruptionBudgetGuard(operatorNamespace, operatorName, readyzPort, readyzEndpoint string, createConditionalFunc func() (bool, bool, error)) Builder {
 	b.operatorNamespace = operatorNamespace
 	b.operatorName = operatorName
 	b.readyzPort = readyzPort
+	b.readyzEndpoint = readyzEndpoint
 	b.guardCreateConditionalFunc = createConditionalFunc
 	return b
 }
@@ -325,13 +327,14 @@ func (b *staticPodOperatorControllerBuilder) ToControllers() (manager.Controller
 	manager.WithController(unsupportedconfigoverridescontroller.NewUnsupportedConfigOverridesController(b.staticPodOperatorClient, eventRecorder), 1)
 	manager.WithController(loglevel.NewClusterOperatorLoggingController(b.staticPodOperatorClient, eventRecorder), 1)
 
-	if len(b.operatorNamespace) > 0 && len(b.operatorName) > 0 && len(b.readyzPort) > 0 {
+	if len(b.operatorNamespace) > 0 && len(b.operatorName) > 0 && len(b.readyzPort) > 0 && len(b.readyzEndpoint) > 0 {
 		if guardController, err := guard.NewGuardController(
 			b.operandNamespace,
 			b.operandPodLabelSelector,
 			b.staticPodName,
 			b.operatorName,
 			b.readyzPort,
+			b.readyzEndpoint,
 			operandInformers,
 			clusterInformers,
 			b.staticPodOperatorClient,


### PR DESCRIPTION
Building on top of https://github.com/openshift/library-go/pull/1478