### PR TITLE
OCPCLOUD-2513: Remove cloud-provider and cloud-config flags

### DIFF
--- a/pkg/operator/configobserver/cloudprovider/observe_cloudprovider.go
+++ b/pkg/operator/configobserver/cloudprovider/observe_cloudprovider.go
@@ -1,17 +1,9 @@
 package cloudprovider
 
 import (
-	"fmt"
-
-	"k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/util/sets"
 	corelisterv1 "k8s.io/client-go/listers/core/v1"
 
-	configv1 "github.com/openshift/api/config/v1"
 	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
-	"github.com/openshift/library-go/pkg/cloudprovider"
 	"github.com/openshift/library-go/pkg/operator/configobserver"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
@@ -33,12 +25,10 @@ type InfrastructureLister interface {
 
 // NewCloudProviderObserver returns a new cloudprovider observer for syncing cloud provider specific
 // information to controller-manager and api-server.
-func NewCloudProviderObserver(targetNamespaceName string, skipCloudProviderExternal bool, cloudProviderNamePath, cloudProviderConfigPath []string) configobserver.ObserveConfigFunc {
+func NewCloudProviderObserver(targetNamespaceName string, skipCloudProviderExternal bool) configobserver.ObserveConfigFunc {
 	cloudObserver := &cloudProviderObserver{
 		targetNamespaceName:       targetNamespaceName,
 		skipCloudProviderExternal: skipCloudProviderExternal,
-		cloudProviderNamePath:     cloudProviderNamePath,
-		cloudProviderConfigPath:   cloudProviderConfigPath,
 	}
 	return cloudObserver.ObserveCloudProviderNames
 }
@@ -46,141 +36,24 @@ func NewCloudProviderObserver(targetNamespaceName string, skipCloudProviderExter
 type cloudProviderObserver struct {
 	targetNamespaceName       string
 	skipCloudProviderExternal bool
-	cloudProviderNamePath     []string
-	cloudProviderConfigPath   []string
 }
 
 // ObserveCloudProviderNames observes the cloud provider from the global cluster infrastructure resource.
 func (c *cloudProviderObserver) ObserveCloudProviderNames(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (ret map[string]interface{}, _ []error) {
 	defer func() {
-		ret = configobserver.Pruned(ret, c.cloudProviderConfigPath, c.cloudProviderNamePath)
+		ret = configobserver.Pruned(ret)
 	}()
 
 	listers := genericListers.(InfrastructureLister)
 	var errs []error
-	observedConfig := map[string]interface{}{}
 
-	infrastructure, err := listers.InfrastructureLister().Get("cluster")
-	if errors.IsNotFound(err) {
-		recorder.Warningf("ObserveCloudProviderNames", "Required infrastructures.%s/cluster not found", configv1.GroupName)
-		return observedConfig, errs
-	}
-	if err != nil {
-		return existingConfig, append(errs, err)
-	}
-
-	external, err := cloudprovider.IsCloudProviderExternal(infrastructure.Status.PlatformStatus)
-	if err != nil {
-		recorder.Warningf("ObserveCloudProviderNames", "Could not determine external cloud provider state: %v", err)
-		return existingConfig, append(errs, err)
-	}
-
-	// Still using in-tree cloud provider, fall back to setting provider information based on platform type.
-	cloudProvider := GetPlatformName(infrastructure.Status.Platform, recorder)
-	if external {
-		if !c.skipCloudProviderExternal {
-			if err := unstructured.SetNestedStringSlice(observedConfig, []string{"external"}, c.cloudProviderNamePath...); err != nil {
-				errs = append(errs, err)
-			}
-		}
-	} else if len(cloudProvider) > 0 {
-		if err := unstructured.SetNestedStringSlice(observedConfig, []string{cloudProvider}, c.cloudProviderNamePath...); err != nil {
-			errs = append(errs, err)
-		}
-	}
-
-	sourceCloudConfigMap := infrastructure.Spec.CloudConfig.Name
-	sourceCloudConfigNamespace := configNamespace
-	sourceCloudConfigKey := infrastructure.Spec.CloudConfig.Key
-
-	// If a managed cloud-provider config is available, it should be used instead of the default. If the configmap is not
-	// found, the default values should be used.
-	if _, err = listers.ConfigMapLister().ConfigMaps(machineSpecifiedConfigNamespace).Get(machineSpecifiedConfig); err == nil {
-		sourceCloudConfigMap = machineSpecifiedConfig
-		sourceCloudConfigNamespace = machineSpecifiedConfigNamespace
-		sourceCloudConfigKey = "cloud.conf"
-	} else if !errors.IsNotFound(err) {
-		return existingConfig, append(errs, err)
-	}
-
-	sourceLocation := resourcesynccontroller.ResourceLocation{
-		Namespace: sourceCloudConfigNamespace,
-		Name:      sourceCloudConfigMap,
-	}
-
-	// we set cloudprovider configmap values only for some cloud providers.
-	validCloudProviders := sets.New("aws", "azure", "gce", "vsphere")
-	if !validCloudProviders.Has(cloudProvider) {
-		sourceCloudConfigMap = ""
-	}
-
-	if len(sourceCloudConfigMap) == 0 {
-		sourceLocation = resourcesynccontroller.ResourceLocation{}
-	}
-
-	if err := listers.ResourceSyncer().SyncConfigMap(
+	// Use a blank resource location to delete the old, unused cloud-config configmap, if it exists.
+	_ = listers.ResourceSyncer().SyncConfigMap(
 		resourcesynccontroller.ResourceLocation{
 			Namespace: c.targetNamespaceName,
 			Name:      "cloud-config",
 		},
-		sourceLocation); err != nil {
-		return existingConfig, append(errs, err)
-	}
+		resourcesynccontroller.ResourceLocation{})
 
-	if len(sourceCloudConfigMap) == 0 {
-		return observedConfig, errs
-	}
-
-	staticCloudConfFile := fmt.Sprintf(cloudProviderConfFilePath, sourceCloudConfigKey)
-
-	if err := unstructured.SetNestedStringSlice(observedConfig, []string{staticCloudConfFile}, c.cloudProviderConfigPath...); err != nil {
-		recorder.Warningf("ObserveCloudProviderNames", "Failed setting cloud-config : %v", err)
-		return existingConfig, append(errs, err)
-	}
-
-	existingCloudConfig, _, err := unstructured.NestedStringSlice(existingConfig, c.cloudProviderConfigPath...)
-	if err != nil {
-		errs = append(errs, err)
-		// keep going on read error from existing config
-	}
-
-	if !equality.Semantic.DeepEqual(existingCloudConfig, []string{staticCloudConfFile}) {
-		recorder.Eventf("ObserveCloudProviderNamesChanges", "CloudProvider config file changed to %s", staticCloudConfFile)
-	}
-
-	return observedConfig, errs
-}
-
-// GetPlatformName returns the platform name as required by flags such as `cloud-provider`.
-// If no in-tree cloud provider exists for a platform, an empty value will be returned.
-func GetPlatformName(platformType configv1.PlatformType, recorder events.Recorder) string {
-	cloudProvider := ""
-	switch platformType {
-	case "":
-		recorder.Warningf("ObserveCloudProvidersFailed", "Required status.platform field is not set in infrastructures.%s/cluster", configv1.GroupName)
-	case configv1.AWSPlatformType:
-		cloudProvider = "aws"
-	case configv1.AzurePlatformType:
-		cloudProvider = "azure"
-	case configv1.VSpherePlatformType:
-		cloudProvider = "vsphere"
-	case configv1.BareMetalPlatformType:
-	case configv1.GCPPlatformType:
-		cloudProvider = "gce"
-	case configv1.LibvirtPlatformType:
-	case configv1.OpenStackPlatformType:
-	case configv1.IBMCloudPlatformType:
-	case configv1.NonePlatformType:
-	case configv1.NutanixPlatformType:
-	case configv1.OvirtPlatformType:
-	case configv1.KubevirtPlatformType:
-	case configv1.AlibabaCloudPlatformType:
-	case configv1.PowerVSPlatformType:
-	case configv1.ExternalPlatformType:
-	default:
-		// the new doc on the infrastructure fields requires that we treat an unrecognized thing the same bare metal.
-		// TODO find a way to indicate to the user that we didn't honor their choice
-		recorder.Warningf("ObserveCloudProvidersFailed", fmt.Sprintf("No recognized cloud provider platform found in infrastructures.%s/cluster.status.platform", configv1.GroupName))
-	}
-	return cloudProvider
+	return existingConfig, errs
 }

--- a/pkg/operator/configobserver/cloudprovider/observe_cloudprovider_test.go
+++ b/pkg/operator/configobserver/cloudprovider/observe_cloudprovider_test.go
@@ -87,7 +87,7 @@ func TestObserveCloudProviderNames(t *testing.T) {
 		},
 		skipCloudProviderExternal: true,
 		expected:                  "",
-		cloudProviderCount:        1,
+		cloudProviderCount:        0,
 	}, {
 		name: "AWS platform",
 		infrastructureStatus: configv1.InfrastructureStatus{
@@ -97,7 +97,7 @@ func TestObserveCloudProviderNames(t *testing.T) {
 			},
 		},
 		expected:           "external",
-		cloudProviderCount: 1,
+		cloudProviderCount: 0,
 	}, {
 		name: "AlibabaCloud Platform",
 		infrastructureStatus: configv1.InfrastructureStatus{
@@ -107,7 +107,7 @@ func TestObserveCloudProviderNames(t *testing.T) {
 			},
 		},
 		expected:           "external",
-		cloudProviderCount: 1,
+		cloudProviderCount: 0,
 	}, {
 		name: "Nutanix Platform",
 		infrastructureStatus: configv1.InfrastructureStatus{
@@ -117,7 +117,7 @@ func TestObserveCloudProviderNames(t *testing.T) {
 			},
 		},
 		expected:           "external",
-		cloudProviderCount: 1,
+		cloudProviderCount: 0,
 	}, {
 		name: "Azure platform",
 		infrastructureStatus: configv1.InfrastructureStatus{
@@ -127,7 +127,7 @@ func TestObserveCloudProviderNames(t *testing.T) {
 			},
 		},
 		expected:           "external",
-		cloudProviderCount: 1,
+		cloudProviderCount: 0,
 	}, {
 		name: "Azure Stack Hub defaulting to external configuration",
 		infrastructureStatus: configv1.InfrastructureStatus{
@@ -140,7 +140,7 @@ func TestObserveCloudProviderNames(t *testing.T) {
 			},
 		},
 		expected:           "external",
-		cloudProviderCount: 1,
+		cloudProviderCount: 0,
 	}, {
 		name: "BareMetal platform",
 		infrastructureStatus: configv1.InfrastructureStatus{
@@ -168,7 +168,7 @@ func TestObserveCloudProviderNames(t *testing.T) {
 			},
 		},
 		expected:           "external",
-		cloudProviderCount: 1,
+		cloudProviderCount: 0,
 	}, {
 		name: "GCP platform",
 		infrastructureStatus: configv1.InfrastructureStatus{
@@ -178,7 +178,7 @@ func TestObserveCloudProviderNames(t *testing.T) {
 			},
 		},
 		expected:           "external",
-		cloudProviderCount: 1,
+		cloudProviderCount: 0,
 	}, {
 		name: "IBM Cloud platform",
 		infrastructureStatus: configv1.InfrastructureStatus{
@@ -188,7 +188,7 @@ func TestObserveCloudProviderNames(t *testing.T) {
 			},
 		},
 		expected:           "external",
-		cloudProviderCount: 1,
+		cloudProviderCount: 0,
 	}, {
 		name: "Power VS platform",
 		infrastructureStatus: configv1.InfrastructureStatus{
@@ -198,7 +198,7 @@ func TestObserveCloudProviderNames(t *testing.T) {
 			},
 		},
 		expected:           "external",
-		cloudProviderCount: 1,
+		cloudProviderCount: 0,
 	}, {
 		name: "Kubevirt platform",
 		infrastructureStatus: configv1.InfrastructureStatus{
@@ -208,7 +208,7 @@ func TestObserveCloudProviderNames(t *testing.T) {
 			},
 		},
 		expected:           "external",
-		cloudProviderCount: 1,
+		cloudProviderCount: 0,
 	}, {
 		name: "None platform",
 		infrastructureStatus: configv1.InfrastructureStatus{
@@ -232,7 +232,7 @@ func TestObserveCloudProviderNames(t *testing.T) {
 			},
 		},
 		expected:           "external",
-		cloudProviderCount: 1,
+		cloudProviderCount: 0,
 	}, {
 		name: "External platform, CloudControllerManager.State = None",
 		infrastructureStatus: configv1.InfrastructureStatus{
@@ -261,7 +261,7 @@ func TestObserveCloudProviderNames(t *testing.T) {
 		infrastructureStatus: configv1.InfrastructureStatus{},
 		expected:             "",
 		cloudProviderCount:   0,
-		expectErrors:         true,
+		expectErrors:         false,
 	}}
 	for _, c := range cases {
 		t.Run(string(c.name), func(t *testing.T) {
@@ -281,9 +281,7 @@ func TestObserveCloudProviderNames(t *testing.T) {
 				ResourceSync:          &FakeResourceSyncer{},
 				ConfigMapLister_:      &FakeConfigMapLister{},
 			}
-			cloudProvidersPath := []string{"extendedArguments", "cloud-provider"}
-			cloudProviderConfPath := []string{"extendedArguments", "cloud-config"}
-			observerFunc := NewCloudProviderObserver("kube-controller-manager", c.skipCloudProviderExternal, cloudProvidersPath, cloudProviderConfPath)
+			observerFunc := NewCloudProviderObserver("kube-controller-manager", c.skipCloudProviderExternal)
 			result, errs := observerFunc(listers, events.NewInMemoryRecorder("cloud"), map[string]interface{}{})
 			if errorsOccured := len(errs) > 0; c.expectErrors != errorsOccured {
 				t.Fatalf("expected errors: %v, got: %v", c.expectErrors, errs)


### PR DESCRIPTION
These flags are being deprecated and will eventually raise an error when
set.

Sibling PRs to remove the calls to the NewCloudProviderObserver function will be added here.

Signed-off-by: Nolan Brubaker <nolan@nbrubaker.com>
