### PR TITLE
OCPBUGS-24195: controller/apiservice: support for defining multiple preconditions

### DIFF
--- a/pkg/operator/apiserver/controller/apiservice/apigroup.go
+++ b/pkg/operator/apiserver/controller/apiservice/apigroup.go
@@ -3,13 +3,13 @@ package apiservice
 import (
 	"context"
 	"fmt"
-	kubeinformers "k8s.io/client-go/informers"
 	"net/http"
 	"sync"
 	"time"
 
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	kubeinformers "k8s.io/client-go/informers"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/rest"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"

--- a/pkg/operator/apiserver/controller/apiservice/apigroup.go
+++ b/pkg/operator/apiserver/controller/apiservice/apigroup.go
@@ -3,6 +3,7 @@ package apiservice
 import (
 	"context"
 	"fmt"
+	kubeinformers "k8s.io/client-go/informers"
 	"net/http"
 	"sync"
 	"time"
@@ -15,6 +16,13 @@ import (
 
 	"github.com/openshift/library-go/pkg/operator/events"
 )
+
+func preconditionsForEnabledAPIServices(kubeInformers kubeinformers.SharedInformerFactory) func(apiServices []*apiregistrationv1.APIService) (bool, error) {
+	endpointsLister := kubeInformers.Core().V1().Endpoints().Lister()
+	return func(apiServices []*apiregistrationv1.APIService) (bool, error) {
+		return checkEndpointsPresence(endpointsLister, apiServices)
+	}
+}
 
 func checkEndpointsPresence(endpointsLister corev1listers.EndpointsLister, apiServices []*apiregistrationv1.APIService) (bool, error) {
 	type coordinate struct {

--- a/pkg/operator/apiserver/controller/apiservice/apigroup.go
+++ b/pkg/operator/apiserver/controller/apiservice/apigroup.go
@@ -9,62 +9,56 @@ import (
 
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	kubeinformers "k8s.io/client-go/informers"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/rest"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 
 	"github.com/openshift/library-go/pkg/operator/events"
 )
 
-func newEndpointPrecondition(kubeInformers kubeinformers.SharedInformerFactory) func(apiServices []*apiregistrationv1.APIService) (bool, error) {
-	// this is outside the func so it always registers before the informers start
-	endpointsLister := kubeInformers.Core().V1().Endpoints().Lister()
-
+func checkEndpointsPresence(endpointsLister corev1listers.EndpointsLister, apiServices []*apiregistrationv1.APIService) (bool, error) {
 	type coordinate struct {
 		namespace string
 		name      string
 	}
 
-	return func(apiServices []*apiregistrationv1.APIService) (bool, error) {
-
-		coordinates := []coordinate{}
-		for _, apiService := range apiServices {
-			curr := coordinate{namespace: apiService.Spec.Service.Namespace, name: apiService.Spec.Service.Name}
-			exists := false
-			for _, j := range coordinates {
-				if j == curr {
-					exists = true
-					break
-				}
-			}
-			if !exists {
-				coordinates = append(coordinates, curr)
+	coordinates := []coordinate{}
+	for _, apiService := range apiServices {
+		curr := coordinate{namespace: apiService.Spec.Service.Namespace, name: apiService.Spec.Service.Name}
+		exists := false
+		for _, j := range coordinates {
+			if j == curr {
+				exists = true
+				break
 			}
 		}
-
-		for _, curr := range coordinates {
-			endpoints, err := endpointsLister.Endpoints(curr.namespace).Get(curr.name)
-			if err != nil {
-				return false, err
-			}
-			if len(endpoints.Subsets) == 0 {
-				return false, nil
-			}
-
-			exists := false
-			for _, subset := range endpoints.Subsets {
-				if len(subset.Addresses) > 0 {
-					exists = true
-					break
-				}
-			}
-			if !exists {
-				return false, nil
-			}
+		if !exists {
+			coordinates = append(coordinates, curr)
 		}
-
-		return true, nil
 	}
+
+	for _, curr := range coordinates {
+		endpoints, err := endpointsLister.Endpoints(curr.namespace).Get(curr.name)
+		if err != nil {
+			return false, err
+		}
+		if len(endpoints.Subsets) == 0 {
+			return false, nil
+		}
+
+		exists := false
+		for _, subset := range endpoints.Subsets {
+			if len(subset.Addresses) > 0 {
+				exists = true
+				break
+			}
+		}
+		if !exists {
+			return false, nil
+		}
+	}
+
+	return true, nil
 }
 
 func checkDiscoveryForByAPIServices(ctx context.Context, recorder events.Recorder, restclient rest.Interface, apiServices []*apiregistrationv1.APIService) []string {

--- a/pkg/operator/apiserver/controller/apiservice/apiservice_controller.go
+++ b/pkg/operator/apiserver/controller/apiservice/apiservice_controller.go
@@ -55,7 +55,7 @@ func NewAPIServiceController(
 	informers ...factory.Informer,
 ) factory.Controller {
 	c := &APIServiceController{
-		preconditionForEnabledAPIServices: newEndpointPrecondition(kubeInformersForOperandNamespace),
+		preconditionForEnabledAPIServices: preconditionsForEnabledAPIServices(kubeInformersForOperandNamespace),
 		getAPIServicesToManageFn:          getAPIServicesToManageFunc,
 
 		operatorClient:          operatorClient,

--- a/pkg/operator/apiserver/controller/apiservice/apiservice_controller_test.go
+++ b/pkg/operator/apiserver/controller/apiservice/apiservice_controller_test.go
@@ -175,10 +175,10 @@ func TestAvailableStatus(t *testing.T) {
 				}
 			}
 			operator := &APIServiceController{
-				preconditionForEnabledAPIServices: func([]*apiregistrationv1.APIService) (bool, error) { return true, nil },
-				kubeClient:                        kubeClient,
-				operatorClient:                    fakeOperatorClient,
-				apiregistrationv1Client:           kubeAggregatorClient.ApiregistrationV1(),
+				preconditionsForEnabledAPIServices: func([]*apiregistrationv1.APIService) (bool, error) { return true, nil },
+				kubeClient:                         kubeClient,
+				operatorClient:                     fakeOperatorClient,
+				apiregistrationv1Client:            kubeAggregatorClient.ApiregistrationV1(),
 				getAPIServicesToManageFn: func() (enabled []*apiregistrationv1.APIService, disabled []*apiregistrationv1.APIService, err error) {
 					return []*apiregistrationv1.APIService{
 						{
@@ -265,11 +265,11 @@ func TestDisabledAPIService(t *testing.T) {
 	informerFactory := externalversions.NewSharedInformerFactory(kubeAggregatorClient, 10*time.Minute)
 
 	operator := &APIServiceController{
-		preconditionForEnabledAPIServices: func([]*apiregistrationv1.APIService) (bool, error) { return true, nil },
-		kubeClient:                        kubeClient,
-		operatorClient:                    fakeOperatorClient,
-		apiregistrationv1Client:           kubeAggregatorClient.ApiregistrationV1(),
-		apiservicelister:                  informerFactory.Apiregistration().V1().APIServices().Lister(),
+		preconditionsForEnabledAPIServices: func([]*apiregistrationv1.APIService) (bool, error) { return true, nil },
+		kubeClient:                         kubeClient,
+		operatorClient:                     fakeOperatorClient,
+		apiregistrationv1Client:            kubeAggregatorClient.ApiregistrationV1(),
+		apiservicelister:                   informerFactory.Apiregistration().V1().APIServices().Lister(),
 	}
 
 	stopCh := make(chan struct{})


### PR DESCRIPTION
This PR refactors `newEndpointPrecondition ` into `preconditionsForEnabledAPIServices` so that other preconditions can be defined.

I'm planing to use it in https://github.com/openshift/library-go/pull/1694 and later on in https://github.com/openshift/cluster-authentication-operator/pull/662