### PR TITLE
OCPBUGS-13946: report fast resync interval only when > 0 and < 60

### DIFF
--- a/pkg/controller/factory/base_controller.go
+++ b/pkg/controller/factory/base_controller.go
@@ -131,6 +131,11 @@ func (c *baseController) Run(ctx context.Context, workers int) {
 	// runPeriodicalResync is independent from queue
 	if c.resyncEvery > 0 {
 		workerWg.Add(1)
+		if c.resyncEvery < 60*time.Second {
+			// Warn about too fast resyncs as they might drain the operators QPS.
+			// This event is cheap as it is only emitted on operator startup.
+			c.syncContext.Recorder().Warningf("FastControllerResync", "Controller %q resync interval is set to %s which might lead to client request throttling", c.name, c.resyncEvery)
+		}
 		go func() {
 			defer workerWg.Done()
 			c.runPeriodicalResync(ctx, c.resyncEvery)

--- a/pkg/controller/factory/factory.go
+++ b/pkg/controller/factory/factory.go
@@ -279,12 +279,6 @@ func (f *Factory) ToController(name string, eventRecorder events.Recorder) Contr
 		cacheSyncTimeout:   defaultCacheSyncTimeout,
 	}
 
-	// Warn about too fast resyncs as they might drain the operators QPS.
-	// This event is cheap as it is only emitted on operator startup.
-	if c.resyncEvery.Seconds() < 60 {
-		ctx.Recorder().Warningf("FastControllerResync", "Controller %q resync interval is set to %s which might lead to client request throttling", name, c.resyncEvery)
-	}
-
 	for i := range f.informerQueueKeys {
 		for d := range f.informerQueueKeys[i].informers {
 			informer := f.informerQueueKeys[i].informers[d]


### PR DESCRIPTION
before you could find `Controller %q resync interval is set to %s which might lead to client request throttling` in the logs for `0` interval which was misleading because the controller requires an interval to be > 0 and < 60s

xref: https://github.com/openshift/cluster-kube-apiserver-operator/pull/1503