### PR TITLE
CFE-866: Add secret manager for routes to consume secret_monitor

### DIFF
--- a/pkg/route/secretmanager/fake/fake_manager.go
+++ b/pkg/route/secretmanager/fake/fake_manager.go
@@ -1,0 +1,33 @@
+package fake
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+)
+
+type SecretManager struct {
+	Err          error
+	Secret       *corev1.Secret
+	IsRegistered bool
+}
+
+func (m *SecretManager) RegisterRoute(ctx context.Context, namespace string, routeName string, secretName string, handler cache.ResourceEventHandlerFuncs) error {
+	return m.Err
+}
+func (m *SecretManager) UnregisterRoute(namespace string, routeName string) error {
+	return m.Err
+}
+
+func (m *SecretManager) GetSecret(ctx context.Context, namespace string, routeName string) (*corev1.Secret, error) {
+	return m.Secret, m.Err
+}
+func (m *SecretManager) IsRouteRegistered(namespace string, routeName string) bool {
+	return m.IsRegistered
+}
+
+func (m *SecretManager) Queue() workqueue.RateLimitingInterface {
+	return nil
+}

--- a/pkg/route/secretmanager/manager.go
+++ b/pkg/route/secretmanager/manager.go
@@ -1,0 +1,147 @@
+package secretmanager
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/openshift/library-go/pkg/secret"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+)
+
+type SecretManager interface {
+	RegisterRoute(ctx context.Context, namespace string, routeName string, secretName string, handler cache.ResourceEventHandlerFuncs) error
+	UnregisterRoute(namespace string, routeName string) error
+	GetSecret(ctx context.Context, namespace string, routeName string) (*v1.Secret, error)
+	IsRouteRegistered(namespace string, routeName string) bool
+	Queue() workqueue.RateLimitingInterface
+}
+
+// Manager is responsible for managing secrets associated with routes. It implements SecretManager.
+type manager struct {
+	// monitor for managing and watching "single" secret dynamically.
+	monitor secret.SecretMonitor
+
+	// Map of registered handlers for each route.
+	// Populated inside RegisterRoute() and used in UnregisterRoute(), GetSecret.
+	// generateKey() will create the map key.
+	registeredHandlers map[string]secret.SecretEventHandlerRegistration
+
+	// Lock to protect access to registeredHandlers map.
+	handlersLock sync.RWMutex
+
+	// Work queue to be used by the consumer of this Manager, mostly to add secret change events.
+	queue workqueue.RateLimitingInterface
+}
+
+func NewManager(kubeClient kubernetes.Interface, queue workqueue.RateLimitingInterface) SecretManager {
+	return &manager{
+		monitor:            secret.NewSecretMonitor(kubeClient),
+		handlersLock:       sync.RWMutex{},
+		queue:              queue,
+		registeredHandlers: make(map[string]secret.SecretEventHandlerRegistration),
+	}
+}
+
+// Queue returns the work queue for the manager.
+func (m *manager) Queue() workqueue.RateLimitingInterface {
+	return m.queue
+}
+
+// RegisterRoute registers a route with a secret, enabling the manager to watch for the secret changes and associate them with the handler functions.
+// Returns an error if the route is already registered with a secret or if adding the secret event handler fails.
+func (m *manager) RegisterRoute(ctx context.Context, namespace, routeName, secretName string, handler cache.ResourceEventHandlerFuncs) error {
+	m.handlersLock.Lock()
+	defer m.handlersLock.Unlock()
+
+	// Generate a unique key for the provided namespace and routeName.
+	key := generateKey(namespace, routeName)
+
+	// Check if the route is already registered with the given key.
+	// Each route (namespace/routeName) should be registered only once with any secret.
+	// Note: inside a namespace multiple different routes can be registered(watch) with a common secret.
+	if _, exists := m.registeredHandlers[key]; exists {
+		return fmt.Errorf("route already registered with key %s", key)
+	}
+
+	// Add a secret event handler for the specified namespace and secret, with the handler functions.
+	klog.V(5).Infof("trying to add handler for key %s with secret %s", key, secretName)
+	handlerRegistration, err := m.monitor.AddSecretEventHandler(ctx, namespace, secretName, handler)
+	if err != nil {
+		return err
+	}
+
+	// Store the registration in the manager's map. Used during UnregisterRoute() and GetSecret().
+	m.registeredHandlers[key] = handlerRegistration
+	klog.Infof("secret manager registered route for key %s with secret %s", key, secretName)
+
+	return nil
+}
+
+// UnregisterRoute removes the registration of a route from the manager.
+// It removes the secret event handler from secret monitor and deletes its associated handler from manager's map.
+func (m *manager) UnregisterRoute(namespace, routeName string) error {
+	m.handlersLock.Lock()
+	defer m.handlersLock.Unlock()
+
+	key := generateKey(namespace, routeName)
+
+	// Get the registered handler.
+	handlerRegistration, exists := m.registeredHandlers[key]
+	if !exists {
+		return fmt.Errorf("no handler registered with key %s", key)
+	}
+
+	// Remove the corresponding secret event handler from the secret monitor.
+	klog.V(5).Info("trying to remove handler with key", key)
+	err := m.monitor.RemoveSecretEventHandler(handlerRegistration)
+	if err != nil {
+		return err
+	}
+
+	// delete the registered handler from manager's map of handlers.
+	delete(m.registeredHandlers, key)
+	klog.Infof("secret manager unregistered route for key %s", key)
+
+	return nil
+}
+
+// GetSecret retrieves the secret object registered with a route.
+func (m *manager) GetSecret(ctx context.Context, namespace, routeName string) (*v1.Secret, error) {
+	m.handlersLock.RLock()
+	defer m.handlersLock.RUnlock()
+
+	key := generateKey(namespace, routeName)
+
+	handlerRegistration, exists := m.registeredHandlers[key]
+	if !exists {
+		return nil, fmt.Errorf("no handler registered with key %s", key)
+	}
+
+	// Get the secret from the secret monitor's cache using the registered handler.
+	obj, err := m.monitor.GetSecret(ctx, handlerRegistration)
+	if err != nil {
+		return nil, err
+	}
+
+	return obj, nil
+}
+
+// IsRouteRegistered returns true if route is registered, false otherwise
+func (m *manager) IsRouteRegistered(namespace, routeName string) bool {
+	m.handlersLock.RLock()
+	defer m.handlersLock.RUnlock()
+
+	key := generateKey(namespace, routeName)
+	_, exists := m.registeredHandlers[key]
+	return exists
+}
+
+// generateKey creates a unique identifier for a route
+func generateKey(namespace, route string) string {
+	return fmt.Sprintf("%s/%s", namespace, route)
+}

