### PR TITLE
OCPBUGS-21846: Revert "OCPBUGS-21846: revision_controller: be more verbose about LatestAvailableRevision and resourceVersion"

### DIFF
--- a/pkg/operator/revisioncontroller/revision_controller.go
+++ b/pkg/operator/revisioncontroller/revision_controller.go
@@ -290,8 +290,6 @@ func (c RevisionController) sync(ctx context.Context, syncCtx factory.SyncContex
 		return nil
 	}
 
-	klog.V(2).Infof("status.LatestAvailableRevision: %v, resourceVersion: %v", latestAvailableRevision, resourceVersion)
-
 	// If the operator status has 0 as its latest available revision, this is either the first revision
 	// or possibly the operator resource was deleted and reset back to 0, which is not what we want so check configmaps
 	if latestAvailableRevision == 0 {

--- a/pkg/operator/v1helpers/helpers.go
+++ b/pkg/operator/v1helpers/helpers.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/util/retry"
-	"k8s.io/klog/v2"
 
 	"github.com/ghodss/yaml"
 
@@ -207,7 +206,7 @@ func UpdateStaticPodStatus(ctx context.Context, client StaticPodOperatorClient, 
 		if err != nil {
 			return err
 		}
-		klog.V(2).Infof("status.LatestAvailableRevision: %v, resourceVersion: %v", oldStatus.LatestAvailableRevision, resourceVersion)
+
 		newStatus := oldStatus.DeepCopy()
 		for _, update := range updateFuncs {
 			if err := update(newStatus); err != nil {


### PR DESCRIPTION
Reverts openshift/library-go#1631