### PR TITLE
CFE-882: Route external certificate validation

### DIFF
--- a/pkg/route/common.go
+++ b/pkg/route/common.go
@@ -1,0 +1,60 @@
+package route
+
+import (
+	"context"
+	"fmt"
+
+	authorizationv1 "k8s.io/api/authorization/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/endpoints/request"
+
+	routev1 "github.com/openshift/api/route/v1"
+	"github.com/openshift/library-go/pkg/authorization/authorizationutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// SubjectAccessReviewCreator is an interface for performing subject access reviews
+type SubjectAccessReviewCreator interface {
+	Create(ctx context.Context, sar *authorizationv1.SubjectAccessReview, opts metav1.CreateOptions) (*authorizationv1.SubjectAccessReview, error)
+}
+
+// RouteValidationOptions used to tweak how/what fields are validated. These
+// options are propagated by the apiserver.
+type RouteValidationOptions struct {
+
+	// AllowExternalCertificates option is set when the RouteExternalCertificate
+	// feature gate is enabled.
+	AllowExternalCertificates bool
+}
+
+// CheckRouteCustomHostSAR checks if user has permission to create and update routes/custom-host
+// sub-resource
+func CheckRouteCustomHostSAR(ctx context.Context, fldPath *field.Path, sarc SubjectAccessReviewCreator) field.ErrorList {
+	user, ok := request.UserFrom(ctx)
+	if !ok {
+		return field.ErrorList{field.InternalError(fldPath, fmt.Errorf("unable to verify host field can be set"))}
+	}
+
+	var errs field.ErrorList
+	if err := authorizationutil.Authorize(sarc, user, &authorizationv1.ResourceAttributes{
+		Namespace:   request.NamespaceValue(ctx),
+		Verb:        "create",
+		Group:       routev1.GroupName,
+		Resource:    "routes",
+		Subresource: "custom-host",
+	}); err != nil {
+		errs = append(errs, field.Forbidden(fldPath, "user does not have create permission on custom-host"))
+	}
+
+	if err := authorizationutil.Authorize(sarc, user, &authorizationv1.ResourceAttributes{
+		Namespace:   request.NamespaceValue(ctx),
+		Verb:        "update",
+		Group:       routev1.GroupName,
+		Resource:    "routes",
+		Subresource: "custom-host",
+	}); err != nil {
+		errs = append(errs, field.Forbidden(fldPath, "user does not have update permission on custom-host"))
+	}
+
+	return errs
+}

--- a/pkg/route/hostassignment/assignment.go
+++ b/pkg/route/hostassignment/assignment.go
@@ -12,15 +12,11 @@ import (
 
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/openshift/library-go/pkg/authorization/authorizationutil"
+	"github.com/openshift/library-go/pkg/route"
 )
 
 // HostGeneratedAnnotationKey is the key for an annotation set to "true" if the route's host was generated
 const HostGeneratedAnnotationKey = "openshift.io/host.generated"
-
-// Registry is an interface for performing subject access reviews
-type SubjectAccessReviewCreator interface {
-	Create(ctx context.Context, sar *authorizationv1.SubjectAccessReview, opts metav1.CreateOptions) (*authorizationv1.SubjectAccessReview, error)
-}
 
 type HostnameGenerator interface {
 	GenerateHostname(*routev1.Route) (string, error)
@@ -29,9 +25,18 @@ type HostnameGenerator interface {
 // AllocateHost allocates a host name ONLY if the route doesn't specify a subdomain wildcard policy and
 // the host name on the route is empty and an allocator is configured.
 // It must first allocate the shard and may return an error if shard allocation fails.
-func AllocateHost(ctx context.Context, route *routev1.Route, sarc SubjectAccessReviewCreator, routeAllocator HostnameGenerator) field.ErrorList {
+func AllocateHost(ctx context.Context, route *routev1.Route, sarc route.SubjectAccessReviewCreator, routeAllocator HostnameGenerator, opts route.RouteValidationOptions) field.ErrorList {
 	hostSet := len(route.Spec.Host) > 0
-	certSet := route.Spec.TLS != nil && (len(route.Spec.TLS.CACertificate) > 0 || len(route.Spec.TLS.Certificate) > 0 || len(route.Spec.TLS.DestinationCACertificate) > 0 || len(route.Spec.TLS.Key) > 0)
+	certSet := route.Spec.TLS != nil &&
+		(len(route.Spec.TLS.CACertificate) > 0 ||
+			len(route.Spec.TLS.Certificate) > 0 ||
+			len(route.Spec.TLS.DestinationCACertificate) > 0 ||
+			len(route.Spec.TLS.Key) > 0)
+
+	if opts.AllowExternalCertificates && route.Spec.TLS != nil && route.Spec.TLS.ExternalCertificate != nil {
+		certSet = certSet || len(route.Spec.TLS.ExternalCertificate.Name) > 0
+	}
+
 	if hostSet || certSet {
 		user, ok := request.UserFrom(ctx)
 		if !ok {
@@ -86,41 +91,65 @@ func AllocateHost(ctx context.Context, route *routev1.Route, sarc SubjectAccessR
 	return nil
 }
 
-func hasCertificateInfo(tls *routev1.TLSConfig) bool {
+func hasCertificateInfo(tls *routev1.TLSConfig, opts route.RouteValidationOptions) bool {
 	if tls == nil {
 		return false
 	}
-	return len(tls.Certificate) > 0 ||
+	hasInfo := len(tls.Certificate) > 0 ||
 		len(tls.Key) > 0 ||
 		len(tls.CACertificate) > 0 ||
 		len(tls.DestinationCACertificate) > 0
+
+	if opts.AllowExternalCertificates && tls.ExternalCertificate != nil {
+		hasInfo = hasInfo || len(tls.ExternalCertificate.Name) > 0
+	}
+	return hasInfo
 }
 
-func certificateChangeRequiresAuth(route, older *routev1.Route) bool {
+// certificateChangeRequiresAuth determines whether changes to the TLS certificate configuration require authentication.
+// Note: If either route uses externalCertificate, this function always returns true, as we cannot definitively verify if
+// the content of the referenced secret has been modified. Even if the secret name remains the same,
+// we must assume that the secret content is changed, necessitating authentication.
+func certificateChangeRequiresAuth(route, older *routev1.Route, opts route.RouteValidationOptions) bool {
 	switch {
 	case route.Spec.TLS != nil && older.Spec.TLS != nil:
 		a, b := route.Spec.TLS, older.Spec.TLS
-		if !hasCertificateInfo(a) {
+		if !hasCertificateInfo(a, opts) {
 			// removing certificate info is allowed
 			return false
 		}
-		return a.CACertificate != b.CACertificate ||
+
+		certChanged := a.CACertificate != b.CACertificate ||
 			a.Certificate != b.Certificate ||
 			a.DestinationCACertificate != b.DestinationCACertificate ||
 			a.Key != b.Key
+
+		if opts.AllowExternalCertificates {
+			if route.Spec.TLS.ExternalCertificate != nil || older.Spec.TLS.ExternalCertificate != nil {
+				certChanged = true
+			}
+		}
+
+		return certChanged
 	case route.Spec.TLS != nil:
 		// using any default certificate is allowed
-		return hasCertificateInfo(route.Spec.TLS)
+		return hasCertificateInfo(route.Spec.TLS, opts)
 	default:
 		// all other cases we are not adding additional certificate info
 		return false
 	}
 }
 
-func ValidateHostUpdate(ctx context.Context, route, older *routev1.Route, sarc SubjectAccessReviewCreator) field.ErrorList {
+// ValidateHostUpdate checks if the user has the correct permissions based on the updates
+// done to the route object. If the route's host/subdomain has been updated it checks if
+// the user has "update" permission on custom-host subresource. If only the certificate
+// has changed, it checks if the user has "create" permission on the custom-host subresource.
+// Caveat here is that if the route uses externalCertificate, the certChanged condition will
+// always be true since we cannot verify state of external secret object.
+func ValidateHostUpdate(ctx context.Context, route, older *routev1.Route, sarc route.SubjectAccessReviewCreator, opts route.RouteValidationOptions) field.ErrorList {
 	hostChanged := route.Spec.Host != older.Spec.Host
 	subdomainChanged := route.Spec.Subdomain != older.Spec.Subdomain
-	certChanged := certificateChangeRequiresAuth(route, older)
+	certChanged := certificateChangeRequiresAuth(route, older, opts)
 	if !hostChanged && !certChanged && !subdomainChanged {
 		return nil
 	}
@@ -190,6 +219,14 @@ func ValidateHostUpdate(ctx context.Context, route, older *routev1.Route, sarc S
 			errs = append(errs, apimachineryvalidation.ValidateImmutableField(route.Spec.TLS.Certificate, older.Spec.TLS.Certificate, field.NewPath("spec", "tls", "certificate"))...)
 			errs = append(errs, apimachineryvalidation.ValidateImmutableField(route.Spec.TLS.DestinationCACertificate, older.Spec.TLS.DestinationCACertificate, field.NewPath("spec", "tls", "destinationCACertificate"))...)
 			errs = append(errs, apimachineryvalidation.ValidateImmutableField(route.Spec.TLS.Key, older.Spec.TLS.Key, field.NewPath("spec", "tls", "key"))...)
+
+			if opts.AllowExternalCertificates {
+				if route.Spec.TLS.ExternalCertificate == nil || older.Spec.TLS.ExternalCertificate == nil {
+					errs = append(errs, apimachineryvalidation.ValidateImmutableField(route.Spec.TLS.ExternalCertificate, older.Spec.TLS.ExternalCertificate, field.NewPath("spec", "tls", "externalCertificate"))...)
+				} else {
+					errs = append(errs, apimachineryvalidation.ValidateImmutableField(route.Spec.TLS.ExternalCertificate.Name, older.Spec.TLS.ExternalCertificate.Name, field.NewPath("spec", "tls", "externalCertificate"))...)
+				}
+			}
 			return errs
 		}
 	}

--- a/pkg/route/hostassignment/externalcertificate.go
+++ b/pkg/route/hostassignment/externalcertificate.go
@@ -1,0 +1,35 @@
+package hostassignment
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	routev1 "github.com/openshift/api/route/v1"
+	routecommon "github.com/openshift/library-go/pkg/route"
+)
+
+// ValidateHostExternalCertificate checks if the user has permissions to create and update
+// custom-host subresource of routes. This check is required to be done prior to ValidateHostUpdate()
+// since updating hosts while using externalCertificate is contingent on the user having both these
+// permissions. The ValidateHostUpdate() cannot differentiate if the certificate has changed since
+// now the certificates will be present as a secret object, due to this it proceeds with the assumption
+// that the certificate has changed when the route has externalCertificate set.
+// TODO: Consider merging this function into ValidateHostUpdate.
+func ValidateHostExternalCertificate(ctx context.Context, new, older *routev1.Route, sarc routecommon.SubjectAccessReviewCreator, opts routecommon.RouteValidationOptions) field.ErrorList {
+
+	if !opts.AllowExternalCertificates {
+		// Return nil since the feature gate is off.
+		// ValidateHostUpdate() is sufficient to validate
+		// permissions.
+		return nil
+	}
+
+	newTLS := new.Spec.TLS
+	oldTLS := older.Spec.TLS
+	if (newTLS != nil && newTLS.ExternalCertificate != nil) || (oldTLS != nil && oldTLS.ExternalCertificate != nil) {
+		return routecommon.CheckRouteCustomHostSAR(ctx, field.NewPath("spec", "tls", "externalCertificate"), sarc)
+	}
+
+	return nil
+}

--- a/pkg/route/hostassignment/externalcertificate_test.go
+++ b/pkg/route/hostassignment/externalcertificate_test.go
@@ -1,0 +1,340 @@
+package hostassignment
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/endpoints/request"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	routev1 "github.com/openshift/api/route/v1"
+	routecommon "github.com/openshift/library-go/pkg/route"
+)
+
+func TestValidateHostExternalCertificate(t *testing.T) {
+	tests := []struct {
+		name  string
+		ctx   context.Context
+		new   *routev1.Route
+		old   *routev1.Route
+		allow bool
+		opts  routecommon.RouteValidationOptions
+		want  field.ErrorList
+	}{
+		{
+			name: "Updating new route and old route with nil TLS",
+			ctx:  request.WithUser(context.Background(), &user.DefaultInfo{Name: "user1"}),
+			old: &routev1.Route{
+				Spec: routev1.RouteSpec{},
+			},
+			new: &routev1.Route{
+				Spec: routev1.RouteSpec{},
+			},
+			allow: false,
+			opts:  routecommon.RouteValidationOptions{AllowExternalCertificates: true},
+			want:  nil,
+		},
+		{
+			name: "Updating new route with nil TLS",
+			ctx:  request.WithUser(context.Background(), &user.DefaultInfo{Name: "user1"}),
+			old: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					TLS: &routev1.TLSConfig{
+						Certificate: "old-cert",
+					},
+				},
+			},
+			new: &routev1.Route{
+				Spec: routev1.RouteSpec{},
+			},
+			allow: false,
+			opts:  routecommon.RouteValidationOptions{AllowExternalCertificates: true},
+			want:  nil,
+		},
+		{
+			name: "Updating new route with certificate from nil TLS",
+			ctx:  request.WithUser(context.Background(), &user.DefaultInfo{Name: "user1"}),
+			old: &routev1.Route{
+				Spec: routev1.RouteSpec{},
+			},
+			new: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					TLS: &routev1.TLSConfig{
+						Certificate: "new-cert",
+					},
+				},
+			},
+			allow: false,
+			opts:  routecommon.RouteValidationOptions{AllowExternalCertificates: true},
+			want:  nil,
+		},
+		{
+			name: "Updating new route with externalCertificate from nil TLS without permission",
+			ctx:  request.WithUser(context.Background(), &user.DefaultInfo{Name: "user1"}),
+			old: &routev1.Route{
+				Spec: routev1.RouteSpec{},
+			},
+			new: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					TLS: &routev1.TLSConfig{
+						ExternalCertificate: &routev1.LocalObjectReference{
+							Name: "dummy-cert",
+						},
+					},
+				},
+			},
+			allow: false,
+			opts:  routecommon.RouteValidationOptions{AllowExternalCertificates: true},
+			want: field.ErrorList{
+				field.Forbidden(nil, "somedetail"),
+				field.Forbidden(nil, "somedetail"),
+			},
+		},
+		{
+			name: "Updating new route with externalCertificate from nil TLS with permission",
+			ctx:  request.WithUser(context.Background(), &user.DefaultInfo{Name: "user1"}),
+			old: &routev1.Route{
+				Spec: routev1.RouteSpec{},
+			},
+			new: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					TLS: &routev1.TLSConfig{
+						ExternalCertificate: &routev1.LocalObjectReference{
+							Name: "dummy-cert",
+						},
+					},
+				},
+			},
+			allow: true,
+			opts:  routecommon.RouteValidationOptions{AllowExternalCertificates: true},
+			want:  nil,
+		},
+		{
+			name: "Updating new route with nil TLS from externalCertificate without permission",
+			ctx:  request.WithUser(context.Background(), &user.DefaultInfo{Name: "user1"}),
+			old: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					TLS: &routev1.TLSConfig{
+						ExternalCertificate: &routev1.LocalObjectReference{
+							Name: "dummy-cert",
+						},
+					},
+				},
+			},
+			new: &routev1.Route{
+				Spec: routev1.RouteSpec{},
+			},
+			allow: false,
+			opts:  routecommon.RouteValidationOptions{AllowExternalCertificates: true},
+			want: field.ErrorList{
+				field.Forbidden(nil, "somedetail"),
+				field.Forbidden(nil, "somedetail"),
+			},
+		},
+		{
+			name: "Updating new route with nil TLS from externalCertificate with permission",
+			ctx:  request.WithUser(context.Background(), &user.DefaultInfo{Name: "user1"}),
+			old: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					TLS: &routev1.TLSConfig{
+						ExternalCertificate: &routev1.LocalObjectReference{
+							Name: "dummy-cert",
+						},
+					},
+				},
+			},
+			new: &routev1.Route{
+				Spec: routev1.RouteSpec{},
+			},
+			allow: true,
+			opts:  routecommon.RouteValidationOptions{AllowExternalCertificates: true},
+			want:  nil,
+		},
+		{
+			name: "Updating new route with externalCertificate from old certificate without permissions",
+			ctx:  request.WithUser(context.Background(), &user.DefaultInfo{Name: "user1"}),
+			old: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					TLS: &routev1.TLSConfig{
+						Certificate: "old-cert",
+					},
+				},
+			},
+			new: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					TLS: &routev1.TLSConfig{
+						ExternalCertificate: &routev1.LocalObjectReference{
+							Name: "dummy-cert",
+						},
+					},
+				},
+			},
+			allow: false,
+			opts:  routecommon.RouteValidationOptions{AllowExternalCertificates: true},
+			want: field.ErrorList{
+				field.Forbidden(nil, "somedetail"),
+				field.Forbidden(nil, "somedetail"),
+			},
+		},
+		{
+			name: "Updating new route with externalCertificate from old certificate with permissions",
+			ctx:  request.WithUser(context.Background(), &user.DefaultInfo{Name: "user1"}),
+			old: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					TLS: &routev1.TLSConfig{
+						Certificate: "old-cert",
+					},
+				},
+			},
+			new: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					TLS: &routev1.TLSConfig{
+						ExternalCertificate: &routev1.LocalObjectReference{
+							Name: "dummy-cert",
+						},
+					},
+				},
+			},
+			allow: true,
+			opts:  routecommon.RouteValidationOptions{AllowExternalCertificates: true},
+			want:  nil,
+		},
+		{
+			name: "Updating new route to certificate from old externalCertificate without permissions",
+			ctx:  request.WithUser(context.Background(), &user.DefaultInfo{Name: "user1"}),
+			old: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					TLS: &routev1.TLSConfig{
+						ExternalCertificate: &routev1.LocalObjectReference{
+							Name: "dummy-cert",
+						},
+					},
+				},
+			},
+			new: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					TLS: &routev1.TLSConfig{
+						Certificate: "new-cert",
+					},
+				},
+			},
+			allow: false,
+			opts:  routecommon.RouteValidationOptions{AllowExternalCertificates: true},
+			want: field.ErrorList{
+				field.Forbidden(nil, "somedetail"),
+				field.Forbidden(nil, "somedetail"),
+			},
+		},
+		{
+			name: "Updating new route to certificate from old externalCertificate with permissions",
+			ctx:  request.WithUser(context.Background(), &user.DefaultInfo{Name: "user1"}),
+			old: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					TLS: &routev1.TLSConfig{
+						ExternalCertificate: &routev1.LocalObjectReference{
+							Name: "dummy-cert",
+						},
+					},
+				},
+			},
+			new: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					TLS: &routev1.TLSConfig{
+						Certificate: "new-cert",
+					},
+				},
+			},
+			allow: true,
+			opts:  routecommon.RouteValidationOptions{AllowExternalCertificates: true},
+			want:  nil,
+		},
+		{
+			name: "Updating new route to externalCertificate from old externalCertificate without permissions",
+			ctx:  request.WithUser(context.Background(), &user.DefaultInfo{Name: "user1"}),
+			old: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					TLS: &routev1.TLSConfig{
+						ExternalCertificate: &routev1.LocalObjectReference{
+							Name: "old-cert",
+						},
+					},
+				},
+			},
+			new: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					TLS: &routev1.TLSConfig{
+						ExternalCertificate: &routev1.LocalObjectReference{
+							Name: "new-cert",
+						},
+					},
+				},
+			},
+			allow: false,
+			opts:  routecommon.RouteValidationOptions{AllowExternalCertificates: true},
+			want: field.ErrorList{
+				field.Forbidden(nil, "somedetail"),
+				field.Forbidden(nil, "somedetail"),
+			},
+		},
+		{
+			name: "Updating new route to externalCertificate from old externalCertificate with permissions",
+			ctx:  request.WithUser(context.Background(), &user.DefaultInfo{Name: "user1"}),
+			old: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					TLS: &routev1.TLSConfig{
+						ExternalCertificate: &routev1.LocalObjectReference{
+							Name: "old-cert",
+						},
+					},
+				},
+			},
+			new: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					TLS: &routev1.TLSConfig{
+						ExternalCertificate: &routev1.LocalObjectReference{
+							Name: "new-cert",
+						},
+					},
+				},
+			},
+			allow: true,
+			opts:  routecommon.RouteValidationOptions{AllowExternalCertificates: true},
+			want:  nil,
+		},
+		{
+			name: "Updating new route to certificate from externalCertificate when feature gate is off and no permission",
+			ctx:  request.WithUser(context.Background(), &user.DefaultInfo{Name: "user1"}),
+			old: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					TLS: &routev1.TLSConfig{
+						ExternalCertificate: &routev1.LocalObjectReference{
+							Name: "dummy-cert",
+						},
+					},
+				},
+			},
+			new: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					TLS: &routev1.TLSConfig{
+						Certificate: "new-cert",
+					},
+				},
+			},
+			allow: false,
+			opts:  routecommon.RouteValidationOptions{AllowExternalCertificates: false},
+			want:  nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := cmpopts.IgnoreFields(field.Error{}, "Field", "BadValue", "Detail")
+			if got := ValidateHostExternalCertificate(tt.ctx, tt.new, tt.old, &testSAR{allow: tt.allow}, tt.opts); !cmp.Equal(got, tt.want, opts, cmpopts.EquateEmpty()) {
+				t.Errorf("ValidateHostExternalCertificate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/route/validation/validation.go
+++ b/pkg/route/validation/validation.go
@@ -1,10 +1,6 @@
 package validation
 
 import (
-	"crypto/ecdsa"
-	"crypto/rsa"
-	"crypto/x509"
-	"encoding/pem"
 	"fmt"
 	"regexp"
 	"strings"
@@ -226,82 +222,6 @@ func ValidateRouteStatusUpdate(route *routev1.Route, older *routev1.Route) field
 
 	// TODO: validate route status
 	return allErrs
-}
-
-type blockVerifierFunc func(block *pem.Block) (*pem.Block, error)
-
-func publicKeyBlockVerifier(block *pem.Block) (*pem.Block, error) {
-	key, err := x509.ParsePKIXPublicKey(block.Bytes)
-	if err != nil {
-		return nil, err
-	}
-	block = &pem.Block{
-		Type: "PUBLIC KEY",
-	}
-	if block.Bytes, err = x509.MarshalPKIXPublicKey(key); err != nil {
-		return nil, err
-	}
-	return block, nil
-}
-
-func certificateBlockVerifier(block *pem.Block) (*pem.Block, error) {
-	cert, err := x509.ParseCertificate(block.Bytes)
-	if err != nil {
-		return nil, err
-	}
-	block = &pem.Block{
-		Type:  "CERTIFICATE",
-		Bytes: cert.Raw,
-	}
-	return block, nil
-}
-
-func privateKeyBlockVerifier(block *pem.Block) (*pem.Block, error) {
-	key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
-	if err != nil {
-		key, err = x509.ParsePKCS1PrivateKey(block.Bytes)
-		if err != nil {
-			key, err = x509.ParseECPrivateKey(block.Bytes)
-			if err != nil {
-				return nil, fmt.Errorf("block %s is not valid", block.Type)
-			}
-		}
-	}
-	switch t := key.(type) {
-	case *rsa.PrivateKey:
-		block = &pem.Block{
-			Type:  "RSA PRIVATE KEY",
-			Bytes: x509.MarshalPKCS1PrivateKey(t),
-		}
-	case *ecdsa.PrivateKey:
-		block = &pem.Block{
-			Type: "ECDSA PRIVATE KEY",
-		}
-		if block.Bytes, err = x509.MarshalECPrivateKey(t); err != nil {
-			return nil, err
-		}
-	default:
-		return nil, fmt.Errorf("block private key %T is not valid", key)
-	}
-	return block, nil
-}
-
-func ignoreBlockVerifier(block *pem.Block) (*pem.Block, error) {
-	return nil, nil
-}
-
-var knownBlockDecoders = map[string]blockVerifierFunc{
-	"RSA PRIVATE KEY":   privateKeyBlockVerifier,
-	"ECDSA PRIVATE KEY": privateKeyBlockVerifier,
-	"PRIVATE KEY":       privateKeyBlockVerifier,
-	"PUBLIC KEY":        publicKeyBlockVerifier,
-	// Potential "in the wild" PEM encoded blocks that can be normalized
-	"RSA PUBLIC KEY":   publicKeyBlockVerifier,
-	"DSA PUBLIC KEY":   publicKeyBlockVerifier,
-	"ECDSA PUBLIC KEY": publicKeyBlockVerifier,
-	"CERTIFICATE":      certificateBlockVerifier,
-	// Blocks that should be dropped
-	"EC PARAMETERS": ignoreBlockVerifier,
 }
 
 // validateTLS tests fields for different types of TLS combinations are set.  Called


### PR DESCRIPTION
## Description
Updates route validations based on openshift/enhancements#1307 which introduces a new field in the route API externalCertificate behind the TP feature gate.
### Changes
- `ValidateRoute()` has been updated to pass additional args (secrets lister and subjectaccessreviewer) to validate
`externalCertificate` and the rbac required. Now it also does additional subject access review authorization checks to verify if the router SA has the correct permissions to parse `externalCertificate`. It also adds a hard requirement that the secret referenced in `externalCertificate` be present prior to creating the route.
- `ValidateHostUpdate()` has also been updated since updating route host/subdomain is also affected by updating
certificates on the route. Now `certificateChangeRequiresAuth()` will always return `true` if the route has a `externalCertificate` set (check EP for additional info).
- `ValidateHostExternalCertificate()` has been introduced as part of the validations done during route updates, this function specifically checks if the user has the correct permissions on the `custom-host` sub-resource. Additional details can be found on the EP.


