### PR TITLE
♻️ remove duplicated time provider behaviour

### DIFF
--- a/pkg/operator/staticpod/controller/installer/installer_controller_test.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller_test.go
@@ -558,7 +558,7 @@ func TestNewNodeStateForInstallInProgress(t *testing.T) {
 				kubeClient.CoreV1(),
 				eventRecorder,
 			)
-			c.now = func() time.Time { return now.Time }
+			c.clock = clocktesting.NewFakeClock(now.Time)
 			c.startupMonitorEnabled = func() (bool, error) {
 				return test.startupMonitorEnabled, nil
 			}


### PR DESCRIPTION
`now` and `clock` fields are both present in the `InstallerController` struct for the same purpose.

This PR migrates all `now` calls to `clock.Now`.