### PR TITLE
WRKLDS-1071: revision_controller: do not create a new revision when a required object is missing

### DIFF
--- a/pkg/operator/revisioncontroller/revision_controller_test.go
+++ b/pkg/operator/revisioncontroller/revision_controller_test.go
@@ -218,6 +218,12 @@ func TestRevisionController(t *testing.T) {
 					t.Errorf("expected status to be 'configmaps test-config not found', got: %s", status.Conditions[0].Message)
 				}
 			},
+			validateActions: func(t *testing.T, actions []clienttesting.Action, kclient *fake.Clientset) {
+				createdObjects := filterCreateActions(actions)
+				if createdObjectCount := len(createdObjects); createdObjectCount != 0 {
+					t.Errorf("expected no objects to be created, got %d", createdObjectCount)
+				}
+			},
 		},
 		{
 			testName:        "copy-resources",


### PR DESCRIPTION
To avoid:
```
I0212 20:55:40.998366       1 event.go:364] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-controller-manager-operator", Name:"kube-controller-manager-operator", UID:"9612bc5b-32b2-4ecd-9e94-fef6cd80cd70", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'StartingNewRevision' new revision 1 triggered by "configmap \"kube-controller-manager-pod\" not found"
I0212 20:55:43.628387       1 event.go:364] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-controller-manager-operator", Name:"kube-controller-manager-operator", UID:"9612bc5b-32b2-4ecd-9e94-fef6cd80cd70", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'StartingNewRevision' new revision 2 triggered by "configmap \"kube-controller-manager-pod\" not found"
I0212 20:55:45.205554       1 event.go:364] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-controller-manager-operator", Name:"kube-controller-manager-operator", UID:"9612bc5b-32b2-4ecd-9e94-fef6cd80cd70", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'StartingNewRevision' new revision 3 triggered by "configmap \"kube-controller-manager-pod\" not found"
I0212 20:55:46.790127       1 event.go:364] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-controller-manager-operator", Name:"kube-controller-manager-operator", UID:"9612bc5b-32b2-4ecd-9e94-fef6cd80cd70", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'StartingNewRevision' new revision 4 triggered by "configmap \"kube-controller-manager-pod\" not found"
I0212 20:55:48.389468       1 event.go:364] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-controller-manager-operator", Name:"kube-controller-manager-operator", UID:"9612bc5b-32b2-4ecd-9e94-fef6cd80cd70", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'StartingNewRevision' new revision 5 triggered by "configmap \"kube-controller-manager-pod\" not found"
I0212 20:55:49.788097       1 event.go:364] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-controller-manager-operator", Name:"kube-controller-manager-operator", UID:"9612bc5b-32b2-4ecd-9e94-fef6cd80cd70", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'StartingNewRevision' new revision 6 triggered by "configmap \"kube-controller-manager-pod\" not found"
I0212 20:55:51.189945       1 event.go:364] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-controller-manager-operator", Name:"kube-controller-manager-operator", UID:"9612bc5b-32b2-4ecd-9e94-fef6cd80cd70", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'StartingNewRevision' new revision 7 triggered by "configmap \"kube-controller-manager-pod\" not found"
I0212 20:55:52.601616       1 event.go:364] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-controller-manager-operator", Name:"kube-controller-manager-operator", UID:"9612bc5b-32b2-4ecd-9e94-fef6cd80cd70", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'StartingNewRevision' new revision 8 triggered by "configmap \"kube-controller-manager-pod\" not found"
I0212 20:55:54.195098       1 event.go:364] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-controller-manager-operator", Name:"kube-controller-manager-operator", UID:"9612bc5b-32b2-4ecd-9e94-fef6cd80cd70", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'StartingNewRevision' new revision 9 triggered by "configmap \"kube-controller-manager-pod\" not found"
I0212 20:55:55.784154       1 event.go:364] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-controller-manager-operator", Name:"kube-controller-manager-operator", UID:"9612bc5b-32b2-4ecd-9e94-fef6cd80cd70", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'StartingNewRevision' new revision 9 triggered by "configmap \"kube-controller-manager-pod\" not found"
I0212 20:55:57.594248       1 event.go:364] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-controller-manager-operator", Name:"kube-controller-manager-operator", UID:"9612bc5b-32b2-4ecd-9e94-fef6cd80cd70", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'StartingNewRevision' new revision 10 triggered by "configmap \"kube-controller-manager-pod\" not found"
I0212 20:55:59.389118       1 event.go:364] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-controller-manager-operator", Name:"kube-controller-manager-operator", UID:"9612bc5b-32b2-4ecd-9e94-fef6cd80cd70", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'StartingNewRevision' new revision 11 triggered by "configmap \"kube-controller-manager-pod\" not found"
I0212 20:56:01.179975       1 event.go:364] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-controller-manager-operator", Name:"kube-controller-manager-operator", UID:"9612bc5b-32b2-4ecd-9e94-fef6cd80cd70", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'StartingNewRevision' new revision 11 triggered by "configmap \"kube-controller-manager-pod\" not found"
I0212 20:56:02.989900       1 event.go:364] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-controller-manager-operator", Name:"kube-controller-manager-operator", UID:"9612bc5b-32b2-4ecd-9e94-fef6cd80cd70", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'StartingNewRevision' new revision 12 triggered by "configmap \"kube-controller-manager-pod\" not found"
I0212 20:56:04.797411       1 event.go:364] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-controller-manager-operator", Name:"kube-controller-manager-operator", UID:"9612bc5b-32b2-4ecd-9e94-fef6cd80cd70", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'StartingNewRevision' new revision 13 triggered by "configmap \"kube-controller-manager-pod\" not found"
I0212 20:56:06.411235       1 event.go:364] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-controller-manager-operator", Name:"kube-controller-manager-operator", UID:"9612bc5b-32b2-4ecd-9e94-fef6cd80cd70", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'StartingNewRevision' new revision 14 triggered by "configmap \"kube-controller-manager-pod\" not found"
I0212 20:56:07.996553       1 event.go:364] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-controller-manager-operator", Name:"kube-controller-manager-operator", UID:"9612bc5b-32b2-4ecd-9e94-fef6cd80cd70", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'StartingNewRevision' new revision 15 triggered by "configmap \"kube-controller-manager-pod\" not found"
I0212 20:56:09.591794       1 event.go:364] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-controller-manager-operator", Name:"kube-controller-manager-operator", UID:"9612bc5b-32b2-4ecd-9e94-fef6cd80cd70", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'StartingNewRevision' new revision 16 triggered by "configmap \"kube-controller-manager-pod\" not found"
I0212 20:56:11.202873       1 event.go:364] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-controller-manager-operator", Name:"kube-controller-manager-operator", UID:"9612bc5b-32b2-4ecd-9e94-fef6cd80cd70", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'StartingNewRevision' new revision 17 triggered by "configmap \"kube-controller-manager-pod\" not found"
I0212 20:56:12.801424       1 event.go:364] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-controller-manager-operator", Name:"kube-controller-manager-operator", UID:"9612bc5b-32b2-4ecd-9e94-fef6cd80cd70", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'StartingNewRevision' new revision 18 triggered by "configmap \"kube-controller-manager-pod\" not found"
I0212 20:56:14.409313       1 event.go:364] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-controller-manager-operator", Name:"kube-controller-manager-operator", UID:"9612bc5b-32b2-4ecd-9e94-fef6cd80cd70", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'StartingNewRevision' new revision 19 triggered by "configmap \"kube-controller-manager-pod\" not found"
I0212 20:56:16.006990       1 event.go:364] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-controller-manager-operator", Name:"kube-controller-manager-operator", UID:"9612bc5b-32b2-4ecd-9e94-fef6cd80cd70", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'StartingNewRevision' new revision 20 triggered by "configmap \"kube-controller-manager-pod\" not found"
I0212 20:56:17.606377       1 event.go:364] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-controller-manager-operator", Name:"kube-controller-manager-operator", UID:"9612bc5b-32b2-4ecd-9e94-fef6cd80cd70", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'StartingNewRevision' new revision 21 triggered by "configmap \"kube-controller-manager-pod\" not found"
I0212 20:56:19.198104       1 event.go:364] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-controller-manager-operator", Name:"kube-controller-manager-operator", UID:"9612bc5b-32b2-4ecd-9e94-fef6cd80cd70", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'StartingNewRevision' new revision 22 triggered by "configmap \"kube-controller-manager-pod\" not found"
I0212 20:56:20.589504       1 event.go:364] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-controller-manager-operator", Name:"kube-controller-manager-operator", UID:"9612bc5b-32b2-4ecd-9e94-fef6cd80cd70", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'StartingNewRevision' new revision 23 triggered by "configmap \"kube-controller-manager-pod\" not found"
I0212 20:56:22.205045       1 event.go:364] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-controller-manager-operator", Name:"kube-controller-manager-operator", UID:"9612bc5b-32b2-4ecd-9e94-fef6cd80cd70", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'StartingNewRevision' new revision 24 triggered by "configmap \"kube-controller-manager-pod\" not found"
```