### PR TITLE
resourceapply: update events to be more legible

### DIFF
--- a/pkg/operator/resource/resourceapply/core.go
+++ b/pkg/operator/resource/resourceapply/core.go
@@ -335,7 +335,7 @@ func ApplyConfigMapImproved(ctx context.Context, client coreclientv1.ConfigMapsG
 	var details string
 	if !dataSame {
 		sort.Sort(sort.StringSlice(modifiedKeys))
-		details = fmt.Sprintf("cause by changes in %v", strings.Join(modifiedKeys, ","))
+		details = fmt.Sprintf("caused by changes in %v", strings.Join(modifiedKeys, ","))
 	}
 	if klog.V(2).Enabled() {
 		klog.Infof("ConfigMap %q changes: %v", required.Namespace+"/"+required.Name, JSONPatchNoError(existing, required))

--- a/pkg/operator/resource/resourceapply/event_helpers.go
+++ b/pkg/operator/resource/resourceapply/event_helpers.go
@@ -39,7 +39,7 @@ func reportUpdateEvent(recorder events.Recorder, obj runtime.Object, originalErr
 	case len(details) == 0:
 		recorder.Eventf(fmt.Sprintf("%sUpdated", gvk.Kind), "Updated %s because it changed", resourcehelper.FormatResourceForCLIWithNamespace(obj))
 	default:
-		recorder.Eventf(fmt.Sprintf("%sUpdated", gvk.Kind), "Updated %s:\n%s", resourcehelper.FormatResourceForCLIWithNamespace(obj), strings.Join(details, "\n"))
+		recorder.Eventf(fmt.Sprintf("%sUpdated", gvk.Kind), "Updated %s: %s", resourcehelper.FormatResourceForCLIWithNamespace(obj), strings.Join(details, "\n"))
 	}
 }
 
@@ -51,6 +51,6 @@ func reportDeleteEvent(recorder events.Recorder, obj runtime.Object, originalErr
 	case len(details) == 0:
 		recorder.Eventf(fmt.Sprintf("%sDeleted", gvk.Kind), "Deleted %s", resourcehelper.FormatResourceForCLIWithNamespace(obj))
 	default:
-		recorder.Eventf(fmt.Sprintf("%sDeleted", gvk.Kind), "Deleted %s:\n%s", resourcehelper.FormatResourceForCLIWithNamespace(obj), strings.Join(details, "\n"))
+		recorder.Eventf(fmt.Sprintf("%sDeleted", gvk.Kind), "Deleted %s: %s", resourcehelper.FormatResourceForCLIWithNamespace(obj), strings.Join(details, "\n"))
 	}
 }


### PR DESCRIPTION
 - `s/cause by/caused by/` for better English
 - remove newlines in event logs, everyone exepcts single-line logs