--- a/pkg/route/secretmanager/manager_test.go
+++ b/pkg/route/secretmanager/manager_test.go
@@ -1,0 +1,306 @@
+package secretmanager
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/openshift/library-go/pkg/secret"
+	"github.com/openshift/library-go/pkg/secret/fake"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+type routeSecret struct {
+	routeName  string
+	secretName string
+}
+
+func TestRegisterRoute(t *testing.T) {
+	namespace := "ns"
+
+	scenarios := []struct {
+		name               string
+		rs                 []routeSecret
+		sm                 fake.SecretMonitor
+		expectHandlersKeys []string
+		expectErr          int
+	}{
+		{
+			name: "route can be registered only once with any secret",
+			rs: []routeSecret{
+				{routeName: "route", secretName: "secret"},
+			},
+			expectHandlersKeys: []string{namespace + "/route"},
+			expectErr:          0,
+		},
+		{
+			name: "same route cannot be registered again with same secret",
+			rs: []routeSecret{
+				{routeName: "route1", secretName: "secret1"},
+				{routeName: "route1", secretName: "secret1"},
+			},
+			expectHandlersKeys: []string{namespace + "/route1"},
+			expectErr:          1,
+		},
+		{
+			name: "same route cannot be registered again with different secrets",
+			rs: []routeSecret{
+				{routeName: "route1", secretName: "secret1"},
+				{routeName: "route1", secretName: "secret2"},
+				{routeName: "route1", secretName: "secret3"},
+			},
+			expectHandlersKeys: []string{namespace + "/route1"},
+			expectErr:          2,
+		},
+		{
+			name: "different routes can be registered with same secret",
+			rs: []routeSecret{
+				{routeName: "route1", secretName: "secret1"},
+				{routeName: "route2", secretName: "secret1"},
+			},
+			expectHandlersKeys: []string{namespace + "/route1", namespace + "/route2"},
+			expectErr:          0,
+		},
+		{
+			name: "different routes can be registered with different secrets",
+			rs: []routeSecret{
+				{routeName: "route1", secretName: "secret1"},
+				{routeName: "route2", secretName: "secret2"},
+			},
+			expectHandlersKeys: []string{namespace + "/route1", namespace + "/route2"},
+			expectErr:          0,
+		},
+		{
+			name: "error while adding SecretEventHandler",
+			rs: []routeSecret{
+				{routeName: "route", secretName: "secret"},
+			},
+			sm: fake.SecretMonitor{
+				Err: fmt.Errorf("some error"),
+			},
+			expectErr: 1,
+		},
+	}
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+			mgr := &manager{
+				registeredHandlers: make(map[string]secret.SecretEventHandlerRegistration),
+				monitor:            &s.sm,
+			}
+
+			gotErr := 0
+			for _, rs := range s.rs {
+				if err := mgr.RegisterRoute(context.TODO(), namespace, rs.routeName, rs.secretName, cache.ResourceEventHandlerFuncs{}); err != nil {
+					gotErr += 1
+				}
+			}
+			if gotErr != s.expectErr {
+				t.Fatalf("expected %d errors, got %d errors", s.expectErr, gotErr)
+			}
+			if len(s.expectHandlersKeys) != len(mgr.registeredHandlers) {
+				t.Fatalf("expected %d keys: %v, got %d keys: %v", len(s.expectHandlersKeys), s.expectHandlersKeys, len(mgr.registeredHandlers), mgr.registeredHandlers)
+			}
+			for _, key := range s.expectHandlersKeys {
+				if _, exists := mgr.registeredHandlers[key]; !exists {
+					t.Errorf("%s key should exist", key)
+				}
+			}
+		})
+	}
+}
+
+func TestUnregisterRoute(t *testing.T) {
+
+	type routeName string
+	namespace := "ns"
+
+	scenarios := []struct {
+		name               string
+		register           []routeSecret
+		unregister         []routeName
+		sm                 fake.SecretMonitor
+		expectHandlersKeys []string
+		expectErr          int
+	}{
+		{
+			name:       "unregister route without register",
+			register:   []routeSecret{},
+			unregister: []routeName{"route1"},
+			expectErr:  1,
+		},
+		{
+			name: "unregister route more than once",
+			register: []routeSecret{
+				{routeName: "route1", secretName: "secret1"},
+			},
+			unregister: []routeName{"route1", "route1"},
+			expectErr:  1,
+		},
+		{
+			name: "error while removing SecretEventHandler",
+			register: []routeSecret{
+				{routeName: "route1", secretName: "secret1"},
+			},
+			unregister: []routeName{"route1"},
+			sm: fake.SecretMonitor{
+				Err: fmt.Errorf("some error"),
+			},
+			expectHandlersKeys: []string{namespace + "/route1"},
+			expectErr:          1,
+		},
+		{
+			name: "correctly unregister route",
+			register: []routeSecret{
+				{routeName: "route1", secretName: "secret1"},
+			},
+			unregister: []routeName{"route1"},
+			expectErr:  0,
+		},
+	}
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+			mgr := &manager{registeredHandlers: make(map[string]secret.SecretEventHandlerRegistration)}
+			// register
+			mgr.monitor = &fake.SecretMonitor{} // avoid error from AddSecretEventHandler
+			for _, rs := range s.register {
+				if err := mgr.RegisterRoute(context.TODO(), namespace, rs.routeName, rs.secretName, cache.ResourceEventHandlerFuncs{}); err != nil {
+					t.Fatalf("failed to register %v: %v", rs, err)
+				}
+			}
+
+			// unregister
+			mgr.monitor = &s.sm
+			gotErr := 0
+			for _, routeName := range s.unregister {
+				if err := mgr.UnregisterRoute(namespace, string(routeName)); err != nil {
+					t.Log(err)
+					gotErr += 1
+				}
+			}
+			if gotErr != s.expectErr {
+				t.Fatalf("expected %d errors, got %d errors", s.expectErr, gotErr)
+			}
+			if len(s.expectHandlersKeys) != len(mgr.registeredHandlers) {
+				t.Fatalf("expected %d keys: %v, got %d keys: %v", len(s.expectHandlersKeys), s.expectHandlersKeys, len(mgr.registeredHandlers), mgr.registeredHandlers)
+			}
+			for _, key := range s.expectHandlersKeys {
+				if _, exists := mgr.registeredHandlers[key]; !exists {
+					t.Errorf("%s key should exist", key)
+				}
+			}
+		})
+	}
+}
+
+func TestGetSecret(t *testing.T) {
+	var (
+		namespace = "ns"
+		routeName = "route"
+	)
+
+	scenarios := []struct {
+		name      string
+		register  []routeSecret
+		sm        fake.SecretMonitor
+		expectErr bool
+	}{
+		{
+			name:      "get secret without register",
+			register:  []routeSecret{},
+			expectErr: true,
+		},
+		{
+			name:     "error from secret monitor while calling GetSecret",
+			register: []routeSecret{{routeName, "secretName"}},
+			sm: fake.SecretMonitor{
+				Err: fmt.Errorf("some error"),
+			},
+			expectErr: true,
+		},
+		{
+			name:     "successfully got secret",
+			register: []routeSecret{{routeName, "secretName"}},
+			sm: fake.SecretMonitor{
+				Err: nil,
+				Secret: &corev1.Secret{
+					Type: corev1.SecretTypeOpaque,
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secretName",
+						Namespace: namespace,
+					},
+				},
+			},
+			expectErr: false,
+		},
+	}
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+			mgr := manager{registeredHandlers: make(map[string]secret.SecretEventHandlerRegistration)}
+			// register
+			mgr.monitor = &fake.SecretMonitor{} // avoid error from AddSecretEventHandler
+			for _, rs := range s.register {
+				if err := mgr.RegisterRoute(context.TODO(), namespace, rs.routeName, rs.secretName, cache.ResourceEventHandlerFuncs{}); err != nil {
+					t.Fatalf("failed to register %v: %v", rs, err)
+				}
+			}
+
+			mgr.monitor = &s.sm
+			gotSec, err := mgr.GetSecret(context.TODO(), namespace, routeName)
+
+			if (err != nil) != s.expectErr {
+				t.Fatalf("expected errors to be %t, but got %t", s.expectErr, err != nil)
+			}
+
+			if !reflect.DeepEqual(s.sm.Secret, gotSec) {
+				t.Fatalf("expected %v got %v", s.sm.Secret, gotSec)
+			}
+		})
+	}
+}
+
+func TestIsRouteRegistered(t *testing.T) {
+	var (
+		namespace = "ns"
+		routeName = "route"
+	)
+
+	scenarios := []struct {
+		name     string
+		register []routeSecret
+		expect   bool
+	}{
+		{
+			name:     "when route is not registered",
+			register: []routeSecret{},
+			expect:   false,
+		},
+		{
+			name:     "when route is registered",
+			register: []routeSecret{{routeName, "secretName"}},
+			expect:   true,
+		},
+	}
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+			mgr := &manager{
+				registeredHandlers: make(map[string]secret.SecretEventHandlerRegistration),
+				monitor:            &fake.SecretMonitor{},
+			}
+			// register
+			for _, rs := range s.register {
+				if err := mgr.RegisterRoute(context.TODO(), namespace, rs.routeName, rs.secretName, cache.ResourceEventHandlerFuncs{}); err != nil {
+					t.Fatalf("failed to register %v: %v", rs, err)
+				}
+			}
+
+			got := mgr.IsRouteRegistered(namespace, routeName)
+
+			if got != s.expect {
+				t.Fatalf("expected %t, but got %t", s.expect, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
This PR adds `route` layer (introduces a new `secretmanager` package) on top of https://github.com/openshift/library-go/pull/1675 to consume the `secret_monitor`.
These changes primarily focus on enhancing the functionality of managing secrets associated with routes. 


### Important Functions:
- **RegisterRoute**: Allows registering a route with a secret, enabling dynamic monitoring of secret changes associated with the route.
- **UnregisterRoute**: Provides functionality to remove the registration of a route from the monitor.
- **GetSecret**: Enables retrieving the secret object registered with a route.


Related: [CFE-866](https://issues.redhat.com//browse/CFE-866)
Implements: https://github.com/openshift/enhancements/pull/1307