### PR TITLE
OCPBUGS-31807: [release-4.15] use update only secret-apply for cert rotation logic

### DIFF
--- a/pkg/operator/certrotation/signer.go
+++ b/pkg/operator/certrotation/signer.go
@@ -52,6 +52,12 @@ type RotatedSigningCASecret struct {
 	Lister        corev1listers.SecretLister
 	Client        corev1client.SecretsGetter
 	EventRecorder events.Recorder
+
+	// Deprecated: DO NOT eanble, it is intended as a short term hack for a very specific use case,
+	// and it works in tandem with a particular carry patch applied to the openshift kube-apiserver.
+	// we will remove this when we migrate all of the affected secret
+	// objects to their intended type: https://issues.redhat.com/browse/API-1800
+	UseSecretUpdateOnly bool
 }
 
 func (c RotatedSigningCASecret) ensureSigningCertKeyPair(ctx context.Context) (*crypto.CA, error) {
@@ -72,10 +78,15 @@ func (c RotatedSigningCASecret) ensureSigningCertKeyPair(ctx context.Context) (*
 		}
 	}
 
+	applyFn := resourceapply.ApplySecret
+	if c.UseSecretUpdateOnly {
+		applyFn = resourceapply.ApplySecretDoNotUse
+	}
+
 	// apply necessary metadata (possibly via delete+recreate) if secret exists
 	// this is done before content update to prevent unexpected rollouts
 	if ensureMetadataUpdate(signingCertKeyPairSecret, c.Owner, c.AdditionalAnnotations) && ensureSecretTLSTypeSet(signingCertKeyPairSecret) {
-		actualSigningCertKeyPairSecret, _, err := resourceapply.ApplySecret(ctx, c.Client, c.EventRecorder, signingCertKeyPairSecret)
+		actualSigningCertKeyPairSecret, _, err := applyFn(ctx, c.Client, c.EventRecorder, signingCertKeyPairSecret)
 		if err != nil {
 			return nil, err
 		}
@@ -90,7 +101,7 @@ func (c RotatedSigningCASecret) ensureSigningCertKeyPair(ctx context.Context) (*
 
 		LabelAsManagedSecret(signingCertKeyPairSecret, CertificateTypeSigner)
 
-		actualSigningCertKeyPairSecret, _, err := resourceapply.ApplySecret(ctx, c.Client, c.EventRecorder, signingCertKeyPairSecret)
+		actualSigningCertKeyPairSecret, _, err := applyFn(ctx, c.Client, c.EventRecorder, signingCertKeyPairSecret)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/operator/certrotation/signer_test.go
+++ b/pkg/operator/certrotation/signer_test.go
@@ -1,16 +1,21 @@
 package certrotation
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/google/go-cmp/cmp"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	kubefake "k8s.io/client-go/kubernetes/fake"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
@@ -19,18 +24,256 @@ import (
 	"github.com/openshift/library-go/pkg/operator/events"
 )
 
+func TestRotatedSigningCASecretShouldNotUseDelete(t *testing.T) {
+	ns, name := "ns", "test-signer"
+	// represents a secret that was created before 4.7 and
+	// hasn't been updated until now (upgrade to 4.15)
+	existing := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       ns,
+			Name:            name,
+			ResourceVersion: "10",
+		},
+		Type: "SecretTypeTLS",
+		Data: map[string][]byte{"tls.crt": {}, "tls.key": {}},
+	}
+	// not-after and not-before annotations are filled when new signer is generated
+	if err := setSigningCertKeyPairSecret(existing, 24*time.Hour); err != nil {
+		t.Fatal(err)
+	}
+
+	// give it a second so we have a unique signer name,
+	// and also unique not-after, and not-before values
+	<-time.After(2 * time.Second)
+
+	// get the original crt and key bytes to compare later
+	tlsCertWant, ok := existing.Data["tls.crt"]
+	if !ok || len(tlsCertWant) == 0 {
+		t.Fatalf("missing data in 'tls.crt' key of Data: %#v", existing.Data)
+	}
+	tlsKeyWant, ok := existing.Data["tls.key"]
+	if !ok || len(tlsKeyWant) == 0 {
+		t.Fatalf("missing data in 'tls.key' key of Data: %#v", existing.Data)
+	}
+
+	// copy the existing object before test begins, so we can diff it against
+	// the final object on the cluster after the controllers finish
+	secretWant := existing.DeepCopy()
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	syncCacheFn := func(t *testing.T, obj runtime.Object) {
+		switch {
+		case obj == nil:
+			if err := indexer.Delete(existing); err != nil {
+				t.Fatalf("unexpected error while syncing the cache, op=delete: %v", err)
+			}
+		default:
+			indexer.Delete(obj)
+			if err := indexer.Add(obj); err != nil {
+				t.Fatalf("unexpected error while syncing the cache: %v", err)
+			}
+		}
+	}
+	syncCacheFn(t, existing)
+	clientset := kubefake.NewSimpleClientset(existing)
+
+	// the list cache is synced as soon as we have a delete, create, or update
+	clientset.PrependReactor("delete", "secrets", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+		syncCacheFn(t, nil)
+		return false, nil, nil
+	})
+	clientset.PrependReactor("create", "secrets", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+		switch action := action.(type) {
+		case clienttesting.CreateActionImpl:
+			syncCacheFn(t, action.GetObject())
+			return false, action.GetObject(), nil
+		}
+		t.Fatalf("wrong test setup, expected an action object of %T", clienttesting.CreateActionImpl{})
+		return false, nil, nil
+	})
+	clientset.PrependReactor("update", "secrets", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+		switch action := action.(type) {
+		case clienttesting.UpdateActionImpl:
+			syncCacheFn(t, action.GetObject())
+			return false, action.GetObject(), nil
+		}
+		t.Fatalf("wrong test setup, expected an action object of %T", clienttesting.UpdateActionImpl{})
+		return false, nil, nil
+	})
+
+	options := events.RecommendedClusterSingletonCorrelatorOptions()
+	client := clientset.CoreV1().Secrets(ns)
+	newControllerFn := func(ctrlName string, wrapped *wrapped) *RotatedSigningCASecret {
+		recorder := events.NewKubeRecorderWithOptions(clientset.CoreV1().Events(ns), options, "operator", &corev1.ObjectReference{Name: ctrlName, Namespace: ns})
+		return &RotatedSigningCASecret{
+			Namespace:             ns,
+			Name:                  name,
+			Validity:              24 * time.Hour,
+			Refresh:               12 * time.Hour,
+			Client:                &getter{w: wrapped},
+			Lister:                corev1listers.NewSecretLister(indexer),
+			AdditionalAnnotations: AdditionalAnnotations{JiraComponent: "test"},
+			Owner:                 &metav1.OwnerReference{Name: "operator"},
+			EventRecorder:         recorder,
+			UseSecretUpdateOnly:   true,
+		}
+	}
+
+	// we have two controllers, running cncurrently, A and B
+	// a) A starts
+	// b) A detects secret type mismatch, it proceeds to do delete + create
+	// c) A completes delete operation, we make A stop here, and let B start
+	// d) B sees a NotFound error (from the list cache), constructs an in-memory
+	//    secret object, creates a new signer, and then invokes ApplySecret
+	// e) let's make B pause just before it is about to invoke a GET
+	// f) let A resume and finish
+	// g) let B resume
+	// h) B proceeds with the GET operation, the secret object on the cluster
+	//    has a signer that does not match
+	// i) B updates the secret with the signer from 'd'
+	ctrlAPauses, ctrlBStart, ctrlBPauses := make(chan struct{}), make(chan struct{}), make(chan struct{})
+	hookA := func(name, op string) {
+		switch {
+		case name == "controller-A" && op == "delete":
+			// step 'c' has completed, B can strat, and A should block
+			close(ctrlBStart)
+			<-ctrlAPauses
+		}
+	}
+	hookB := func(name, op string) {
+		switch {
+		case name == "controller-B" && op == "get":
+			// step 'e': B is about to GET the secret, A should resume, and B should pause
+			close(ctrlAPauses)
+			<-ctrlBPauses
+		}
+	}
+	wrappedA := &wrapped{SecretInterface: client, name: "controller-A", t: t, hook: hookA}
+	ctrlA := newControllerFn("controller-A", wrappedA)
+	wrappedB := &wrapped{SecretInterface: client, name: "controller-B", t: t, hook: hookB}
+	ctrlB := newControllerFn("controller-B", wrappedB)
+
+	ctrlADone, ctrlBDone := make(chan struct{}), make(chan struct{})
+	go func() {
+		defer close(ctrlADone)
+		defer close(ctrlBPauses)
+		// step 'a': A starts first
+		_, err := ctrlA.ensureSigningCertKeyPair(context.TODO())
+		if err != nil {
+			t.Logf("error from controller-A - %v", err)
+		}
+	}()
+	go func() {
+		defer close(ctrlBDone)
+		// wait until step 'c' completes
+		<-ctrlBStart
+		_, err := ctrlB.ensureSigningCertKeyPair(context.TODO())
+		if err != nil {
+			t.Logf("error from controller-B - %v", err)
+		}
+	}()
+
+	<-ctrlADone
+	select {
+	case <-ctrlBStart:
+	default:
+		// controller A did not exercise delete + create, make
+		// sure the test does not block
+		close(ctrlBStart)
+	}
+	<-ctrlBDone
+
+	// controllers are done, we don't expect the signer to change
+	secretGot, err := client.Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tlsCertGot, ok := secretGot.Data["tls.crt"]; !ok || !bytes.Equal(tlsCertWant, tlsCertGot) {
+		t.Errorf("the signer cert has mutated unexpectedly")
+	}
+	if tlsKeyGot, ok := secretGot.Data["tls.key"]; !ok || !bytes.Equal(tlsKeyWant, tlsKeyGot) {
+		t.Errorf("the signer key has mutated unexpectedly")
+	}
+	if got, exists := secretGot.Annotations["openshift.io/owning-component"]; !exists || got != "test" {
+		t.Errorf("owner annotation is missing: %#v", secretGot.Annotations)
+	}
+	if secretGot.Type != corev1.SecretTypeTLS {
+		t.Errorf("expected the secret type to be: %q, but got: %q", corev1.SecretTypeTLS, secretGot.Type)
+	}
+
+	t.Logf("diff: %s", cmp.Diff(secretWant, secretGot))
+}
+
+type getter struct {
+	w *wrapped
+}
+
+func (g *getter) Secrets(string) corev1client.SecretInterface {
+	return g.w
+}
+
+type wrapped struct {
+	corev1client.SecretInterface
+	name string
+	t    *testing.T
+	// the hooks are not invoked for every operation
+	hook func(controllerName, op string)
+}
+
+func (w wrapped) Create(ctx context.Context, secret *corev1.Secret, opts metav1.CreateOptions) (*corev1.Secret, error) {
+	w.t.Logf("[%s] op=Create, secret=%s/%s", w.name, secret.Namespace, secret.Name)
+	return w.SecretInterface.Create(ctx, secret, opts)
+}
+func (w wrapped) Update(ctx context.Context, secret *corev1.Secret, opts metav1.UpdateOptions) (*corev1.Secret, error) {
+	w.t.Logf("[%s] op=Update, secret=%s/%s", w.name, secret.Namespace, secret.Name)
+	return w.SecretInterface.Update(ctx, secret, opts)
+}
+func (w wrapped) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
+	w.t.Logf("[%s] op=Delete, secret=%s", w.name, name)
+	defer func() {
+		if w.hook != nil {
+			w.hook(w.name, operation(w.t, opts))
+		}
+	}()
+	return w.SecretInterface.Delete(ctx, name, opts)
+}
+func (w wrapped) Get(ctx context.Context, name string, opts metav1.GetOptions) (*corev1.Secret, error) {
+	if w.hook != nil {
+		w.hook(w.name, operation(w.t, opts))
+	}
+	obj, err := w.SecretInterface.Get(ctx, name, opts)
+	w.t.Logf("[%s] op=Get, secret=%s, err: %v", w.name, name, err)
+	return obj, err
+}
+
+func operation(t *testing.T, options interface{}) string {
+	switch options.(type) {
+	case metav1.CreateOptions:
+		return "create"
+	case metav1.DeleteOptions:
+		return "delete"
+	case metav1.UpdateOptions:
+		return "update"
+	case metav1.GetOptions:
+		return "get"
+	case metav1.PatchOptions:
+		return "get"
+	}
+	t.Fatalf("wrong test setup: we shouldn't be here for this test")
+	return ""
+}
+
 func TestEnsureSigningCertKeyPair(t *testing.T) {
 	tests := []struct {
 		name string
 
 		initialSecret *corev1.Secret
 
-		verifyActions func(t *testing.T, client *kubefake.Clientset)
+		verifyActions func(t *testing.T, updateOnly bool, client *kubefake.Clientset)
 		expectedError string
 	}{
 		{
 			name: "initial create",
-			verifyActions: func(t *testing.T, client *kubefake.Clientset) {
+			verifyActions: func(t *testing.T, updateOnly bool, client *kubefake.Clientset) {
 				t.Helper()
 				actions := client.Actions()
 				if len(actions) != 2 {
@@ -76,7 +319,7 @@ func TestEnsureSigningCertKeyPair(t *testing.T) {
 				Type:       corev1.SecretTypeTLS,
 				Data:       map[string][]byte{"tls.crt": {}, "tls.key": {}},
 			},
-			verifyActions: func(t *testing.T, client *kubefake.Clientset) {
+			verifyActions: func(t *testing.T, updateOnly bool, client *kubefake.Clientset) {
 				t.Helper()
 				actions := client.Actions()
 				if len(actions) != 2 {
@@ -124,7 +367,7 @@ func TestEnsureSigningCertKeyPair(t *testing.T) {
 				Type: corev1.SecretTypeTLS,
 				Data: map[string][]byte{"tls.crt": {}, "tls.key": {}},
 			},
-			verifyActions: func(t *testing.T, client *kubefake.Clientset) {
+			verifyActions: func(t *testing.T, updateOnly bool, client *kubefake.Clientset) {
 				t.Helper()
 				actions := client.Actions()
 				if len(actions) != 0 {
@@ -145,23 +388,42 @@ func TestEnsureSigningCertKeyPair(t *testing.T) {
 				Type: "SecretTypeTLS",
 				Data: map[string][]byte{"tls.crt": {}, "tls.key": {}},
 			},
-			verifyActions: func(t *testing.T, client *kubefake.Clientset) {
+			verifyActions: func(t *testing.T, updateOnly bool, client *kubefake.Clientset) {
 				t.Helper()
+				lengthWant := 3
+				if updateOnly {
+					lengthWant = 2
+				}
+
 				actions := client.Actions()
-				if len(actions) != 3 {
+				if len(actions) != lengthWant {
 					t.Fatal(spew.Sdump(actions))
 				}
 
-				if !actions[0].Matches("get", "secrets") {
-					t.Error(actions[0])
+				var idx int
+				switch updateOnly {
+				case true:
+					idx = 1
+					if !actions[0].Matches("get", "secrets") {
+						t.Error(actions[0])
+					}
+					if !actions[1].Matches("update", "secrets") {
+						t.Error(actions[1])
+					}
+				default:
+					idx = 2
+					if !actions[0].Matches("get", "secrets") {
+						t.Error(actions[0])
+					}
+					if !actions[1].Matches("delete", "secrets") {
+						t.Error(actions[1])
+					}
+					if !actions[2].Matches("create", "secrets") {
+						t.Error(actions[2])
+					}
 				}
-				if !actions[1].Matches("delete", "secrets") {
-					t.Error(actions[1])
-				}
-				if !actions[2].Matches("create", "secrets") {
-					t.Error(actions[2])
-				}
-				actual := actions[2].(clienttesting.UpdateAction).GetObject().(*corev1.Secret)
+
+				actual := actions[idx].(clienttesting.UpdateAction).GetObject().(*corev1.Secret)
 				if actual.Type != corev1.SecretTypeTLS {
 					t.Errorf("expected secret type to be kubernetes.io/tls, got: %v", actual.Type)
 				}
@@ -200,23 +462,42 @@ func TestEnsureSigningCertKeyPair(t *testing.T) {
 				Type: corev1.SecretTypeOpaque,
 				Data: map[string][]byte{"foo": {}, "bar": {}},
 			},
-			verifyActions: func(t *testing.T, client *kubefake.Clientset) {
+			verifyActions: func(t *testing.T, updateOnly bool, client *kubefake.Clientset) {
 				t.Helper()
+				lengthWant := 3
+				if updateOnly {
+					lengthWant = 2
+				}
+
 				actions := client.Actions()
-				if len(actions) != 3 {
+				if len(actions) != lengthWant {
 					t.Fatal(spew.Sdump(actions))
 				}
 
-				if !actions[0].Matches("get", "secrets") {
-					t.Error(actions[0])
+				var idx int
+				switch updateOnly {
+				case true:
+					idx = 1
+					if !actions[0].Matches("get", "secrets") {
+						t.Error(actions[0])
+					}
+					if !actions[1].Matches("update", "secrets") {
+						t.Error(actions[1])
+					}
+				default:
+					idx = 2
+					if !actions[0].Matches("get", "secrets") {
+						t.Error(actions[0])
+					}
+					if !actions[1].Matches("delete", "secrets") {
+						t.Error(actions[1])
+					}
+					if !actions[2].Matches("create", "secrets") {
+						t.Error(actions[2])
+					}
 				}
-				if !actions[1].Matches("delete", "secrets") {
-					t.Error(actions[1])
-				}
-				if !actions[2].Matches("create", "secrets") {
-					t.Error(actions[2])
-				}
-				actual := actions[2].(clienttesting.UpdateAction).GetObject().(*corev1.Secret)
+
+				actual := actions[idx].(clienttesting.UpdateAction).GetObject().(*corev1.Secret)
 				if actual.Type != corev1.SecretTypeTLS {
 					t.Errorf("expected secret type to be kubernetes.io/tls, got: %v", actual.Type)
 				}
@@ -231,43 +512,46 @@ func TestEnsureSigningCertKeyPair(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	for _, b := range []bool{true, false} {
+		for _, test := range tests {
+			t.Run(fmt.Sprintf("%s/update-only/%t", test.name, b), func(t *testing.T) {
+				indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 
-			client := kubefake.NewSimpleClientset()
-			if test.initialSecret != nil {
-				indexer.Add(test.initialSecret)
-				client = kubefake.NewSimpleClientset(test.initialSecret)
-			}
+				client := kubefake.NewSimpleClientset()
+				if test.initialSecret != nil {
+					indexer.Add(test.initialSecret)
+					client = kubefake.NewSimpleClientset(test.initialSecret)
+				}
 
-			c := &RotatedSigningCASecret{
-				Namespace:     "ns",
-				Name:          "signer",
-				Validity:      24 * time.Hour,
-				Refresh:       12 * time.Hour,
-				Client:        client.CoreV1(),
-				Lister:        corev1listers.NewSecretLister(indexer),
-				EventRecorder: events.NewInMemoryRecorder("test"),
-				AdditionalAnnotations: AdditionalAnnotations{
-					JiraComponent: "test",
-				},
-				Owner: &metav1.OwnerReference{
-					Name: "operator",
-				},
-			}
+				c := &RotatedSigningCASecret{
+					Namespace:     "ns",
+					Name:          "signer",
+					Validity:      24 * time.Hour,
+					Refresh:       12 * time.Hour,
+					Client:        client.CoreV1(),
+					Lister:        corev1listers.NewSecretLister(indexer),
+					EventRecorder: events.NewInMemoryRecorder("test"),
+					AdditionalAnnotations: AdditionalAnnotations{
+						JiraComponent: "test",
+					},
+					Owner: &metav1.OwnerReference{
+						Name: "operator",
+					},
+					UseSecretUpdateOnly: b,
+				}
 
-			_, err := c.ensureSigningCertKeyPair(context.TODO())
-			switch {
-			case err != nil && len(test.expectedError) == 0:
-				t.Error(err)
-			case err != nil && !strings.Contains(err.Error(), test.expectedError):
-				t.Error(err)
-			case err == nil && len(test.expectedError) != 0:
-				t.Errorf("missing %q", test.expectedError)
-			}
+				_, err := c.ensureSigningCertKeyPair(context.TODO())
+				switch {
+				case err != nil && len(test.expectedError) == 0:
+					t.Error(err)
+				case err != nil && !strings.Contains(err.Error(), test.expectedError):
+					t.Error(err)
+				case err == nil && len(test.expectedError) != 0:
+					t.Errorf("missing %q", test.expectedError)
+				}
 
-			test.verifyActions(t, client)
-		})
+				test.verifyActions(t, b, client)
+			})
+		}
 	}
 }

--- a/pkg/operator/certrotation/target.go
+++ b/pkg/operator/certrotation/target.go
@@ -68,6 +68,12 @@ type RotatedSelfSignedCertKeySecret struct {
 	Lister        corev1listers.SecretLister
 	Client        corev1client.SecretsGetter
 	EventRecorder events.Recorder
+
+	// Deprecated: DO NOT eanble, it is intended as a short term hack for a very specific use case,
+	// and it works in tandem with a particular carry patch applied to the openshift kube-apiserver.
+	// we will remove this when we migrate all of the affected secret
+	// objects to their intended type: https://issues.redhat.com/browse/API-1800
+	UseSecretUpdateOnly bool
 }
 
 type TargetCertCreator interface {
@@ -107,10 +113,15 @@ func (c RotatedSelfSignedCertKeySecret) ensureTargetCertKeyPair(ctx context.Cont
 		}
 	}
 
+	applyFn := resourceapply.ApplySecret
+	if c.UseSecretUpdateOnly {
+		applyFn = resourceapply.ApplySecretDoNotUse
+	}
+
 	// apply necessary metadata (possibly via delete+recreate) if secret exists
 	// this is done before content update to prevent unexpected rollouts
 	if ensureMetadataUpdate(targetCertKeyPairSecret, c.Owner, c.AdditionalAnnotations) && ensureSecretTLSTypeSet(targetCertKeyPairSecret) {
-		actualTargetCertKeyPairSecret, _, err := resourceapply.ApplySecret(ctx, c.Client, c.EventRecorder, targetCertKeyPairSecret)
+		actualTargetCertKeyPairSecret, _, err := applyFn(ctx, c.Client, c.EventRecorder, targetCertKeyPairSecret)
 		if err != nil {
 			return err
 		}
@@ -125,7 +136,7 @@ func (c RotatedSelfSignedCertKeySecret) ensureTargetCertKeyPair(ctx context.Cont
 
 		LabelAsManagedSecret(targetCertKeyPairSecret, CertificateTypeTarget)
 
-		actualTargetCertKeyPairSecret, _, err := resourceapply.ApplySecret(ctx, c.Client, c.EventRecorder, targetCertKeyPairSecret)
+		actualTargetCertKeyPairSecret, _, err := applyFn(ctx, c.Client, c.EventRecorder, targetCertKeyPairSecret)
 		if err != nil {
 			return err
 		}

--- a/pkg/operator/certrotation/target_test.go
+++ b/pkg/operator/certrotation/target_test.go
@@ -3,6 +3,7 @@ package certrotation
 import (
 	"context"
 	"crypto/x509/pkix"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -139,7 +140,7 @@ func TestEnsureTargetCertKeyPair(t *testing.T) {
 		initialSecretFn func() *corev1.Secret
 		caFn            func() (*crypto.CA, error)
 
-		verifyActions func(t *testing.T, client *kubefake.Clientset)
+		verifyActions func(t *testing.T, updateOnly bool, client *kubefake.Clientset)
 		expectedError string
 	}{
 		{
@@ -148,7 +149,7 @@ func TestEnsureTargetCertKeyPair(t *testing.T) {
 				return newTestCACertificate(pkix.Name{CommonName: "signer-tests"}, int64(1), metav1.Duration{Duration: time.Hour * 24 * 60}, time.Now)
 			},
 			initialSecretFn: func() *corev1.Secret { return nil },
-			verifyActions: func(t *testing.T, client *kubefake.Clientset) {
+			verifyActions: func(t *testing.T, updateonly bool, client *kubefake.Clientset) {
 				actions := client.Actions()
 				if len(actions) != 2 {
 					t.Fatal(spew.Sdump(actions))
@@ -196,7 +197,7 @@ func TestEnsureTargetCertKeyPair(t *testing.T) {
 				}
 				return caBundleSecret
 			},
-			verifyActions: func(t *testing.T, client *kubefake.Clientset) {
+			verifyActions: func(t *testing.T, updateOnly bool, client *kubefake.Clientset) {
 				actions := client.Actions()
 				if len(actions) != 2 {
 					t.Fatal(spew.Sdump(actions))
@@ -244,29 +245,52 @@ func TestEnsureTargetCertKeyPair(t *testing.T) {
 				}
 				return caBundleSecret
 			},
-			verifyActions: func(t *testing.T, client *kubefake.Clientset) {
+			verifyActions: func(t *testing.T, updateOnly bool, client *kubefake.Clientset) {
+				lengthWant := 5
+				if updateOnly {
+					lengthWant = 4
+				}
 				actions := client.Actions()
-				if len(actions) != 5 {
+				if len(actions) != lengthWant {
 					t.Fatal(spew.Sdump(actions))
 				}
 
-				if !actions[0].Matches("get", "secrets") {
-					t.Error(actions[0])
-				}
-				if !actions[1].Matches("delete", "secrets") {
-					t.Error(actions[1])
-				}
-				if !actions[2].Matches("create", "secrets") {
-					t.Error(actions[2])
-				}
-				if !actions[3].Matches("get", "secrets") {
-					t.Error(actions[3])
-				}
-				if !actions[4].Matches("update", "secrets") {
-					t.Error(actions[4])
+				var idx int
+				switch updateOnly {
+				case true:
+					idx = 3
+					if !actions[0].Matches("get", "secrets") {
+						t.Error(actions[0])
+					}
+					if !actions[1].Matches("update", "secrets") {
+						t.Error(actions[1])
+					}
+					if !actions[2].Matches("get", "secrets") {
+						t.Error(actions[2])
+					}
+					if !actions[3].Matches("update", "secrets") {
+						t.Error(actions[3])
+					}
+				default:
+					idx = 4
+					if !actions[0].Matches("get", "secrets") {
+						t.Error(actions[0])
+					}
+					if !actions[1].Matches("delete", "secrets") {
+						t.Error(actions[1])
+					}
+					if !actions[2].Matches("create", "secrets") {
+						t.Error(actions[2])
+					}
+					if !actions[3].Matches("get", "secrets") {
+						t.Error(actions[3])
+					}
+					if !actions[4].Matches("update", "secrets") {
+						t.Error(actions[4])
+					}
 				}
 
-				actual := actions[4].(clienttesting.UpdateAction).GetObject().(*corev1.Secret)
+				actual := actions[idx].(clienttesting.UpdateAction).GetObject().(*corev1.Secret)
 				if len(actual.Annotations) == 0 {
 					t.Errorf("expected certificates to be annotated")
 				}
@@ -307,29 +331,53 @@ func TestEnsureTargetCertKeyPair(t *testing.T) {
 				}
 				return caBundleSecret
 			},
-			verifyActions: func(t *testing.T, client *kubefake.Clientset) {
+			verifyActions: func(t *testing.T, updateOnly bool, client *kubefake.Clientset) {
+				lengthWant := 5
+				if updateOnly {
+					lengthWant = 4
+				}
+
 				actions := client.Actions()
-				if len(actions) != 5 {
+				if len(actions) != lengthWant {
 					t.Fatal(spew.Sdump(actions))
 				}
 
-				if !actions[0].Matches("get", "secrets") {
-					t.Error(actions[0])
-				}
-				if !actions[1].Matches("delete", "secrets") {
-					t.Error(actions[1])
-				}
-				if !actions[2].Matches("create", "secrets") {
-					t.Error(actions[2])
-				}
-				if !actions[3].Matches("get", "secrets") {
-					t.Error(actions[3])
-				}
-				if !actions[4].Matches("update", "secrets") {
-					t.Error(actions[4])
+				var idx int
+				switch updateOnly {
+				case true:
+					idx = 3
+					if !actions[0].Matches("get", "secrets") {
+						t.Error(actions[0])
+					}
+					if !actions[1].Matches("update", "secrets") {
+						t.Error(actions[1])
+					}
+					if !actions[2].Matches("get", "secrets") {
+						t.Error(actions[2])
+					}
+					if !actions[3].Matches("update", "secrets") {
+						t.Error(actions[3])
+					}
+				default:
+					idx = 4
+					if !actions[0].Matches("get", "secrets") {
+						t.Error(actions[0])
+					}
+					if !actions[1].Matches("delete", "secrets") {
+						t.Error(actions[1])
+					}
+					if !actions[2].Matches("create", "secrets") {
+						t.Error(actions[2])
+					}
+					if !actions[3].Matches("get", "secrets") {
+						t.Error(actions[3])
+					}
+					if !actions[4].Matches("update", "secrets") {
+						t.Error(actions[4])
+					}
 				}
 
-				actual := actions[4].(clienttesting.UpdateAction).GetObject().(*corev1.Secret)
+				actual := actions[idx].(clienttesting.UpdateAction).GetObject().(*corev1.Secret)
 				if len(actual.Annotations) == 0 {
 					t.Errorf("expected certificates to be annotated")
 				}
@@ -359,52 +407,55 @@ func TestEnsureTargetCertKeyPair(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	for _, b := range []bool{true, false} {
+		for _, test := range tests {
+			t.Run(fmt.Sprintf("%s/update-only/%t", test.name, b), func(t *testing.T) {
+				indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 
-			client := kubefake.NewSimpleClientset()
-			if startingObj := test.initialSecretFn(); startingObj != nil {
-				indexer.Add(startingObj)
-				client = kubefake.NewSimpleClientset(startingObj)
-			}
+				client := kubefake.NewSimpleClientset()
+				if startingObj := test.initialSecretFn(); startingObj != nil {
+					indexer.Add(startingObj)
+					client = kubefake.NewSimpleClientset(startingObj)
+				}
 
-			c := &RotatedSelfSignedCertKeySecret{
-				Namespace: "ns",
-				Validity:  24 * time.Hour,
-				Refresh:   12 * time.Hour,
-				Name:      "target-secret",
-				CertCreator: &ServingRotation{
-					Hostnames: func() []string { return []string{"foo", "bar"} },
-				},
+				c := &RotatedSelfSignedCertKeySecret{
+					Namespace: "ns",
+					Validity:  24 * time.Hour,
+					Refresh:   12 * time.Hour,
+					Name:      "target-secret",
+					CertCreator: &ServingRotation{
+						Hostnames: func() []string { return []string{"foo", "bar"} },
+					},
 
-				Client:        client.CoreV1(),
-				Lister:        corev1listers.NewSecretLister(indexer),
-				EventRecorder: events.NewInMemoryRecorder("test"),
-				AdditionalAnnotations: AdditionalAnnotations{
-					JiraComponent: "test",
-				},
-				Owner: &metav1.OwnerReference{
-					Name: "operator",
-				},
-			}
+					Client:        client.CoreV1(),
+					Lister:        corev1listers.NewSecretLister(indexer),
+					EventRecorder: events.NewInMemoryRecorder("test"),
+					AdditionalAnnotations: AdditionalAnnotations{
+						JiraComponent: "test",
+					},
+					Owner: &metav1.OwnerReference{
+						Name: "operator",
+					},
+					UseSecretUpdateOnly: b,
+				}
 
-			newCA, err := test.caFn()
-			if err != nil {
-				t.Fatal(err)
-			}
-			err = c.ensureTargetCertKeyPair(context.TODO(), newCA, newCA.Config.Certs)
-			switch {
-			case err != nil && len(test.expectedError) == 0:
-				t.Error(err)
-			case err != nil && !strings.Contains(err.Error(), test.expectedError):
-				t.Error(err)
-			case err == nil && len(test.expectedError) != 0:
-				t.Errorf("missing %q", test.expectedError)
-			}
+				newCA, err := test.caFn()
+				if err != nil {
+					t.Fatal(err)
+				}
+				err = c.ensureTargetCertKeyPair(context.TODO(), newCA, newCA.Config.Certs)
+				switch {
+				case err != nil && len(test.expectedError) == 0:
+					t.Error(err)
+				case err != nil && !strings.Contains(err.Error(), test.expectedError):
+					t.Error(err)
+				case err == nil && len(test.expectedError) != 0:
+					t.Errorf("missing %q", test.expectedError)
+				}
 
-			test.verifyActions(t, client)
-		})
+				test.verifyActions(t, b, client)
+			})
+		}
 	}
 }
 
@@ -469,7 +520,7 @@ func TestEnsureTargetSignerCertKeyPair(t *testing.T) {
 		initialSecretFn func() *corev1.Secret
 		caFn            func() (*crypto.CA, error)
 
-		verifyActions func(t *testing.T, client *kubefake.Clientset)
+		verifyActions func(t *testing.T, updateOnly bool, client *kubefake.Clientset)
 		expectedError string
 	}{
 		{
@@ -478,7 +529,7 @@ func TestEnsureTargetSignerCertKeyPair(t *testing.T) {
 				return newTestCACertificate(pkix.Name{CommonName: "signer-tests"}, int64(1), metav1.Duration{Duration: time.Hour * 24 * 60}, time.Now)
 			},
 			initialSecretFn: func() *corev1.Secret { return nil },
-			verifyActions: func(t *testing.T, client *kubefake.Clientset) {
+			verifyActions: func(t *testing.T, updateOnly bool, client *kubefake.Clientset) {
 				actions := client.Actions()
 				if len(actions) != 2 {
 					t.Fatal(spew.Sdump(actions))
@@ -526,7 +577,7 @@ func TestEnsureTargetSignerCertKeyPair(t *testing.T) {
 				}
 				return caBundleSecret
 			},
-			verifyActions: func(t *testing.T, client *kubefake.Clientset) {
+			verifyActions: func(t *testing.T, updateOnly bool, client *kubefake.Clientset) {
 				actions := client.Actions()
 				if len(actions) != 2 {
 					t.Fatal(spew.Sdump(actions))
@@ -559,45 +610,48 @@ func TestEnsureTargetSignerCertKeyPair(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	for _, b := range []bool{true, false} {
+		for _, test := range tests {
+			t.Run(fmt.Sprintf("%s/update-only/%t", test.name, b), func(t *testing.T) {
+				indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 
-			client := kubefake.NewSimpleClientset()
-			if startingObj := test.initialSecretFn(); startingObj != nil {
-				indexer.Add(startingObj)
-				client = kubefake.NewSimpleClientset(startingObj)
-			}
+				client := kubefake.NewSimpleClientset()
+				if startingObj := test.initialSecretFn(); startingObj != nil {
+					indexer.Add(startingObj)
+					client = kubefake.NewSimpleClientset(startingObj)
+				}
 
-			c := &RotatedSelfSignedCertKeySecret{
-				Namespace: "ns",
-				Validity:  24 * time.Hour,
-				Refresh:   12 * time.Hour,
-				Name:      "target-secret",
-				CertCreator: &SignerRotation{
-					SignerName: "lower-signer",
-				},
+				c := &RotatedSelfSignedCertKeySecret{
+					Namespace: "ns",
+					Validity:  24 * time.Hour,
+					Refresh:   12 * time.Hour,
+					Name:      "target-secret",
+					CertCreator: &SignerRotation{
+						SignerName: "lower-signer",
+					},
 
-				Client:        client.CoreV1(),
-				Lister:        corev1listers.NewSecretLister(indexer),
-				EventRecorder: events.NewInMemoryRecorder("test"),
-			}
+					Client:              client.CoreV1(),
+					Lister:              corev1listers.NewSecretLister(indexer),
+					EventRecorder:       events.NewInMemoryRecorder("test"),
+					UseSecretUpdateOnly: b,
+				}
 
-			newCA, err := test.caFn()
-			if err != nil {
-				t.Fatal(err)
-			}
-			err = c.ensureTargetCertKeyPair(context.TODO(), newCA, newCA.Config.Certs)
-			switch {
-			case err != nil && len(test.expectedError) == 0:
-				t.Error(err)
-			case err != nil && !strings.Contains(err.Error(), test.expectedError):
-				t.Error(err)
-			case err == nil && len(test.expectedError) != 0:
-				t.Errorf("missing %q", test.expectedError)
-			}
+				newCA, err := test.caFn()
+				if err != nil {
+					t.Fatal(err)
+				}
+				err = c.ensureTargetCertKeyPair(context.TODO(), newCA, newCA.Config.Certs)
+				switch {
+				case err != nil && len(test.expectedError) == 0:
+					t.Error(err)
+				case err != nil && !strings.Contains(err.Error(), test.expectedError):
+					t.Error(err)
+				case err == nil && len(test.expectedError) != 0:
+					t.Errorf("missing %q", test.expectedError)
+				}
 
-			test.verifyActions(t, client)
-		})
+				test.verifyActions(t, b, client)
+			})
+		}
 	}
 }

--- a/pkg/operator/resource/resourceapply/core.go
+++ b/pkg/operator/resource/resourceapply/core.go
@@ -84,7 +84,15 @@ func ApplyConfigMap(ctx context.Context, client coreclientv1.ConfigMapsGetter, r
 
 // ApplySecret merges objectmeta, requires data
 func ApplySecret(ctx context.Context, client coreclientv1.SecretsGetter, recorder events.Recorder, required *corev1.Secret) (*corev1.Secret, bool, error) {
-	return ApplySecretImproved(ctx, client, recorder, required, noCache)
+	return applySecretImproved(ctx, client, recorder, required, noCache, false)
+}
+
+// ApplySecretDoNotUse is depreated and will be removed
+// Deprecated: DO NOT USE, it is intended as a short term hack for a very specific use case,
+// and it works in tandem with a particular carry patch applied to the openshift kube-apiserver.
+// Use ApplySecret instead.
+func ApplySecretDoNotUse(ctx context.Context, client coreclientv1.SecretsGetter, recorder events.Recorder, required *corev1.Secret) (*corev1.Secret, bool, error) {
+	return applySecretImproved(ctx, client, recorder, required, noCache, true)
 }
 
 // ApplyNamespace merges objectmeta, does not worry about anything else
@@ -347,6 +355,10 @@ func ApplyConfigMapImproved(ctx context.Context, client coreclientv1.ConfigMapsG
 
 // ApplySecret merges objectmeta, requires data
 func ApplySecretImproved(ctx context.Context, client coreclientv1.SecretsGetter, recorder events.Recorder, requiredInput *corev1.Secret, cache ResourceCache) (*corev1.Secret, bool, error) {
+	return applySecretImproved(ctx, client, recorder, requiredInput, cache, false)
+}
+
+func applySecretImproved(ctx context.Context, client coreclientv1.SecretsGetter, recorder events.Recorder, requiredInput *corev1.Secret, cache ResourceCache, updateOnly bool) (*corev1.Secret, bool, error) {
 	// copy the stringData to data.  Error on a data content conflict inside required.  This is usually a bug.
 
 	existing, err := client.Secrets(requiredInput.Namespace).Get(ctx, requiredInput.Name, metav1.GetOptions{})
@@ -426,6 +438,12 @@ func ApplySecretImproved(ctx context.Context, client coreclientv1.SecretsGetter,
 	 * https://github.com/kubernetes/kubernetes/blob/98e65951dccfd40d3b4f31949c2ab8df5912d93e/pkg/apis/core/validation/validation.go#L5048
 	 * We need to explicitly opt for delete+create in that case.
 	 */
+	if updateOnly {
+		actual, err = client.Secrets(required.Namespace).Update(ctx, existingCopy, metav1.UpdateOptions{})
+		reportUpdateEvent(recorder, existingCopy, err)
+		return actual, err == nil, err
+	}
+
 	if existingCopy.Type == existing.Type {
 		actual, err = client.Secrets(required.Namespace).Update(ctx, existingCopy, metav1.UpdateOptions{})
 		reportUpdateEvent(recorder, existingCopy, err)


### PR DESCRIPTION
back port of https://github.com/openshift/library-go/pull/1705
not clean, requires reviewing.