### PR TITLE
pkg/manifest: Add Manifest.String() method

### DIFF
--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -88,6 +88,18 @@ func (r resourceId) String() string {
 	}
 }
 
+func (m *Manifest) String() string {
+	if m == nil {
+		return "nil pointer manifest"
+	}
+
+	if m.OriginalFilename != "" {
+		return fmt.Sprintf("Filename: %q %s", m.OriginalFilename, m.id.String())
+	}
+
+	return m.id.String()
+}
+
 func (m Manifest) SameResourceID(manifest Manifest) bool {
 	return m.id.equal(manifest.id)
 }
@@ -344,8 +356,9 @@ func ManifestsFromFiles(files []string) ([]Manifest, error) {
 			errs = append(errs, errors.Wrapf(err, "error parsing %s", file.Name()))
 			continue
 		}
-		for _, m := range ms {
-			m.OriginalFilename = filepath.Base(file.Name())
+		filename := filepath.Base(file.Name())
+		for i, m := range ms {
+			ms[i].OriginalFilename = filename
 			err = addIfNotDuplicateResource(m, ids)
 			if err != nil {
 				errs = append(errs, errors.Wrapf(err, "File %s contains", file.Name()))

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -282,11 +282,13 @@ data:
 			}},
 		},
 		want: []Manifest{{
-			id:  resourceId{Group: "extensions", Kind: "Ingress", Name: "test-ingress", Namespace: "test-namespace"},
-			GVK: schema.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "Ingress"},
+			OriginalFilename: "f0",
+			id:               resourceId{Group: "extensions", Kind: "Ingress", Name: "test-ingress", Namespace: "test-namespace"},
+			GVK:              schema.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "Ingress"},
 		}, {
-			id:  resourceId{Group: "", Kind: "ConfigMap", Name: "a-config", Namespace: "default"},
-			GVK: schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"},
+			OriginalFilename: "f1",
+			id:               resourceId{Group: "", Kind: "ConfigMap", Name: "a-config", Namespace: "default"},
+			GVK:              schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"},
 		}},
 	}, {
 		name: "files-with-multiple-manifests",
@@ -337,14 +339,17 @@ data:
 			}},
 		},
 		want: []Manifest{{
-			id:  resourceId{Group: "extensions", Kind: "Ingress", Name: "test-ingress", Namespace: "test-namespace"},
-			GVK: schema.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "Ingress"},
+			OriginalFilename: "f0",
+			id:               resourceId{Group: "extensions", Kind: "Ingress", Name: "test-ingress", Namespace: "test-namespace"},
+			GVK:              schema.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "Ingress"},
 		}, {
-			id:  resourceId{Group: "", Kind: "ConfigMap", Name: "a-config", Namespace: "default"},
-			GVK: schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"},
+			OriginalFilename: "f0",
+			id:               resourceId{Group: "", Kind: "ConfigMap", Name: "a-config", Namespace: "default"},
+			GVK:              schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"},
 		}, {
-			id:  resourceId{Group: "", Kind: "ConfigMap", Name: "b-config", Namespace: "default"},
-			GVK: schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"},
+			OriginalFilename: "f1",
+			id:               resourceId{Group: "", Kind: "ConfigMap", Name: "b-config", Namespace: "default"},
+			GVK:              schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"},
 		}},
 	}}
 	for _, test := range tests {
@@ -365,6 +370,7 @@ data:
 				t.Fatal(err)
 			}
 			for i := range got {
+				t.Logf("loaded %s", &got[i])
 				got[i].Raw = nil
 				got[i].Obj = nil
 			}


### PR DESCRIPTION
Because the default Go serialization causes some very long lines:

```console
$ curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_cluster-ingress-operator/950/pull-ci-openshift-cluster-ingress-operator-master-e2e-aws-ovn/1670881314321993728/artifacts/e2e-aws-ovn/gather-extra/artifacts/pods/openshift-cluster-version_cluster-version-operator-8598f95688-jswk8_cluster-version-operator.log | grep ' excluding ' | head -n1
I0619 20:21:07.321663       1 payload.go:210] excluding {0000_10_config-operator_01_apiserver-CustomNoUpgrade.crd.yaml {apiextensions.k8s.io CustomResourceDefinition apiservers.config.openshift.io } {"apiVersion":"apiextensions.k8s.io/v1","kind":"CustomResourceDefinition","metadata":{"annotations":{...
$ curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_cluster-ingress-operator/950/pull-ci-openshift-cluster-ingress-operator-master-e2e-aws-ovn/1670881314321993728/artifacts/e2e-aws-ovn/gather-extra/artifacts/pods/openshift-cluster-version_cluster-version-operator-8598f95688-jswk8_cluster-version-operator.log | grep ' excluding ' | head -n1 | wc
        1    1361   13998
 ```