### PR TITLE
Use corev1 consts for tls.crt and tls.key

### DIFF
--- a/pkg/operator/certrotation/signer.go
+++ b/pkg/operator/certrotation/signer.go
@@ -71,7 +71,7 @@ func (c RotatedSigningCASecret) ensureSigningCertKeyPair(ctx context.Context) (*
 		signingCertKeyPairSecret = actualSigningCertKeyPairSecret
 	}
 	// at this point, the secret has the correct signer, so we should read that signer to be able to sign
-	signingCertKeyPair, err := crypto.GetCAFromBytes(signingCertKeyPairSecret.Data["tls.crt"], signingCertKeyPairSecret.Data["tls.key"])
+	signingCertKeyPair, err := crypto.GetCAFromBytes(signingCertKeyPairSecret.Data[corev1.TLSCertKey], signingCertKeyPairSecret.Data[corev1.TLSPrivateKeyKey])
 	if err != nil {
 		return nil, err
 	}
@@ -148,8 +148,8 @@ func setSigningCertKeyPairSecret(signingCertKeyPairSecret *corev1.Secret, validi
 	if signingCertKeyPairSecret.Data == nil {
 		signingCertKeyPairSecret.Data = map[string][]byte{}
 	}
-	signingCertKeyPairSecret.Data["tls.crt"] = certBytes.Bytes()
-	signingCertKeyPairSecret.Data["tls.key"] = keyBytes.Bytes()
+	signingCertKeyPairSecret.Data[corev1.TLSCertKey] = certBytes.Bytes()
+	signingCertKeyPairSecret.Data[corev1.TLSPrivateKeyKey] = keyBytes.Bytes()
 	signingCertKeyPairSecret.Annotations[CertificateNotAfterAnnotation] = ca.Certs[0].NotAfter.Format(time.RFC3339)
 	signingCertKeyPairSecret.Annotations[CertificateNotBeforeAnnotation] = ca.Certs[0].NotBefore.Format(time.RFC3339)
 	signingCertKeyPairSecret.Annotations[CertificateIssuer] = ca.Certs[0].Issuer.CommonName

--- a/pkg/operator/certrotation/signer_test.go
+++ b/pkg/operator/certrotation/signer_test.go
@@ -47,7 +47,7 @@ func TestEnsureSigningCertKeyPair(t *testing.T) {
 				if certType, _ := CertificateTypeFromObject(actual); certType != CertificateTypeSigner {
 					t.Errorf("expected certificate type 'signer', got: %v", certType)
 				}
-				if len(actual.Data["tls.crt"]) == 0 || len(actual.Data["tls.key"]) == 0 {
+				if len(actual.Data[corev1.TLSCertKey]) == 0 || len(actual.Data[corev1.TLSPrivateKeyKey]) == 0 {
 					t.Error(actual.Data)
 				}
 			},
@@ -73,7 +73,7 @@ func TestEnsureSigningCertKeyPair(t *testing.T) {
 				if certType, _ := CertificateTypeFromObject(actual); certType != CertificateTypeSigner {
 					t.Errorf("expected certificate type 'signer', got: %v", certType)
 				}
-				if len(actual.Data["tls.crt"]) == 0 || len(actual.Data["tls.key"]) == 0 {
+				if len(actual.Data[corev1.TLSCertKey]) == 0 || len(actual.Data[corev1.TLSPrivateKeyKey]) == 0 {
 					t.Error(actual.Data)
 				}
 			},

--- a/pkg/operator/certrotation/target.go
+++ b/pkg/operator/certrotation/target.go
@@ -204,7 +204,7 @@ func setTargetCertKeyPairSecret(targetCertKeyPairSecret *corev1.Secret, validity
 		return err
 	}
 
-	targetCertKeyPairSecret.Data["tls.crt"], targetCertKeyPairSecret.Data["tls.key"], err = certKeyPair.GetPEMBytes()
+	targetCertKeyPairSecret.Data[corev1.TLSCertKey], targetCertKeyPairSecret.Data[corev1.TLSPrivateKeyKey], err = certKeyPair.GetPEMBytes()
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/certrotation/target_test.go
+++ b/pkg/operator/certrotation/target_test.go
@@ -161,7 +161,7 @@ func TestEnsureTargetCertKeyPair(t *testing.T) {
 				}
 
 				actual := actions[1].(clienttesting.CreateAction).GetObject().(*corev1.Secret)
-				if len(actual.Data["tls.crt"]) == 0 || len(actual.Data["tls.key"]) == 0 {
+				if len(actual.Data[corev1.TLSCertKey]) == 0 || len(actual.Data[corev1.TLSPrivateKeyKey]) == 0 {
 					t.Error(actual.Data)
 				}
 			},
@@ -190,7 +190,7 @@ func TestEnsureTargetCertKeyPair(t *testing.T) {
 				}
 
 				actual := actions[1].(clienttesting.UpdateAction).GetObject().(*corev1.Secret)
-				if len(actual.Data["tls.crt"]) == 0 || len(actual.Data["tls.key"]) == 0 {
+				if len(actual.Data[corev1.TLSCertKey]) == 0 || len(actual.Data[corev1.TLSPrivateKeyKey]) == 0 {
 					t.Error(actual.Data)
 				}
 				if actual.Annotations[CertificateHostnames] != "bar,foo" {
@@ -328,7 +328,7 @@ func TestEnsureTargetSignerCertKeyPair(t *testing.T) {
 				}
 
 				actual := actions[1].(clienttesting.CreateAction).GetObject().(*corev1.Secret)
-				if len(actual.Data["tls.crt"]) == 0 || len(actual.Data["tls.key"]) == 0 {
+				if len(actual.Data[corev1.TLSCertKey]) == 0 || len(actual.Data[corev1.TLSPrivateKeyKey]) == 0 {
 					t.Error(actual.Data)
 				}
 
@@ -336,7 +336,7 @@ func TestEnsureTargetSignerCertKeyPair(t *testing.T) {
 					t.Errorf("expected certificate type 'target', got: %v", certType)
 				}
 
-				signingCertKeyPair, err := crypto.GetCAFromBytes(actual.Data["tls.crt"], actual.Data["tls.key"])
+				signingCertKeyPair, err := crypto.GetCAFromBytes(actual.Data[corev1.TLSCertKey], actual.Data[corev1.TLSPrivateKeyKey])
 				if err != nil {
 					t.Error(actual.Data)
 				}
@@ -373,14 +373,14 @@ func TestEnsureTargetSignerCertKeyPair(t *testing.T) {
 				}
 
 				actual := actions[1].(clienttesting.UpdateAction).GetObject().(*corev1.Secret)
-				if len(actual.Data["tls.crt"]) == 0 || len(actual.Data["tls.key"]) == 0 {
+				if len(actual.Data[corev1.TLSCertKey]) == 0 || len(actual.Data[corev1.TLSPrivateKeyKey]) == 0 {
 					t.Error(actual.Data)
 				}
 				if certType, _ := CertificateTypeFromObject(actual); certType != CertificateTypeTarget {
 					t.Errorf("expected certificate type 'target', got: %v", certType)
 				}
 
-				signingCertKeyPair, err := crypto.GetCAFromBytes(actual.Data["tls.crt"], actual.Data["tls.key"])
+				signingCertKeyPair, err := crypto.GetCAFromBytes(actual.Data[corev1.TLSCertKey], actual.Data[corev1.TLSPrivateKeyKey])
 				if err != nil {
 					t.Error(actual.Data)
 				}

--- a/pkg/operator/csr/cert_controller.go
+++ b/pkg/operator/csr/cert_controller.go
@@ -30,9 +30,9 @@ import (
 
 const (
 	// TLSKeyFile is the name of tls key file in kubeconfigSecret
-	TLSKeyFile = "tls.key"
+	TLSKeyFile = corev1.TLSPrivateKeyKey
 	// TLSCertFile is the name of the tls cert file in kubeconfigSecret
-	TLSCertFile = "tls.crt"
+	TLSCertFile = corev1.TLSCertKey
 )
 
 // ControllerResyncInterval is exposed so that integration tests can crank up the constroller sync speed.

--- a/pkg/operator/csr/csrtestinghelpers/testinghelpers.go
+++ b/pkg/operator/csr/csrtestinghelpers/testinghelpers.go
@@ -116,12 +116,12 @@ func NewKubeconfig(key, cert []byte) []byte {
 	if key != nil {
 		clientKeyData = key
 	} else {
-		clientKey = "tls.key"
+		clientKey = corev1.TLSPrivateKeyKey
 	}
 	if cert != nil {
 		clientCertificateData = cert
 	} else {
-		clientCertificate = "tls.crt"
+		clientCertificate = corev1.TLSCertKey
 	}
 
 	kubeconfig := clientcmdapi.Config{
@@ -165,10 +165,10 @@ func NewHubKubeconfigSecret(namespace, name, resourceVersion string, cert *TestC
 		Data: data,
 	}
 	if cert != nil && cert.Cert != nil {
-		secret.Data["tls.crt"] = cert.Cert
+		secret.Data[corev1.TLSCertKey] = cert.Cert
 	}
 	if cert != nil && cert.Key != nil {
-		secret.Data["tls.key"] = cert.Key
+		secret.Data[corev1.TLSPrivateKeyKey] = cert.Key
 	}
 	return secret
 }

--- a/pkg/operator/resource/resourceapply/core_test.go
+++ b/pkg/operator/resource/resourceapply/core_test.go
@@ -420,7 +420,7 @@ func TestApplySecret(t *testing.T) {
 					ObjectMeta: m,
 					Type:       corev1.SecretTypeServiceAccountToken,
 					Data: map[string][]byte{
-						"tls.key": []byte("aaa"),
+						corev1.TLSPrivateKeyKey: []byte("aaa"),
 					},
 				},
 			},
@@ -434,7 +434,7 @@ func TestApplySecret(t *testing.T) {
 				ObjectMeta: m,
 				Type:       corev1.SecretTypeServiceAccountToken,
 				Data: map[string][]byte{
-					"tls.key": []byte("aaa"),
+					corev1.TLSPrivateKeyKey: []byte("aaa"),
 				},
 			},
 			actions: []clienttesting.Action{


### PR DESCRIPTION
Just a drive by cleanup.