### PR TITLE
OCPBUGS-15390: Support Group/Version format in manifest override

### DIFF
--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -249,8 +249,12 @@ func (m *Manifest) getOverrideForManifest(overrides []configv1.ComponentOverride
 		if m.id.Namespace == "" {
 			namespace = "" // cluster-scoped objects don't have namespace.
 		}
+		group := override.Group
+		if gv, err := schema.ParseGroupVersion(group); err == nil && gv.Group != "" {
+			group = gv.Group
+		}
 		if m.id.equal(resourceId{
-			Group:     override.Group,
+			Group:     group,
 			Kind:      override.Kind,
 			Name:      override.Name,
 			Namespace: namespace,

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -785,6 +785,45 @@ func Test_include(t *testing.T) {
 			},
 		},
 		{
+			name:        "wrong group override",
+			annotations: map[string]interface{}{},
+			overrides: []configv1.ComponentOverride{
+				{
+					Kind:      "Deployment",
+					Group:     "v1",
+					Name:      "my-deployment",
+					Namespace: "my-namespace",
+					Unmanaged: true,
+				},
+			},
+		},
+		{
+			name:        "wrong name override",
+			annotations: map[string]interface{}{},
+			overrides: []configv1.ComponentOverride{
+				{
+					Kind:      "Deployment",
+					Group:     "apps",
+					Name:      "not-my-deployment",
+					Namespace: "my-namespace",
+					Unmanaged: true,
+				},
+			},
+		},
+		{
+			name:        "wrong namespace override",
+			annotations: map[string]interface{}{},
+			overrides: []configv1.ComponentOverride{
+				{
+					Kind:      "Deployment",
+					Group:     "apps",
+					Name:      "my-deployment",
+					Namespace: "not-my-namespace",
+					Unmanaged: true,
+				},
+			},
+		},
+		{
 			name:        "override, but managed",
 			annotations: map[string]interface{}{},
 			overrides: []configv1.ComponentOverride{

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -850,6 +850,20 @@ func Test_include(t *testing.T) {
 			expected: fmt.Errorf("overridden"),
 		},
 		{
+			name:        "unmanaged gv override",
+			annotations: map[string]interface{}{},
+			overrides: []configv1.ComponentOverride{
+				{
+					Group:     "apps/v1",
+					Kind:      "Deployment",
+					Name:      "my-deployment",
+					Namespace: "my-namespace",
+					Unmanaged: true,
+				},
+			},
+			expected: fmt.Errorf("overridden"),
+		},
+		{
 			name:        "all nil",
 			profile:     nil,
 			annotations: nil,


### PR DESCRIPTION
Prior to https://github.com/openshift/cluster-version-operator/pull/689 the 'group' field in an
override was ignored. During that time, the documented way to use this
field was to specify a Group/Version (e.g. "apps/v1") matching the
apiVersion field in the manifest.

After that change, only an exact match of the override's 'group' field
and the Group part of the GVK is allowed, so the 'group' must be set to
e.g. "apps" and never "apps/v1".

This change allows both "apps" and "apps/v1" formats to work.