### PR TITLE
Revert "Merge pull request #1477 from dgrisonnet/fix-encryption-test"

### DIFF
--- a/test/library/encryption/helpers.go
+++ b/test/library/encryption/helpers.go
@@ -174,8 +174,7 @@ func WaitForNextMigratedKey(t testing.TB, kubeClient kubernetes.Interface, prevK
 		}
 
 		if currentKeyMeta.Name == nextKeyName {
-			if (len(prevKeyMeta.Migrated) == len(currentKeyMeta.Migrated)) ||
-				(len(prevKeyMeta.Name) == 0 && len(currentKeyMeta.Migrated) > 0) {
+			if len(prevKeyMeta.Migrated) == len(currentKeyMeta.Migrated) {
 				for _, expectedGR := range prevKeyMeta.Migrated {
 					if !hasResource(expectedGR, prevKeyMeta.Migrated) {
 						return false, nil


### PR DESCRIPTION
This reverts commit 38724ca8e236fbd938f9c0b737b35c9d6f5091f6, reversing changes made to 4db74c34da22999cca8b30bbd5b52d0f408af731.

This patch was actually incorrect and introduced a bug in the test:
> Mar  2 16:23:34.132: ERROR: Wrong number of migrated resources for "encryption-key-openshift-kube-apiserver-1" key, expected 2, got 1

Looking at it again the scenario of a previous key not existing is correctly handled here: https://github.com/openshift/library-go/blob/master/test/library/encryption/helpers.go#L150-L153