### PR TITLE
Fix ordering bug

### DIFF
--- a/pkg/operator/revisioncontroller/revision_controller.go
+++ b/pkg/operator/revisioncontroller/revision_controller.go
@@ -89,12 +89,14 @@ func (c RevisionController) createRevisionIfNeeded(ctx context.Context, recorder
 
 	// check to make sure that the latestRevision has the exact content we expect.  No mutation here, so we start creating the next Revision only when it is required
 	if isLatestRevisionCurrent {
+		klog.V(4).Infof("Returning early, %d triggered and up to date", latestAvailableRevision)
 		return false, nil
 	}
 
 	nextRevision := latestAvailableRevision + 1
-	recorder.Eventf("RevisionTriggered", "new revision %d triggered by %q", nextRevision, reason)
-	if err := c.createNewRevision(ctx, recorder, nextRevision, reason); err != nil {
+	recorder.Eventf("StartingNewRevision", "new revision %d triggered by %q", nextRevision, reason)
+	createdNewRevision, err := c.createNewRevision(ctx, recorder, nextRevision, reason)
+	if err != nil {
 		cond := operatorv1.OperatorCondition{
 			Type:    "RevisionControllerDegraded",
 			Status:  operatorv1.ConditionTrue,
@@ -107,6 +109,12 @@ func (c RevisionController) createRevisionIfNeeded(ctx context.Context, recorder
 		}
 		return true, nil
 	}
+
+	if !createdNewRevision {
+		klog.V(4).Infof("Revision %v not created", nextRevision)
+		return false, nil
+	}
+	recorder.Eventf("RevisionTriggered", "new revision %d triggered by %q", nextRevision, reason)
 
 	cond := operatorv1.OperatorCondition{
 		Type:   "RevisionControllerDegraded",
@@ -208,50 +216,74 @@ func (c RevisionController) isLatestRevisionCurrent(ctx context.Context, revisio
 	return true, ""
 }
 
-func (c RevisionController) createNewRevision(ctx context.Context, recorder events.Recorder, revision int32, reason string) error {
+// returns true if we created a revision
+func (c RevisionController) createNewRevision(ctx context.Context, recorder events.Recorder, revision int32, reason string) (bool, error) {
 	// Create a new InProgress status configmap
-	statusConfigMap := &corev1.ConfigMap{
+	desiredStatusConfigMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: c.targetNamespace,
 			Name:      nameFor("revision-status", revision),
+			Annotations: map[string]string{
+				"operator.openshift.io/revision-ready": "false",
+			},
 		},
 		Data: map[string]string{
 			"revision": fmt.Sprintf("%d", revision),
 			"reason":   reason,
 		},
 	}
-	statusConfigMap, _, err := resourceapply.ApplyConfigMap(ctx, c.configMapGetter, recorder, statusConfigMap)
-	if err != nil {
-		return err
+	createdStatus, err := c.configMapGetter.ConfigMaps(desiredStatusConfigMap.Namespace).Create(ctx, desiredStatusConfigMap, metav1.CreateOptions{})
+	switch {
+	case apierrors.IsAlreadyExists(err):
+		if createdStatus == nil || len(createdStatus.UID) == 0 {
+			createdStatus, err = c.configMapGetter.ConfigMaps(desiredStatusConfigMap.Namespace).Get(ctx, desiredStatusConfigMap.Name, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+		}
+		// take a live GET here to get current status to check the annotation
+		if createdStatus.Annotations["operator.openshift.io/revision-ready"] == "true" {
+			// no work to do because our cache is out of date and when we're updated, we will be able to see the result
+			klog.Infof("down the branch indicating that our cache was out of date and we're trying to recreate a revision.")
+			return false, nil
+		}
+		// update the sync and continue
+	case err != nil:
+		return false, err
 	}
 
 	ownerRefs := []metav1.OwnerReference{{
 		APIVersion: "v1",
 		Kind:       "ConfigMap",
-		Name:       statusConfigMap.Name,
-		UID:        statusConfigMap.UID,
+		Name:       createdStatus.Name,
+		UID:        createdStatus.UID,
 	}}
 
 	for _, cm := range c.configMaps {
 		obj, _, err := resourceapply.SyncConfigMap(ctx, c.configMapGetter, recorder, c.targetNamespace, cm.Name, c.targetNamespace, nameFor(cm.Name, revision), ownerRefs)
 		if err != nil {
-			return err
+			return false, err
 		}
 		if obj == nil && !cm.Optional {
-			return apierrors.NewNotFound(corev1.Resource("configmaps"), cm.Name)
+			return false, apierrors.NewNotFound(corev1.Resource("configmaps"), cm.Name)
 		}
 	}
 	for _, s := range c.secrets {
 		obj, _, err := resourceapply.SyncSecret(ctx, c.secretGetter, recorder, c.targetNamespace, s.Name, c.targetNamespace, nameFor(s.Name, revision), ownerRefs)
 		if err != nil {
-			return err
+			return false, err
 		}
 		if obj == nil && !s.Optional {
-			return apierrors.NewNotFound(corev1.Resource("secrets"), s.Name)
+			return false, apierrors.NewNotFound(corev1.Resource("secrets"), s.Name)
 		}
 	}
 
-	return nil
+	createdStatus.Annotations["operator.openshift.io/revision-ready"] = "true"
+	if _, err := c.configMapGetter.ConfigMaps(createdStatus.Namespace).Update(ctx, createdStatus, metav1.UpdateOptions{}); err != nil {
+		return false, err
+	}
+
+	return true, nil
 }
 
 // getLatestAvailableRevision returns the latest known revision to the operator

--- a/pkg/operator/revisioncontroller/revision_controller_test.go
+++ b/pkg/operator/revisioncontroller/revision_controller_test.go
@@ -2,6 +2,7 @@ package revisioncontroller
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -16,6 +17,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
+	"k8s.io/klog/v2"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/library-go/pkg/operator/events"
@@ -536,5 +538,112 @@ func TestRevisionController(t *testing.T) {
 				return
 			}
 		})
+	}
+}
+
+type fakeStaticPodLatestRevisionClient struct {
+	v1helpers.StaticPodOperatorClient
+	client                                 *StaticPodLatestRevisionClient
+	updateLatestRevisionOperatorStatusErrs bool
+}
+
+var _ LatestRevisionClient = &fakeStaticPodLatestRevisionClient{}
+
+func (c fakeStaticPodLatestRevisionClient) GetLatestRevisionState() (*operatorv1.OperatorSpec, *operatorv1.OperatorStatus, int32, string, error) {
+	return c.client.GetLatestRevisionState()
+}
+
+func (c fakeStaticPodLatestRevisionClient) UpdateLatestRevisionOperatorStatus(ctx context.Context, latestAvailableRevision int32, updateFuncs ...v1helpers.UpdateStatusFunc) (*operatorv1.OperatorStatus, bool, error) {
+	if c.updateLatestRevisionOperatorStatusErrs {
+		return nil, false, fmt.Errorf("Operation cannot be fulfilled on kubeapiservers.operator.openshift.io \"cluster\": the object has been modified; please apply your changes to the latest version and try again")
+	}
+	return c.client.UpdateLatestRevisionOperatorStatus(ctx, latestAvailableRevision, updateFuncs...)
+}
+
+func TestRevisionControllerRevisionCreatedFailedStatusUpdate(t *testing.T) {
+	startingObjects := []runtime.Object{
+		&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "test-secret", Namespace: targetNamespace}},
+		&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "test-secret-2", Namespace: targetNamespace}},
+		&v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "test-config", Namespace: targetNamespace}, Data: map[string]string{"key": "value", "key2": "value"}},
+		&v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "test-config-2", Namespace: targetNamespace}, Data: map[string]string{"key": "value"}},
+		&v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "revision-status-2", Namespace: targetNamespace, Annotations: map[string]string{"operator.openshift.io/revision-ready": "false"}}},
+	}
+
+	testConfigs := []RevisionResource{{Name: "test-config"}, {Name: "test-config-opt", Optional: true}}
+	testSecrets := []RevisionResource{{Name: "test-secret"}, {Name: "test-secret-opt", Optional: true}}
+
+	staticPodOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(
+		&operatorv1.StaticPodOperatorSpec{
+			OperatorSpec: operatorv1.OperatorSpec{
+				ManagementState: operatorv1.Managed,
+			},
+		},
+		&operatorv1.StaticPodOperatorStatus{
+			LatestAvailableRevision: 2,
+			NodeStatuses: []operatorv1.NodeStatus{
+				{
+					NodeName:        "test-node-1",
+					CurrentRevision: 0,
+					TargetRevision:  0,
+				},
+			},
+		},
+		nil,
+		nil,
+	)
+
+	fakeStaticPodOperatosClient := &fakeStaticPodLatestRevisionClient{client: &StaticPodLatestRevisionClient{StaticPodOperatorClient: staticPodOperatorClient}, StaticPodOperatorClient: staticPodOperatorClient}
+
+	kubeClient := fake.NewSimpleClientset(startingObjects...)
+	eventRecorder := events.NewRecorder(kubeClient.CoreV1().Events("test"), "test-operator", &v1.ObjectReference{})
+
+	c := NewRevisionController(
+		targetNamespace,
+		testConfigs,
+		testSecrets,
+		informers.NewSharedInformerFactoryWithOptions(kubeClient, 1*time.Minute, informers.WithNamespace(targetNamespace)),
+		fakeStaticPodOperatosClient,
+		kubeClient.CoreV1(),
+		kubeClient.CoreV1(),
+		eventRecorder,
+	)
+
+	klog.Infof("Running NewRevisionController.Sync with UpdateLatestRevisionOperatorStatus returning an error")
+	// make the first UpdateLatestRevisionOperatorStatus call fail
+	fakeStaticPodOperatosClient.updateLatestRevisionOperatorStatusErrs = true
+	syncErr := c.Sync(context.TODO(), factory.NewSyncContext("RevisionController", eventRecorder))
+	klog.Infof("Validating NewRevisionController.Sync returned an error: %v", syncErr)
+	if syncErr == nil {
+		t.Errorf("expected error after running NewRevisionController.Sync, got nil")
+		return
+	}
+	_, status, _, statusErr := staticPodOperatorClient.GetStaticPodOperatorState()
+	if statusErr != nil {
+		t.Errorf("unexpected status err: %v", statusErr)
+		return
+	}
+	klog.Infof("Validating status.LatestAvailableRevision (%v) has not changed", status.LatestAvailableRevision)
+	if status.LatestAvailableRevision != 2 {
+		t.Errorf("unexpected status.LatestAvailableRevision: %v, expected 2", status.LatestAvailableRevision)
+		return
+	}
+
+	klog.Infof("Running NewRevisionController.Sync with UpdateLatestRevisionOperatorStatus succeeding")
+	// make the second UpdateLatestRevisionOperatorStatus call to succeed
+	fakeStaticPodOperatosClient.updateLatestRevisionOperatorStatusErrs = false
+	syncErr = c.Sync(context.TODO(), factory.NewSyncContext("RevisionController", eventRecorder))
+	if syncErr != nil && syncErr != factory.SyntheticRequeueError {
+		t.Errorf("unexpected error after running NewRevisionController.Sync: %v", syncErr)
+		return
+	}
+	_, status, _, statusErr = staticPodOperatorClient.GetStaticPodOperatorState()
+	if statusErr != nil {
+		t.Errorf("unexpected status err: %v", statusErr)
+		return
+	}
+	klog.Infof("Validating status.LatestAvailableRevision (%v) changed", status.LatestAvailableRevision)
+	if status.LatestAvailableRevision != 3 {
+		t.Errorf("unexpected status.LatestAvailableRevision: %v, expected 3", status.LatestAvailableRevision)
+		return
 	}
 }


