### PR TITLE
tokenrequest: add webconsoleurl to basicauth challenger

### DIFF
--- a/pkg/oauth/tokenrequest/challengehandlers/basicauth.go
+++ b/pkg/oauth/tokenrequest/challengehandlers/basicauth.go
@@ -26,7 +26,7 @@ func NewBasicAuthNoUsernameError() error {
 }
 
 func NewBasicChallengeHandler(
-	host string,
+	host, consoleURL string,
 	reader io.Reader,
 	writer io.Writer,
 	passwordPrompter PasswordPrompter,
@@ -34,6 +34,7 @@ func NewBasicChallengeHandler(
 ) *BasicChallengeHandler {
 	return &BasicChallengeHandler{
 		Host:             host,
+		WebConsoleURL:    consoleURL,
 		Reader:           reader,
 		Writer:           writer,
 		passwordPrompter: passwordPrompter,
@@ -47,6 +48,9 @@ func NewBasicChallengeHandler(
 type BasicChallengeHandler struct {
 	// Host is the server being authenticated to. Used only for displaying messages when prompting for username/password
 	Host string
+
+	// WebConsoleURL is an optional URL to a web interface where the user might go if they prefer login from the browser instead
+	WebConsoleURL string
 
 	// Reader is used to prompt for username/password. If nil, no prompting is done
 	Reader io.Reader
@@ -105,6 +109,10 @@ func (c *BasicChallengeHandler) HandleChallenge(requestURL string, headers http.
 		w := c.Writer
 		if w == nil {
 			w = os.Stdout
+		}
+
+		if len(c.WebConsoleURL) > 0 {
+			fmt.Fprintf(w, "Console URL: %s/console\n", c.WebConsoleURL)
 		}
 
 		if _, realm := basicRealm(headers); len(realm) > 0 {

--- a/pkg/oauth/tokenrequest/request_token_test.go
+++ b/pkg/oauth/tokenrequest/request_token_test.go
@@ -149,7 +149,7 @@ func TestRequestToken(t *testing.T) {
 
 		// Prompting basic handler
 		"prompting basic handler, no challenge, success": {
-			Handler: challengehandlers.NewBasicChallengeHandler("", bytes.NewBufferString("mypassword\n"), nil, &testPasswordPrompter{}, "myuser", ""),
+			Handler: challengehandlers.NewBasicChallengeHandler("", "", bytes.NewBufferString("mypassword\n"), nil, &testPasswordPrompter{}, "myuser", ""),
 			Requests: []requestResponse{
 				{initialHead, initialHeadResp},
 				{initialRequest, success},
@@ -157,7 +157,7 @@ func TestRequestToken(t *testing.T) {
 			ExpectedToken: successfulToken,
 		},
 		"prompting basic handler, basic challenge, success": {
-			Handler: challengehandlers.NewBasicChallengeHandler("", bytes.NewBufferString("mypassword\n"), nil, &testPasswordPrompter{}, "myuser", ""),
+			Handler: challengehandlers.NewBasicChallengeHandler("", "", bytes.NewBufferString("mypassword\n"), nil, &testPasswordPrompter{}, "myuser", ""),
 			Requests: []requestResponse{
 				{initialHead, initialHeadResp},
 				{initialRequest, basicChallenge1},
@@ -166,7 +166,7 @@ func TestRequestToken(t *testing.T) {
 			ExpectedToken: successfulToken,
 		},
 		"prompting basic handler, basic+negotiate challenge, success": {
-			Handler: challengehandlers.NewBasicChallengeHandler("", bytes.NewBufferString("mypassword\n"), nil, &testPasswordPrompter{}, "myuser", ""),
+			Handler: challengehandlers.NewBasicChallengeHandler("", "", bytes.NewBufferString("mypassword\n"), nil, &testPasswordPrompter{}, "myuser", ""),
 			Requests: []requestResponse{
 				{initialHead, initialHeadResp},
 				{initialRequest, doubleChallenge},
@@ -175,7 +175,7 @@ func TestRequestToken(t *testing.T) {
 			ExpectedToken: successfulToken,
 		},
 		"prompting basic handler, basic challenge, failure": {
-			Handler: challengehandlers.NewBasicChallengeHandler("", nil, nil, &testPasswordPrompter{}, "myuser", ""),
+			Handler: challengehandlers.NewBasicChallengeHandler("", "", nil, nil, &testPasswordPrompter{}, "myuser", ""),
 			Requests: []requestResponse{
 				{initialHead, initialHeadResp},
 				{initialRequest, basicChallenge1},
@@ -184,7 +184,7 @@ func TestRequestToken(t *testing.T) {
 			ExpectedError: "challenger chose not to retry the request",
 		},
 		"prompting basic handler, negotiate challenge, failure": {
-			Handler: challengehandlers.NewBasicChallengeHandler("", bytes.NewBufferString("myuser\nmypassword\n"), nil, &testPasswordPrompter{}, "myuser", ""),
+			Handler: challengehandlers.NewBasicChallengeHandler("", "", bytes.NewBufferString("myuser\nmypassword\n"), nil, &testPasswordPrompter{}, "myuser", ""),
 			Requests: []requestResponse{
 				{initialHead, initialHeadResp},
 				{initialRequest, negotiateChallenge1},


### PR DESCRIPTION
This is to sync the lib-go code with what's in oc.

xref https://github.com/openshift/oc/pull/991