### PR TITLE
cert collection: skip secret if it contains bootstrap certs

### DIFF
--- a/pkg/certs/cert-inspection/certgraphanalysis/collection_options.go
+++ b/pkg/certs/cert-inspection/certgraphanalysis/collection_options.go
@@ -56,6 +56,19 @@ var (
 	}
 )
 
+func SkipBootstrapCerts(bootstrapIP string) *resourceFilteringOptions {
+	if bootstrapIP == "" {
+		return &resourceFilteringOptions{}
+	} else {
+		return &resourceFilteringOptions{
+			rejectSecretFn: func(secret *corev1.Secret) bool {
+				certHostNames, ok := secret.Annotations["auth.openshift.io/certificate-hostnames"]
+				return ok && strings.Contains(certHostNames, bootstrapIP)
+			},
+		}
+	}
+}
+
 type annotationOptions struct {
 	annotationKeys []string
 }


### PR DESCRIPTION
etcd leaves bootstrap certificates around, which cannot be anonymized in RewriteNodeIPs. This function receives bootstrap IP, fetched from an annotation in `etcd-endpoints-*` configmap in `openshift-etcd` namespace.

Tested in https://github.com/openshift/origin/pull/28657