### PR DESCRIPTION
fixes https://github.com/openshift/library-go/pull/1649 by adding a commit that ensures that the latestAvailableRevision  actually is the latest instead of hoping that the second update actually works.

Looking at https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.16-e2e-gcp-sdn-techpreview-serial/1736680969496170496 we can see 

> 2023-12-18T09:56:54.930966948Z I1218 09:56:54.930910       1 revision_controller.go:247] down the branch indicating that our cache was out of date and we're trying to recreate a revision.
2023-12-18T09:56:54.939349351Z I1218 09:56:54.939268       1 event.go:298] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-apiserver-operator", Name:"kube-apiserver-operator", UID:"6089fa8c-6cad-4981-aba0-abf51375184a", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'StartingNewRevision' new revision 4 triggered by "required secret/localhost-recovery-client-token has changed,required configmap/config has changed,required configmap/sa-token-signing-certs has changed"


in the kas-o log

Looking at the openshift-kube-apiserver configmaps, we can see 
```yaml
 apiVersion: v1
  data:
    reason: required configmap/sa-token-signing-certs has changed
    revision: "4"
  kind: ConfigMap
  metadata:
    annotations:
      operator.openshift.io/revision-ready: "true"
    name: revision-status-4
    namespace: openshift-kube-apiserver
```

