### PR TITLE
OCPBUGS-18697: guard controller: delay in some cases to avoid quick reconciliation

### DIFF
--- a/pkg/operator/staticpod/controller/guard/guard_controller_test.go
+++ b/pkg/operator/staticpod/controller/guard/guard_controller_test.go
@@ -512,6 +512,7 @@ func TestRenderGuardPod(t *testing.T) {
 				pdbLister:               kubeInformers.Policy().V1().PodDisruptionBudgets().Lister(),
 				installerPodImageFn:     getInstallerPodImageFromEnv,
 				createConditionalFunc:   createConditionalFunc,
+				delayTimeout:            time.Second,
 			}
 
 			ctx, cancel := context.WithCancel(context.TODO())


### PR DESCRIPTION
Follow up for https://github.com/openshift/library-go/pull/1620/files#r1399213346.

E.g. to avoid:
```
E1114 01:36:14.472523       1 guard_controller.go:271] Missing operand on node libvirt-s390x-2-1-4fc-dwwjq-master-0
E1114 01:36:14.472549       1 guard_controller.go:271] Missing operand on node libvirt-s390x-2-1-4fc-dwwjq-master-1
E1114 01:36:14.472568       1 guard_controller.go:271] Missing operand on node libvirt-s390x-2-1-4fc-dwwjq-master-2
E1114 01:36:14.484316       1 guard_controller.go:271] Missing operand on node libvirt-s390x-2-1-4fc-dwwjq-master-0
E1114 01:36:14.484341       1 guard_controller.go:271] Missing operand on node libvirt-s390x-2-1-4fc-dwwjq-master-1
E1114 01:36:14.484363       1 guard_controller.go:271] Missing operand on node libvirt-s390x-2-1-4fc-dwwjq-master-2
E1114 01:36:14.506314       1 guard_controller.go:271] Missing operand on node libvirt-s390x-2-1-4fc-dwwjq-master-0
E1114 01:36:14.506347       1 guard_controller.go:271] Missing operand on node libvirt-s390x-2-1-4fc-dwwjq-master-1
E1114 01:36:14.506366       1 guard_controller.go:271] Missing operand on node libvirt-s390x-2-1-4fc-dwwjq-master-2
E1114 01:36:14.548493       1 guard_controller.go:271] Missing operand on node libvirt-s390x-2-1-4fc-dwwjq-master-0
E1114 01:36:14.548531       1 guard_controller.go:271] Missing operand on node libvirt-s390x-2-1-4fc-dwwjq-master-1
E1114 01:36:14.548550       1 guard_controller.go:271] Missing operand on node libvirt-s390x-2-1-4fc-dwwjq-master-2
E1114 01:36:14.630401       1 guard_controller.go:271] Missing operand on node libvirt-s390x-2-1-4fc-dwwjq-master-0
E1114 01:36:14.630423       1 guard_controller.go:271] Missing operand on node libvirt-s390x-2-1-4fc-dwwjq-master-1
E1114 01:36:14.630448       1 guard_controller.go:271] Missing operand on node libvirt-s390x-2-1-4fc-dwwjq-master-2
E1114 01:36:14.792342       1 guard_controller.go:271] Missing operand on node libvirt-s390x-2-1-4fc-dwwjq-master-0
E1114 01:36:14.792363       1 guard_controller.go:271] Missing operand on node libvirt-s390x-2-1-4fc-dwwjq-master-1
E1114 01:36:14.792381       1 guard_controller.go:271] Missing operand on node libvirt-s390x-2-1-4fc-dwwjq-master-2
```
and log only:
```
E1114 01:36:14.472523       1 guard_controller.go:271] Missing operand on node libvirt-s390x-2-1-4fc-dwwjq-master-0
E1114 01:36:14.472549       1 guard_controller.go:271] Missing operand on node libvirt-s390x-2-1-4fc-dwwjq-master-1
E1114 01:36:14.472549       1 guard_controller.go:271] Missing operand on node libvirt-s390x-2-1-4fc-dwwjq-master-2
E1114 01:36:14.972523       1 guard_controller.go:271] Missing operand on node libvirt-s390x-2-1-4fc-dwwjq-master-0
E1114 01:36:14.972549       1 guard_controller.go:271] Missing operand on node libvirt-s390x-2-1-4fc-dwwjq-master-1
E1114 01:36:14.972549       1 guard_controller.go:271] Missing operand on node libvirt-s390x-2-1-4fc-dwwjq-master-2
```