### PR TITLE
OCPBUGS-15256: installerpod: change config map based files mode to 0600

### DIFF
--- a/pkg/operator/staticpod/installerpod/cmd.go
+++ b/pkg/operator/staticpod/installerpod/cmd.go
@@ -625,7 +625,7 @@ func (o *InstallOptions) writePod(rawPodBytes []byte, manifestFileName, resource
 func writeConfig(content []byte, fullFilename string) error {
 	klog.Infof("Writing config file %q ...", fullFilename)
 
-	filePerms := os.FileMode(0644)
+	filePerms := os.FileMode(0600)
 	if strings.HasSuffix(fullFilename, ".sh") {
 		filePerms = 0755
 	}


### PR DESCRIPTION
To be more compliant with CIS benchmarks

/hold
so the change can be verified in KSO and KCMO first.