### PR TITLE
OCPBUGS-8691: Allow CSI driver operators to override nodeSelector on HyperShift

### DIFF
--- a/pkg/operator/csi/csidrivercontrollerservicecontroller/csi_driver_controller_service_controller.go
+++ b/pkg/operator/csi/csidrivercontrollerservicecontroller/csi_driver_controller_service_controller.go
@@ -82,7 +82,7 @@ func NewCSIDriverControllerServiceController(
 	optionalManifestHooks = append(optionalManifestHooks, WithLeaderElectionReplacerHook(leConfig))
 
 	var deploymentHooks []dc.DeploymentHookFunc
-	deploymentHooks = append(deploymentHooks, optionalDeploymentHooks...)
 	deploymentHooks = append(deploymentHooks, WithControlPlaneTopologyHook(configInformer))
+	deploymentHooks = append(deploymentHooks, optionalDeploymentHooks...)
 	return dc.NewDeploymentController(name, manifest, recorder, operatorClient, kubeClient, deployInformer, optionalInformers, optionalManifestHooks, deploymentHooks...)
 }


### PR DESCRIPTION
`ControlPlaneTopologyHook` is currently always the last in CSIControllerSet and sets `nodeSelector=nil` on HyperShift. This does not allow CSI driver operators that run in Hypershift's hosted control plane to set their own `nodeSelector` that would match HostedControlPlane CR.

Inspired by https://github.com/openshift/vmware-vsphere-csi-driver-operator/pull/93

Set the hook as the first one, so subsequent hooks can add their own node selector.