### PR TITLE
Make sure the directory path is included in rendered manifest paths

### DIFF
--- a/pkg/operator/render/options/generic.go
+++ b/pkg/operator/render/options/generic.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"path/filepath"
 	"text/template"
 
 	"github.com/ghodss/yaml"
@@ -107,7 +108,7 @@ func (o *GenericOptions) ReadInputManifests() (RenderedManifests, error) {
 		}
 		for manifestFile, content := range manifestContent {
 			ret = append(ret, RenderedManifest{
-				OriginalFilename: manifestFile,
+				OriginalFilename: filepath.Join(filename, manifestFile),
 				Content:          content,
 			})
 		}


### PR DESCRIPTION
This aims to fix [this comment](https://github.com/openshift/installer/pull/7158#issuecomment-1547582330).

Because the `LoadFilesRecusively` function returns the path names relative to the directory passed into it, the original filenames currently do not take into account the path to the directory. We must include the directory in the original filename else files will likely just be dumped back into CWD (which is what I saw in debugging the feature gate issue)