### PR TITLE
Revert "Migrate Azure to out of tree cloud provider"

### DIFF
--- a/pkg/cloudprovider/external.go
+++ b/pkg/cloudprovider/external.go
@@ -25,9 +25,13 @@ func IsCloudProviderExternal(platformStatus *configv1.PlatformStatus, featureGat
 	case configv1.GCPPlatformType:
 		// Platforms that are external based on feature gate presence
 		return isExternalFeatureGateEnabled(featureGate)
+	case configv1.AzurePlatformType:
+		if isAzureStackHub(platformStatus) {
+			return true, nil
+		}
+		return isExternalFeatureGateEnabled(featureGate)
 	case configv1.AlibabaCloudPlatformType,
 		configv1.AWSPlatformType,
-		configv1.AzurePlatformType,
 		configv1.IBMCloudPlatformType,
 		configv1.KubevirtPlatformType,
 		configv1.NutanixPlatformType,
@@ -39,6 +43,10 @@ func IsCloudProviderExternal(platformStatus *configv1.PlatformStatus, featureGat
 		// Platforms that do not have external cloud providers implemented
 		return false, nil
 	}
+}
+
+func isAzureStackHub(platformStatus *configv1.PlatformStatus) bool {
+	return platformStatus.Azure != nil && platformStatus.Azure.CloudName == configv1.AzureStackCloud
 }
 
 // isExternalFeatureGateEnabled determines whether the ExternalCloudProvider feature gate is present in the current

--- a/pkg/operator/configobserver/cloudprovider/observe_cloudprovider_test.go
+++ b/pkg/operator/configobserver/cloudprovider/observe_cloudprovider_test.go
@@ -134,7 +134,7 @@ func TestObserveCloudProviderNames(t *testing.T) {
 				Type: configv1.AzurePlatformType,
 			},
 		},
-		expected:           "external",
+		expected:           "azure",
 		cloudProviderCount: 1,
 	}, {
 		name: "Azure platform set for external configuration",


### PR DESCRIPTION
This reverts commit 3706d32a00d0cb0ed02d92f1789960440903dd4a.

Revert of https://github.com/openshift/library-go/pull/1484 to compare impact related to OCPBUGS-11308