### PR TITLE
add mechanism to read previously rendered manifests during rendering

### DIFF
--- a/pkg/operator/render/options/config.go
+++ b/pkg/operator/render/options/config.go
@@ -1,5 +1,12 @@
 package options
 
+import (
+	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
+)
+
 // ManifestConfig is a struct of values to be used in manifest templates.
 type ManifestConfig struct {
 	// ConfigHostPath is a host path mounted into the controller manager pods to hold the config file.
@@ -34,9 +41,50 @@ type FileConfig struct {
 
 	// Assets holds the loaded assets like certs and keys.
 	Assets map[string][]byte
+
+	// RenderedManifests are the files, content, and (optionally) decoded objects that were passed to the command
+	// as already present to be created by cluster-bootstrap.
+	RenderedManifests []RenderedManifest
+}
+
+type RenderedManifest struct {
+	OriginalFilename string
+	Content          []byte
+
+	// use GetDecodedObj to access
+	decodedObj runtime.Object
 }
 
 type TemplateData struct {
 	ManifestConfig
 	FileConfig
+}
+
+func (c *FileConfig) ListManifestOfType(gvk schema.GroupVersionKind) []RenderedManifest {
+	ret := []RenderedManifest{}
+	for i := range c.RenderedManifests {
+		obj, err := c.RenderedManifests[i].GetDecodedObj()
+		if err != nil {
+			klog.Warningf("failure to read %q: %v", c.RenderedManifests[i].OriginalFilename, err)
+			continue
+		}
+		if obj.GetObjectKind().GroupVersionKind() == gvk {
+			ret = append(ret, c.RenderedManifests[i])
+		}
+	}
+
+	return ret
+}
+
+func (c *RenderedManifest) GetDecodedObj() (runtime.Object, error) {
+	if c.decodedObj != nil {
+		return c.decodedObj, nil
+	}
+	obj, err := resourceread.ReadGenericWithUnstructured(c.Content)
+	if err != nil {
+		return nil, err
+	}
+	c.decodedObj = obj
+
+	return c.decodedObj, nil
 }

--- a/pkg/operator/resource/resourceread/generic.go
+++ b/pkg/operator/resource/resourceread/generic.go
@@ -20,6 +20,7 @@ var (
 )
 
 func init() {
+	utilruntime.Must(api.Install(genericScheme))
 	utilruntime.Must(api.InstallKube(genericScheme))
 	utilruntime.Must(apiextensionsv1beta1.AddToScheme(genericScheme))
 	utilruntime.Must(apiextensionsv1.AddToScheme(genericScheme))


### PR DESCRIPTION
This will make it easier to consume input from previous steps to do things like read featuregates.

/hold

holding for proof in cluster-config-operator.