### PR TITLE
USHIFT-1593: Regenerate certs on hostname changes

### DIFF
--- a/pkg/crypto/crypto.go
+++ b/pkg/crypto/crypto.go
@@ -758,11 +758,10 @@ func GetServerCert(certFile, keyFile string, hostnames sets.String) (*TLSCertifi
 	}
 
 	cert := server.Certs[0]
-	stringCertIPs := make([]string, len(cert.IPAddresses))
-	for i, ip := range cert.IPAddresses {
-		stringCertIPs[i] = ip.String()
+	certNames := sets.NewString()
+	for _, ip := range cert.IPAddresses {
+		certNames.Insert(ip.String())
 	}
-	certNames := sets.NewString(stringCertIPs...)
 	certNames.Insert(cert.DNSNames...)
 	if hostnames.Equal(certNames) {
 		klog.V(4).Infof("Found existing server certificate in %s", certFile)

--- a/pkg/crypto/crypto.go
+++ b/pkg/crypto/crypto.go
@@ -758,15 +758,18 @@ func GetServerCert(certFile, keyFile string, hostnames sets.String) (*TLSCertifi
 	}
 
 	cert := server.Certs[0]
-	ips, dns := IPAddressesDNSNames(hostnames.List())
-	missingIps := ipsNotInSlice(ips, cert.IPAddresses)
-	missingDns := stringsNotInSlice(dns, cert.DNSNames)
-	if len(missingIps) == 0 && len(missingDns) == 0 {
+	stringCertIPs := make([]string, len(cert.IPAddresses))
+	for i, ip := range cert.IPAddresses {
+		stringCertIPs[i] = ip.String()
+	}
+	certNames := sets.NewString(stringCertIPs...)
+	certNames.Insert(cert.DNSNames...)
+	if hostnames.Equal(certNames) {
 		klog.V(4).Infof("Found existing server certificate in %s", certFile)
 		return server, nil
 	}
 
-	return nil, fmt.Errorf("Existing server certificate in %s was missing some hostnames (%v) or IP addresses (%v).", certFile, missingDns, missingIps)
+	return nil, fmt.Errorf("Existing server certificate in %s does not match required hostnames.", certFile)
 }
 
 func (ca *CA) MakeAndWriteServerCert(certFile, keyFile string, hostnames sets.String, expireDays int) (*TLSCertificateConfig, error) {
@@ -1211,42 +1214,4 @@ func writeKeyFile(f io.Writer, key crypto.PrivateKey) error {
 	}
 
 	return nil
-}
-
-func stringsNotInSlice(needles []string, haystack []string) []string {
-	missing := []string{}
-	for _, needle := range needles {
-		if !stringInSlice(needle, haystack) {
-			missing = append(missing, needle)
-		}
-	}
-	return missing
-}
-
-func stringInSlice(needle string, haystack []string) bool {
-	for _, straw := range haystack {
-		if needle == straw {
-			return true
-		}
-	}
-	return false
-}
-
-func ipsNotInSlice(needles []net.IP, haystack []net.IP) []net.IP {
-	missing := []net.IP{}
-	for _, needle := range needles {
-		if !ipInSlice(needle, haystack) {
-			missing = append(missing, needle)
-		}
-	}
-	return missing
-}
-
-func ipInSlice(needle net.IP, haystack []net.IP) bool {
-	for _, straw := range haystack {
-		if needle.Equal(straw) {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
When generating certificates there is a check to see if the cert already exists. If it does, it compares the existing IPs and DNSs in the cert against the hostnames it should have. If there is one missing entry from the hostnames in the cert it is regenerated. If not, then the cert is left untouched.
There is no check to see if the entries in the cert are present in the hostname list, leaving room for outdated IP/DNS entries to remain.
In other words: If the certificate already exists and one or more entries are removed from the hostnames list, the cert will be left untouched and those wrong values will be part of the CN/SANs.