### PR TITLE
controllercmd: allow configuring topology detection

### DIFF
--- a/pkg/controller/controllercmd/builder.go
+++ b/pkg/controller/controllercmd/builder.go
@@ -95,9 +95,31 @@ type ControllerBuilder struct {
 	// We use this flag to determine at runtime if we can alter leader election for SNO configurations
 	userExplicitlySetLeaderElectionValues bool
 
+	// different deployment strategies will require sensing topologies in disjoint manners
+	topologyDetector TopologyDetector
+
 	// Allow enabling HTTP2
 	enableHTTP2 bool
 }
+
+type TopologyDetector interface {
+	DetectTopology(ctx context.Context, restClient *rest.Config) (configv1.TopologyMode, error)
+}
+
+type infrastructureStatusTopologyDetector struct{}
+
+func (i infrastructureStatusTopologyDetector) DetectTopology(ctx context.Context, restClient *rest.Config) (configv1.TopologyMode, error) {
+	infraStatus, err := clusterstatus.GetClusterInfraStatus(ctx, restClient)
+	if err != nil {
+		return "", err
+	}
+	if infraStatus == nil {
+		return "", nil
+	}
+	return infraStatus.ControlPlaneTopology, nil
+}
+
+var _ TopologyDetector = (*infrastructureStatusTopologyDetector)(nil)
 
 // NewController returns a builder struct for constructing the command you want to run
 func NewController(componentName string, startFunc StartFunc) *ControllerBuilder {
@@ -109,6 +131,7 @@ func NewController(componentName string, startFunc StartFunc) *ControllerBuilder
 			klog.Warning(args...)
 			os.Exit(1)
 		},
+		topologyDetector: infrastructureStatusTopologyDetector{},
 	}
 }
 
@@ -157,6 +180,11 @@ func (b *ControllerBuilder) WithLeaderElection(leaderElection configv1.LeaderEle
 
 	defaulted := leaderelectionconverter.LeaderElectionDefaulting(leaderElection, defaultNamespace, defaultName)
 	b.leaderElection = &defaulted
+	return b
+}
+
+func (b *ControllerBuilder) WithTopologyDetector(topologyDetector TopologyDetector) *ControllerBuilder {
+	b.topologyDetector = topologyDetector
 	return b
 }
 
@@ -324,12 +352,12 @@ func (b *ControllerBuilder) Run(ctx context.Context, config *unstructured.Unstru
 	}
 
 	if !b.userExplicitlySetLeaderElectionValues {
-		infraStatus, err := clusterstatus.GetClusterInfraStatus(ctx, clientConfig)
-		if err != nil || infraStatus == nil {
-			eventRecorder.Warningf("ClusterInfrastructureStatus", "unable to get cluster infrastructure status, using HA cluster values for leader election: %v", err)
-			klog.Warningf("unable to get cluster infrastructure status, using HA cluster values for leader election: %v", err)
+		topology, err := b.topologyDetector.DetectTopology(ctx, clientConfig)
+		if err != nil || topology == "" {
+			eventRecorder.Warningf("ControlPlaneTopology", "unable to get control plane topology, using HA cluster values for leader election: %v", err)
+			klog.Warningf("unable to get control plane topology, using HA cluster values for leader election: %v", err)
 		} else {
-			snoLeaderElection := infraStatusTopologyLeaderElection(infraStatus, *b.leaderElection)
+			snoLeaderElection := topologyLeaderElection(topology, *b.leaderElection)
 			b.leaderElection = &snoLeaderElection
 		}
 	}
@@ -401,14 +429,14 @@ func (b *ControllerBuilder) getClientConfig() (*rest.Config, error) {
 	return client.GetKubeConfigOrInClusterConfig(kubeconfig, b.clientOverrides)
 }
 
-func infraStatusTopologyLeaderElection(infraStatus *configv1.InfrastructureStatus, original configv1.LeaderElection) configv1.LeaderElection {
+func topologyLeaderElection(topology configv1.TopologyMode, original configv1.LeaderElection) configv1.LeaderElection {
 	// if we can't determine the infra toplogy, return original
-	if infraStatus == nil {
+	if topology == "" {
 		return original
 	}
 
 	// If we are running in a SingleReplicaTopologyMode and leader election is not disabled, configure leader election for SNO Toplogy
-	if infraStatus.ControlPlaneTopology == configv1.SingleReplicaTopologyMode && !original.Disable {
+	if topology == configv1.SingleReplicaTopologyMode && !original.Disable {
 		klog.Info("detected SingleReplicaTopologyMode, the original leader election has been altered for the default SingleReplicaToplogy")
 		return leaderelectionconverter.LeaderElectionSNOConfig(original)
 	}

--- a/pkg/controller/controllercmd/builder_test.go
+++ b/pkg/controller/controllercmd/builder_test.go
@@ -191,13 +191,13 @@ func TestControllerBuilder_OnLeadingFunc_NonZeroExit(t *testing.T) {
 func TestInfraStatusTopologyLeaderElection(t *testing.T) {
 	testCases := []struct {
 		desc     string
-		infra    *configv1.InfrastructureStatus
+		topology configv1.TopologyMode
 		original configv1.LeaderElection
 		expected configv1.LeaderElection
 	}{
 		{
-			desc:  "should not set SNO config when infra is nil",
-			infra: nil,
+			desc:     "should not set SNO config when no topology found",
+			topology: "",
 			original: configv1.LeaderElection{
 				LeaseDuration: metav1.Duration{Duration: 60 * time.Second},
 				RenewDeadline: metav1.Duration{Duration: 40 * time.Second},
@@ -210,10 +210,8 @@ func TestInfraStatusTopologyLeaderElection(t *testing.T) {
 			},
 		},
 		{
-			desc: "should not set SNO config when infra is HighlyAvailableTopologyMode",
-			infra: &configv1.InfrastructureStatus{
-				ControlPlaneTopology: configv1.HighlyAvailableTopologyMode,
-			},
+			desc:     "should not set SNO config when infra is HighlyAvailableTopologyMode",
+			topology: configv1.HighlyAvailableTopologyMode,
 			original: configv1.LeaderElection{
 				LeaseDuration: metav1.Duration{Duration: 60 * time.Second},
 				RenewDeadline: metav1.Duration{Duration: 40 * time.Second},
@@ -226,10 +224,8 @@ func TestInfraStatusTopologyLeaderElection(t *testing.T) {
 			},
 		},
 		{
-			desc: "should set SNO leader election config when SingleReplicaToplogy Controlplane",
-			infra: &configv1.InfrastructureStatus{
-				ControlPlaneTopology: configv1.SingleReplicaTopologyMode,
-			},
+			desc:     "should set SNO leader election config when SingleReplicaToplogy Controlplane",
+			topology: configv1.SingleReplicaTopologyMode,
 			original: configv1.LeaderElection{
 				LeaseDuration: metav1.Duration{Duration: 60 * time.Second},
 				RenewDeadline: metav1.Duration{Duration: 40 * time.Second},
@@ -244,7 +240,7 @@ func TestInfraStatusTopologyLeaderElection(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			leConfig := infraStatusTopologyLeaderElection(tc.infra, tc.original)
+			leConfig := topologyLeaderElection(tc.topology, tc.original)
 			if !reflect.DeepEqual(tc.expected, leConfig) {
 				t.Errorf("expected %#v, got %#v", tc.expected, leConfig)
 			}


### PR DESCRIPTION
In a HyperShift context, the toplogy that a component is expected to adhere to is not the management-cluster-wiide infrastructure, but the tenant-specific value. This commit allows consumers to detect topology in less rigid ways.