### PR TITLE
certrotation: replace JiraComponent/Description with AdditionalMetadata struct

### DIFF
--- a/pkg/operator/certrotation/annotations.go
+++ b/pkg/operator/certrotation/annotations.go
@@ -5,30 +5,34 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func NewTLSArtifactObjectMeta(name, namespace, jiraComponent, description string) metav1.ObjectMeta {
-	return metav1.ObjectMeta{
-		Namespace: namespace,
-		Name:      name,
-		Annotations: map[string]string{
-			annotations.OpenShiftComponent:   jiraComponent,
-			annotations.OpenShiftDescription: description,
-		},
-	}
+type AdditionalAnnotations struct {
+	// JiraComponent annotates tls artifacts so that owner could be easily found
+	JiraComponent string
+	// Description is a human-readable one sentence description of certificate purpose
+	Description string
 }
 
-// EnsureTLSMetadataUpdate mutates objectMeta setting necessary annotations if unset
-func EnsureTLSMetadataUpdate(meta *metav1.ObjectMeta, jiraComponent, description string) bool {
+func (a AdditionalAnnotations) EnsureTLSMetadataUpdate(meta *metav1.ObjectMeta) bool {
 	modified := false
 	if meta.Annotations == nil {
 		meta.Annotations = make(map[string]string)
 	}
-	if len(jiraComponent) > 0 && meta.Annotations[annotations.OpenShiftComponent] != jiraComponent {
-		meta.Annotations[annotations.OpenShiftComponent] = jiraComponent
+	if len(a.JiraComponent) > 0 && meta.Annotations[annotations.OpenShiftComponent] != a.JiraComponent {
+		meta.Annotations[annotations.OpenShiftComponent] = a.JiraComponent
 		modified = true
 	}
-	if len(description) > 0 && meta.Annotations[annotations.OpenShiftDescription] != description {
-		meta.Annotations[annotations.OpenShiftDescription] = description
+	if len(a.Description) > 0 && meta.Annotations[annotations.OpenShiftDescription] != a.Description {
+		meta.Annotations[annotations.OpenShiftDescription] = a.Description
 		modified = true
 	}
 	return modified
+}
+
+func NewTLSArtifactObjectMeta(name, namespace string, annotations AdditionalAnnotations) metav1.ObjectMeta {
+	meta := metav1.ObjectMeta{
+		Namespace: namespace,
+		Name:      name,
+	}
+	_ = annotations.EnsureTLSMetadataUpdate(&meta)
+	return meta
 }

--- a/pkg/operator/certrotation/annotations.go
+++ b/pkg/operator/certrotation/annotations.go
@@ -5,11 +5,18 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	AutoRegenerateAfterOfflineExpiryAnnotation string = "certificates.openshift.io/auto-regenerate-after-offline-expiry"
+)
+
 type AdditionalAnnotations struct {
 	// JiraComponent annotates tls artifacts so that owner could be easily found
 	JiraComponent string
 	// Description is a human-readable one sentence description of certificate purpose
 	Description string
+	// AutoRegenerateAfterOfflineExpiry contains a link to PR and an e2e test name which verifies
+	// that TLS artifact is correctly regenerated after it has expired
+	AutoRegenerateAfterOfflineExpiry string
 }
 
 func (a AdditionalAnnotations) EnsureTLSMetadataUpdate(meta *metav1.ObjectMeta) bool {
@@ -23,6 +30,10 @@ func (a AdditionalAnnotations) EnsureTLSMetadataUpdate(meta *metav1.ObjectMeta) 
 	}
 	if len(a.Description) > 0 && meta.Annotations[annotations.OpenShiftDescription] != a.Description {
 		meta.Annotations[annotations.OpenShiftDescription] = a.Description
+		modified = true
+	}
+	if len(a.AutoRegenerateAfterOfflineExpiry) > 0 && meta.Annotations[AutoRegenerateAfterOfflineExpiryAnnotation] != a.AutoRegenerateAfterOfflineExpiry {
+		meta.Annotations[AutoRegenerateAfterOfflineExpiryAnnotation] = a.Description
 		modified = true
 	}
 	return modified

--- a/pkg/operator/certrotation/signer.go
+++ b/pkg/operator/certrotation/signer.go
@@ -44,11 +44,9 @@ type RotatedSigningCASecret struct {
 	// is used, early deletion will be catastrophic.
 	Owner *metav1.OwnerReference
 
-	// JiraComponent annotates tls artifacts so that owner could be easily found
-	JiraComponent string
+	// AdditionalAnnotations is a collection of annotations set for the secret
+	AdditionalAnnotations AdditionalAnnotations
 
-	// Description is a human-readable one sentence description of certificate purpose
-	Description string
 	// Plumbing:
 	Informer      corev1informers.SecretInformer
 	Lister        corev1listers.SecretLister
@@ -67,8 +65,7 @@ func (c RotatedSigningCASecret) EnsureSigningCertKeyPair(ctx context.Context) (*
 		signingCertKeyPairSecret = &corev1.Secret{ObjectMeta: NewTLSArtifactObjectMeta(
 			c.Name,
 			c.Namespace,
-			c.JiraComponent,
-			c.Description,
+			c.AdditionalAnnotations,
 		)}
 	}
 	signingCertKeyPairSecret.Type = corev1.SecretTypeTLS
@@ -77,9 +74,7 @@ func (c RotatedSigningCASecret) EnsureSigningCertKeyPair(ctx context.Context) (*
 	if c.Owner != nil {
 		needsMetadataUpdate = ensureOwnerReference(&signingCertKeyPairSecret.ObjectMeta, c.Owner)
 	}
-	if len(c.JiraComponent) > 0 || len(c.Description) > 0 {
-		needsMetadataUpdate = EnsureTLSMetadataUpdate(&signingCertKeyPairSecret.ObjectMeta, c.JiraComponent, c.Description) || needsMetadataUpdate
-	}
+	needsMetadataUpdate = c.AdditionalAnnotations.EnsureTLSMetadataUpdate(&signingCertKeyPairSecret.ObjectMeta) || needsMetadataUpdate
 	if needsMetadataUpdate && len(signingCertKeyPairSecret.ResourceVersion) > 0 {
 		_, _, err := resourceapply.ApplySecret(ctx, c.Client, c.EventRecorder, signingCertKeyPairSecret)
 		if err != nil {

--- a/pkg/operator/resourcesynccontroller/core.go
+++ b/pkg/operator/resourcesynccontroller/core.go
@@ -14,7 +14,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/certrotation"
 )
 
-func CombineCABundleConfigMaps(destinationConfigMap ResourceLocation, lister corev1listers.ConfigMapLister, jiraComponent, description string, inputConfigMaps ...ResourceLocation) (*corev1.ConfigMap, error) {
+func CombineCABundleConfigMaps(destinationConfigMap ResourceLocation, lister corev1listers.ConfigMapLister, additionalAnnotations certrotation.AdditionalAnnotations, inputConfigMaps ...ResourceLocation) (*corev1.ConfigMap, error) {
 	certificates := []*x509.Certificate{}
 	for _, input := range inputConfigMaps {
 		inputConfigMap, err := lister.ConfigMaps(input.Namespace).Get(input.Name)
@@ -62,8 +62,7 @@ func CombineCABundleConfigMaps(destinationConfigMap ResourceLocation, lister cor
 		ObjectMeta: certrotation.NewTLSArtifactObjectMeta(
 			destinationConfigMap.Name,
 			destinationConfigMap.Namespace,
-			jiraComponent,
-			description,
+			additionalAnnotations,
 		),
 		Data: map[string]string{
 			"ca-bundle.crt": string(caBytes),


### PR DESCRIPTION
Function signature won't require changes when new cert requirements are being created

Tested in https://github.com/openshift/cluster-kube-apiserver-operator/pull/1631