### PR TITLE
OCPBUGS-18697: controller/factory: skip event handler registration for base controller when ResyncEvery and WithoutEventHandlers is set

### DIFF
--- a/pkg/operator/staticpod/controller/guard/guard_controller.go
+++ b/pkg/operator/staticpod/controller/guard/guard_controller.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/policy/v1"
@@ -106,7 +107,7 @@ func NewGuardController(
 	return factory.New().WithInformers(
 		kubeInformersForTargetNamespace.Core().V1().Pods().Informer(),
 		kubeInformersClusterScoped.Core().V1().Nodes().Informer(),
-	).WithSync(c.sync).WithSyncDegradedOnError(operatorClient).ToController("GuardController", eventRecorder), nil
+	).ResyncEvery(20*time.Second).WithoutEventHandlers().WithSync(c.sync).WithSyncDegradedOnError(operatorClient).ToController("GuardController", eventRecorder), nil
 }
 
 func getInstallerPodImageFromEnv() string {


### PR DESCRIPTION
When ResyncEvery is used update events can still invoke Sync more often than resyncInterval specified for ResyncEvery. Making ResyncEvery obsolete.

Expected usage:
```
return factory.New().WithInformers(
		kubeInformersForTargetNamespace.Core().V1().Pods().Informer(),
		kubeInformersClusterScoped.Core().V1().Nodes().Informer(),
).ResyncEvery(10*time.Second).WithoutEventHandlers().WithSync(c.sync).WithSyncDegradedOnError(operatorClient).ToController("ControllerName", eventRecorder), nil
```

Follow up for https://github.com/openshift/library-go/pull/1620/files#r1399213346.

Testing in https://github.com/openshift/cluster-kube-scheduler-operator/pull/525.