### PR TITLE
[OCPCLOUD-1988] Migrate AWS to out of tree cloud provider

### DIFF
--- a/pkg/cloudprovider/external.go
+++ b/pkg/cloudprovider/external.go
@@ -22,8 +22,7 @@ func IsCloudProviderExternal(platformStatus *configv1.PlatformStatus, featureGat
 		return false, fmt.Errorf("platformStatus is required")
 	}
 	switch platformStatus.Type {
-	case configv1.AWSPlatformType,
-		configv1.GCPPlatformType:
+	case configv1.GCPPlatformType:
 		// Platforms that are external based on feature gate presence
 		return isExternalFeatureGateEnabled(featureGate)
 	case configv1.AzurePlatformType:
@@ -32,6 +31,7 @@ func IsCloudProviderExternal(platformStatus *configv1.PlatformStatus, featureGat
 		}
 		return isExternalFeatureGateEnabled(featureGate)
 	case configv1.AlibabaCloudPlatformType,
+		configv1.AWSPlatformType,
 		configv1.IBMCloudPlatformType,
 		configv1.KubevirtPlatformType,
 		configv1.NutanixPlatformType,

--- a/pkg/operator/configobserver/cloudprovider/observe_cloudprovider_test.go
+++ b/pkg/operator/configobserver/cloudprovider/observe_cloudprovider_test.go
@@ -104,7 +104,7 @@ func TestObserveCloudProviderNames(t *testing.T) {
 				Type: configv1.AWSPlatformType,
 			},
 		},
-		expected:           "aws",
+		expected:           "external",
 		cloudProviderCount: 1,
 	}, {
 		name: "AlibabaCloud Platform",


### PR DESCRIPTION
This PR migrates the AWS cloud provider from in-tree to out-of-tree. It must be merged in tandem with the PR for KCMO and CCMO to avoid a build that contains one or the other operator PRs without the other. If either merges without the other, it will either lead to no cloud controllers or duplicate cloud controllers, either of which will not work well.

Note the AWS cloud provider code has been removed from K8s in-tree in 1.27, this must merge in 4.14.

* [KCMO PR](https://github.com/openshift/cluster-kube-controller-manager-operator/pull/707)
* [CCMO PR](https://github.com/openshift/cluster-cloud-controller-manager-operator/pull/232)
* [Tested with Cluster Bot](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-origin-installer-launch-aws-modern/1633075931457261568)
* [Origin PR](https://github.com/openshift/origin/pull/27777)