### PR TITLE
s/toplogy/topology/

### DIFF
--- a/pkg/controller/controllercmd/builder.go
+++ b/pkg/controller/controllercmd/builder.go
@@ -430,14 +430,14 @@ func (b *ControllerBuilder) getClientConfig() (*rest.Config, error) {
 }
 
 func topologyLeaderElection(topology configv1.TopologyMode, original configv1.LeaderElection) configv1.LeaderElection {
-	// if we can't determine the infra toplogy, return original
+	// if we can't determine the infra topology, return original
 	if topology == "" {
 		return original
 	}
 
-	// If we are running in a SingleReplicaTopologyMode and leader election is not disabled, configure leader election for SNO Toplogy
+	// If we are running in a SingleReplicaTopologyMode and leader election is not disabled, configure leader election for SNO Topology
 	if topology == configv1.SingleReplicaTopologyMode && !original.Disable {
-		klog.Info("detected SingleReplicaTopologyMode, the original leader election has been altered for the default SingleReplicaToplogy")
+		klog.Info("detected SingleReplicaTopologyMode, the original leader election has been altered for the default SingleReplicaTopology")
 		return leaderelectionconverter.LeaderElectionSNOConfig(original)
 	}
 	return original

--- a/pkg/controller/controllercmd/builder_test.go
+++ b/pkg/controller/controllercmd/builder_test.go
@@ -224,7 +224,7 @@ func TestInfraStatusTopologyLeaderElection(t *testing.T) {
 			},
 		},
 		{
-			desc:     "should set SNO leader election config when SingleReplicaToplogy Controlplane",
+			desc:     "should set SNO leader election config when SingleReplicaTopology Controlplane",
 			topology: configv1.SingleReplicaTopologyMode,
 			original: configv1.LeaderElection{
 				LeaseDuration: metav1.Duration{Duration: 60 * time.Second},

--- a/vendor/github.com/openshift/api/config/v1/types_feature.go
+++ b/vendor/github.com/openshift/api/config/v1/types_feature.go
@@ -45,7 +45,7 @@ var (
 	// your cluster may fail in an unrecoverable way.
 	CustomNoUpgrade FeatureSet = "CustomNoUpgrade"
 
-	// TopologyManager enables ToplogyManager support. Upgrades are enabled with this feature.
+	// TopologyManager enables TopologyManager support. Upgrades are enabled with this feature.
 	LatencySensitive FeatureSet = "LatencySensitive"
 )
 


### PR DESCRIPTION
Fix multiple occurrences of topology being misspelled "toplogy".

This is a resubmission of a previous pull request that was ignored.