### PR TITLE
Handle new tls.CertificateVerificationError type in Go 1.20

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.19-openshift-4.13
+  tag: rhel-8-release-golang-1.20-openshift-4.14

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/library-go
 
-go 1.19
+go 1.20
 
 require (
 	github.com/RangelReale/osincli v0.0.0-20160924135400-fababb0555f2


### PR DESCRIPTION
In Go 1.20, x509 certificates are embedded into new `tls.CertificateVerificationError` type. But currently, request_token in origin only relies onx509 certificates and when Go version is bumped to 1.20, this will no longer be a valid case. That's why, this PR also handles `tls.CertificateVerificationError` as well as other x509 certificates whose are necessary for the backwards compatibility.

But since new type only exists in Go 1.20, this PR should also bump origin images to Go 1.20.