### PR TITLE
Fix flakiness of `TestGetName` and an issue in `GetName`

### DIFF
--- a/pkg/build/naming/namer.go
+++ b/pkg/build/naming/namer.go
@@ -24,7 +24,7 @@ func GetName(base, suffix string, maxLength int) string {
 	baseLength := maxLength - 10 /*length of -hash-*/ - len(suffix)
 
 	// if the suffix is too long, ignore it
-	if baseLength < 0 {
+	if baseLength <= 0 {
 		prefix := base[0:min(len(base), max(0, maxLength-9))]
 		// Calculate hash on initial base-suffix string
 		shortName := fmt.Sprintf("%s-%s", prefix, hash(name))

--- a/pkg/build/naming/namer_test.go
+++ b/pkg/build/naming/namer_test.go
@@ -11,6 +11,8 @@ func TestGetName(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		shortName := randSeq(rand.Intn(kvalidation.DNS1123SubdomainMaxLength-1) + 1)
 		shortNameForDeploy := randSeq(rand.Intn(kvalidation.DNS1123SubdomainMaxLength-len("-deploy")-1) + 1)
+		shortNameLongerThan9 := randSeq(rand.Intn(kvalidation.DNS1123SubdomainMaxLength-10) + 10)
+		mediumName := randSeq(kvalidation.DNS1123SubdomainMaxLength - 10)
 		longName := randSeq(kvalidation.DNS1123SubdomainMaxLength + rand.Intn(100))
 
 		tests := []struct {
@@ -30,6 +32,11 @@ func TestGetName(t *testing.T) {
 				base:     shortName,
 				suffix:   longName,
 				expected: shortName[0:min(len(shortName), kvalidation.DNS1123SubdomainMaxLength-9)] + "-" + hash(shortName+"-"+longName),
+			},
+			{
+				base:     shortNameLongerThan9,
+				suffix:   mediumName,
+				expected: shortNameLongerThan9[0:min(len(shortNameLongerThan9), kvalidation.DNS1123SubdomainMaxLength-9)] + "-" + hash(shortNameLongerThan9+"-"+mediumName),
 			},
 			{
 				base:     "",

--- a/pkg/build/naming/namer_test.go
+++ b/pkg/build/naming/namer_test.go
@@ -10,15 +10,16 @@ import (
 func TestGetName(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		shortName := randSeq(rand.Intn(kvalidation.DNS1123SubdomainMaxLength-1) + 1)
+		shortNameForDeploy := randSeq(rand.Intn(kvalidation.DNS1123SubdomainMaxLength-len("-deploy")-1) + 1)
 		longName := randSeq(kvalidation.DNS1123SubdomainMaxLength + rand.Intn(100))
 
 		tests := []struct {
 			base, suffix, expected string
 		}{
 			{
-				base:     shortName,
+				base:     shortNameForDeploy,
 				suffix:   "deploy",
-				expected: shortName + "-deploy",
+				expected: shortNameForDeploy + "-deploy",
 			},
 			{
 				base:     longName,
@@ -28,7 +29,7 @@ func TestGetName(t *testing.T) {
 			{
 				base:     shortName,
 				suffix:   longName,
-				expected: shortName + "-" + hash(shortName+"-"+longName),
+				expected: shortName[0:min(len(shortName), kvalidation.DNS1123SubdomainMaxLength-9)] + "-" + hash(shortName+"-"+longName),
 			},
 			{
 				base:     "",


### PR DESCRIPTION
The PR consist of two commits. The first fixes two independent cases of flakiness in `TestGetName`. These issues are easy to reproduce by running `go test -count=1 ./pkg/build/naming/...` several times. Commit description explains them in full details.

The second commit fixes a real issue in `GetName` itself: if the `base` arg is not super-short (>= 10 symbols) and `suffix` arg is of 243 symbol exactly, the function returns value like this: `-somthing-hash`. This is violates https://kubernetes.io/docs/concepts/overview/working-with-objects/names/: the name must start with an alphanumeric character.