### PR TITLE
OCPBUGS-23796: add pdbUnhealthyPodEvictionPolicy option to a GuardController 

### DIFF
--- a/pkg/operator/staticpod/controller/guard/guard_controller.go
+++ b/pkg/operator/staticpod/controller/guard/guard_controller.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,6 +24,7 @@ import (
 	corelisterv1 "k8s.io/client-go/listers/core/v1"
 	policylisterv1 "k8s.io/client-go/listers/policy/v1"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
@@ -39,6 +41,7 @@ type GuardController struct {
 	readyzPort                         string
 	readyzEndpoint                     string
 	operandPodLabelSelector            labels.Selector
+	pdbUnhealthyPodEvictionPolicy      *v1.UnhealthyPodEvictionPolicyType
 
 	nodeLister corelisterv1.NodeLister
 	podLister  corelisterv1.PodLister
@@ -58,6 +61,7 @@ func NewGuardController(
 	operatorName string,
 	readyzPort string,
 	readyzEndpoint string,
+	pdbUnhealthyPodEvictionPolicy *v1.UnhealthyPodEvictionPolicyType,
 	kubeInformersForTargetNamespace informers.SharedInformerFactory,
 	kubeInformersClusterScoped informers.SharedInformerFactory,
 	operatorClient operatorv1helpers.StaticPodOperatorClient,
@@ -73,20 +77,29 @@ func NewGuardController(
 		return nil, fmt.Errorf("GuardController: operandPodLabelSelector cannot be empty")
 	}
 
+	// test any new UnhealthyPodEvictionPolicyType before adding them to the supported list
+	if !(pdbUnhealthyPodEvictionPolicy == nil ||
+		*pdbUnhealthyPodEvictionPolicy == v1.IfHealthyBudget ||
+		*pdbUnhealthyPodEvictionPolicy == v1.AlwaysAllow) {
+		return nil, fmt.Errorf("GuardController: only <nil>, %q and %q pdbUnhealthyPodEvictionPolicy values are supported", v1.IfHealthyBudget, v1.AlwaysAllow)
+
+	}
+
 	c := &GuardController{
-		targetNamespace:         targetNamespace,
-		operandPodLabelSelector: operandPodLabelSelector,
-		podResourcePrefix:       podResourcePrefix,
-		operatorName:            operatorName,
-		readyzPort:              readyzPort,
-		readyzEndpoint:          readyzEndpoint,
-		nodeLister:              kubeInformersClusterScoped.Core().V1().Nodes().Lister(),
-		podLister:               kubeInformersForTargetNamespace.Core().V1().Pods().Lister(),
-		podGetter:               podGetter,
-		pdbGetter:               pdbGetter,
-		pdbLister:               kubeInformersForTargetNamespace.Policy().V1().PodDisruptionBudgets().Lister(),
-		installerPodImageFn:     getInstallerPodImageFromEnv,
-		createConditionalFunc:   createConditionalFunc,
+		targetNamespace:               targetNamespace,
+		operandPodLabelSelector:       operandPodLabelSelector,
+		podResourcePrefix:             podResourcePrefix,
+		operatorName:                  operatorName,
+		readyzPort:                    readyzPort,
+		readyzEndpoint:                readyzEndpoint,
+		pdbUnhealthyPodEvictionPolicy: pdbUnhealthyPodEvictionPolicy,
+		nodeLister:                    kubeInformersClusterScoped.Core().V1().Nodes().Lister(),
+		podLister:                     kubeInformersForTargetNamespace.Core().V1().Pods().Lister(),
+		podGetter:                     podGetter,
+		pdbGetter:                     pdbGetter,
+		pdbLister:                     kubeInformersForTargetNamespace.Policy().V1().PodDisruptionBudgets().Lister(),
+		installerPodImageFn:           getInstallerPodImageFromEnv,
+		createConditionalFunc:         createConditionalFunc,
 	}
 
 	return factory.New().WithInformers(
@@ -222,14 +235,16 @@ func (c *GuardController) sync(ctx context.Context, syncCtx factory.SyncContext)
 		pdb := resourceread.ReadPodDisruptionBudgetV1OrDie(pdbTemplate)
 		pdb.ObjectMeta.Name = getGuardPDBName(c.podResourcePrefix)
 		pdb.ObjectMeta.Namespace = c.targetNamespace
+		pdb.Spec.UnhealthyPodEvictionPolicy = c.pdbUnhealthyPodEvictionPolicy
 		if len(nodes) > 1 {
-			minAvailable := intstr.FromInt(len(nodes) - 1)
+			minAvailable := intstr.FromInt32(int32(len(nodes)) - 1)
 			pdb.Spec.MinAvailable = &minAvailable
 		}
 
 		pdbObj, err := c.pdbLister.PodDisruptionBudgets(pdb.Namespace).Get(pdb.Name)
 		if err == nil {
-			if pdbObj.Spec.MinAvailable != pdb.Spec.MinAvailable {
+			if !ptr.Equal(pdbObj.Spec.UnhealthyPodEvictionPolicy, pdb.Spec.UnhealthyPodEvictionPolicy) ||
+				!ptr.Equal(pdbObj.Spec.MinAvailable, pdb.Spec.MinAvailable) {
 				_, _, err = resourceapply.ApplyPodDisruptionBudget(ctx, c.pdbGetter, syncCtx.Recorder(), pdb)
 				if err != nil {
 					klog.Errorf("Unable to apply PodDisruptionBudget changes: %v", err)


### PR DESCRIPTION
optionally `pdbUnhealthyPodEvictionPolicy` can be set to `AlwaysAllow` to allows
eviction of unhealthy (not ready) pods even if there are no disruptions allowed
on a PodDisruptionBudget. This can help to drain/maintain a node and recover
without a manual intervention when multiple instances of nodes or pods are
misbehaving. Use this with caution, as this option can disrupt perspective pods
that have not yet had a chance to become healthy (ready).

Solves the following issue:

1. upgrade the cluster 
2. 2 or more kube-apiserver pod do not become online. Network access could be lost due to misconfiguration or wrong rhel update. We can simulate this with:
    - ssh into a node 
    -  run `iptables -A INPUT -p tcp --destination-port 6443 -j DROP`
3. 2 or more kube-apiserver-guard pods lose readiness
4. kube-apiserver-guard-pdb PDB blocks the drain because `status.currentHealthy` is less than `status.desiredHealthy`
5. it is not possible to drain the node without overriding eviction requests (forcefully deleting the guard pods)`
```
    evicting pod openshift-kube-apiserver/kube-apiserver-guard-ip-10-0-19-181.eu-north-1.compute.internal
    error when evicting pods/"kube-apiserver-guard-ip-10-0-19-181.eu-north-1.compute.internal" -n "openshift-kube-apiserver" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
```

By loosening the unhealthyPodEvictionPolicy on the pdb, we (or MCO) can drain these nodes and do a maintenance (e.g. fixing the networking). 