### PR TITLE
Allow enabling HTTP, the default is off [4.13]

### DIFF
--- a/pkg/config/serving/server.go
+++ b/pkg/config/serving/server.go
@@ -20,7 +20,7 @@ import (
 )
 
 func ToServerConfig(ctx context.Context, servingInfo configv1.HTTPServingInfo, authenticationConfig operatorv1alpha1.DelegatedAuthentication, authorizationConfig operatorv1alpha1.DelegatedAuthorization,
-	kubeConfigFile string, kubeClient *kubernetes.Clientset, le *configv1.LeaderElection) (*genericapiserver.Config, error) {
+	kubeConfigFile string, kubeClient *kubernetes.Clientset, le *configv1.LeaderElection, enableHTTP2 bool) (*genericapiserver.Config, error) {
 	scheme := runtime.NewScheme()
 	metav1.AddToGroupVersion(scheme, metav1.SchemeGroupVersion)
 	config := genericapiserver.NewConfig(serializer.NewCodecFactory(scheme))
@@ -81,6 +81,8 @@ func ToServerConfig(ctx context.Context, servingInfo configv1.HTTPServingInfo, a
 			return nil, fmt.Errorf("error initializing delegating authentication: %w", err)
 		}
 	}
+
+	config.SecureServing.DisableHTTP2 = !enableHTTP2
 
 	return config, nil
 }

--- a/pkg/controller/controllercmd/builder.go
+++ b/pkg/controller/controllercmd/builder.go
@@ -94,6 +94,9 @@ type ControllerBuilder struct {
 	// Keep track if we defaulted leader election, used to make sure we don't stomp on the users intent for leader election
 	// We use this flag to determine at runtime if we can alter leader election for SNO configurations
 	userExplicitlySetLeaderElectionValues bool
+
+	// Allow enabling HTTP2
+	enableHTTP2 bool
 }
 
 // NewController returns a builder struct for constructing the command you want to run
@@ -169,6 +172,12 @@ func (b *ControllerBuilder) WithServer(servingInfo configv1.HTTPServingInfo, aut
 	configdefaults.SetRecommendedHTTPServingInfoDefaults(b.servingInfo)
 	b.authenticationConfig = &authenticationConfig
 	b.authorizationConfig = &authorizationConfig
+	return b
+}
+
+// WithHTTP2 indicates that http2 should be enabled
+func (b *ControllerBuilder) WithHTTP2() *ControllerBuilder {
+	b.enableHTTP2 = true
 	return b
 }
 
@@ -269,7 +278,7 @@ func (b *ControllerBuilder) Run(ctx context.Context, config *unstructured.Unstru
 
 	var server *genericapiserver.GenericAPIServer
 	if b.servingInfo != nil {
-		serverConfig, err := serving.ToServerConfig(ctx, *b.servingInfo, *b.authenticationConfig, *b.authorizationConfig, kubeConfig, kubeClient, b.leaderElection)
+		serverConfig, err := serving.ToServerConfig(ctx, *b.servingInfo, *b.authenticationConfig, *b.authorizationConfig, kubeConfig, kubeClient, b.leaderElection, b.enableHTTP2)
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/controllercmd/cmd.go
+++ b/pkg/controller/controllercmd/cmd.go
@@ -43,6 +43,9 @@ type ControllerCommandConfig struct {
 	// DisableServing disables serving metrics, debug and health checks and so on.
 	DisableServing bool
 
+	// Allow enabling HTTP2
+	EnableHTTP2 bool
+
 	// DisableLeaderElection allows leader election to be suspended
 	DisableLeaderElection bool
 
@@ -289,6 +292,9 @@ func (c *ControllerCommandConfig) StartController(ctx context.Context) error {
 
 	if !c.DisableServing {
 		builder = builder.WithServer(config.ServingInfo, config.Authentication, config.Authorization)
+		if c.EnableHTTP2 {
+			builder = builder.WithHTTP2()
+		}
 	}
 
 	return builder.Run(controllerCtx, unstructuredConfig)


### PR DESCRIPTION
backport of https://github.com/openshift/library-go/pull/1587