### PR TITLE
cert-inspection: add RewriteNodeIP options

### DIFF
--- a/pkg/certs/cert-inspection/certgraphanalysis/collection_options.go
+++ b/pkg/certs/cert-inspection/certgraphanalysis/collection_options.go
@@ -21,16 +21,10 @@ func (resourceFilteringOptions) approved() {}
 var (
 	SkipRevisioned = &resourceFilteringOptions{
 		rejectConfigMap: func(configMap *corev1.ConfigMap) bool {
-			if isRevisioned(configMap.OwnerReferences) {
-				return true
-			}
-			return false
+			return isRevisioned(configMap.OwnerReferences)
 		},
 		rejectSecret: func(secret *corev1.Secret) bool {
-			if isRevisioned(secret.OwnerReferences) {
-				return true
-			}
-			return false
+			return isRevisioned(secret.OwnerReferences)
 		},
 	}
 	SkipHashed = &resourceFilteringOptions{

--- a/pkg/certs/cert-inspection/certgraphanalysis/filtering_options.go
+++ b/pkg/certs/cert-inspection/certgraphanalysis/filtering_options.go
@@ -70,3 +70,29 @@ func (l certGenerationOptionList) rewriteCertKeyPair(certKeyPair *certgraphapi.C
 		option.rewriteCertKeyPair(certKeyPair)
 	}
 }
+
+func (l certGenerationOptionList) rewriteConfigMap(configMap *corev1.ConfigMap) {
+	for _, curr := range l {
+		option, ok := curr.(*metadataOptions)
+		if !ok {
+			continue
+		}
+		if option.rewriteConfigMap == nil {
+			continue
+		}
+		option.rewriteConfigMap(configMap)
+	}
+}
+
+func (l certGenerationOptionList) rewriteSecret(secret *corev1.Secret) {
+	for _, curr := range l {
+		option, ok := curr.(*metadataOptions)
+		if !ok {
+			continue
+		}
+		if option.rewriteSecret == nil {
+			continue
+		}
+		option.rewriteSecret(secret)
+	}
+}


### PR DESCRIPTION
Skip secrets and configmaps hashed by openshift-monitoring, i.e. prometheus-adapter secret. Follow up for https://github.com/openshift/library-go/pull/1599

Testing this in https://github.com/openshift/origin/pull/28373