### PR TITLE
Update fakeSharedIndexInformer with upstream interface changes

### DIFF
--- a/pkg/operator/v1helpers/test_helpers.go
+++ b/pkg/operator/v1helpers/test_helpers.go
@@ -25,10 +25,20 @@ func NewFakeSharedIndexInformer() cache.SharedIndexInformer {
 
 type fakeSharedIndexInformer struct{}
 
-func (fakeSharedIndexInformer) AddEventHandler(handler cache.ResourceEventHandler) {
+func (fakeSharedIndexInformer) AddEventHandler(handler cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
+	panic("implement me")
 }
 
-func (fakeSharedIndexInformer) AddEventHandlerWithResyncPeriod(handler cache.ResourceEventHandler, resyncPeriod time.Duration) {
+func (fakeSharedIndexInformer) AddEventHandlerWithResyncPeriod(handler cache.ResourceEventHandler, resyncPeriod time.Duration) (cache.ResourceEventHandlerRegistration, error) {
+	panic("implement me")
+}
+
+func (fakeSharedIndexInformer) RemoveEventHandler(handle cache.ResourceEventHandlerRegistration) error {
+	panic("implement me")
+}
+
+func (fakeSharedIndexInformer) IsStopped() bool {
+	panic("implement me")
 }
 
 func (fakeSharedIndexInformer) GetStore() cache.Store {


### PR DESCRIPTION
fixing a vendoring issue observed with https://github.com/openshift/cluster-etcd-operator/pull/1148 