### PR TITLE
TRT-1420: Revert "revision_controller: update last revision only when a revisio…

### DIFF
--- a/pkg/operator/revisioncontroller/revision_controller_test.go
+++ b/pkg/operator/revisioncontroller/revision_controller_test.go
@@ -2,7 +2,6 @@ package revisioncontroller
 
 import (
 	"context"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -26,11 +25,6 @@ func filterCreateActions(actions []clienttesting.Action) []runtime.Object {
 	for _, a := range actions {
 		createAction, isCreate := a.(clienttesting.CreateAction)
 		if !isCreate {
-			continue
-		}
-		// Filter out Update actions as both clienttesting.CreateAction
-		// and clienttesting.UpdateAction implement the same interface
-		if reflect.TypeOf(a) == reflect.TypeOf(clienttesting.UpdateActionImpl{}) {
 			continue
 		}
 		_, isEvent := createAction.GetObject().(*v1.Event)
@@ -107,7 +101,7 @@ func TestRevisionController(t *testing.T) {
 			},
 			validateActions: func(t *testing.T, actions []clienttesting.Action, kclient *fake.Clientset) {
 				updatedObjects := filterUpdateActions(actions)
-				if len(updatedObjects) != 4 {
+				if len(updatedObjects) != 3 {
 					t.Errorf("expected 4 updated objects, but got %v", len(updatedObjects))
 				}
 				_, err := kclient.CoreV1().ConfigMaps(targetNamespace).Get(context.TODO(), "revision-status-2", metav1.GetOptions{})


### PR DESCRIPTION
…n is completely rendered"

This reverts commit 889623906b2bc0b9c86c6793dad98b09aaabe8c4.

This reverts https://github.com/openshift/library-go/pull/1641, which started failing after we brought it in https://github.com/openshift/cluster-kube-apiserver-operator/pull/1596

/cc @deads2k @ingvagabund 