### PR TITLE
OCPBUGS-2765: don't log jwt tokens

### DIFF
--- a/pkg/operator/apiserver/audit/manifests/allrequestbodies-rules.yaml
+++ b/pkg/operator/apiserver/audit/manifests/allrequestbodies-rules.yaml
@@ -3,10 +3,10 @@
   resources:
   - group: "route.openshift.io"
     resources: ["routes", "routes/status"]
-  - resources: ["secrets"]
+  - resources: ["secrets", "serviceaccounts/token"]
   - group: "authentication.k8s.io"
     resources: ["tokenreviews", "tokenrequests"]
   - group: "oauth.openshift.io"
-    resources: ["oauthclients"]
+    resources: ["oauthclients", "tokenreviews"]
 # catch-all rule to log all other requests with request and response payloads
 - level: RequestResponse

--- a/pkg/operator/apiserver/audit/manifests/writerequestbodies-rules.yaml
+++ b/pkg/operator/apiserver/audit/manifests/writerequestbodies-rules.yaml
@@ -3,11 +3,11 @@
   resources:
   - group: "route.openshift.io"
     resources: ["routes", "routes/status"]
-  - resources: ["secrets"]
+  - resources: ["secrets", "serviceaccounts/token"]
   - group: "authentication.k8s.io"
     resources: ["tokenreviews", "tokenrequests"]
   - group: "oauth.openshift.io"
-    resources: ["oauthclients"]
+    resources: ["oauthclients", "tokenreviews"]
 # log request and response payloads for all write requests
 - level: RequestResponse
   verbs:

--- a/pkg/operator/apiserver/audit/testdata/allrequestbodies.yaml
+++ b/pkg/operator/apiserver/audit/testdata/allrequestbodies.yaml
@@ -33,10 +33,10 @@ rules:
   resources:
   - group: "route.openshift.io"
     resources: ["routes","routes/status"]
-  - resources: ["secrets"]
+  - resources: ["secrets", "serviceaccounts/token"]
   - group: "authentication.k8s.io"
     resources: ["tokenreviews", "tokenrequests"]
   - group: "oauth.openshift.io"
-    resources: ["oauthclients"]
+    resources: ["oauthclients", "tokenreviews"]
 # catch-all rule to log all other requests with request and response payloads
 - level: RequestResponse

--- a/pkg/operator/apiserver/audit/testdata/multipleCr.yaml
+++ b/pkg/operator/apiserver/audit/testdata/multipleCr.yaml
@@ -33,11 +33,11 @@ rules:
   resources:
   - group: "route.openshift.io"
     resources: ["routes", "routes/status"]
-  - resources: ["secrets"]
+  - resources: ["secrets", "serviceaccounts/token"]
   - group: "authentication.k8s.io"
     resources: ["tokenreviews", "tokenrequests"]
   - group: "oauth.openshift.io"
-    resources: ["oauthclients"]
+    resources: ["oauthclients", "tokenreviews"]
   userGroups:
   - system:authenticated:oauth
 # log request and response payloads for all write requests
@@ -63,11 +63,11 @@ rules:
   resources:
     - group: "route.openshift.io"
       resources: ["routes", "routes/status"]
-    - resources: ["secrets"]
+    - resources: ["secrets", serviceaccounts/token]
     - group: "authentication.k8s.io"
       resources: ["tokenreviews", "tokenrequests"]
     - group: "oauth.openshift.io"
-      resources: ["oauthclients"]
+      resources: ["oauthclients", "tokenreviews"]
   userGroups:
     - system:authenticated
 - level: RequestResponse

--- a/pkg/operator/apiserver/audit/testdata/oauth.yaml
+++ b/pkg/operator/apiserver/audit/testdata/oauth.yaml
@@ -33,11 +33,11 @@ rules:
   resources:
   - group: "route.openshift.io"
     resources: ["routes", "routes/status"]
-  - resources: ["secrets"]
+  - resources: ["secrets", "serviceaccounts/token"]
   - group: "authentication.k8s.io"
     resources: ["tokenreviews", "tokenrequests"]
   - group: "oauth.openshift.io"
-    resources: ["oauthclients"]
+    resources: ["oauthclients", "tokenreviews"]
   userGroups:
   - system:authenticated:oauth
 # log request and response payloads for all write requests

--- a/pkg/operator/apiserver/audit/testdata/writerequestbodies.yaml
+++ b/pkg/operator/apiserver/audit/testdata/writerequestbodies.yaml
@@ -33,11 +33,11 @@ rules:
   resources:
   - group: "route.openshift.io"
     resources: ["routes", "routes/status"]
-  - resources: ["secrets"]
+  - resources: ["secrets", "serviceaccounts/token"]
   - group: "authentication.k8s.io"
     resources: ["tokenreviews", "tokenrequests"]
   - group: "oauth.openshift.io"
-    resources: ["oauthclients"]
+    resources: ["oauthclients", "tokenreviews"]
 # log request and response payloads for all write requests
 - level: RequestResponse
   verbs:


### PR DESCRIPTION
# What

Don't audit-log jwt tokens (pre-SHA'ed).

# Why

- the **kube-apiserver** logs `serviceaccounts/token`.
- The **oauth-apiserver** logs `tokenreviews` from `oauth.openshift.io`.
  - I couldn't find `tokenrequests` from `oauth.openshift.io`, but added it anyway.

# Note

I couldn't find any references to `tokenreviews` from `oauth.openshift.io`.
Should we be worried about that?

## Matching attributes for `RequestResponse`

### kube-apiserver

```yaml
User: &{system:node:$NODE_NAME [system:nodes system:authenticated] map[]}
Verb: create
IsReadOnly: false
Namespace: openshift-cluster-csi-drivers
Resource: serviceaccounts
Subresource: token
Name: gcp-pd-csi-driver-operator
APIGroup: 
APIVersion: v1
IsResourceRequest: true
Path: /api/v1/namespaces/openshift-cluster-csi-drivers/serviceaccounts/gcp-pd-csi-driver-operator/token
```

### oauth-apiserver

```yaml
User: &{system:serviceaccount:openshift-oauth-apiserver:openshift-authenticator  [system:authenticated] map[]}
Verb: create
IsReadOnly: false
Namespace: 
Resource: tokenreviews
Subresource: 
Name: 
APIGroup: oauth.openshift.io
APIVersion: v1
IsResourceRequest: true
Path: /apis/oauth.openshift.io/v1/tokenreviews
```