### PR TITLE
Add ability to collect whitelisted annotations specified by the caller

### DIFF
--- a/pkg/certs/cert-inspection/certgraphapi/type_registry.go
+++ b/pkg/certs/cert-inspection/certgraphapi/type_registry.go
@@ -18,9 +18,15 @@ type PKIRegistryInClusterCertKeyPair struct {
 
 // PKIRegistryCertKeyPairInfo holds information about certificate key pair
 type PKIRegistryCertKeyPairInfo struct {
+	// SelectedCertMetadataAnnotations is a specified subset of annotations. NOT all annotations.
+	// The caller will specify which annotations he wants.
+	SelectedCertMetadataAnnotations []AnnotationValue `json:"selectedCertMetadataAnnotations,omitempty"`
+
 	// OwningJiraComponent is a component name when a new OCP issue is filed in Jira
+	// Deprecated
 	OwningJiraComponent string `json:"owningJiraComponent"`
 	// Description is a one sentence description of the certificate pair purpose
+	// Deprecated
 	Description string `json:"description"`
 
 	//CertificateData PKIRegistryCertKeyMetadata
@@ -36,10 +42,21 @@ type PKIRegistryInClusterCABundle struct {
 
 // PKIRegistryCertificateAuthorityInfo holds information about certificate authority bundle
 type PKIRegistryCertificateAuthorityInfo struct {
+	// SelectedCertMetadataAnnotations is a specified subset of annotations. NOT all annotations.
+	// The caller will specify which annotations he wants.
+	SelectedCertMetadataAnnotations []AnnotationValue `json:"selectedCertMetadataAnnotations,omitempty"`
+
 	// OwningJiraComponent is a component name when a new OCP issue is filed in Jira
+	// Deprecated
 	OwningJiraComponent string `json:"owningJiraComponent"`
 	// Description is a one sentence description of the certificate pair purpose
+	// Deprecated
 	Description string `json:"description"`
+}
 
-	//CertificateData []PKIRegistryCertKeyMetadata
+type AnnotationValue struct {
+	// Key is the annotation key from the resource
+	Key string `json:"key"`
+	// Value is the annotation value from the resource
+	Value string `json:"value"`
 }


### PR DESCRIPTION
This is useful so that we can have a calling repo (like origin for instance), specify the annotations to be collected without updating the schema.  But we are able to avoid a free-for-all of "any annotation you like" by requiring a list to be provided.