### PR TITLE
OCPCLOUD-2514: Cloud Provider External no longer depends on a feature gate

### DIFF
--- a/pkg/cloudprovider/external.go
+++ b/pkg/cloudprovider/external.go
@@ -3,8 +3,6 @@ package cloudprovider
 import (
 	"fmt"
 
-	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
-
 	configv1 "github.com/openshift/api/config/v1"
 )
 
@@ -27,24 +25,15 @@ var (
 // IsCloudProviderExternal is used to check whether external cloud provider settings should be used in a component.
 // It checks whether the ExternalCloudProvider feature gate is enabled and whether the ExternalCloudProvider feature
 // has been implemented for the platform.
-func IsCloudProviderExternal(platformStatus *configv1.PlatformStatus, featureGateAccessor featuregates.FeatureGateAccess) (bool, error) {
-	if !featureGateAccessor.AreInitialFeatureGatesObserved() {
-		return false, fmt.Errorf("featureGates have not been read yet")
-	}
+func IsCloudProviderExternal(platformStatus *configv1.PlatformStatus) (bool, error) {
 	if platformStatus == nil {
 		return false, fmt.Errorf("platformStatus is required")
 	}
 	switch platformStatus.Type {
-	case configv1.GCPPlatformType:
-		// Platforms that are external based on feature gate presence
-		return isExternalFeatureGateEnabled(featureGateAccessor, ExternalCloudProviderFeature, ExternalCloudProviderFeatureGCP)
-	case configv1.AzurePlatformType:
-		if isAzureStackHub(platformStatus) {
-			return true, nil
-		}
-		return isExternalFeatureGateEnabled(featureGateAccessor, ExternalCloudProviderFeature, ExternalCloudProviderFeatureAzure)
 	case configv1.AlibabaCloudPlatformType,
 		configv1.AWSPlatformType,
+		configv1.AzurePlatformType,
+		configv1.GCPPlatformType,
 		configv1.IBMCloudPlatformType,
 		configv1.KubevirtPlatformType,
 		configv1.NutanixPlatformType,
@@ -53,23 +42,14 @@ func IsCloudProviderExternal(platformStatus *configv1.PlatformStatus, featureGat
 		configv1.VSpherePlatformType:
 		return true, nil
 	case configv1.ExternalPlatformType:
-		return isExternalPlatformCCMEnabled(platformStatus, featureGateAccessor)
+		return isExternalPlatformCCMEnabled(platformStatus)
 	default:
 		// Platforms that do not have external cloud providers implemented
 		return false, nil
 	}
 }
 
-func isAzureStackHub(platformStatus *configv1.PlatformStatus) bool {
-	return platformStatus.Azure != nil && platformStatus.Azure.CloudName == configv1.AzureStackCloud
-}
-
-func isExternalPlatformCCMEnabled(platformStatus *configv1.PlatformStatus, featureGateAccessor featuregates.FeatureGateAccess) (bool, error) {
-	featureEnabled, err := isExternalFeatureGateEnabled(featureGateAccessor, ExternalCloudProviderFeature, ExternalCloudProviderFeatureExternal)
-	if err != nil || !featureEnabled {
-		return featureEnabled, err
-	}
-
+func isExternalPlatformCCMEnabled(platformStatus *configv1.PlatformStatus) (bool, error) {
 	if platformStatus == nil || platformStatus.External == nil {
 		return false, nil
 	}
@@ -78,24 +58,5 @@ func isExternalPlatformCCMEnabled(platformStatus *configv1.PlatformStatus, featu
 		return true, nil
 	}
 
-	return false, nil
-}
-
-// isExternalFeatureGateEnabled determines whether the ExternalCloudProvider feature gate is present in the current
-// feature set.
-func isExternalFeatureGateEnabled(featureGateAccess featuregates.FeatureGateAccess, featureGateNames ...configv1.FeatureGateName) (bool, error) {
-	featureGates, err := featureGateAccess.CurrentFeatureGates()
-	if err != nil {
-		return false, fmt.Errorf("unable to read current featuregates: %w", err)
-	}
-
-	// If any of the desired feature gates are enabled, then the external cloud provider should be used.
-	for _, featureGateName := range featureGateNames {
-		if featureGates.Enabled(featureGateName) {
-			return true, nil
-		}
-	}
-
-	// No explicit opinion on the feature gate, assume it's not enabled.
 	return false, nil
 }

--- a/pkg/cloudprovider/external_test.go
+++ b/pkg/cloudprovider/external_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
-
 	configv1 "github.com/openshift/api/config/v1"
 )
 
@@ -16,121 +14,51 @@ func TestIsCloudProviderExternal(t *testing.T) {
 	cases := []struct {
 		name        string
 		status      *configv1.PlatformStatus
-		featureGate featuregates.FeatureGateAccess
 		expected    bool
 		expectedErr error
 	}{{
-		name: "No FeatureGate, Platform: OpenStack",
+		name: "Platform: OpenStack",
 		status: &configv1.PlatformStatus{
 			Type: configv1.OpenStackPlatformType,
 		},
 		expected: true,
 	}, {
-		name: "FeatureSet: Unknown, Platform: OpenStack",
-		status: &configv1.PlatformStatus{
-			Type: configv1.OpenStackPlatformType,
-		},
-		featureGate: featuregates.NewHardcodedFeatureGateAccessForTesting(nil, nil, readyCh, fmt.Errorf("missing")),
-		expected:    true,
-	}, {
-		name: "FeatureSet: TechPreviewNoUpgrade, Platform: OpenStack",
-		status: &configv1.PlatformStatus{
-			Type: configv1.OpenStackPlatformType,
-		},
-		featureGate: featuregates.NewHardcodedFeatureGateAccess([]configv1.FeatureGateName{configv1.FeatureGateExternalCloudProvider}, nil),
-		expected:    true,
-	}, {
-		name: "FeatureSet: LatencySensitive, Platform: OpenStack",
-		status: &configv1.PlatformStatus{
-			Type: configv1.OpenStackPlatformType,
-		},
-		featureGate: featuregates.NewHardcodedFeatureGateAccess(nil, nil),
-		expected:    true,
-	}, {
-		name: "FeatureSet: CustomNoUpgrade (No External Feature Gate), Platform: OpenStack",
-		status: &configv1.PlatformStatus{
-			Type: configv1.OpenStackPlatformType,
-		},
-		featureGate: featuregates.NewHardcodedFeatureGateAccess(nil, nil),
-		expected:    true,
-	}, {
-		name: "FeatureSet: CustomNoUpgrade (With External Feature Gate Enabled), Platform: OpenStack",
-		status: &configv1.PlatformStatus{
-			Type: configv1.OpenStackPlatformType,
-		},
-		featureGate: featuregates.NewHardcodedFeatureGateAccess([]configv1.FeatureGateName{configv1.FeatureGateExternalCloudProvider}, nil),
-		expected:    true,
-	}, {
-		name: "FeatureSet: CustomNoUpgrade (With External Feature Gate Enabled & Disabled), Platform: OpenStack",
-		status: &configv1.PlatformStatus{
-			Type: configv1.OpenStackPlatformType,
-		},
-		featureGate: featuregates.NewHardcodedFeatureGateAccess([]configv1.FeatureGateName{configv1.FeatureGateExternalCloudProvider}, []configv1.FeatureGateName{configv1.FeatureGateExternalCloudProvider}),
-		expected:    true,
-	}, {
-		name: "FeatureSet: CustomNoUpgrade (With External Feature Gate Disabled), Platform: OpenStack",
-		status: &configv1.PlatformStatus{
-			Type: configv1.OpenStackPlatformType,
-		},
-		featureGate: featuregates.NewHardcodedFeatureGateAccess(nil, []configv1.FeatureGateName{configv1.FeatureGateExternalCloudProvider}),
-		expected:    true,
-	}, {
-		name: "FeatureSet: CustomNoUpgrade (With External Feature Gate), Platform: AWS",
+		name: "Platform: AWS",
 		status: &configv1.PlatformStatus{
 			Type: configv1.AWSPlatformType,
 		},
-		featureGate: featuregates.NewHardcodedFeatureGateAccess([]configv1.FeatureGateName{configv1.FeatureGateExternalCloudProvider}, nil),
-		expected:    true,
+		expected: true,
 	}, {
-		name: "No FeatureGate: Platform: AlibabaCloud",
+		name: "Platform: AlibabaCloud",
 		status: &configv1.PlatformStatus{
 			Type: configv1.AlibabaCloudPlatformType,
 		},
-		featureGate: featuregates.NewHardcodedFeatureGateAccessForTesting(nil, nil, readyCh, fmt.Errorf("missing")),
-		expected:    true,
+		expected: true,
 	}, {
-		name: "No FeatureGate, Platform: IBMCloud",
+		name: "Platform: IBMCloud",
 		status: &configv1.PlatformStatus{
 			Type: configv1.IBMCloudPlatformType,
 		},
-		featureGate: featuregates.NewHardcodedFeatureGateAccessForTesting(nil, nil, readyCh, fmt.Errorf("missing")),
-		expected:    true,
+		expected: true,
 	}, {
-		name: "No FeatureGate, Platform: Nutanix",
+		name: " Platform: Nutanix",
 		status: &configv1.PlatformStatus{
 			Type: configv1.NutanixPlatformType,
 		},
-		featureGate: featuregates.NewHardcodedFeatureGateAccessForTesting(nil, nil, readyCh, fmt.Errorf("missing")),
-		expected:    true,
-	}, {
-		name: "No FeatureGate, Platform: External, CloudControllerManager.State = External",
-		status: &configv1.PlatformStatus{
-			Type: configv1.ExternalPlatformType,
-			External: &configv1.ExternalPlatformStatus{
-				CloudControllerManager: configv1.CloudControllerManagerStatus{
-					State: configv1.CloudControllerManagerExternal,
-				},
-			},
-		},
-		featureGate: featuregates.NewHardcodedFeatureGateAccessForTesting(nil, nil, readyCh, fmt.Errorf("missing")),
-		expected:    false,
-	}, {
-		name: "FeatureSet: TechPreviewNoUpgrade, Platform: External, CloudControllerManager.State = External",
-		status: &configv1.PlatformStatus{
-			Type: configv1.ExternalPlatformType,
-			External: &configv1.ExternalPlatformStatus{
-				CloudControllerManager: configv1.CloudControllerManagerStatus{
-					State: configv1.CloudControllerManagerExternal,
-				},
-			},
-		},
-		featureGate: featuregates.NewHardcodedFeatureGateAccess(
-			[]configv1.FeatureGateName{configv1.FeatureGateExternalCloudProvider, configv1.FeatureGateExternalCloudProviderExternal},
-			nil,
-		),
 		expected: true,
 	}, {
-		name: "FeatureSet: TechPreviewNoUpgrade, Platform: External, CloudControllerManager.State = None",
+		name: "Platform: External, CloudControllerManager.State = External",
+		status: &configv1.PlatformStatus{
+			Type: configv1.ExternalPlatformType,
+			External: &configv1.ExternalPlatformStatus{
+				CloudControllerManager: configv1.CloudControllerManagerStatus{
+					State: configv1.CloudControllerManagerExternal,
+				},
+			},
+		},
+		expected: true,
+	}, {
+		name: "Platform: External, CloudControllerManager.State = None",
 		status: &configv1.PlatformStatus{
 			Type: configv1.ExternalPlatformType,
 			External: &configv1.ExternalPlatformStatus{
@@ -139,92 +67,38 @@ func TestIsCloudProviderExternal(t *testing.T) {
 				},
 			},
 		},
-		featureGate: featuregates.NewHardcodedFeatureGateAccess(
-			[]configv1.FeatureGateName{configv1.FeatureGateExternalCloudProvider, configv1.FeatureGateExternalCloudProviderExternal},
-			nil,
-		),
 		expected: false,
 	}, {
-		name: "FeatureSet: TechPreviewNoUpgrade, Platform: External, CloudControllerManager.State is empty",
+		name: "Platform: External, CloudControllerManager.State is empty",
 		status: &configv1.PlatformStatus{
 			Type:     configv1.ExternalPlatformType,
 			External: &configv1.ExternalPlatformStatus{},
 		},
-		featureGate: featuregates.NewHardcodedFeatureGateAccess(
-			[]configv1.FeatureGateName{configv1.FeatureGateExternalCloudProvider, configv1.FeatureGateExternalCloudProviderExternal},
-			nil,
-		),
 		expected: false,
 	}, {
-		name: "FeatureSet: TechPreviewNoUpgrade, Platform: External, ExternalPlatformSpec is nil",
+		name: "Platform: External, ExternalPlatformSpec is nil",
 		status: &configv1.PlatformStatus{
 			Type:     configv1.ExternalPlatformType,
 			External: nil,
 		},
-		featureGate: featuregates.NewHardcodedFeatureGateAccess(
-			[]configv1.FeatureGateName{configv1.FeatureGateExternalCloudProvider, configv1.FeatureGateExternalCloudProviderExternal},
-			nil,
-		),
 		expected: false,
 	}, {
-		name: "FeatureSet: CustomNoUpgrade (With External Feature Gate Enabled), Platform: Nutanix",
-		status: &configv1.PlatformStatus{
-			Type: configv1.NutanixPlatformType,
-		},
-		featureGate: featuregates.NewHardcodedFeatureGateAccess([]configv1.FeatureGateName{configv1.FeatureGateExternalCloudProvider}, nil),
-
-		expected: true,
-	}, {
-		name: "FeatureSet: CustomNoUpgrade (With External Feature Gate Disabled), Platform: Nutanix",
-		status: &configv1.PlatformStatus{
-			Type: configv1.NutanixPlatformType,
-		},
-		featureGate: featuregates.NewHardcodedFeatureGateAccess(nil, []configv1.FeatureGateName{configv1.FeatureGateExternalCloudProvider}),
-
-		expected: true,
-	}, {
-		name: "No FeatureGate, Platform: PowerVS",
+		name: "Platform: PowerVS",
 		status: &configv1.PlatformStatus{
 			Type: configv1.PowerVSPlatformType,
 		},
-		featureGate: featuregates.NewHardcodedFeatureGateAccessForTesting(nil, nil, readyCh, fmt.Errorf("missing")),
-		expected:    true,
+		expected: true,
 	}, {
-		name: "No FeatureGate, Platform: Kubevirt",
+		name: "Platform: Kubevirt",
 		status: &configv1.PlatformStatus{
 			Type: configv1.KubevirtPlatformType,
 		},
-		featureGate: featuregates.NewHardcodedFeatureGateAccessForTesting(nil, nil, readyCh, fmt.Errorf("missing")),
-		expected:    true,
-	}, {
-		name: "FeatureSet: CustomNoUpgrade (With External Feature Gate), Platform: Azure",
-		status: &configv1.PlatformStatus{
-			Type: configv1.AzurePlatformType,
-		},
-		featureGate: featuregates.NewHardcodedFeatureGateAccess(
-			[]configv1.FeatureGateName{configv1.FeatureGateExternalCloudProvider, configv1.FeatureGateExternalCloudProviderAzure},
-			[]configv1.FeatureGateName{},
-		),
 		expected: true,
 	}, {
-		name: "FeatureSet: CustomNoUpgrade (With External Feature Gate Azure), Platform: Azure",
+		name: "Platform: Azure",
 		status: &configv1.PlatformStatus{
 			Type: configv1.AzurePlatformType,
 		},
-		featureGate: featuregates.NewHardcodedFeatureGateAccess(
-			[]configv1.FeatureGateName{configv1.FeatureGateExternalCloudProviderAzure, configv1.FeatureGateExternalCloudProvider},
-			[]configv1.FeatureGateName{},
-		),
-		expected: true,
-	}, {
-		name: "FeatureSet: CustomNoUpgrade (With External Feature Gate Enabled but External Feature Gate Azure Disabled), Platform: Azure",
-		status: &configv1.PlatformStatus{
-			Type: configv1.AzurePlatformType,
-		},
-		featureGate: featuregates.NewHardcodedFeatureGateAccess(
-			[]configv1.FeatureGateName{configv1.FeatureGateExternalCloudProvider},
-			[]configv1.FeatureGateName{configv1.FeatureGateExternalCloudProviderAzure},
-		),
 		expected: true,
 	}, {
 		name: "Platform: Azure, CloudName: AzureStackHub",
@@ -234,114 +108,47 @@ func TestIsCloudProviderExternal(t *testing.T) {
 				CloudName: configv1.AzureStackCloud,
 			},
 		},
-		featureGate: featuregates.NewHardcodedFeatureGateAccessForTesting(nil, nil, readyCh, fmt.Errorf("missing")),
-		expected:    true,
+		expected: true,
 	}, {
-		name: "FeatureSet: CustomNoUpgrade (With External Feature Gate), Platform: BareMetal",
+		name: "Platform: BareMetal",
 		status: &configv1.PlatformStatus{
 			Type: configv1.BareMetalPlatformType,
 		},
-		featureGate: featuregates.NewHardcodedFeatureGateAccess([]configv1.FeatureGateName{configv1.FeatureGateExternalCloudProvider}, nil),
-		expected:    false,
+		expected: false,
 	}, {
-		name: "FeatureSet: CustomNoUpgrade (With External Feature Gate), Platform: Libvirt",
+		name: "Platform: Libvirt",
 		status: &configv1.PlatformStatus{
 			Type: configv1.LibvirtPlatformType,
 		},
-		featureGate: featuregates.NewHardcodedFeatureGateAccess([]configv1.FeatureGateName{configv1.FeatureGateExternalCloudProvider}, nil),
-
 		expected: false,
 	}, {
-		name: "No FeatureGate, Platform: GCP",
+		name: "Platform: GCP",
 		status: &configv1.PlatformStatus{
 			Type: configv1.GCPPlatformType,
 		},
-		featureGate: featuregates.NewHardcodedFeatureGateAccessForTesting(nil, nil, readyCh, fmt.Errorf("missing")),
-		expected:    false,
-	}, {
-		name: "FeatureSet: CustomNoUpgrade (With External Feature Gate), Platform: GCP",
-		status: &configv1.PlatformStatus{
-			Type: configv1.GCPPlatformType,
-		},
-		featureGate: featuregates.NewHardcodedFeatureGateAccess(
-			[]configv1.FeatureGateName{configv1.FeatureGateExternalCloudProvider, configv1.FeatureGateExternalCloudProviderGCP},
-			[]configv1.FeatureGateName{},
-		),
 		expected: true,
 	}, {
-		name: "FeatureSet: CustomNoUpgrade (With External Feature Gate GCP), Platform: GCP",
-		status: &configv1.PlatformStatus{
-			Type: configv1.GCPPlatformType,
-		},
-		featureGate: featuregates.NewHardcodedFeatureGateAccess(
-			[]configv1.FeatureGateName{configv1.FeatureGateExternalCloudProvider, configv1.FeatureGateExternalCloudProviderGCP},
-			[]configv1.FeatureGateName{},
-		),
-		expected: true,
-	}, {
-		name: "FeatureSet: CustomNoUpgrade (With External Feature Gate Enabled but External Feature Gate GCP Disabled), Platform: GCP",
-		status: &configv1.PlatformStatus{
-			Type: configv1.GCPPlatformType,
-		},
-		featureGate: featuregates.NewHardcodedFeatureGateAccess(
-			[]configv1.FeatureGateName{configv1.FeatureGateExternalCloudProvider},
-			[]configv1.FeatureGateName{configv1.FeatureGateExternalCloudProviderGCP},
-		),
-		expected: true,
-	}, {
-		name: "FeatureSet: TechPreviewNoUpgrade, Platform: GCP",
-		status: &configv1.PlatformStatus{
-			Type: configv1.GCPPlatformType,
-		},
-		featureGate: featuregates.NewHardcodedFeatureGateAccess(
-			[]configv1.FeatureGateName{configv1.FeatureGateExternalCloudProvider, configv1.FeatureGateExternalCloudProviderGCP},
-			nil),
-		expected: true,
-	}, {
-		name: "No FeatureGate, Platform: vSphere",
+		name: "Platform: vSphere",
 		status: &configv1.PlatformStatus{
 			Type: configv1.VSpherePlatformType,
 		},
-		featureGate: featuregates.NewHardcodedFeatureGateAccessForTesting(nil, nil, readyCh, fmt.Errorf("missing")),
-		expected:    true,
-	}, {
-		name: "FeatureSet: CustomNoUpgrade (With External Feature Gate), Platform: vSphere",
-		status: &configv1.PlatformStatus{
-			Type: configv1.VSpherePlatformType,
-		},
-		featureGate: featuregates.NewHardcodedFeatureGateAccess(
-			[]configv1.FeatureGateName{configv1.FeatureGateExternalCloudProvider},
-			nil,
-		),
 		expected: true,
 	}, {
-		name: "FeatureSet: TechPreviewNoUpgrade, Platform: vSphere",
-		status: &configv1.PlatformStatus{
-			Type: configv1.VSpherePlatformType,
-		},
-		featureGate: featuregates.NewHardcodedFeatureGateAccess([]configv1.FeatureGateName{configv1.FeatureGateExternalCloudProvider}, nil),
-		expected:    true,
-	}, {
-		name: "FeatureSet: CustomNoUpgrade (With External Feature Gate), Platform: None",
+		name: "Platform: None",
 		status: &configv1.PlatformStatus{
 			Type: configv1.NonePlatformType,
 		},
-		featureGate: featuregates.NewHardcodedFeatureGateAccess([]configv1.FeatureGateName{configv1.FeatureGateExternalCloudProvider}, nil),
-		expected:    false,
+
+		expected: false,
 	}, {
 		name:        "Platform status is empty",
 		status:      nil,
-		featureGate: featuregates.NewHardcodedFeatureGateAccess([]configv1.FeatureGateName{configv1.FeatureGateExternalCloudProvider}, nil),
 		expected:    false,
 		expectedErr: fmt.Errorf("platformStatus is required"),
 	}}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			featureGateAccessor := featuregates.NewHardcodedFeatureGateAccess(nil, nil)
-			if c.featureGate != nil {
-				featureGateAccessor = c.featureGate
-			}
-			got, err := IsCloudProviderExternal(c.status, featureGateAccessor)
+			got, err := IsCloudProviderExternal(c.status)
 			if c.expectedErr != nil {
 				if err == nil {
 					t.Errorf("expected error: %v, but got no error", c.expectedErr)


### PR DESCRIPTION
The final external cloud providers were promoted in 4.15. Feature gates are no longer required to make the decision on whether the CCMs should be GA or not. This PR removes the feature gate access and cleans up the function so that it may continue to provide a respect of which platforms are external going forward, without the need for feature gate access.

Once this is merged, KASO, KCMO, MCO and CCMO will all need to be updated.