### PR TITLE
cert-inspection: remove InspectCSRv1beta1

### DIFF
--- a/pkg/certs/cert-inspection/certgraphanalysis/analyzer.go
+++ b/pkg/certs/cert-inspection/certgraphanalysis/analyzer.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/openshift/library-go/pkg/certs/cert-inspection/certgraphapi"
 	certificatesv1 "k8s.io/api/certificates/v1"
-	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/util/cert"
 )
@@ -53,11 +52,6 @@ func inspectCSR(resourceString, objName string, certificate []byte) (*certgrapha
 		return detail, nil
 	}
 	return nil, fmt.Errorf("didn't see that coming")
-}
-
-func InspectCSRv1beta1(obj *certificatesv1beta1.CertificateSigningRequest) (*certgraphapi.CertKeyPair, error) {
-	resourceString := fmt.Sprintf("csr/%s[%s]", obj.Name, obj.Namespace)
-	return inspectCSR(resourceString, obj.Name, obj.Status.Certificate)
 }
 
 func InspectCSR(obj *certificatesv1.CertificateSigningRequest) (*certgraphapi.CertKeyPair, error) {


### PR DESCRIPTION
v1beta1 has different fields and apparently not used in any supportable OCP version anymore.

Follow up for https://github.com/openshift/library-go/pull/1581#discussion_r1350548131