### PR TITLE
WRKLDS-1167: tolerate node-role.kubernetes.io/control-plane:NoExecute 

### DIFF
--- a/pkg/operator/staticpod/controller/guard/manifests/guard-pod.yaml
+++ b/pkg/operator/staticpod/controller/guard/manifests/guard-pod.yaml
@@ -13,21 +13,7 @@ spec:
   priorityClassName: "system-cluster-critical"
   terminationGracePeriodSeconds: 3
   tolerations:
-    - key: node-role.kubernetes.io/control-plane
-      effect: NoExecute
-      operator: Exists
-    - key: node-role.kubernetes.io/master
-      effect: NoSchedule
-      operator: Exists
-    - key: node.kubernetes.io/not-ready
-      effect: NoExecute
-      operator: Exists
-    - key: node.kubernetes.io/unreachable
-      effect: NoExecute
-      operator: Exists
-    - key: node-role.kubernetes.io/etcd
-      operator: Exists
-      effect: NoSchedule
+    - operator: Exists
   containers:
     - name: guard
       image: # Value set by operator

--- a/pkg/operator/staticpod/controller/guard/manifests/guard-pod.yaml
+++ b/pkg/operator/staticpod/controller/guard/manifests/guard-pod.yaml
@@ -13,6 +13,9 @@ spec:
   priorityClassName: "system-cluster-critical"
   terminationGracePeriodSeconds: 3
   tolerations:
+    - key: node-role.kubernetes.io/control-plane
+      effect: NoExecute
+      operator: Exists
     - key: node-role.kubernetes.io/master
       effect: NoSchedule
       operator: Exists


### PR DESCRIPTION
Required to be able to advise customers to follow workflow described in https://github.com/openshift/enhancements/pull/1583. If they want to taint control-plane nodes to avoid any other thing to run there (while enforcing it further with validating admission policies), control plane workloads need to tolerate that taint.

installer-pods: already tolerate every taint

pruner-pods: already tolerate every taint

guard-pods: toleration to relevant NoExecute taint added

monitor-pods: already tolerate every taint