### PR TITLE
BUILD-689: update feature flag unit tests to reflect BuildCSIVolumes GA

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/imdario/mergo v0.3.7
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
 	github.com/opencontainers/go-digest v1.0.0
-	github.com/openshift/api v0.0.0-20230807132801-600991d550ac
+	github.com/openshift/api v0.0.0-20230815201604-a2362cf53230
 	github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d
 	github.com/openshift/client-go v0.0.0-20230503144108-75015d2347cb
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -308,8 +308,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.2 h1:9yCKha/T5XdGtO0q9Q9a6T5NUCsTn/DrBg0D7ufOcFM=
 github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
-github.com/openshift/api v0.0.0-20230807132801-600991d550ac h1:HqT8MmYGXiUGUW0BjygTGOOvqO2wIsTaG3q8nboJyPY=
-github.com/openshift/api v0.0.0-20230807132801-600991d550ac/go.mod h1:yimSGmjsI+XF1mr+AKBs2//fSXIOhhetHGbMlBEfXbs=
+github.com/openshift/api v0.0.0-20230815201604-a2362cf53230 h1:PY2JBJdSkzTxathfsYMa/Mb2Xcw9YphTZ6IcvURayKk=
+github.com/openshift/api v0.0.0-20230815201604-a2362cf53230/go.mod h1:yimSGmjsI+XF1mr+AKBs2//fSXIOhhetHGbMlBEfXbs=
 github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d h1:RR4ah7FfaPR1WePizm0jlrsbmPu91xQZnAsVVreQV1k=
 github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20230503144108-75015d2347cb h1:Nij5OnaECrkmcRQMAE9LMbQXPo95aqFnf+12B7SyFVI=

