### PR TITLE
Add OWNERS file for cloudprovider package

### DIFF
--- a/pkg/cloudprovider/OWNERS
+++ b/pkg/cloudprovider/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - JoelSpeed
+  - elmiko
+approvers:
+  - JoelSpeed
+  - elmiko


### PR DESCRIPTION
The cloud team should own this, for now, myself and @elmiko have the context on this