### PR TITLE
Add FeatureGateAccess for reading from a static FeatureGate object

### DIFF
--- a/pkg/operator/configobserver/featuregates/hardcoded_featuregate_reader.go
+++ b/pkg/operator/configobserver/featuregates/hardcoded_featuregate_reader.go
@@ -2,6 +2,7 @@ package featuregates
 
 import (
 	"context"
+	"fmt"
 
 	configv1 "github.com/openshift/api/config/v1"
 )
@@ -62,4 +63,16 @@ func (c *hardcodedFeatureGateAccess) AreInitialFeatureGatesObserved() bool {
 
 func (c *hardcodedFeatureGateAccess) CurrentFeatureGates() ([]configv1.FeatureGateName, []configv1.FeatureGateName, error) {
 	return c.enabled, c.disabled, c.readErr
+}
+
+// NewHardcodedFeatureGateAccessFromFeatureGate returns a FeatureGateAccess that is static and initialised from
+// a populated FeatureGate status.
+// If the desired version is missing, this will return an error.
+func NewHardcodedFeatureGateAccessFromFeatureGate(featureGate *configv1.FeatureGate, desiredVersion string) (FeatureGateAccess, error) {
+	features, err := featuresFromFeatureGate(featureGate, desiredVersion)
+	if err != nil {
+		return nil, fmt.Errorf("unable to determine features: %w", err)
+	}
+
+	return NewHardcodedFeatureGateAccess(features.Enabled, features.Disabled), nil
 }


### PR DESCRIPTION
In MCO, I need to be able to read a rendered `FeatureGate` from disk, and understand what the desired features are for the current version.

This wraps the hardcoded accessor with a function that extracts the data from the `FeatureGate.Status`, which should allow render stage operators to read from the installer generated features