### PR TITLE
Remove: insecure TLS ciphers.

### DIFF
--- a/pkg/crypto/crypto.go
+++ b/pkg/crypto/crypto.go
@@ -266,14 +266,12 @@ func DefaultCiphers() []uint16 {
 		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, // required by http/2
 		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
 		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-		tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, // forbidden by http/2, not flagged by http2isBadCipher() in go1.8
-		tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,   // forbidden by http/2, not flagged by http2isBadCipher() in go1.8
-		tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,    // forbidden by http/2
-		tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,    // forbidden by http/2
-		tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,      // forbidden by http/2
-		tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,      // forbidden by http/2
-		tls.TLS_RSA_WITH_AES_128_GCM_SHA256,         // forbidden by http/2
-		tls.TLS_RSA_WITH_AES_256_GCM_SHA384,         // forbidden by http/2
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA, // forbidden by http/2
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA, // forbidden by http/2
+		tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,   // forbidden by http/2
+		tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,   // forbidden by http/2
+		tls.TLS_RSA_WITH_AES_128_GCM_SHA256,      // forbidden by http/2
+		tls.TLS_RSA_WITH_AES_256_GCM_SHA384,      // forbidden by http/2
 		// the next one is in the intermediate suite, but go1.8 http2isBadCipher() complains when it is included at the recommended index
 		// because it comes after ciphers forbidden by the http/2 spec
 		// tls.TLS_RSA_WITH_AES_128_CBC_SHA256,


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/ACM-5458

The log msgs: 
```
W0313 15:52:29.855515 1 secure_serving.go:69] Use of insecure cipher 'TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256' detected.
5W0313 15:52:29.855549 1 secure_serving.go:69] Use of insecure cipher 'TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256' detected.
```

Expect:  certain customers (especially in the FSI) would see the big scary warning message and be rather paranoid/panicked about it. So it's better to remove these unsafe ciphers from the default cipher set.