### PR TITLE
OCPBUGS-14824: library-go: `ApplyStorageClass()` must not ignore `Res…

### DIFF
--- a/pkg/operator/csi/csistorageclasscontroller/csi_storageclass_controller.go
+++ b/pkg/operator/csi/csistorageclasscontroller/csi_storageclass_controller.go
@@ -167,6 +167,7 @@ func SetDefaultStorageClass(storageClassLister v1.StorageClassLister, storageCla
 				} else {
 					annotationKeyPresent = false
 				}
+				storageClass.ObjectMeta.ResourceVersion = sc.ObjectMeta.ResourceVersion
 			}
 		}
 		// There already is a default, and it's not set on the SC we intend to apply. Also, if there is any value for

--- a/pkg/operator/resource/resourceapply/storage.go
+++ b/pkg/operator/resource/resourceapply/storage.go
@@ -18,6 +18,8 @@ import (
 const (
 	// Label on the CSIDriver to declare the driver's effective pod security profile
 	csiInlineVolProfileLabel = "security.openshift.io/csi-ephemeral-volume-profile"
+
+	defaultScAnnotationKey = "storageclass.kubernetes.io/is-default-class"
 )
 
 var (
@@ -40,6 +42,22 @@ func ApplyStorageClass(ctx context.Context, client storageclientv1.StorageClasse
 	}
 	if err != nil {
 		return nil, false, err
+	}
+
+	if required.ObjectMeta.ResourceVersion != "" && required.ObjectMeta.ResourceVersion != existing.ObjectMeta.ResourceVersion {
+		err = fmt.Errorf("rejected to update StorageClass %s because the object has been modified: desired/actual ResourceVersion: %v/%v",
+			required.Name, required.ObjectMeta.ResourceVersion, existing.ObjectMeta.ResourceVersion)
+		return nil, false, err
+	}
+	// Our caller may not be able to set required.ObjectMeta.ResourceVersion. We only want to overwrite value of
+	// default storage class annotation if it is missing in existing.Annotations
+	if existing.Annotations != nil {
+		if _, ok := existing.Annotations[defaultScAnnotationKey]; ok {
+			if required.Annotations == nil {
+				required.Annotations = make(map[string]string)
+			}
+			required.Annotations[defaultScAnnotationKey] = existing.Annotations[defaultScAnnotationKey]
+		}
 	}
 
 	// First, let's compare ObjectMeta from both objects


### PR DESCRIPTION
…ourceVersion` of `required` arg

A caller of `ApplyStorageClass()`, for example `syncStorageClass()` from `pkg/operator/csi/csistorageclasscontroller/csi_storageclass_controller.go`, may want to make decision about new state of `StorageClass` based on a state of objects it received by:
```
	existingSCs, err := storageClassLister.List(labels.Everything())
```

In this case, to avoid races (like one explained in https://issues.redhat.com/browse/OCPBUGS-14824), it's crucial to pass `ResourceVersion` from the caller to `ApplyStorageClass()`.

If `required` arg of `ApplyStorageClass()` has `ResourceVersion` set, then it must fail update operation if newly read `StorageClass` has newer version.

The caller who is interested in the behavior explained abobe (`syncStorageClass()` from `pkg/operator/csi/csistorageclasscontroller/csi_storageclass_controller.go`) will set `ResourceVersion` properly.

Any other caller (who doesn't set `ResourceVersion`) won't be able to overwrite default StorageClass annotation if it is already set.
