### PR TITLE
revision_controller: print the right revision when all created/updated

### DIFF
--- a/pkg/operator/revisioncontroller/revision_controller.go
+++ b/pkg/operator/revisioncontroller/revision_controller.go
@@ -115,7 +115,7 @@ func (c RevisionController) createRevisionIfNeeded(ctx context.Context, recorder
 	if _, updated, updateError := c.operatorClient.UpdateLatestRevisionOperatorStatus(ctx, nextRevision, v1helpers.UpdateConditionFn(cond)); updateError != nil {
 		return true, updateError
 	} else if updated {
-		recorder.Eventf("RevisionCreate", "Revision %d created because %s", latestAvailableRevision, reason)
+		recorder.Eventf("RevisionCreate", "Revision %d created because %s", nextRevision, reason)
 	}
 
 	return false, nil


### PR DESCRIPTION
When `UpdateLatestRevisionOperatorStatus` updates the status `updated` is true. The status is updated with `status.LatestAvailableRevision` set to `nextRevision`. So the recorded event is expected to print `nextRevision`.