But in the kubeapiserver.operator.openshift.io we see
```yaml
  latestAvailableRevision: 3
  nodeStatuses:
  - currentRevision: 3
    nodeName: ci-op-p2zlksxd-3e2f4-cv54q-master-2
  - currentRevision: 3
    nodeName: ci-op-p2zlksxd-3e2f4-cv54q-master-0
  - currentRevision: 3
    nodeName: ci-op-p2zlksxd-3e2f4-cv54q-master-1
```

This results in the kas-o not installing revision 4 AND it means that revision 5 is not created.

We could either reorder the update of kubeapiserver.operator.openshift.io to be done *before* declaring the revision ready (this isn't good) or we can update the check at the beginning of the loop to always ensure the latestlAvailableRevision on the kubeapiserver.operator.openshfit.io is correct.


This conflict from the kas-o log probably killed it
> 2023-12-18T09:56:13.969003270Z I1218 09:56:13.968342       1 event.go:298] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-apiserver-operator", Name:"kube-apiserver-operator", UID:"6089fa8c-6cad-4981-aba0-abf51375184a", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'RevisionTriggered' new revision 4 triggered by "required secret/localhost-recovery-client-token has changed,required configmap/config has changed,required configmap/sa-token-signing-certs has changed"
2023-12-18T09:56:14.710317251Z E1218 09:56:14.710223       1 base_controller.go:268] RevisionController reconciliation failed: Operation cannot be fulfilled on kubeapiservers.operator.openshift.io "cluster": the object has been modified; please apply your changes to the latest version and try again
