### PR TITLE
[OCPCLOUD-1987] Migrate Azure to out of tree cloud provider

### DIFF
--- a/pkg/cloudprovider/external.go
+++ b/pkg/cloudprovider/external.go
@@ -25,13 +25,9 @@ func IsCloudProviderExternal(platformStatus *configv1.PlatformStatus, featureGat
 	case configv1.GCPPlatformType:
 		// Platforms that are external based on feature gate presence
 		return isExternalFeatureGateEnabled(featureGate)
-	case configv1.AzurePlatformType:
-		if isAzureStackHub(platformStatus) {
-			return true, nil
-		}
-		return isExternalFeatureGateEnabled(featureGate)
 	case configv1.AlibabaCloudPlatformType,
 		configv1.AWSPlatformType,
+		configv1.AzurePlatformType,
 		configv1.IBMCloudPlatformType,
 		configv1.KubevirtPlatformType,
 		configv1.NutanixPlatformType,
@@ -43,10 +39,6 @@ func IsCloudProviderExternal(platformStatus *configv1.PlatformStatus, featureGat
 		// Platforms that do not have external cloud providers implemented
 		return false, nil
 	}
-}
-
-func isAzureStackHub(platformStatus *configv1.PlatformStatus) bool {
-	return platformStatus.Azure != nil && platformStatus.Azure.CloudName == configv1.AzureStackCloud
 }
 
 // isExternalFeatureGateEnabled determines whether the ExternalCloudProvider feature gate is present in the current

--- a/pkg/operator/configobserver/cloudprovider/observe_cloudprovider_test.go
+++ b/pkg/operator/configobserver/cloudprovider/observe_cloudprovider_test.go
@@ -134,7 +134,7 @@ func TestObserveCloudProviderNames(t *testing.T) {
 				Type: configv1.AzurePlatformType,
 			},
 		},
-		expected:           "azure",
+		expected:           "external",
 		cloudProviderCount: 1,
 	}, {
 		name: "Azure platform set for external configuration",


### PR DESCRIPTION
This PR migrates the Azure cloud provider from in-tree to out-of-tree. It must be merged in tandem with the PR for KCMO and CCMO to avoid a build that contains one or the other operator PRs without the other. If either merges without the other, it will either lead to no cloud controllers or duplicate cloud controllers, either of which will not work well.
* [KCMO PR](https://github.com/openshift/cluster-kube-controller-manager-operator/pull/705)
* [CCMO PR](https://github.com/openshift/cluster-cloud-controller-manager-operator/pull/231)
* [Cluster Bot](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-origin-installer-launch-azure-modern/1633496854534557696)
* [Origin PR](https://github.com/openshift/origin/pull/27776)