### PR TITLE
Add cert status info if CSR is not approved

### DIFF
--- a/pkg/operator/csr/cert_controller.go
+++ b/pkg/operator/csr/cert_controller.go
@@ -237,13 +237,13 @@ func (c *clientCertificateController) syncCSR(secret *corev1.Secret) (map[string
 		return nil, err
 	}
 
-	// skip if csr is not approved yet
 	if !isCSRApproved(csr) {
+		klog.V(4).Infof("csr %q is not approved yet. Reason %v", csr.Name, csr.Status)
 		return nil, nil
 	}
 
-	// skip if csr has no certificate in its status yet
 	if len(csr.Status.Certificate) == 0 {
+		klog.V(4).Infof("csr %q has no certificate in its status yet. Reason %v", csr.Name, csr.Status.Certificate)
 		return nil, nil
 	}
 


### PR DESCRIPTION
If CSR is not approved for any reason, csr.Status is printed in the logs to get some information.

Even if there is just an skip for next iteration, if there is a error in the approve func it will be miss in the logs and can be hard to debug.