### PR TITLE
staticpod installer: set the manifests directory permissions to 0600

### DIFF
--- a/pkg/operator/staticpod/installerpod/cmd.go
+++ b/pkg/operator/staticpod/installerpod/cmd.go
@@ -616,7 +616,7 @@ func (o *InstallOptions) writePod(rawPodBytes []byte, manifestFileName, resource
 		return err
 	}
 	klog.Infof("Writing static pod manifest %q ...\n%s", path.Join(o.PodManifestDir, manifestFileName), finalPodBytes)
-	if err := ioutil.WriteFile(path.Join(o.PodManifestDir, manifestFileName), []byte(finalPodBytes), 0644); err != nil {
+	if err := ioutil.WriteFile(path.Join(o.PodManifestDir, manifestFileName), []byte(finalPodBytes), 0600); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
To conform to CIS benchmarks

Testing PR: https://github.com/openshift/cluster-kube-scheduler-operator/pull/485