### PR TITLE
CFE-866: feature: monitoring and handling "single" secret dynamically

### DIFF
--- a/pkg/secret/OWNERS
+++ b/pkg/secret/OWNERS
@@ -1,0 +1,7 @@
+reviewers:
+  - deads2k
+  - soltysh
+  - chiragkyal
+approvers:
+  - deads2k
+  - soltysh

--- a/pkg/secret/OWNERS
+++ b/pkg/secret/OWNERS
@@ -1,7 +1,9 @@
 reviewers:
   - deads2k
   - soltysh
+  - Miciah
   - chiragkyal
 approvers:
   - deads2k
   - soltysh
+  - Miciah

--- a/pkg/secret/fake/fake_secret_monitor.go
+++ b/pkg/secret/fake/fake_secret_monitor.go
@@ -1,0 +1,24 @@
+package fake
+
+import (
+	"context"
+
+	"github.com/openshift/library-go/pkg/secret"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+type SecretMonitor struct {
+	Err    error
+	Secret *corev1.Secret
+}
+
+func (sm *SecretMonitor) AddSecretEventHandler(_ context.Context, _ string, _ string, _ cache.ResourceEventHandler) (secret.SecretEventHandlerRegistration, error) {
+	return nil, sm.Err
+}
+func (sm *SecretMonitor) RemoveSecretEventHandler(_ secret.SecretEventHandlerRegistration) error {
+	return sm.Err
+}
+func (sm *SecretMonitor) GetSecret(_ context.Context, _ secret.SecretEventHandlerRegistration) (*corev1.Secret, error) {
+	return sm.Secret, sm.Err
+}

--- a/pkg/secret/monitor.go
+++ b/pkg/secret/monitor.go
@@ -49,7 +49,7 @@ func (i *singleItemMonitor) HasSynced() bool {
 	return i.informer.HasSynced()
 }
 
-// StartInformer starts and runs the informer util the provided context is canceled,
+// StartInformer starts and runs the informer until the provided context is canceled,
 // or StopInformer() is called. It will block, so call via goroutine.
 func (i *singleItemMonitor) StartInformer(ctx context.Context) {
 	i.lock.Lock()
@@ -102,7 +102,7 @@ func (i *singleItemMonitor) AddEventHandler(handler cache.ResourceEventHandler) 
 	defer i.lock.Unlock()
 
 	if i.stopped {
-		return nil, fmt.Errorf("can not add handler %v to already stopped informer", handler)
+		return nil, fmt.Errorf("cannot add handler %v to already stopped informer", handler)
 	}
 
 	registration, err := i.informer.AddEventHandler(handler)
@@ -120,6 +120,10 @@ func (i *singleItemMonitor) AddEventHandler(handler cache.ResourceEventHandler) 
 func (i *singleItemMonitor) RemoveEventHandler(handle SecretEventHandlerRegistration) error {
 	i.lock.Lock()
 	defer i.lock.Unlock()
+
+	if handle == nil {
+		return fmt.Errorf("nil handler registration is provided")
+	}
 
 	if i.stopped {
 		return fmt.Errorf("can not remove handler %v from stopped informer", handle.GetHandler())

--- a/pkg/secret/monitor.go
+++ b/pkg/secret/monitor.go
@@ -50,13 +50,13 @@ func (i *singleItemMonitor) HasSynced() bool {
 }
 
 // StartInformer starts and runs the informer until the provided context is canceled,
-// or StopInformer() is called. It will block, so call via goroutine.
+// or StopInformer() is called.
 func (i *singleItemMonitor) StartInformer(ctx context.Context) {
 	i.lock.Lock()
+	defer i.lock.Unlock()
 
 	if !i.stopped {
 		klog.Warning("informer is already running")
-		i.lock.Unlock()
 		return
 	}
 
@@ -75,9 +75,8 @@ func (i *singleItemMonitor) StartInformer(ctx context.Context) {
 
 	klog.Info("starting informer")
 	i.stopped = false
-	i.lock.Unlock()
 
-	i.informer.Run(i.stopCh)
+	go i.informer.Run(i.stopCh)
 }
 
 // StopInformer stops the informer.

--- a/pkg/secret/monitor.go
+++ b/pkg/secret/monitor.go
@@ -1,0 +1,136 @@
+package secret
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+)
+
+// ObjectKey represents the unique identifier for a resource, used to access it in the cache.
+type ObjectKey struct {
+	// Namespace is the namespace in which the resource is located.
+	Namespace string
+	// Name denotes metadata.name of a resource being monitored by informer
+	Name string
+}
+
+// singleItemMonitor monitors a single resource using a SharedInformer.
+type singleItemMonitor struct {
+	key      ObjectKey
+	informer cache.SharedInformer
+	lock     sync.Mutex
+	stopped  bool
+	stopCh   chan struct{}
+}
+
+// NewObjectKey creates a new ObjectKey for the given namespace and name.
+func NewObjectKey(namespace, name string) ObjectKey {
+	return ObjectKey{
+		Namespace: namespace,
+		Name:      name,
+	}
+}
+
+// newSingleItemMonitor creates a new singleItemMonitor for the given key and informer.
+func newSingleItemMonitor(key ObjectKey, informer cache.SharedInformer) *singleItemMonitor {
+	return &singleItemMonitor{
+		key:      key,
+		informer: informer,
+		stopped:  true,
+		stopCh:   make(chan struct{}),
+	}
+}
+
+// HasSynced returns true if the informer's cache has been successfully synced.
+func (i *singleItemMonitor) HasSynced() bool {
+	return i.informer.HasSynced()
+}
+
+// StartInformer starts and runs the informer util the provided context is canceled,
+// or StopInformer() is called. It will block, so call via goroutine.
+func (i *singleItemMonitor) StartInformer(ctx context.Context) {
+	i.lock.Lock()
+
+	if !i.stopped {
+		klog.Warning("informer is already running")
+		i.lock.Unlock()
+		return
+	}
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			klog.V(5).Info("stopping informer due to context cancellation")
+			if !i.StopInformer() {
+				klog.Error("failed to stop informer")
+			}
+		// this case is required to exit from the goroutine
+		// after normal StopInformer() call i.e when stopCh is closed.
+		case <-i.stopCh:
+		}
+	}()
+
+	klog.Info("starting informer")
+	i.stopped = false
+	i.lock.Unlock()
+
+	i.informer.Run(i.stopCh)
+}
+
+// StopInformer stops the informer.
+// Retuns false if called twice, or before StartInformer(); true otherwise.
+func (i *singleItemMonitor) StopInformer() bool {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+
+	if i.stopped {
+		return false
+	}
+	i.stopped = true
+	close(i.stopCh) // Signal the informer to stop
+	klog.Info("informer stopped")
+	return true
+}
+
+// AddEventHandler adds an event handler to the informer and returns
+// secretEventHandlerRegistration after populating objectKey and registration.
+func (i *singleItemMonitor) AddEventHandler(handler cache.ResourceEventHandler) (SecretEventHandlerRegistration, error) {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+
+	if i.stopped {
+		return nil, fmt.Errorf("can not add handler %v to already stopped informer", handler)
+	}
+
+	registration, err := i.informer.AddEventHandler(handler)
+	if err != nil {
+		return nil, err
+	}
+
+	return &secretEventHandlerRegistration{
+		ResourceEventHandlerRegistration: registration,
+		objectKey:                        i.key,
+	}, nil
+}
+
+// RemoveEventHandler removes an event handler from the informer.
+func (i *singleItemMonitor) RemoveEventHandler(handle SecretEventHandlerRegistration) error {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+
+	if i.stopped {
+		return fmt.Errorf("can not remove handler %v from stopped informer", handle.GetHandler())
+	}
+
+	return i.informer.RemoveEventHandler(handle.GetHandler())
+}
+
+// GetItem returns the accumulator being monitored
+// by informer, using keyFunc (namespace/name).
+func (i *singleItemMonitor) GetItem() (item interface{}, exists bool, err error) {
+	keyFunc := i.key.Namespace + "/" + i.key.Name
+	return i.informer.GetStore().GetByKey(keyFunc)
+}

--- a/pkg/secret/monitor_test.go
+++ b/pkg/secret/monitor_test.go
@@ -1,0 +1,361 @@
+package secret
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+)
+
+func fakeMonitor(ctx context.Context, fakeKubeClient *fake.Clientset, key ObjectKey) *singleItemMonitor {
+	sharedInformer := fakeSecretInformer(ctx, fakeKubeClient, key.Namespace, key.Name)
+	return newSingleItemMonitor(key, sharedInformer)
+}
+
+// fakeSecretInformer will list/watch only one secret inside a namespace
+func fakeSecretInformer(ctx context.Context, fakeKubeClient *fake.Clientset, namespace, name string) cache.SharedInformer {
+	fieldSelector := fields.OneTermEqualSelector("metadata.name", name).String()
+	klog.Info(fieldSelector)
+	return cache.NewSharedInformer(&cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			options.FieldSelector = fieldSelector
+			return fakeKubeClient.CoreV1().Secrets(namespace).List(ctx, options)
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			options.FieldSelector = fieldSelector
+			return fakeKubeClient.CoreV1().Secrets(namespace).Watch(ctx, options)
+		},
+	},
+		&corev1.Secret{},
+		0,
+	)
+}
+
+func fakeSecret(namespace, name string) *corev1.Secret {
+	return &corev1.Secret{
+		Type: corev1.SecretTypeOpaque,
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			"test": {1, 2, 3, 4},
+		},
+	}
+}
+
+func TestStartInformer(t *testing.T) {
+	scenarios := []struct {
+		name      string
+		isClosed  bool
+		expectErr bool
+	}{
+		{
+			name:      "pass closed channel into informer",
+			isClosed:  true,
+			expectErr: true,
+		},
+		{
+			name:      "pass unclosed channel into informer",
+			isClosed:  false,
+			expectErr: false,
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+			fakeKubeClient := fake.NewSimpleClientset()
+			monitor := fakeMonitor(context.TODO(), fakeKubeClient, ObjectKey{})
+			if s.isClosed {
+				close(monitor.stopCh)
+			}
+			go monitor.StartInformer(context.TODO())
+
+			select {
+			// this case will execute if stopCh is closed
+			case <-monitor.stopCh:
+				if !s.expectErr {
+					t.Error("informer is not running")
+				}
+			default:
+				// wait for the informer to start
+				if !cache.WaitForCacheSync(context.TODO().Done(), monitor.HasSynced) {
+					t.Fatal("cache not synced yet")
+				}
+				t.Log("informer is running")
+			}
+		})
+	}
+}
+
+func TestStopInformer(t *testing.T) {
+	scenarios := []struct {
+		name             string
+		withStart        bool
+		alreadyStopped   bool
+		expectStopped    bool
+		expectChanClosed bool
+	}{
+		{
+			name:             "stop without starting informer",
+			withStart:        false,
+			expectStopped:    false,
+			expectChanClosed: false,
+		},
+		{
+			name:             "stopping already stopped informer",
+			withStart:        true,
+			alreadyStopped:   true,
+			expectStopped:    false,
+			expectChanClosed: true,
+		},
+		{
+			name:             "correctly stopped informer",
+			withStart:        true,
+			alreadyStopped:   false,
+			expectStopped:    true,
+			expectChanClosed: true,
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+			fakeKubeClient := fake.NewSimpleClientset()
+			monitor := fakeMonitor(context.TODO(), fakeKubeClient, ObjectKey{})
+
+			if s.withStart {
+				go monitor.StartInformer(context.TODO())
+				// wait for the informer to start
+				if !cache.WaitForCacheSync(context.TODO().Done(), monitor.HasSynced) {
+					t.Fatal("cache not synced yet")
+				}
+			}
+			if s.alreadyStopped {
+				monitor.StopInformer()
+			}
+
+			if got := monitor.StopInformer(); got != s.expectStopped {
+				t.Errorf("expected informer stopped to be %t but got %t", s.expectStopped, got)
+			}
+
+			var chanClosed bool
+			select {
+			// this case will execute if stopCh is closed
+			case <-monitor.stopCh:
+				chanClosed = true
+			default:
+				chanClosed = false
+			}
+
+			if s.expectChanClosed != chanClosed {
+				t.Errorf("expected stop channel closed to be %t but got %t", s.expectChanClosed, chanClosed)
+			}
+		})
+	}
+}
+
+func TestStopWithContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.TODO())
+	fakeKubeClient := fake.NewSimpleClientset()
+	monitor := fakeMonitor(ctx, fakeKubeClient, ObjectKey{})
+	stopCh := make(chan bool)
+
+	go func() {
+		monitor.StartInformer(ctx)
+		close(stopCh)
+	}()
+	// wait for the informer to start
+	if !cache.WaitForCacheSync(ctx.Done(), monitor.HasSynced) {
+		t.Fatal("cache not synced yet")
+	}
+
+	// cancel the context to stop the informer
+	cancel()
+	<-stopCh
+
+	// again stopping should deny
+	if monitor.StopInformer() != false {
+		t.Fatal("context cancellation did not work properly")
+	}
+}
+
+func TestAddEventHandler(t *testing.T) {
+	scenarios := []struct {
+		name      string
+		key       ObjectKey
+		isStop    bool
+		expectErr bool
+	}{
+		{
+			name:      "add handler to stopped informer",
+			isStop:    true,
+			expectErr: true,
+		},
+		{
+			name:      "correctly add handler to informer",
+			key:       NewObjectKey("namespace", "name"),
+			isStop:    false,
+			expectErr: false,
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+			fakeKubeClient := fake.NewSimpleClientset()
+			monitor := fakeMonitor(context.TODO(), fakeKubeClient, s.key)
+
+			go monitor.StartInformer(context.TODO())
+			// wait for the informer to start
+			if !cache.WaitForCacheSync(context.TODO().Done(), monitor.HasSynced) {
+				t.Fatal("cache not synced yet")
+			}
+
+			if s.isStop {
+				monitor.StopInformer()
+			}
+
+			handlerRegistration, gotErr := monitor.AddEventHandler(cache.ResourceEventHandlerFuncs{})
+			if gotErr != nil && !s.expectErr {
+				t.Fatalf("unexpected error %v", gotErr)
+			}
+			if gotErr == nil && s.expectErr {
+				t.Fatalf("expecting an error, got nil")
+			}
+
+			if !s.isStop { // for handling nil pointer dereference
+				if !reflect.DeepEqual(handlerRegistration.GetKey(), s.key) {
+					t.Fatalf("expected key %v got key %v", s.key, handlerRegistration.GetKey())
+				}
+			}
+		})
+	}
+
+}
+
+func TestRemoveEventHandler(t *testing.T) {
+	scenarios := []struct {
+		name         string
+		isNilHandler bool
+		isStop       bool
+		expectErr    bool
+	}{
+		{
+			name:      "remove handler from stopped informer",
+			isStop:    true,
+			expectErr: true,
+		},
+		{
+			name:         "nil handler is provided",
+			isNilHandler: true,
+			expectErr:    true,
+		},
+		{
+			name:         "correct handler is provided",
+			isNilHandler: false,
+			expectErr:    false,
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+			fakeKubeClient := fake.NewSimpleClientset()
+			monitor := fakeMonitor(context.TODO(), fakeKubeClient, ObjectKey{})
+			go monitor.StartInformer(context.TODO())
+			// wait for the informer to start
+			if !cache.WaitForCacheSync(context.TODO().Done(), monitor.HasSynced) {
+				t.Fatal("cache not synced yet")
+			}
+
+			handlerRegistration, _ := monitor.AddEventHandler(cache.ResourceEventHandlerFuncs{})
+			if s.isNilHandler {
+				handlerRegistration = nil
+			}
+
+			if s.isStop {
+				monitor.StopInformer()
+			}
+
+			// for handling nil pointer dereference
+			defer func() {
+				if err := recover(); err != nil && !s.expectErr {
+					t.Errorf("unexpected error %v", err)
+				}
+			}()
+
+			gotErr := monitor.RemoveEventHandler(handlerRegistration)
+			if gotErr != nil && !s.expectErr {
+				t.Errorf("unexpected error %v", gotErr)
+			}
+			if gotErr == nil && s.expectErr {
+				t.Errorf("expecting an error, got nil")
+			}
+		})
+	}
+}
+
+func TestGetItem(t *testing.T) {
+	scenarios := []struct {
+		name        string
+		secret      *corev1.Secret
+		objectKey   ObjectKey
+		expectExist bool
+	}{
+		{
+			name:        "looking for secret which is not present",
+			secret:      fakeSecret("sandbox", "wrong-name"),
+			objectKey:   NewObjectKey("sandbox", "correct-name"),
+			expectExist: false,
+		},
+		{
+			name:        "looking for correct secret",
+			secret:      fakeSecret("sandbox", "correct-name"),
+			objectKey:   NewObjectKey("sandbox", "correct-name"),
+			expectExist: true,
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+			fakeKubeClient := fake.NewSimpleClientset(s.secret)
+
+			monitor := fakeMonitor(context.TODO(), fakeKubeClient, s.objectKey)
+
+			go monitor.StartInformer(context.TODO())
+			// wait for the informer to start
+			if !cache.WaitForCacheSync(context.TODO().Done(), monitor.HasSynced) {
+				t.Fatal("cache not synced yet")
+			}
+
+			uncast, gotExist, err := monitor.GetItem()
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if gotExist != s.expectExist {
+				t.Fatalf("item is expected to exist %t but got %t", s.expectExist, gotExist)
+			}
+
+			if s.expectExist {
+				gotSecret, ok := uncast.(*corev1.Secret)
+				if !ok {
+					t.Fatalf("unable to cast the item: %v", uncast)
+				}
+				if !reflect.DeepEqual(s.secret, gotSecret) {
+					t.Fatalf("expected to get item %v but got %v", s.secret, gotSecret)
+				}
+			}
+		})
+	}
+}