--- a/pkg/operator/configobserver/featuregates/observe_featuregates_test.go
+++ b/pkg/operator/configobserver/featuregates/observe_featuregates_test.go
@@ -45,10 +45,14 @@ func TestObserveFeatureFlags(t *testing.T) {
 		{
 			name: "default",
 			accessor: NewHardcodedFeatureGateAccess(
-				[]configv1.FeatureGateName{"OpenShiftPodSecurityAdmission"},
+				[]configv1.FeatureGateName{
+					"OpenShiftPodSecurityAdmission",
+					"BuildCSIVolumes",
+				},
 				[]configv1.FeatureGateName{"RetroactiveDefaultStorageClass"},
 			),
 			expectedResult: []string{
+				"BuildCSIVolumes=true",
 				"OpenShiftPodSecurityAdmission=true",
 				"RetroactiveDefaultStorageClass=false",
 			},
@@ -60,7 +64,6 @@ func TestObserveFeatureFlags(t *testing.T) {
 					"OpenShiftPodSecurityAdmission",
 					"ExternalCloudProvider",
 					"CSIDriverSharedResource",
-					"BuildCSIVolumes",
 					"NodeSwap",
 					"MachineAPIProviderOpenStack",
 					"InsightsConfigAPI",
@@ -72,7 +75,6 @@ func TestObserveFeatureFlags(t *testing.T) {
 				},
 			),
 			expectedResult: []string{
-				"BuildCSIVolumes=true",
 				"CSIDriverSharedResource=true",
 				"ExternalCloudProvider=true",
 				"InsightsConfigAPI=true",

--- a/vendor/github.com/openshift/api/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
+++ b/vendor/github.com/openshift/api/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
@@ -74,6 +74,7 @@ spec:
                           - MachineAPI
                           - Build
                           - DeploymentConfig
+                          - ImageRegistry
                       x-kubernetes-list-type: atomic
                     baselineCapabilitySet:
                       description: baselineCapabilitySet selects an initial set of optional capabilities to enable, which can be extended via additionalEnabledCapabilities.  If unset, the cluster will choose a default, and the default may change over time. The current default is vCurrent.
@@ -199,6 +200,7 @@ spec:
                           - MachineAPI
                           - Build
                           - DeploymentConfig
+                          - ImageRegistry
                       x-kubernetes-list-type: atomic
                     knownCapabilities:
                       description: knownCapabilities lists all the capabilities known to the current cluster.
@@ -218,6 +220,7 @@ spec:
                           - MachineAPI
                           - Build
                           - DeploymentConfig
+                          - ImageRegistry
                       x-kubernetes-list-type: atomic
                 conditionalUpdates:
                   description: conditionalUpdates contains the list of updates that may be recommended for this cluster if it meets specific required conditions. Consumers interested in the set of updates that are actually recommended for this cluster should use availableUpdates. This list may be empty if no updates are recommended, if the update service is unavailable, or if an empty or invalid channel has been specified.
@@ -439,6 +442,9 @@ spec:
                 versionHash:
                   description: versionHash is a fingerprint of the content that the cluster will be updated with. It is used by the operator to avoid unnecessary work and is for internal use only.
                   type: string
+          x-kubernetes-validations:
+            - rule: 'has(self.spec.capabilities) && has(self.spec.capabilities.additionalEnabledCapabilities) && self.spec.capabilities.baselineCapabilitySet == ''None'' && ''baremetal'' in self.spec.capabilities.additionalEnabledCapabilities ? ''MachineAPI'' in self.spec.capabilities.additionalEnabledCapabilities || (has(self.status) && has(self.status.capabilities) && has(self.status.capabilities.enabledCapabilities) && ''MachineAPI'' in self.status.capabilities.enabledCapabilities) : true'
+              message: the `baremetal` capability requires the `MachineAPI` capability, which is neither explicitly or implicitly enabled in this cluster, please enable the `MachineAPI` capability
       served: true
       storage: true
       subresources:

--- a/vendor/github.com/openshift/api/config/v1/0000_10_config-operator_01_infrastructure-Default.crd.yaml
+++ b/vendor/github.com/openshift/api/config/v1/0000_10_config-operator_01_infrastructure-Default.crd.yaml
@@ -381,6 +381,13 @@ spec:
                     - SingleReplica
                     - External
                   type: string
+                cpuPartitioning:
+                  default: None
+                  description: cpuPartitioning expresses if CPU partitioning is a currently enabled feature in the cluster. CPU Partitioning means that this cluster can support partitioning workloads to specific CPU Sets. Valid values are "None" and "AllNodes". When omitted, the default value is "None". The default value of "None" indicates that no nodes will be setup with CPU partitioning. The "AllNodes" value indicates that all nodes have been setup with CPU partitioning, and can then be further configured via the PerformanceProfile API.
+                  enum:
+                    - None
+                    - AllNodes
+                  type: string
                 etcdDiscoveryDomain:
                   description: 'etcdDiscoveryDomain is the domain used to fetch the SRV records for discovering etcd servers and clients. For more info: https://github.com/etcd-io/etcd/blob/329be66e8b3f9e2e6af83c123ff89297e49ebd15/Documentation/op-guide/clustering.md#dns-discovery deprecated: as of 4.7, this field is no longer set or honored.  It will be removed in a future release.'
                   type: string

--- a/vendor/github.com/openshift/api/config/v1/feature_gates.go
+++ b/vendor/github.com/openshift/api/config/v1/feature_gates.go
@@ -23,6 +23,16 @@ var (
 )
 
 var (
+	FeatureGateValidatingAdmissionPolicy = FeatureGateName("ValidatingAdmissionPolicy")
+	validatingAdmissionPolicy            = FeatureGateDescription{
+		FeatureGateAttributes: FeatureGateAttributes{
+			Name: FeatureGateValidatingAdmissionPolicy,
+		},
+		OwningJiraComponent: "kube-apiserver",
+		ResponsiblePerson:   "benluddy",
+		OwningProduct:       kubernetes,
+	}
+
 	FeatureGateGatewayAPI = FeatureGateName("GatewayAPI")
 	gateGatewayAPI        = FeatureGateDescription{
 		FeatureGateAttributes: FeatureGateAttributes{
@@ -141,16 +151,6 @@ var (
 		OwningJiraComponent: "insights",
 		ResponsiblePerson:   "tremes",
 		OwningProduct:       ocpSpecific,
-	}
-
-	FeatureGatePDBUnhealthyPodEvictionPolicy = FeatureGateName("PDBUnhealthyPodEvictionPolicy")
-	pdbUnhealthyPodEvictionPolicy            = FeatureGateDescription{
-		FeatureGateAttributes: FeatureGateAttributes{
-			Name: FeatureGatePDBUnhealthyPodEvictionPolicy,
-		},
-		OwningJiraComponent: "apps",
-		ResponsiblePerson:   "atiratree",
-		OwningProduct:       kubernetes,
 	}
 
 	FeatureGateDynamicResourceAllocation = FeatureGateName("DynamicResourceAllocation")

--- a/vendor/github.com/openshift/api/config/v1/stable.clusterversion.testsuite.yaml
+++ b/vendor/github.com/openshift/api/config/v1/stable.clusterversion.testsuite.yaml
@@ -98,6 +98,38 @@ tests:
           version: 4.11.1
           image: bar
     expectedError: "cannot set both Architecture and Image"
+  - name: Should be able to create a ClusterVersion with base capability None, and additional capabilities baremetal and MachineAPI
+    initial: |
+      apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      spec:
+        clusterID: foo
+        capabilities:
+          baselineCapabilitySet: None
+          additionalEnabledCapabilities:
+          - baremetal
+          - MachineAPI
+    expected: |
+      apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      spec:
+        clusterID: foo
+        capabilities:
+          baselineCapabilitySet: None
+          additionalEnabledCapabilities:
+          - baremetal
+          - MachineAPI
+  - name: Should not be able to create a ClusterVersion with base capability None, and additional capabilities baremetal without MachineAPI
+    initial: |
+      apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      spec:
+        clusterID: foo
+        capabilities:
+          baselineCapabilitySet: None
+          additionalEnabledCapabilities:
+          - baremetal
+    expectedError: the `baremetal` capability requires the `MachineAPI` capability, which is neither explicitly or implicitly enabled in this cluster, please enable the `MachineAPI` capability
   onUpdate:
   - name: Should not allow image to be set if architecture set
     initial: |
@@ -136,3 +168,111 @@ tests:
           version: 4.11.1
           image: bar
     expectedError: "cannot set both Architecture and Image"
+  - name: Should be able to add the baremetal capability with a ClusterVersion with base capability None, and implicitly enabled MachineAPI
+    initial: |
+      apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      spec:
+        clusterID: foo
+        capabilities:
+          baselineCapabilitySet: None
+      status:
+        desired:
+          version: foo
+          image: foo
+        observedGeneration: 1
+        versionHash: foo
+        availableUpdates:
+        - version: foo
+          image: foo
+        capabilities:
+          enabledCapabilities:
+          - MachineAPI
+    updated: |
+      apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      spec:
+        clusterID: foo
+        capabilities:
+          baselineCapabilitySet: None
+          additionalEnabledCapabilities:
+          - baremetal
+      status:
+        desired:
+          version: foo
+          image: foo
+        observedGeneration: 1
+        versionHash: foo
+        availableUpdates:
+        - version: foo
+          image: foo
+        capabilities:
+          enabledCapabilities:
+          - MachineAPI
+    expected: |
+      apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      spec:
+        clusterID: foo
+        capabilities:
+          baselineCapabilitySet: None
+          additionalEnabledCapabilities:
+          - baremetal
+      status:
+        desired:
+          version: foo
+          image: foo
+        observedGeneration: 1
+        versionHash: foo
+        availableUpdates:
+        - version: foo
+          image: foo
+        capabilities:
+          enabledCapabilities:
+          - MachineAPI
+  - name: Should be able to add the baremetal capability with a ClusterVersion with base capability None, with the Machine API capability
+    initial: |
+      apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      spec:
+        clusterID: foo
+        capabilities:
+          baselineCapabilitySet: None
+    updated: |
+      apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      spec:
+        clusterID: foo
+        capabilities:
+          baselineCapabilitySet: None
+          additionalEnabledCapabilities:
+          - baremetal
+          - MachineAPI
+    expected: |
+      apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      spec:
+        clusterID: foo
+        capabilities:
+          baselineCapabilitySet: None
+          additionalEnabledCapabilities:
+          - baremetal
+          - MachineAPI
+  - name: Should not be able to add the baremetal capability with a ClusterVersion with base capability None, and without MachineAPI
+    initial: |
+      apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      spec:
+        clusterID: foo
+        capabilities:
+          baselineCapabilitySet: None
+    updated: |
+      apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      spec:
+        clusterID: foo
+        capabilities:
+          baselineCapabilitySet: None
+          additionalEnabledCapabilities:
+          - baremetal
+    expectedError: the `baremetal` capability requires the `MachineAPI` capability, which is neither explicitly or implicitly enabled in this cluster, please enable the `MachineAPI` capability

--- a/vendor/github.com/openshift/api/config/v1/stable.infrastructure.testsuite.yaml
+++ b/vendor/github.com/openshift/api/config/v1/stable.infrastructure.testsuite.yaml
@@ -208,6 +208,7 @@ tests:
         status:
           controlPlaneTopology: "HighlyAvailable"
           infrastructureTopology: "HighlyAvailable"
+          cpuPartitioning: None
           platform: Azure
           platformStatus:
             azure:
@@ -340,6 +341,7 @@ tests:
             type: OpenStack
         status:
           controlPlaneTopology: HighlyAvailable
+          cpuPartitioning: None
           infrastructureTopology: HighlyAvailable
           platform: OpenStack
           platformStatus:
@@ -378,6 +380,7 @@ tests:
             type: OpenStack
         status:
           controlPlaneTopology: HighlyAvailable
+          cpuPartitioning: None
           infrastructureTopology: HighlyAvailable
           platform: OpenStack
           platformStatus:
@@ -550,6 +553,7 @@ tests:
         status:
           controlPlaneTopology: HighlyAvailable
           infrastructureTopology: HighlyAvailable
+          cpuPartitioning: None
           platform: External
           platformStatus:
             type: External
@@ -657,6 +661,7 @@ tests:
         status:
           controlPlaneTopology: HighlyAvailable
           infrastructureTopology: HighlyAvailable
+          cpuPartitioning: None
           platform: External
           platformStatus:
             type: External
@@ -764,6 +769,7 @@ tests:
         status:
           controlPlaneTopology: HighlyAvailable
           infrastructureTopology: HighlyAvailable
+          cpuPartitioning: None
           platform: External
           platformStatus:
             type: External
@@ -822,6 +828,7 @@ tests:
         status:
           controlPlaneTopology: HighlyAvailable
           infrastructureTopology: HighlyAvailable
+          cpuPartitioning: None
           platform: External
           platformStatus:
             type: External
@@ -857,6 +864,7 @@ tests:
         status:
           controlPlaneTopology: HighlyAvailable
           infrastructureTopology: HighlyAvailable
+          cpuPartitioning: None
           platform: External
           platformStatus:
             type: External
@@ -914,6 +922,7 @@ tests:
         status:
           controlPlaneTopology: HighlyAvailable
           infrastructureTopology: HighlyAvailable
+          cpuPartitioning: None
           platform: External
           platformStatus:
             type: External

--- a/vendor/github.com/openshift/api/config/v1/types_cluster_version.go
+++ b/vendor/github.com/openshift/api/config/v1/types_cluster_version.go
@@ -13,6 +13,7 @@ import (
 //
 // Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
 // +openshift:compatibility-gen:level=1
+// +kubebuilder:validation:XValidation:rule="has(self.spec.capabilities) && has(self.spec.capabilities.additionalEnabledCapabilities) && self.spec.capabilities.baselineCapabilitySet == 'None' && 'baremetal' in self.spec.capabilities.additionalEnabledCapabilities ? 'MachineAPI' in self.spec.capabilities.additionalEnabledCapabilities || (has(self.status) && has(self.status.capabilities) && has(self.status.capabilities.enabledCapabilities) && 'MachineAPI' in self.status.capabilities.enabledCapabilities) : true",message="the `baremetal` capability requires the `MachineAPI` capability, which is neither explicitly or implicitly enabled in this cluster, please enable the `MachineAPI` capability"
 type ClusterVersion struct {
 	metav1.TypeMeta `json:",inline"`
 
@@ -247,7 +248,7 @@ const (
 )
 
 // ClusterVersionCapability enumerates optional, core cluster components.
-// +kubebuilder:validation:Enum=openshift-samples;baremetal;marketplace;Console;Insights;Storage;CSISnapshot;NodeTuning;MachineAPI;Build;DeploymentConfig
+// +kubebuilder:validation:Enum=openshift-samples;baremetal;marketplace;Console;Insights;Storage;CSISnapshot;NodeTuning;MachineAPI;Build;DeploymentConfig;ImageRegistry
 type ClusterVersionCapability string
 
 const (
@@ -330,6 +331,9 @@ const (
 	// The following resources are taken into account:
 	// - deploymentconfigs
 	ClusterVersionCapabilityDeploymentConfig ClusterVersionCapability = "DeploymentConfig"
+	// ClusterVersionCapabilityImageRegistry manages the image registry which
+	// allows to distribute Docker images
+	ClusterVersionCapabilityImageRegistry ClusterVersionCapability = "ImageRegistry"
 )
 
 // KnownClusterVersionCapabilities includes all known optional, core cluster components.
@@ -345,6 +349,7 @@ var KnownClusterVersionCapabilities = []ClusterVersionCapability{
 	ClusterVersionCapabilityMachineAPI,
 	ClusterVersionCapabilityBuild,
 	ClusterVersionCapabilityDeploymentConfig,
+	ClusterVersionCapabilityImageRegistry,
 }
 
 // ClusterVersionCapabilitySet defines sets of cluster version capabilities.
@@ -393,6 +398,7 @@ var ClusterVersionCapabilitySets = map[ClusterVersionCapabilitySet][]ClusterVers
 		ClusterVersionCapabilityBaremetal,
 		ClusterVersionCapabilityMarketplace,
 		ClusterVersionCapabilityOpenShiftSamples,
+		ClusterVersionCapabilityMachineAPI,
 	},
 	ClusterVersionCapabilitySet4_12: {
 		ClusterVersionCapabilityBaremetal,
@@ -402,6 +408,7 @@ var ClusterVersionCapabilitySets = map[ClusterVersionCapabilitySet][]ClusterVers
 		ClusterVersionCapabilityStorage,
 		ClusterVersionCapabilityOpenShiftSamples,
 		ClusterVersionCapabilityCSISnapshot,
+		ClusterVersionCapabilityMachineAPI,
 	},
 	ClusterVersionCapabilitySet4_13: {
 		ClusterVersionCapabilityBaremetal,
@@ -412,6 +419,7 @@ var ClusterVersionCapabilitySets = map[ClusterVersionCapabilitySet][]ClusterVers
 		ClusterVersionCapabilityOpenShiftSamples,
 		ClusterVersionCapabilityCSISnapshot,
 		ClusterVersionCapabilityNodeTuning,
+		ClusterVersionCapabilityMachineAPI,
 	},
 	ClusterVersionCapabilitySet4_14: {
 		ClusterVersionCapabilityBaremetal,
@@ -425,6 +433,7 @@ var ClusterVersionCapabilitySets = map[ClusterVersionCapabilitySet][]ClusterVers
 		ClusterVersionCapabilityMachineAPI,
 		ClusterVersionCapabilityBuild,
 		ClusterVersionCapabilityDeploymentConfig,
+		ClusterVersionCapabilityImageRegistry,
 	},
 	ClusterVersionCapabilitySetCurrent: {
 		ClusterVersionCapabilityBaremetal,
@@ -438,6 +447,7 @@ var ClusterVersionCapabilitySets = map[ClusterVersionCapabilitySet][]ClusterVers
 		ClusterVersionCapabilityMachineAPI,
 		ClusterVersionCapabilityBuild,
 		ClusterVersionCapabilityDeploymentConfig,
+		ClusterVersionCapabilityImageRegistry,
 	},
 }
 

--- a/vendor/github.com/openshift/api/config/v1/types_feature.go
+++ b/vendor/github.com/openshift/api/config/v1/types_feature.go
@@ -163,15 +163,14 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		Disabled: []FeatureGateDescription{},
 	},
 	TechPreviewNoUpgrade: newDefaultFeatures().
+		with(validatingAdmissionPolicy).
 		with(externalCloudProvider).
 		with(externalCloudProviderGCP).
 		with(csiDriverSharedResource).
-		with(buildCSIVolumes).
 		with(nodeSwap).
 		with(machineAPIProviderOpenStack).
 		with(insightsConfigAPI).
 		with(retroactiveDefaultStorageClass).
-		with(pdbUnhealthyPodEvictionPolicy).
 		with(dynamicResourceAllocation).
 		with(admissionWebhookMatchConditions).
 		with(azureWorkloadIdentity).
@@ -198,6 +197,7 @@ var defaultFeatures = &FeatureGateEnabledDisabled{
 		externalCloudProviderAzure,
 		externalCloudProviderExternal,
 		privateHostedZoneAWS,
+		buildCSIVolumes,
 	},
 	Disabled: []FeatureGateDescription{
 		retroactiveDefaultStorageClass,

--- a/vendor/github.com/openshift/api/config/v1/types_infrastructure.go
+++ b/vendor/github.com/openshift/api/config/v1/types_infrastructure.go
@@ -114,7 +114,6 @@ type InfrastructureStatus struct {
 	// +kubebuilder:default=None
 	// +default="None"
 	// +kubebuilder:validation:Enum=None;AllNodes
-	// +openshift:enable:FeatureSets=CustomNoUpgrade;TechPreviewNoUpgrade
 	// +optional
 	CPUPartitioning CPUPartitioningMode `json:"cpuPartitioning,omitempty"`
 }

--- a/vendor/github.com/openshift/api/machine/v1/0000_10_controlplanemachineset.crd.yaml
+++ b/vendor/github.com/openshift/api/machine/v1/0000_10_controlplanemachineset.crd.yaml
@@ -229,6 +229,11 @@ spec:
                                 required:
                                   - zone
                                 properties:
+                                  subnet:
+                                    description: subnet is the name of the network subnet in which the VM will be created. When omitted, the subnet value from the machine providerSpec template will be used.
+                                    type: string
+                                    maxLength: 80
+                                    pattern: ^[a-zA-Z0-9](?:[a-zA-Z0-9._-]*[a-zA-Z0-9_])?$
                                   zone:
                                     description: Availability Zone for the virtual machine. If nil, the virtual machine should be deployed to no zone.
                                     type: string

--- a/vendor/github.com/openshift/api/machine/v1/types_controlplanemachineset.go
+++ b/vendor/github.com/openshift/api/machine/v1/types_controlplanemachineset.go
@@ -287,6 +287,13 @@ type AzureFailureDomain struct {
 	// If nil, the virtual machine should be deployed to no zone.
 	// +kubebuilder:validation:Required
 	Zone string `json:"zone"`
+
+	// subnet is the name of the network subnet in which the VM will be created.
+	// When omitted, the subnet value from the machine providerSpec template will be used.
+	// +kubebuilder:validation:MaxLength=80
+	// +kubebuilder:validation:Pattern=`^[a-zA-Z0-9](?:[a-zA-Z0-9._-]*[a-zA-Z0-9_])?$`
+	// +optional
+	Subnet string `json:"subnet,omitempty"`
 }
 
 // GCPFailureDomain configures failure domain information for the GCP platform

--- a/vendor/github.com/openshift/api/machine/v1/zz_generated.swagger_doc_generated.go
+++ b/vendor/github.com/openshift/api/machine/v1/zz_generated.swagger_doc_generated.go
@@ -159,8 +159,9 @@ func (AWSFailureDomainPlacement) SwaggerDoc() map[string]string {
 }
 
 var map_AzureFailureDomain = map[string]string{
-	"":     "AzureFailureDomain configures failure domain information for the Azure platform.",
-	"zone": "Availability Zone for the virtual machine. If nil, the virtual machine should be deployed to no zone.",
+	"":       "AzureFailureDomain configures failure domain information for the Azure platform.",
+	"zone":   "Availability Zone for the virtual machine. If nil, the virtual machine should be deployed to no zone.",
+	"subnet": "subnet is the name of the network subnet in which the VM will be created. When omitted, the subnet value from the machine providerSpec template will be used.",
 }
 
 func (AzureFailureDomain) SwaggerDoc() map[string]string {

--- a/vendor/github.com/openshift/api/openshiftcontrolplane/v1/types.go
+++ b/vendor/github.com/openshift/api/openshiftcontrolplane/v1/types.go
@@ -192,6 +192,29 @@ type JenkinsPipelineConfig struct {
 	Parameters map[string]string `json:"parameters"`
 }
 
+// OpenShiftControllerName defines a string type used to represent the various
+// OpenShift controllers within openshift-controller-manager. These constants serve as identifiers
+// for the controllers and are used on both openshift/openshift-controller-manager 
+// and openshift/cluster-openshift-controller-manager-operator repositories.
+type OpenShiftControllerName string
+
+const (
+	OpenShiftServiceAccountController            OpenShiftControllerName = "openshift.io/serviceaccount"
+	OpenShiftDefaultRoleBindingsController       OpenShiftControllerName = "openshift.io/default-rolebindings"
+	OpenShiftServiceAccountPullSecretsController OpenShiftControllerName = "openshift.io/serviceaccount-pull-secrets"
+	OpenshiftOriginNamespaceController           OpenShiftControllerName = "openshift.io/origin-namespace"
+	OpenshiftBuildController                     OpenShiftControllerName = "openshift.io/build"
+	OpenshiftBuildConfigChangeController         OpenShiftControllerName = "openshift.io/build-config-change"
+	OpenshiftDeployerController                  OpenShiftControllerName = "openshift.io/deployer"
+	OpenshiftDeploymentConfigController          OpenShiftControllerName = "openshift.io/deploymentconfig"
+	OpenshiftImageTriggerController              OpenShiftControllerName = "openshift.io/image-trigger"
+	OpenshiftImageImportController               OpenShiftControllerName = "openshift.io/image-import"
+	OpenshiftImageSignatureImportController      OpenShiftControllerName = "openshift.io/image-signature-import"
+	OpenshiftTemplateInstanceController          OpenShiftControllerName = "openshift.io/templateinstance"
+	OpenshiftTemplateInstanceFinalizerController OpenShiftControllerName = "openshift.io/templateinstancefinalizer"
+	OpenshiftUnidlingController                  OpenShiftControllerName = "openshift.io/unidling"
+)
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support.

--- a/vendor/github.com/openshift/api/operator/v1/0000_12_etcd-operator_01_config.crd.yaml
+++ b/vendor/github.com/openshift/api/operator/v1/0000_12_etcd-operator_01_config.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   name: etcds.operator.openshift.io
 spec:
   group: operator.openshift.io
@@ -36,6 +37,13 @@ spec:
             spec:
               type: object
               properties:
+                controlPlaneHardwareSpeed:
+                  description: HardwareSpeed allows user to change the etcd tuning profile which configures the latency parameters for heartbeat interval and leader election timeouts allowing the cluster to tolerate longer round-trip-times between etcd members. Valid values are "", "Standard" and "Slower". "" means no opinion and the platform is left to choose a reasonable default which is subject to change without notice.
+                  type: string
+                  enum:
+                    - ""
+                    - Standard
+                    - Slower
                 failedRevisionLimit:
                   description: failedRevisionLimit is the number of failed static pod installer revisions to keep on disk and in the api -1 = unlimited, 0 or unset = 5 (default)
                   type: integer
@@ -102,6 +110,13 @@ spec:
                         type: string
                       type:
                         type: string
+                controlPlaneHardwareSpeed:
+                  description: ControlPlaneHardwareSpeed declares valid hardware speed tolerance levels
+                  type: string
+                  enum:
+                    - ""
+                    - Standard
+                    - Slower
                 generations:
                   description: generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.
                   type: array

--- a/vendor/github.com/openshift/api/operator/v1/techpreview.etcd.testsuite.yaml
+++ b/vendor/github.com/openshift/api/operator/v1/techpreview.etcd.testsuite.yaml
@@ -1,0 +1,62 @@
+apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
+name: "[TechPreview] Etcd"
+crd: 0000_12_etcd-operator_01_config.crd.yaml
+tests:
+  onCreate:
+  - name: Should be able to create with Standard hardware speed
+    initial: |
+      apiVersion: operator.openshift.io/v1
+      kind: Etcd
+      spec:
+        controlPlaneHardwareSpeed: Standard
+    expected: |
+      apiVersion: operator.openshift.io/v1
+      kind: Etcd
+      spec:
+        logLevel: Normal
+        operatorLogLevel: Normal
+        controlPlaneHardwareSpeed: Standard
+  - name: Should be able to create with Slower hardware speed
+    initial: |
+      apiVersion: operator.openshift.io/v1
+      kind: Etcd
+      spec:
+        controlPlaneHardwareSpeed: Slower
+    expected: |
+      apiVersion: operator.openshift.io/v1
+      kind: Etcd
+      spec:
+        logLevel: Normal
+        operatorLogLevel: Normal
+        controlPlaneHardwareSpeed: Slower
+  onUpdate:
+  - name: Should be able to create with Standard, then set to Slower
+    initial: |
+      apiVersion: operator.openshift.io/v1
+      kind: Etcd
+      spec:
+        controlPlaneHardwareSpeed: Standard
+    updated: |
+      apiVersion: operator.openshift.io/v1
+      kind: Etcd
+      spec:
+        controlPlaneHardwareSpeed: Slower
+    expected: |
+      apiVersion: operator.openshift.io/v1
+      kind: Etcd
+      spec:
+        logLevel: Normal
+        operatorLogLevel: Normal
+        controlPlaneHardwareSpeed: Slower
+  - name: Should not be allowed to try to set invalid hardware speed
+    initial: |
+      apiVersion: operator.openshift.io/v1
+      kind: Etcd
+      spec:
+        controlPlaneHardwareSpeed: Standard
+    updated: |
+      apiVersion: operator.openshift.io/v1
+      kind: Etcd
+      spec:
+        controlPlaneHardwareSpeed: foo
+    expectedError: Unsupported value

--- a/vendor/github.com/openshift/api/operator/v1/types_etcd.go
+++ b/vendor/github.com/openshift/api/operator/v1/types_etcd.go
@@ -28,11 +28,40 @@ type Etcd struct {
 
 type EtcdSpec struct {
 	StaticPodOperatorSpec `json:",inline"`
+	// HardwareSpeed allows user to change the etcd tuning profile which configures
+	// the latency parameters for heartbeat interval and leader election timeouts
+	// allowing the cluster to tolerate longer round-trip-times between etcd members.
+	// Valid values are "", "Standard" and "Slower".
+	//	"" means no opinion and the platform is left to choose a reasonable default
+	//	which is subject to change without notice.
+	// +kubebuilder:validation:Optional
+	// +openshift:enable:FeatureSets=CustomNoUpgrade;TechPreviewNoUpgrade
+	// +optional
+	HardwareSpeed ControlPlaneHardwareSpeed `json:"controlPlaneHardwareSpeed"`
 }
 
 type EtcdStatus struct {
 	StaticPodOperatorStatus `json:",inline"`
+	HardwareSpeed           ControlPlaneHardwareSpeed `json:"controlPlaneHardwareSpeed"`
 }
+
+const (
+	// StandardHardwareSpeed provides the normal tolerances for hardware speed and latency.
+	//	Currently sets (values subject to change at any time):
+	//		ETCD_HEARTBEAT_INTERVAL: 100ms
+	// 	ETCD_LEADER_ELECTION_TIMEOUT: 1000ms
+	StandardHardwareSpeed ControlPlaneHardwareSpeed = "Standard"
+	// SlowerHardwareSpeed provides more tolerance for slower hardware and/or higher latency networks.
+	// Sets (values subject to change):
+	//		ETCD_HEARTBEAT_INTERVAL: 5x Standard
+	// 	ETCD_LEADER_ELECTION_TIMEOUT: 2.5x Standard
+	SlowerHardwareSpeed ControlPlaneHardwareSpeed = "Slower"
+)
+
+// ControlPlaneHardwareSpeed declares valid hardware speed tolerance levels
+// +enum
+// +kubebuilder:validation:Enum:="";Standard;Slower
+type ControlPlaneHardwareSpeed string
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 

--- a/vendor/github.com/openshift/api/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/vendor/github.com/openshift/api/operator/v1/zz_generated.swagger_doc_generated.go
@@ -686,6 +686,14 @@ func (EtcdList) SwaggerDoc() map[string]string {
 	return map_EtcdList
 }
 
+var map_EtcdSpec = map[string]string{
+	"controlPlaneHardwareSpeed": "HardwareSpeed allows user to change the etcd tuning profile which configures the latency parameters for heartbeat interval and leader election timeouts allowing the cluster to tolerate longer round-trip-times between etcd members. Valid values are \"\", \"Standard\" and \"Slower\".\n\t\"\" means no opinion and the platform is left to choose a reasonable default\n\twhich is subject to change without notice.",
+}
+
+func (EtcdSpec) SwaggerDoc() map[string]string {
+	return map_EtcdSpec
+}
+
 var map_AWSClassicLoadBalancerParameters = map[string]string{
 	"":                      "AWSClassicLoadBalancerParameters holds configuration parameters for an AWS Classic load balancer.",
 	"connectionIdleTimeout": "connectionIdleTimeout specifies the maximum time period that a connection may be idle before the load balancer closes the connection.  The value must be parseable as a time duration value; see <https://pkg.go.dev/time#ParseDuration>.  A nil or zero value means no opinion, in which case a default value is used.  The default value for this field is 60s.  This default is subject to change.",

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -250,7 +250,7 @@ github.com/opencontainers/go-digest
 ## explicit
 github.com/opencontainers/image-spec/specs-go
 github.com/opencontainers/image-spec/specs-go/v1
-# github.com/openshift/api v0.0.0-20230807132801-600991d550ac
+# github.com/openshift/api v0.0.0-20230815201604-a2362cf53230
 ## explicit; go 1.20
 github.com/openshift/api
 github.com/openshift/api/apiserver


### PR DESCRIPTION
BuildCsiVolume feature is techPreview since 4.10. The feature is promted GA
Tests are succeeding for techPreview clusters
Links:
Related to https://issues.redhat.com/browse/BUILD-689
https://github.com/openshift/api/pull/1553