### PR TITLE
[release-4.10] OCPBUGS-13342: don't log jwt tokens

### DIFF
--- a/pkg/operator/apiserver/audit/manifests/allrequestbodies-rules.yaml
+++ b/pkg/operator/apiserver/audit/manifests/allrequestbodies-rules.yaml
@@ -3,10 +3,10 @@
   resources:
   - group: "route.openshift.io"
     resources: ["routes", "routes/status"]
-  - resources: ["secrets"]
+  - resources: ["secrets", "serviceaccounts/token"]
   - group: "authentication.k8s.io"
     resources: ["tokenreviews", "tokenrequests"]
   - group: "oauth.openshift.io"
-    resources: ["oauthclients"]
+    resources: ["oauthclients", "tokenreviews"]
 # catch-all rule to log all other requests with request and response payloads
 - level: RequestResponse

--- a/pkg/operator/apiserver/audit/manifests/allrequestbodies-rules.yaml
+++ b/pkg/operator/apiserver/audit/manifests/allrequestbodies-rules.yaml
@@ -4,8 +4,8 @@
   - group: "route.openshift.io"
     resources: ["routes", "routes/status"]
   - resources: ["secrets"]
-- level: Metadata
-  resources:
+  - group: "authentication.k8s.io"
+    resources: ["tokenreviews", "tokenrequests"]
   - group: "oauth.openshift.io"
     resources: ["oauthclients"]
 # catch-all rule to log all other requests with request and response payloads

--- a/pkg/operator/apiserver/audit/manifests/writerequestbodies-rules.yaml
+++ b/pkg/operator/apiserver/audit/manifests/writerequestbodies-rules.yaml
@@ -3,11 +3,11 @@
   resources:
   - group: "route.openshift.io"
     resources: ["routes", "routes/status"]
-  - resources: ["secrets"]
+  - resources: ["secrets", "serviceaccounts/token"]
   - group: "authentication.k8s.io"
     resources: ["tokenreviews", "tokenrequests"]
   - group: "oauth.openshift.io"
-    resources: ["oauthclients"]
+    resources: ["oauthclients", "tokenreviews"]
 # log request and response payloads for all write requests
 - level: RequestResponse
   verbs:

--- a/pkg/operator/apiserver/audit/manifests/writerequestbodies-rules.yaml
+++ b/pkg/operator/apiserver/audit/manifests/writerequestbodies-rules.yaml
@@ -4,8 +4,8 @@
   - group: "route.openshift.io"
     resources: ["routes", "routes/status"]
   - resources: ["secrets"]
-- level: Metadata
-  resources:
+  - group: "authentication.k8s.io"
+    resources: ["tokenreviews", "tokenrequests"]
   - group: "oauth.openshift.io"
     resources: ["oauthclients"]
 # log request and response payloads for all write requests

--- a/pkg/operator/apiserver/audit/testdata/allrequestbodies.yaml
+++ b/pkg/operator/apiserver/audit/testdata/allrequestbodies.yaml
@@ -33,10 +33,10 @@ rules:
   resources:
   - group: "route.openshift.io"
     resources: ["routes", "routes/status"]
-  - resources: ["secrets"]
+  - resources: ["secrets", "serviceaccounts/token"]
   - group: "authentication.k8s.io"
     resources: ["tokenreviews", "tokenrequests"]
   - group: "oauth.openshift.io"
-    resources: ["oauthclients"]
+    resources: ["oauthclients", "tokenreviews"]
 # catch-all rule to log all other requests with request and response payloads
 - level: RequestResponse

--- a/pkg/operator/apiserver/audit/testdata/allrequestbodies.yaml
+++ b/pkg/operator/apiserver/audit/testdata/allrequestbodies.yaml
@@ -34,8 +34,8 @@ rules:
   - group: "route.openshift.io"
     resources: ["routes", "routes/status"]
   - resources: ["secrets"]
-- level: Metadata
-  resources:
+  - group: "authentication.k8s.io"
+    resources: ["tokenreviews", "tokenrequests"]
   - group: "oauth.openshift.io"
     resources: ["oauthclients"]
 # catch-all rule to log all other requests with request and response payloads

--- a/pkg/operator/apiserver/audit/testdata/multipleCr.yaml
+++ b/pkg/operator/apiserver/audit/testdata/multipleCr.yaml
@@ -33,11 +33,11 @@ rules:
   resources:
   - group: "route.openshift.io"
     resources: ["routes", "routes/status"]
-  - resources: ["secrets"]
+  - resources: ["secrets", "serviceaccounts/token"]
   - group: "authentication.k8s.io"
     resources: ["tokenreviews", "tokenrequests"]
   - group: "oauth.openshift.io"
-    resources: ["oauthclients"]
+    resources: ["oauthclients", "tokenreviews"]
   userGroups:
   - system:authenticated:oauth
 # log request and response payloads for all write requests
