### PR TITLE
add IsKnown to featuregate for convenience

### DIFF
--- a/pkg/operator/configobserver/featuregates/featuregate.go
+++ b/pkg/operator/configobserver/featuregates/featuregate.go
@@ -13,6 +13,8 @@ type FeatureGate interface {
 	Enabled(key configv1.FeatureGateName) bool
 	// KnownFeatures returns a slice of strings describing the FeatureGate's known features.
 	KnownFeatures() []configv1.FeatureGateName
+	// IsKnown returns a true when the feature is known
+	IsKnown(configv1.FeatureGateName) bool
 }
 
 type featureGate struct {
@@ -44,4 +46,15 @@ func (f *featureGate) KnownFeatures() []configv1.FeatureGateName {
 	allKnown.Insert(FeatureGateNamesToStrings(f.disabled.UnsortedList())...)
 
 	return StringsToFeatureGateNames(allKnown.List())
+}
+
+func (f *featureGate) IsKnown(feature configv1.FeatureGateName) bool {
+	if f.enabled.Has(feature) {
+		return true
+	}
+	if f.disabled.Has(feature) {
+		return true
+	}
+
+	return false
 }


### PR DESCRIPTION
This would clean up some consuming code.  

@gnufied @JoelSpeed 

The argument I see against is that we should never try to read a value that doesn't exist, so we shouldn't make it easy. This is only logically needed during a transition.

/hold

will probably close, but wanted to make the reasoning explicit.