### PR TITLE
AUTH-471: pkg/operator/status - add EvaluationConditionDetected

### DIFF
--- a/pkg/operator/status/condition.go
+++ b/pkg/operator/status/condition.go
@@ -89,8 +89,8 @@ func UnionCondition(conditionType string, defaultConditionStatus operatorv1.Cond
 // on true, but Available merges on false.  Thing of it like an anti-default.
 //
 // If inertia is non-nil, then resist returning a condition with a status opposite the defaultConditionStatus.
-func UnionClusterCondition(conditionType string, defaultConditionStatus operatorv1.ConditionStatus, inertia Inertia, allConditions ...operatorv1.OperatorCondition) configv1.ClusterOperatorStatusCondition {
-	cnd := UnionCondition(conditionType, defaultConditionStatus, inertia, allConditions...)
+func UnionClusterCondition(conditionType configv1.ClusterStatusConditionType, defaultConditionStatus operatorv1.ConditionStatus, inertia Inertia, allConditions ...operatorv1.OperatorCondition) configv1.ClusterOperatorStatusCondition {
+	cnd := UnionCondition(string(conditionType), defaultConditionStatus, inertia, allConditions...)
 	return OperatorConditionToClusterOperatorCondition(cnd)
 }
 

--- a/pkg/operator/status/status_controller.go
+++ b/pkg/operator/status/status_controller.go
@@ -164,6 +164,7 @@ func (c StatusSyncer) Sync(ctx context.Context, syncCtx factory.SyncContext) err
 		configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorProgressing, Status: configv1.ConditionUnknown, Reason: "Unmanaged"})
 		configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorDegraded, Status: configv1.ConditionUnknown, Reason: "Unmanaged"})
 		configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.OperatorUpgradeable, Status: configv1.ConditionUnknown, Reason: "Unmanaged"})
+		configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, configv1.ClusterOperatorStatusCondition{Type: configv1.EvaluationConditionsDetected, Status: configv1.ConditionUnknown, Reason: "Unmanaged"})
 
 		if equality.Semantic.DeepEqual(clusterOperatorObj, originalClusterOperatorObj) {
 			return nil
@@ -199,10 +200,11 @@ func (c StatusSyncer) Sync(ctx context.Context, syncCtx factory.SyncContext) err
 		clusterOperatorObj.Status.RelatedObjects = c.relatedObjects
 	}
 
-	configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, UnionClusterCondition("Degraded", operatorv1.ConditionFalse, c.degradedInertia, currentDetailedStatus.Conditions...))
-	configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, UnionClusterCondition("Progressing", operatorv1.ConditionFalse, nil, currentDetailedStatus.Conditions...))
-	configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, UnionClusterCondition("Available", operatorv1.ConditionTrue, nil, currentDetailedStatus.Conditions...))
-	configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, UnionClusterCondition("Upgradeable", operatorv1.ConditionTrue, nil, currentDetailedStatus.Conditions...))
+	configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, UnionClusterCondition(configv1.OperatorDegraded, operatorv1.ConditionFalse, c.degradedInertia, currentDetailedStatus.Conditions...))
+	configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, UnionClusterCondition(configv1.OperatorProgressing, operatorv1.ConditionFalse, nil, currentDetailedStatus.Conditions...))
+	configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, UnionClusterCondition(configv1.OperatorAvailable, operatorv1.ConditionTrue, nil, currentDetailedStatus.Conditions...))
+	configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, UnionClusterCondition(configv1.OperatorUpgradeable, operatorv1.ConditionTrue, nil, currentDetailedStatus.Conditions...))
+	configv1helpers.SetStatusCondition(&clusterOperatorObj.Status.Conditions, UnionClusterCondition(configv1.EvaluationConditionsDetected, operatorv1.ConditionFalse, nil, currentDetailedStatus.Conditions...))
 
 	c.syncStatusVersions(clusterOperatorObj, syncCtx)
 

--- a/pkg/operator/status/status_controller_test.go
+++ b/pkg/operator/status/status_controller_test.go
@@ -232,6 +232,24 @@ func TestDegraded(t *testing.T) {
 			},
 		},
 		{
+			name: "one EvaluationConditionDetected in conditions",
+			conditions: []operatorv1.OperatorCondition{
+				{
+					Type:               string(configv1.EvaluationConditionsDetected),
+					Status:             operatorv1.ConditionTrue,
+					LastTransitionTime: fiveSecondsAgo,
+					Message:            "a message from evaluation detection",
+					Reason:             "PodSecurityReadinessController",
+				},
+			},
+			expectedType:   configv1.EvaluationConditionsDetected,
+			expectedStatus: configv1.ConditionTrue,
+			expectedReason: "_PodSecurityReadinessController",
+			expectedMessages: []string{
+				"EvaluationConditionsDetected: a message from evaluation detection",
+			},
+		},
+		{
 			name: "one not available/within threshold",
 			conditions: []operatorv1.OperatorCondition{
 				{Type: "TypeAAvailable", Status: operatorv1.ConditionFalse, LastTransitionTime: fiveSecondsAgo, Message: "a message from type a"},


### PR DESCRIPTION
Cherry-pick of https://github.com/openshift/library-go/pull/1634

# What

Add ClusterFleetEvaluationType to status controller.

# Why

It is a valid ClusterOperator status, but doesn't have a mechanism to be pulled from Operator's status into ClusterOperator's status.