--- a/pkg/secret/secret_monitor.go
+++ b/pkg/secret/secret_monitor.go
@@ -1,0 +1,217 @@
+package secret
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+)
+
+// SecretEventHandlerRegistration is for registering and unregistering event handlers for secret monitoring.
+type SecretEventHandlerRegistration interface {
+	cache.ResourceEventHandlerRegistration
+
+	GetKey() ObjectKey
+	GetHandler() cache.ResourceEventHandlerRegistration
+}
+
+// SecretMonitor helps in monitoring and handling a specific secret using singleItemMonitor.
+type SecretMonitor interface {
+	// AddSecretEventHandler adds a secret event handler to the monitor for a specific secret in the given namespace.
+	// The handler will be notified of events related to the "specified" secret only.
+	// The returned SecretEventHandlerRegistration can be used to later remove the handler.
+	AddSecretEventHandler(ctx context.Context, namespace, secretName string, handler cache.ResourceEventHandler) (SecretEventHandlerRegistration, error)
+
+	// RemoveSecretEventHandler removes a previously added secret event handler using the provided registration.
+	// If the handler is not found or if there is an issue removing it, an error is returned.
+	RemoveSecretEventHandler(handlerRegistration SecretEventHandlerRegistration) error
+
+	// GetSecret retrieves the secret object from the informer's cache using the provided SecretEventHandlerRegistration.
+	// This allows accessing the latest state of the secret without making an API call.
+	GetSecret(ctx context.Context, handlerRegistration SecretEventHandlerRegistration) (*corev1.Secret, error)
+}
+
+// secretEventHandlerRegistration is an implementation of the SecretEventHandlerRegistration.
+type secretEventHandlerRegistration struct {
+	cache.ResourceEventHandlerRegistration
+
+	// objectKey represents the unique identifier for the secret associated with this event handler registration.
+	// It will be populated during AddEventHandler, and will be used during RemoveEventHandler, GetSecret.
+	objectKey ObjectKey
+}
+
+func (r *secretEventHandlerRegistration) GetKey() ObjectKey {
+	return r.objectKey
+}
+
+func (r *secretEventHandlerRegistration) GetHandler() cache.ResourceEventHandlerRegistration {
+	return r.ResourceEventHandlerRegistration
+}
+
+type monitoredItem struct {
+	itemMonitor *singleItemMonitor
+	numHandlers int
+}
+
+// secretMonitor is an implementation of the SecretMonitor
+type secretMonitor struct {
+	kubeClient kubernetes.Interface
+	lock       sync.RWMutex
+	monitors   map[ObjectKey]*monitoredItem
+}
+
+func NewSecretMonitor(kubeClient kubernetes.Interface) SecretMonitor {
+	return &secretMonitor{
+		kubeClient: kubeClient,
+		monitors:   map[ObjectKey]*monitoredItem{},
+	}
+}
+
+// AddSecretEventHandler adds a secret event handler to the monitor.
+func (s *secretMonitor) AddSecretEventHandler(ctx context.Context, namespace, secretName string, handler cache.ResourceEventHandler) (SecretEventHandlerRegistration, error) {
+	return s.addSecretEventHandler(ctx, namespace, secretName, handler, s.createSecretInformer(namespace, secretName))
+}
+
+// createSecretInformer creates a SharedInformer for monitoring a specific secret.
+func (s *secretMonitor) createSecretInformer(namespace, name string) cache.SharedInformer {
+	return cache.NewSharedInformer(
+		cache.NewListWatchFromClient(
+			s.kubeClient.CoreV1().RESTClient(),
+			"secrets",
+			namespace,
+			fields.OneTermEqualSelector("metadata.name", name),
+		),
+		&corev1.Secret{},
+		0,
+	)
+}
+
+// addSecretEventHandler adds a secret event handler and starts the informer if not already running.
+func (s *secretMonitor) addSecretEventHandler(ctx context.Context, namespace, secretName string, handler cache.ResourceEventHandler, secretInformer cache.SharedInformer) (SecretEventHandlerRegistration, error) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if handler == nil {
+		return nil, fmt.Errorf("nil handler is provided")
+	}
+
+	// secret identifier (namespace/secret)
+	key := NewObjectKey(namespace, secretName)
+
+	// start secret informer if monitor does not exists
+	m, exists := s.monitors[key]
+	if !exists {
+		m = &monitoredItem{}
+		m.itemMonitor = newSingleItemMonitor(key, secretInformer)
+		go m.itemMonitor.StartInformer(ctx)
+
+		// wait for first sync
+		if !cache.WaitForCacheSync(ctx.Done(), m.itemMonitor.HasSynced) {
+			return nil, fmt.Errorf("failed waiting for cache sync")
+		}
+
+		// add item key to monitors map // add watch to the list
+		s.monitors[key] = m
+
+		klog.Info("secret informer started", " item key ", key)
+	}
+
+	// add the event handler
+	registration, err := m.itemMonitor.AddEventHandler(handler)
+	if err != nil {
+		return nil, err
+	}
+
+	// Increment numHandlers
+	m.numHandlers += 1
+
+	// TODO: this can be too noisy, later we need to use higher verbosity
+	klog.Info("secret handler added", " item key ", key)
+
+	return registration, nil
+}
+
+// RemoveSecretEventHandler removes a secret event handler and stops the informer if no handlers are left.
+// If the handler is not found or if there is an issue removing it, an error is returned.
+func (s *secretMonitor) RemoveSecretEventHandler(handlerRegistration SecretEventHandlerRegistration) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if handlerRegistration == nil {
+		return fmt.Errorf("nil secret handler registration is provided")
+	}
+
+	// Extract the key from the registration to identify the associated monitor.
+	// populated in AddEventHandler()
+	key := handlerRegistration.GetKey()
+
+	// check if secret informer already exists for the secret(key)
+	m, exists := s.monitors[key]
+	if !exists {
+		return fmt.Errorf("secret monitor already removed for item key %v", key)
+	}
+
+	if err := m.itemMonitor.RemoveEventHandler(handlerRegistration); err != nil {
+		return err
+	}
+	// Decrement numHandlers
+	m.numHandlers -= 1
+	klog.Info("secret handler removed", " item key", key)
+
+	// stop informer if there is no handler
+	if m.numHandlers <= 0 {
+		if !m.itemMonitor.StopInformer() {
+			return fmt.Errorf("secret informer already stopped for item key %v", key)
+		}
+		// remove the key from map
+		delete(s.monitors, key)
+		klog.Info("secret informer stopped", " item key ", key)
+	}
+
+	return nil
+}
+
+// GetSecret retrieves the secret object from the informer's cache. Error if the secret is not found in the cache.
+func (s *secretMonitor) GetSecret(ctx context.Context, handlerRegistration SecretEventHandlerRegistration) (*corev1.Secret, error) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	if handlerRegistration == nil {
+		return nil, fmt.Errorf("nil secret handler registration is provided")
+	}
+	key := handlerRegistration.GetKey()
+	secretName := key.Name
+
+	// check if secret informer exists
+	m, exists := s.monitors[key]
+	if !exists {
+		return nil, fmt.Errorf("secret monitor doesn't exist for key %v", key)
+	}
+
+	// wait for informer store sync, to load secrets
+	if !cache.WaitForCacheSync(ctx.Done(), handlerRegistration.HasSynced) {
+		return nil, fmt.Errorf("failed waiting for cache sync")
+	}
+
+	uncast, exists, err := m.itemMonitor.GetItem()
+
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, apierrors.NewNotFound(corev1.Resource("secrets"), secretName)
+	}
+
+	secret, ok := uncast.(*corev1.Secret)
+	if !ok {
+		return nil, fmt.Errorf("unexpected type: %T", uncast)
+	}
+
+	return secret, nil
+}

