### PR TITLE
STOR-1376: Allow CredentialsRequestController to work in STS mode

### DIFF
--- a/pkg/operator/csi/csicontrollerset/csi_controller_set.go
+++ b/pkg/operator/csi/csicontrollerset/csi_controller_set.go
@@ -140,6 +140,7 @@ func (c *CSIControllerSet) WithCredentialsRequestController(
 	file string,
 	dynamicClient dynamic.Interface,
 	operatorInformer operatorinformer.SharedInformerFactory,
+	hooks ...credentialsrequestcontroller.CredentialsRequestHook,
 ) *CSIControllerSet {
 	manifestFile, err := assetFunc(file)
 	if err != nil {
@@ -153,6 +154,7 @@ func (c *CSIControllerSet) WithCredentialsRequestController(
 		c.operatorClient,
 		operatorInformer,
 		c.eventRecorder,
+		hooks...,
 	)
 	return c
 }


### PR DESCRIPTION
When using Amazon Web Services (AWS) Secure Token Service (STS), a OLM-based CSI driver operator must add `cloudTokenPath` and `providerSpec.stsIAMRoleARN` to its CredentialsRequest.

Add hook support to CredentialsRequestController to allow them so.

In addition, CredentialsRequestController must sync CredentialsRequest even when CCO is in Manual mode, because it can still create Secrets for STS CredentialsRequest.

Enhancement: https://github.com/openshift/enhancements/blob/master/enhancements/cloud-integration/tokenized-auth-enablement-operators-on-cloud.md

@openshift/storage 