### PR TITLE
certrotation: add more options for consumers

### DIFF
--- a/pkg/operator/certrotation/cabundle.go
+++ b/pkg/operator/certrotation/cabundle.go
@@ -28,6 +28,8 @@ type CABundleConfigMap struct {
 	Namespace string
 	// Name is the name of the ConfigMap to maintain.
 	Name string
+	// Owner is an optional reference to add to the secret that this rotator creates.
+	Owner *metav1.OwnerReference
 
 	// Plumbing:
 	Informer      corev1informers.ConfigMapInformer
@@ -47,6 +49,18 @@ func (c CABundleConfigMap) ensureConfigMapCABundle(ctx context.Context, signingC
 	if apierrors.IsNotFound(err) {
 		// create an empty one
 		caBundleConfigMap = &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: c.Namespace, Name: c.Name}}
+	}
+	if c.Owner != nil {
+		var found bool
+		for _, ref := range caBundleConfigMap.ObjectMeta.OwnerReferences {
+			if ref == *c.Owner {
+				found = true
+				break
+			}
+		}
+		if !found {
+			caBundleConfigMap.ObjectMeta.OwnerReferences = append(caBundleConfigMap.ObjectMeta.OwnerReferences, *c.Owner)
+		}
 	}
 	updatedCerts, err := manageCABundleConfigMap(caBundleConfigMap, signingCertKeyPair.Config.Certs[0])
 	if err != nil {

--- a/pkg/operator/certrotation/cabundle.go
+++ b/pkg/operator/certrotation/cabundle.go
@@ -51,16 +51,7 @@ func (c CABundleConfigMap) ensureConfigMapCABundle(ctx context.Context, signingC
 		caBundleConfigMap = &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: c.Namespace, Name: c.Name}}
 	}
 	if c.Owner != nil {
-		var found bool
-		for _, ref := range caBundleConfigMap.ObjectMeta.OwnerReferences {
-			if ref == *c.Owner {
-				found = true
-				break
-			}
-		}
-		if !found {
-			caBundleConfigMap.ObjectMeta.OwnerReferences = append(caBundleConfigMap.ObjectMeta.OwnerReferences, *c.Owner)
-		}
+		ensureOwnerReference(&caBundleConfigMap.ObjectMeta, c.Owner)
 	}
 	updatedCerts, err := manageCABundleConfigMap(caBundleConfigMap, signingCertKeyPair.Config.Certs[0])
 	if err != nil {

--- a/pkg/operator/certrotation/client_cert_rotation_controller.go
+++ b/pkg/operator/certrotation/client_cert_rotation_controller.go
@@ -27,15 +27,41 @@ const (
 	RunOnceContextKey = "cert-rotation-controller.openshift.io/run-once"
 )
 
+// StatusReporter knows how to report the status of cert rotation
+type StatusReporter interface {
+	Report(ctx context.Context, syncErr error) (updated bool, updateErr error)
+}
+
+var _ StatusReporter = (*StaticPodConditionStatusReporter)(nil)
+
+type StaticPodConditionStatusReporter struct {
+	// conditionName is used in operator conditions to identify this controller, compare CertRotationDegradedConditionTypeFmt.
+	conditionName string
+
+	// Plumbing:
+	OperatorClient v1helpers.StaticPodOperatorClient
+}
+
+func (s *StaticPodConditionStatusReporter) Report(ctx context.Context, syncErr error) (bool, error) {
+	newCondition := operatorv1.OperatorCondition{
+		Type:   fmt.Sprintf(condition.CertRotationDegradedConditionTypeFmt, s.conditionName),
+		Status: operatorv1.ConditionFalse,
+	}
+	if syncErr != nil {
+		newCondition.Status = operatorv1.ConditionTrue
+		newCondition.Reason = "RotationError"
+		newCondition.Message = syncErr.Error()
+	}
+	_, updated, updateErr := v1helpers.UpdateStaticPodStatus(ctx, s.OperatorClient, v1helpers.UpdateStaticPodConditionFn(newCondition))
+	return updated, updateErr
+}
+
 // CertRotationController does:
 //
 // 1) continuously create a self-signed signing CA (via RotatedSigningCASecret) and store it in a secret.
 // 2) maintain a CA bundle ConfigMap with all not yet expired CA certs.
 // 3) continuously create a target cert and key signed by the latest signing CA and store it in a secret.
 type CertRotationController struct {
-	// name is used in operator conditions to identify this controller, compare CertRotationDegradedConditionTypeFmt.
-	name string
-
 	// rotatedSigningCASecret rotates a self-signed signing CA stored in a secret.
 	rotatedSigningCASecret RotatedSigningCASecret
 	// CABundleConfigMap maintains a CA bundle config map, by adding new CA certs coming from rotatedSigningCASecret, and by removing expired old ones.
@@ -44,7 +70,7 @@ type CertRotationController struct {
 	RotatedSelfSignedCertKeySecret RotatedSelfSignedCertKeySecret
 
 	// Plumbing:
-	OperatorClient v1helpers.StaticPodOperatorClient
+	StatusReporter StatusReporter
 }
 
 func NewCertRotationController(
@@ -52,15 +78,14 @@ func NewCertRotationController(
 	rotatedSigningCASecret RotatedSigningCASecret,
 	caBundleConfigMap CABundleConfigMap,
 	rotatedSelfSignedCertKeySecret RotatedSelfSignedCertKeySecret,
-	operatorClient v1helpers.StaticPodOperatorClient,
 	recorder events.Recorder,
+	reporter StatusReporter,
 ) factory.Controller {
 	c := &CertRotationController{
-		name:                           name,
 		rotatedSigningCASecret:         rotatedSigningCASecret,
 		CABundleConfigMap:              caBundleConfigMap,
 		RotatedSelfSignedCertKeySecret: rotatedSelfSignedCertKeySecret,
-		OperatorClient:                 operatorClient,
+		StatusReporter:                 reporter,
 	}
 	return factory.New().
 		ResyncEvery(time.Minute).
@@ -73,7 +98,7 @@ func NewCertRotationController(
 		WithPostStartHooks(
 			c.targetCertRecheckerPostRunHook,
 		).
-		ToController("CertRotationController", recorder.WithComponentSuffix("cert-rotation-controller"))
+		ToController("CertRotationController", recorder.WithComponentSuffix("cert-rotation-controller").WithComponentSuffix(name))
 }
 
 func (c CertRotationController) Sync(ctx context.Context, syncCtx factory.SyncContext) error {
@@ -85,21 +110,12 @@ func (c CertRotationController) Sync(ctx context.Context, syncCtx factory.SyncCo
 		return syncErr
 	}
 
-	newCondition := operatorv1.OperatorCondition{
-		Type:   fmt.Sprintf(condition.CertRotationDegradedConditionTypeFmt, c.name),
-		Status: operatorv1.ConditionFalse,
-	}
-	if syncErr != nil {
-		newCondition.Status = operatorv1.ConditionTrue
-		newCondition.Reason = "RotationError"
-		newCondition.Message = syncErr.Error()
-	}
-	_, updated, updateErr := v1helpers.UpdateStaticPodStatus(ctx, c.OperatorClient, v1helpers.UpdateStaticPodConditionFn(newCondition))
+	updated, updateErr := c.StatusReporter.Report(ctx, syncErr)
 	if updateErr != nil {
 		return updateErr
 	}
 	if updated && syncErr != nil {
-		syncCtx.Recorder().Warningf("RotationError", newCondition.Message)
+		syncCtx.Recorder().Warningf("RotationError", syncErr.Error())
 	}
 
 	return syncErr


### PR DESCRIPTION
certrotation: allow setting an owner reference on rotated content

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

certrotation: make status reporting optional

When we're rotating certificates in a context that does not have a
static pod on which OperatorConditions are exposed, we need to emit our
status reporting in another manner. Unfortunately, without some external
place to store the prior reporing state, we can't only report on state
transitions. Therefore, we choose to only report errors and hope that it
will not be spammy.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