--- a/pkg/secret/secret_monitor.go
+++ b/pkg/secret/secret_monitor.go
@@ -104,7 +104,7 @@ func (s *secretMonitor) addSecretEventHandler(ctx context.Context, namespace, se
 	// secret identifier (namespace/secret)
 	key := NewObjectKey(namespace, secretName)
 
-	// start secret informer if monitor does not exists
+	// Start secret informer if monitor does not exist.
 	m, exists := s.monitors[key]
 	if !exists {
 		m = &monitoredItem{}
@@ -116,7 +116,7 @@ func (s *secretMonitor) addSecretEventHandler(ctx context.Context, namespace, se
 			return nil, fmt.Errorf("failed waiting for cache sync")
 		}
 
-		// add item key to monitors map // add watch to the list
+		// add item key to monitors map
 		s.monitors[key] = m
 
 		klog.Info("secret informer started", " item key ", key)

--- a/pkg/secret/secret_monitor.go
+++ b/pkg/secret/secret_monitor.go
@@ -109,7 +109,7 @@ func (s *secretMonitor) addSecretEventHandler(ctx context.Context, namespace, se
 	if !exists {
 		m = &monitoredItem{}
 		m.itemMonitor = newSingleItemMonitor(key, secretInformer)
-		go m.itemMonitor.StartInformer(ctx)
+		m.itemMonitor.StartInformer(ctx)
 
 		// wait for first sync
 		if !cache.WaitForCacheSync(ctx.Done(), m.itemMonitor.HasSynced) {

--- a/pkg/secret/secret_monitor_test.go
+++ b/pkg/secret/secret_monitor_test.go
@@ -268,7 +268,7 @@ func TestGetSecret(t *testing.T) {
 
 			gotSec, gotErr := sm.GetSecret(context.TODO(), h)
 			if (gotErr != nil) != s.expectErr {
-				t.Fatalf("expected errors to be %t, but got %t", s.expectErr, err != nil)
+				t.Fatalf("expected errors to be %t, but got %t", s.expectErr, gotErr != nil)
 			}
 			if !s.expectErr {
 				if !reflect.DeepEqual(&s.secret, gotSec) {

--- a/pkg/secret/secret_monitor_test.go
+++ b/pkg/secret/secret_monitor_test.go
@@ -1,0 +1,280 @@
+package secret
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestAddSecretEventHandler(t *testing.T) {
+	scenarios := []struct {
+		name           string
+		handler        cache.ResourceEventHandler
+		inputKeys      []ObjectKey
+		expectHandlers map[ObjectKey]int
+		expectErr      int
+	}{
+		{
+			name:    "nil handler is provided",
+			handler: nil,
+			inputKeys: []ObjectKey{
+				{Namespace: "ns1", Name: "secret1"},
+			},
+			expectErr: 1,
+		},
+		{
+			name:    "correct handler is provided",
+			handler: cache.ResourceEventHandlerFuncs{},
+			inputKeys: []ObjectKey{
+				{Namespace: "ns1", Name: "secret1"},
+				{Namespace: "ns1", Name: "secret1"},
+				{Namespace: "ns2", Name: "secret2"},
+				{Namespace: "ns2", Name: "secret2"},
+				{Namespace: "ns3", Name: "secret3"},
+			},
+			expectHandlers: map[ObjectKey]int{
+				{Namespace: "ns1", Name: "secret1"}: 2,
+				{Namespace: "ns2", Name: "secret2"}: 2,
+				{Namespace: "ns3", Name: "secret3"}: 1,
+			},
+			expectErr: 0,
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+			fakeKubeClient := fake.NewSimpleClientset()
+			sm := secretMonitor{
+				kubeClient: fakeKubeClient,
+				monitors:   map[ObjectKey]*monitoredItem{},
+			}
+
+			gotErr := 0
+			for _, k := range s.inputKeys {
+				fakeInformer := fakeSecretInformer(context.TODO(), fakeKubeClient, k.Namespace, k.Name)
+				if _, err := sm.addSecretEventHandler(context.TODO(), k.Namespace, k.Name, s.handler, fakeInformer); err != nil {
+					gotErr += 1
+				}
+			}
+			if gotErr != s.expectErr {
+				t.Fatalf("expected %d errors, got %d errors", s.expectErr, gotErr)
+			}
+
+			for k, h := range s.expectHandlers {
+				if _, exist := sm.monitors[k]; !exist {
+					t.Fatalf("expected key not found: %v", k)
+				}
+				if sm.monitors[k].numHandlers != h {
+					t.Errorf("expected %d handlers, got %d handlers", h, sm.monitors[k].numHandlers)
+				}
+			}
+		})
+	}
+}
+
+func TestRemoveSecretEventHandler(t *testing.T) {
+	scenarios := []struct {
+		name           string
+		addHandlers    map[ObjectKey]int // to generate SecretEventHandlerRegistrations for keys and associated numHandlers
+		alreadyRemoved []ObjectKey       // to delete keys if already removed
+		removeHandlers map[ObjectKey]int // to call RemoveSecretEventHandler for keys and associated numHandlers
+		expectHandlers map[ObjectKey]int // expected keys and associated numHandlers
+		isNilHandler   bool              // to inject exception of nil HandlerRegistration
+		expectErr      int
+	}{
+		{
+			name: "same number of addition and removal",
+			addHandlers: map[ObjectKey]int{
+				{Namespace: "ns1", Name: "secret1"}: 2,
+				{Namespace: "ns2", Name: "secret2"}: 2,
+				{Namespace: "ns3", Name: "secret3"}: 1,
+			},
+			removeHandlers: map[ObjectKey]int{
+				{Namespace: "ns1", Name: "secret1"}: 2,
+				{Namespace: "ns2", Name: "secret2"}: 2,
+				{Namespace: "ns3", Name: "secret3"}: 1,
+			},
+			expectHandlers: map[ObjectKey]int{},
+			expectErr:      0,
+		},
+		{
+			name: "less number of removal than addition",
+			addHandlers: map[ObjectKey]int{
+				{Namespace: "ns1", Name: "secret1"}: 2,
+				{Namespace: "ns2", Name: "secret2"}: 2,
+				{Namespace: "ns3", Name: "secret3"}: 1,
+			},
+			removeHandlers: map[ObjectKey]int{
+				{Namespace: "ns1", Name: "secret1"}: 2,
+				{Namespace: "ns2", Name: "secret2"}: 1,
+			},
+			expectHandlers: map[ObjectKey]int{
+				{Namespace: "ns2", Name: "secret2"}: 1,
+				{Namespace: "ns3", Name: "secret3"}: 1,
+			},
+			expectErr: 0,
+		},
+		{
+			name: "nil handler is provided",
+			addHandlers: map[ObjectKey]int{
+				{Namespace: "ns1", Name: "secret1"}: 1,
+			},
+			removeHandlers: map[ObjectKey]int{
+				{Namespace: "ns1", Name: "secret1"}: 1,
+			},
+			expectHandlers: map[ObjectKey]int{
+				{Namespace: "ns1", Name: "secret1"}: 1,
+			},
+			isNilHandler: true,
+			expectErr:    1,
+		},
+		{
+			name: "secret monitor key already removed",
+			addHandlers: map[ObjectKey]int{
+				{Namespace: "ns1", Name: "secret1"}: 2,
+				{Namespace: "ns2", Name: "secret2"}: 2,
+				{Namespace: "ns3", Name: "secret3"}: 1,
+			},
+			alreadyRemoved: []ObjectKey{
+				{Namespace: "ns1", Name: "secret1"},
+			},
+			removeHandlers: map[ObjectKey]int{
+				{Namespace: "ns1", Name: "secret1"}: 2,
+				{Namespace: "ns2", Name: "secret2"}: 2,
+			},
+			expectHandlers: map[ObjectKey]int{
+				{Namespace: "ns3", Name: "secret3"}: 1,
+			},
+			expectErr: 2,
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+			fakeKubeClient := fake.NewSimpleClientset()
+			sm := secretMonitor{
+				kubeClient: fakeKubeClient,
+				monitors:   map[ObjectKey]*monitoredItem{},
+			}
+
+			// Generate SecretEventHandlerRegistrations
+			handlersReg := map[ObjectKey][]SecretEventHandlerRegistration{}
+			for k, numHandlers := range s.addHandlers {
+				fakeInformer := fakeSecretInformer(context.TODO(), fakeKubeClient, k.Namespace, k.Name)
+				for i := 0; i < numHandlers; i++ {
+					h, err := sm.addSecretEventHandler(context.TODO(), k.Namespace, k.Name, cache.ResourceEventHandlerFuncs{}, fakeInformer)
+					if err != nil {
+						t.Error(err)
+					}
+					// store the handlersRegistration
+					if s.isNilHandler {
+						handlersReg[k] = append(handlersReg[k], nil)
+					} else {
+						handlersReg[k] = append(handlersReg[k], h)
+					}
+				}
+			}
+
+			// Delete keys if already removed
+			for _, keyRemoved := range s.alreadyRemoved {
+				delete(sm.monitors, keyRemoved)
+			}
+
+			// call RemoveSecretEventHandler
+			gotErr := 0
+			for k, numHandlers := range s.removeHandlers {
+				regList := handlersReg[k]
+				for i := 0; i < numHandlers; i++ {
+					if err := sm.RemoveSecretEventHandler(regList[i]); err != nil {
+						t.Log(err)
+						gotErr += 1
+					}
+				}
+			}
+			if gotErr != s.expectErr {
+				t.Fatalf("expected %d errors, got %d errors", s.expectErr, gotErr)
+			}
+
+			for k, numHandlers := range s.expectHandlers {
+				if _, exist := sm.monitors[k]; !exist {
+					t.Fatalf("expected key not found: %v", k)
+				}
+				if sm.monitors[k].numHandlers != numHandlers {
+					t.Errorf("expected %d handlers, got %d handlers", numHandlers, sm.monitors[k].numHandlers)
+				}
+			}
+		})
+	}
+}
+
+func TestGetSecret(t *testing.T) {
+	var (
+		namespace  = "testNamespace"
+		secretName = "testSecretName"
+	)
+
+	scenarios := []struct {
+		name            string
+		isNilHandlerReg bool
+		isKeyRemoved    bool
+		secret          corev1.Secret
+		expectErr       bool
+	}{
+		{
+			name:      "secret exists and correct handlerRegistration is provided",
+			secret:    *fakeSecret(namespace, secretName),
+			expectErr: false,
+		},
+		{
+			name:            "nil handlerRegistration is provided",
+			isNilHandlerReg: true,
+			expectErr:       true,
+		},
+		{
+			name:         "secret monitor key already removed",
+			isKeyRemoved: true,
+			expectErr:    true,
+		},
+		{
+			name:      "secret does not exist and correct handlerRegistration is provided",
+			expectErr: true,
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+			kubeClient := fake.NewSimpleClientset(&s.secret)
+			fakeInformer := fakeSecretInformer(context.TODO(), kubeClient, namespace, secretName)
+			key := NewObjectKey(namespace, secretName)
+			sm := secretMonitor{
+				kubeClient: kubeClient,
+				monitors:   map[ObjectKey]*monitoredItem{},
+			}
+			h, err := sm.addSecretEventHandler(context.TODO(), key.Namespace, key.Name, cache.ResourceEventHandlerFuncs{}, fakeInformer)
+			if err != nil {
+				t.Error(err)
+			}
+
+			if s.isNilHandlerReg {
+				h = nil
+			}
+			if s.isKeyRemoved {
+				delete(sm.monitors, key)
+			}
+
+			gotSec, gotErr := sm.GetSecret(context.TODO(), h)
+			if (gotErr != nil) != s.expectErr {
+				t.Fatalf("expected errors to be %t, but got %t", s.expectErr, err != nil)
+			}
+			if !s.expectErr {
+				if !reflect.DeepEqual(&s.secret, gotSec) {
+					t.Errorf("expected %v got %v", s.secret, gotSec)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Functionality for monitoring and handling "single" secret dynamically. 

### Changes in `single_item_monitor.go`:

- `ObjectKey`  representing the unique identifier for a resource.
- `singleItemMonitor`  responsible for monitoring a single resource using a SharedInformer.
- Defined methods for starting and stopping informers, adding and removing event handlers, and retrieving items from the informer's cache.

### Changes in `secret_monitor.go`:

- Implemented functionalities to create and manage informers for specific secrets.
- `SecretEventHandlerRegistration`  for registering and unregistering event handlers for secret monitoring.
- `SecretMonitor`  for monitoring and handling specific secrets using `singleItemMonitor`.
- Added methods for adding and removing secret event handlers, retrieving secret objects from the informer's cache.
- operations for counting the number of event handlers associated with a secret.

Related: [CFE-866](https://issues.redhat.com//browse/CFE-866)
Implements: https://github.com/openshift/enhancements/pull/1307
