### PR TITLE
OCPBUGS-19056: apiserver: optimize IsLongRunningRequest

### DIFF
--- a/pkg/apiserver/apiserverconfig/longrunning_test.go
+++ b/pkg/apiserver/apiserverconfig/longrunning_test.go
@@ -1,0 +1,93 @@
+package apiserverconfig
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+
+	buildv1 "github.com/openshift/api/build/v1"
+	imagev1 "github.com/openshift/api/image/v1"
+	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+)
+
+func TestLongRunning(t *testing.T) {
+	request := http.Request{
+		URL:  &url.URL{Path: "/"},
+		Host: "127.0.0.1",
+	}
+	scenarios := []struct {
+		name        string
+		requestInfo *apirequest.RequestInfo
+		expected    bool
+	}{
+		{
+			name:        "happy path",
+			requestInfo: &apirequest.RequestInfo{},
+			expected:    false,
+		},
+		{
+			name:        "nil requestInfo",
+			requestInfo: nil,
+			expected:    false,
+		},
+		{
+			name: "buildconfigs instantiatebinary",
+			requestInfo: &apirequest.RequestInfo{
+				APIGroup:    buildv1.GroupName,
+				Resource:    "buildconfigs",
+				Subresource: "instantiatebinary",
+			},
+			expected: true,
+		},
+		{
+			name: "buildconfigs no subresource set",
+			requestInfo: &apirequest.RequestInfo{
+				APIGroup: buildv1.GroupName,
+				Resource: "buildconfigs",
+			},
+			expected: false,
+		},
+		{
+			name: "imagestreamimports",
+			requestInfo: &apirequest.RequestInfo{
+				APIGroup: imagev1.GroupName,
+				Resource: "imagestreamimports",
+			},
+			expected: true,
+		},
+	}
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			actual := IsLongRunningRequest(&request, scenario.requestInfo)
+			if actual != scenario.expected {
+				t.Fatalf("expected %v, but was %v", scenario.expected, actual)
+			}
+		})
+	}
+
+	// verbs for kubeLongRunningFunc
+	for verb := range longRunningVerbs {
+		t.Run(fmt.Sprintf("verb %s", verb), func(t *testing.T) {
+			requestInfo := &apirequest.RequestInfo{
+				Verb: verb,
+			}
+			if IsLongRunningRequest(&request, requestInfo) == false {
+				t.Fatalf("expected true, but was false")
+			}
+		})
+	}
+
+	// subresources for kubeLongRunningFunc
+	for subresource := range longRunningSubresources {
+		t.Run(fmt.Sprintf("subresource %s", subresource), func(t *testing.T) {
+			requestInfo := &apirequest.RequestInfo{
+				IsResourceRequest: true,
+				Subresource:       subresource,
+			}
+			if IsLongRunningRequest(&request, requestInfo) == false {
+				t.Fatalf("expected true, but was false")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Avoid using expensive MatchString when request params are already set in requestInfo

Back in 3.x days this was necessary as buildconfigs and imagestreams was served under `/oapi`, but now they are proper CRs so its better to match them via requestInfo params

```
$ benchstat -delta-test=none old.txt new.txt               
name                                                                 old time/op  new time/op  delta
IsLongRunningRequest/path_/api-8                                     11.5ns ± 5%   9.9ns ± 8%  -14.20%
IsLongRunningRequest/path_/api/buildconfigs/foo/instantiatebinary-8   870ns ± 7%     6ns ± 9%  -99.32%
IsLongRunningRequest/path_/api/imagestreamimports-8                   391ns ± 3%    10ns ± 5%  -97.47%
```

Next this needs to be re-imported by openshift-apiserver
