### PR TITLE
OCPBUGS-21846: revision_controller: be more verbose about LatestAvailableRevision and resourceVersion

### DIFF
--- a/pkg/operator/revisioncontroller/revision_controller.go
+++ b/pkg/operator/revisioncontroller/revision_controller.go
@@ -290,6 +290,8 @@ func (c RevisionController) sync(ctx context.Context, syncCtx factory.SyncContex
 		return nil
 	}
 
+	klog.V(2).Infof("status.LatestAvailableRevision: %v, resourceVersion: %v", latestAvailableRevision, resourceVersion)
+
 	// If the operator status has 0 as its latest available revision, this is either the first revision
 	// or possibly the operator resource was deleted and reset back to 0, which is not what we want so check configmaps
 	if latestAvailableRevision == 0 {

--- a/pkg/operator/v1helpers/helpers.go
+++ b/pkg/operator/v1helpers/helpers.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
 
 	"github.com/ghodss/yaml"
 
@@ -206,7 +207,7 @@ func UpdateStaticPodStatus(ctx context.Context, client StaticPodOperatorClient, 
 		if err != nil {
 			return err
 		}
-
+		klog.V(2).Infof("status.LatestAvailableRevision: %v, resourceVersion: %v", oldStatus.LatestAvailableRevision, resourceVersion)
 		newStatus := oldStatus.DeepCopy()
 		for _, update := range updateFuncs {
 			if err := update(newStatus); err != nil {


### PR DESCRIPTION
In some cases a status yields two different revisions for supposedly the same status. Either there's some other code updating the status in parallel or the static pod operator client is slow in updating its internal cache. Either way the revision controller reports a possible race when updating the latest available revision.

This PR is meant strictly to get better idea about the operator status to help in debugging https://issues.redhat.com/browse/OCPBUGS-21846. Once the underlying issue is resolved, this change is expected to be reverted.