### PR TITLE
APIServiceController: allow to pass informers for registering additional event handlers

### DIFF
--- a/pkg/operator/apiserver/controller/apiservice/apiservice_controller.go
+++ b/pkg/operator/apiserver/controller/apiservice/apiservice_controller.go
@@ -52,6 +52,7 @@ func NewAPIServiceController(
 	kubeInformersForOperandNamespace kubeinformers.SharedInformerFactory,
 	kubeClient kubernetes.Interface,
 	eventRecorder events.Recorder,
+	informers ...factory.Informer,
 ) factory.Controller {
 	c := &APIServiceController{
 		preconditionForEnabledAPIServices: newEndpointPrecondition(kubeInformersForOperandNamespace),
@@ -64,9 +65,11 @@ func NewAPIServiceController(
 	}
 
 	return factory.New().WithSync(c.sync).ResyncEvery(10*time.Second).WithInformers(
-		kubeInformersForOperandNamespace.Core().V1().Services().Informer(),
-		kubeInformersForOperandNamespace.Core().V1().Endpoints().Informer(),
-		apiregistrationInformers.Apiregistration().V1().APIServices().Informer(),
+		append(informers,
+			kubeInformersForOperandNamespace.Core().V1().Services().Informer(),
+			kubeInformersForOperandNamespace.Core().V1().Endpoints().Informer(),
+			apiregistrationInformers.Apiregistration().V1().APIServices().Informer(),
+		)...,
 	).ToController("APIServiceController_"+name, eventRecorder.WithComponentSuffix("apiservice-"+name+"-controller"))
 }
 

--- a/pkg/operator/apiserver/controllerset/apiservercontrollerset.go
+++ b/pkg/operator/apiserver/controllerset/apiservercontrollerset.go
@@ -180,6 +180,7 @@ func (cs *APIServerControllerSet) WithAPIServiceController(
 	apiregistrationv1Client apiregistrationv1client.ApiregistrationV1Interface,
 	kubeInformersForTargetNamesace kubeinformers.SharedInformerFactory,
 	kubeClient kubernetes.Interface,
+	informers ...factory.Informer,
 ) *APIServerControllerSet {
 	cs.apiServiceController.controller = apiservice.NewAPIServiceController(
 		controllerName,
@@ -190,6 +191,7 @@ func (cs *APIServerControllerSet) WithAPIServiceController(
 		kubeInformersForTargetNamesace,
 		kubeClient,
 		cs.eventRecorder,
+		informers...,
 	)
 	return cs
 }


### PR DESCRIPTION
https://github.com/openshift/cluster-openshift-apiserver-operator/pull/532#discussion_r1284264567

APIServiceController can be passed a list of disabled/enabled APIs which might require additional resource to take into account when reconciling. In the case of https://github.com/openshift/cluster-openshift-apiserver-operator/pull/532 new capabilities are taken into account when rendering a list of enabled/disabled API services.