@@ -63,11 +63,11 @@ rules:
   resources:
     - group: "route.openshift.io"
       resources: ["routes", "routes/status"]
-    - resources: ["secrets"]
+    - resources: ["secrets", serviceaccounts/token]
     - group: "authentication.k8s.io"
       resources: ["tokenreviews", "tokenrequests"]
     - group: "oauth.openshift.io"
-      resources: ["oauthclients"]
+      resources: ["oauthclients", "tokenreviews"]
   userGroups:
     - system:authenticated
 - level: RequestResponse

--- a/pkg/operator/apiserver/audit/testdata/multipleCr.yaml
+++ b/pkg/operator/apiserver/audit/testdata/multipleCr.yaml
@@ -34,10 +34,8 @@ rules:
   - group: "route.openshift.io"
     resources: ["routes", "routes/status"]
   - resources: ["secrets"]
-  userGroups:
-  - system:authenticated:oauth
-- level: Metadata
-  resources:
+  - group: "authentication.k8s.io"
+    resources: ["tokenreviews", "tokenrequests"]
   - group: "oauth.openshift.io"
     resources: ["oauthclients"]
   userGroups:
@@ -66,10 +64,8 @@ rules:
     - group: "route.openshift.io"
       resources: ["routes", "routes/status"]
     - resources: ["secrets"]
-  userGroups:
-    - system:authenticated
-- level: Metadata
-  resources:
+    - group: "authentication.k8s.io"
+      resources: ["tokenreviews", "tokenrequests"]
     - group: "oauth.openshift.io"
       resources: ["oauthclients"]
   userGroups:

--- a/pkg/operator/apiserver/audit/testdata/oauth.yaml
+++ b/pkg/operator/apiserver/audit/testdata/oauth.yaml
@@ -33,11 +33,11 @@ rules:
   resources:
   - group: "route.openshift.io"
     resources: ["routes", "routes/status"]
-  - resources: ["secrets"]
+  - resources: ["secrets", "serviceaccounts/token"]
   - group: "authentication.k8s.io"
     resources: ["tokenreviews", "tokenrequests"]
   - group: "oauth.openshift.io"
-    resources: ["oauthclients"]
+    resources: ["oauthclients", "tokenreviews"]
   userGroups:
   - system:authenticated:oauth
 # log request and response payloads for all write requests

--- a/pkg/operator/apiserver/audit/testdata/oauth.yaml
+++ b/pkg/operator/apiserver/audit/testdata/oauth.yaml
@@ -34,10 +34,8 @@ rules:
   - group: "route.openshift.io"
     resources: ["routes", "routes/status"]
   - resources: ["secrets"]
-  userGroups:
-  - system:authenticated:oauth
-- level: Metadata
-  resources:
+  - group: "authentication.k8s.io"
+    resources: ["tokenreviews", "tokenrequests"]
   - group: "oauth.openshift.io"
     resources: ["oauthclients"]
   userGroups:

--- a/pkg/operator/apiserver/audit/testdata/writerequestbodies.yaml
+++ b/pkg/operator/apiserver/audit/testdata/writerequestbodies.yaml
@@ -33,11 +33,11 @@ rules:
   resources:
   - group: "route.openshift.io"
     resources: ["routes", "routes/status"]
-  - resources: ["secrets"]
+  - resources: ["secrets", "serviceaccounts/token"]
   - group: "authentication.k8s.io"
     resources: ["tokenreviews", "tokenrequests"]
   - group: "oauth.openshift.io"
-    resources: ["oauthclients"]
+    resources: ["oauthclients", "tokenreviews"]
 # log request and response payloads for all write requests
 - level: RequestResponse
   verbs:

--- a/pkg/operator/apiserver/audit/testdata/writerequestbodies.yaml
+++ b/pkg/operator/apiserver/audit/testdata/writerequestbodies.yaml
@@ -34,8 +34,8 @@ rules:
   - group: "route.openshift.io"
     resources: ["routes", "routes/status"]
   - resources: ["secrets"]
-- level: Metadata
-  resources:
+  - group: "authentication.k8s.io"
+    resources: ["tokenreviews", "tokenrequests"]
   - group: "oauth.openshift.io"
     resources: ["oauthclients"]
 # log request and response payloads for all write requests


### PR DESCRIPTION
## What

Manual cherry-Pick to release-4.10 of
- https://github.com/openshift/library-go/pull/1500 (with a resolved merge conflict on a whitespace) and
- https://github.com/openshift/library-go/pull/1327.

## Why

In version 4.11 there was an exclusion of the most common tokens by @s-urbaniak in the audit logs.
To keep the history I am adding my changes on top of his change.
There was still a small merge conflict on the whitespace that was introduced in the mean time in front of `"routes/status"`.

/assign @soltysh @stlaz @xingxingxia