### PR TITLE
operator/bootstrap: expose IsBootstrapComplete function

### DIFF
--- a/pkg/operator/bootstrap/bootstrap.go
+++ b/pkg/operator/bootstrap/bootstrap.go
@@ -1,0 +1,44 @@
+package bootstrap
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/klog/v2"
+)
+
+// IsBootstrapComplete returns true if bootstrap has completed.
+//
+// This function checks if "bootstrap" config map in "kube-system" namespace
+// was created and has status equal to complete.
+//
+// The configmap is created when bootstrapping is done by the installer (https://github.com/openshift/installer/blob/911203db89a5728f00aaef011b5fb8add7abf646/data/data/bootstrap/files/usr/local/bin/report-progress.sh#L21)
+// As of today it is used by etcd and network operators
+//
+// As of today there is nothing else we could depend on to know if bootstrap was done.
+//
+// It is important to note that the bootstrap node might not be removed until additional conditions are met.
+// For example, on a SNO cluster, the installer waits until the CEO removes the bootstrap member from the etcd cluster.
+// In HA clusters, the bootstrap node is torn down as soon as the configmap is created with the appropriate content.
+func IsBootstrapComplete(configMapClient corev1listers.ConfigMapLister) (bool, error) {
+	bootstrapFinishedConfigMap, err := configMapClient.ConfigMaps("kube-system").Get("bootstrap")
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// If the resource was deleted (e.g. by an admin) after bootstrap is actually complete,
+			// this is a false negative.
+			klog.V(4).Infof("bootstrap considered incomplete because the kube-system/bootstrap configmap wasn't found")
+			return false, nil
+		}
+		// We don't know, give up quickly.
+		return false, fmt.Errorf("failed to get configmap %s/%s: %w", "kube-system", "bootstrap", err)
+	}
+
+	if status, ok := bootstrapFinishedConfigMap.Data["status"]; !ok || status != "complete" {
+		// do nothing, not torn down
+		klog.V(4).Infof("bootstrap considered incomplete because status is %q", status)
+		return false, nil
+	}
+
+	return true, nil
+}

--- a/pkg/operator/bootstrap/bootstrap_test.go
+++ b/pkg/operator/bootstrap/bootstrap_test.go
@@ -1,0 +1,75 @@
+package bootstrap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+var (
+	bootstrapComplete = &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "bootstrap", Namespace: "kube-system"},
+		Data:       map[string]string{"status": "complete"},
+	}
+
+	bootstrapProgressing = &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "bootstrap", Namespace: "kube-system"},
+		Data:       map[string]string{"status": "progressing"},
+	}
+
+	bootstrapNoStatus = &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "bootstrap", Namespace: "kube-system"},
+		Data:       map[string]string{"noStatus": "complete"},
+	}
+)
+
+func TestIsBootstrapComplete(t *testing.T) {
+	tests := map[string]struct {
+		bootstrapConfigMap *corev1.ConfigMap
+		expectComplete     bool
+		expectError        error
+	}{
+		"bootstrap complete": {
+			bootstrapConfigMap: bootstrapComplete,
+			expectComplete:     true,
+			expectError:        nil,
+		},
+		"bootstrap progressing": {
+			bootstrapConfigMap: bootstrapProgressing,
+			expectComplete:     false,
+			expectError:        nil,
+		},
+		"bootstrap no status": {
+			bootstrapConfigMap: bootstrapNoStatus,
+			expectComplete:     false,
+			expectError:        nil,
+		},
+		"bootstrap configmap missing": {
+			bootstrapConfigMap: nil,
+			expectComplete:     false,
+			expectError:        nil,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			if test.bootstrapConfigMap != nil {
+				if err := indexer.Add(test.bootstrapConfigMap); err != nil {
+					t.Fatal(err)
+				}
+			}
+			fakeConfigMapLister := corev1listers.NewConfigMapLister(indexer)
+
+			actualComplete, actualErr := IsBootstrapComplete(fakeConfigMapLister)
+
+			assert.Equal(t, test.expectComplete, actualComplete)
+			assert.Equal(t, test.expectError, actualErr)
+		})
+	}
+}


### PR DESCRIPTION
`IsBootstrapComplete` returns true if bootstrap has completed.

This function checks if `bootstrap` config map in `kube-system` namespace was created and has status equal to complete.
The configmap is created when bootstrapping is done [by the installer](https://github.com/openshift/installer/blob/911203db89a5728f00aaef011b5fb8add7abf646/data/data/bootstrap/files/usr/local/bin/report-progress.sh#L21). 
As of today it is used by [etcd](https://github.com/openshift/cluster-etcd-operator/blob/3d5483e1871ba147a692736c71645175a85769c4/pkg/operator/ceohelpers/bootstrap.go#L110) and [network](https://github.com/openshift/cluster-network-operator/blob/d25562d4a52220b7ed3be76bc848ba26eae068f2/pkg/network/node_identity.go#L37-L46) operators
As of today there is nothing else we could depend on to know if bootstrap was done.

The function was copied from https://github.com/openshift/cluster-etcd-operator/blob/3d5483e1871ba147a692736c71645175a85769c4/pkg/operator/ceohelpers/bootstrap.go#L110
I'm planing to update etcd-o to make use of this function.

Having this function in library-go allows other operators to implement logic that is different pre and post bootstrap.

xref: https://github.com/openshift/cluster-authentication-operator/pull/662
xref: https://github.com/openshift/library-go/pull/1694
xref: https://github.com/openshift/oauth-apiserver/pull/105