### PR TITLE
Avoid using sets when existing slices suffice

### DIFF
--- a/pkg/config/validation/general.go
+++ b/pkg/config/validation/general.go
@@ -5,9 +5,9 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"slices"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
@@ -126,5 +126,5 @@ func HostnameMatchSpecCandidates(hostname string) []string {
 
 // HostnameMatches returns true if the given hostname is matched by the given matchSpec
 func HostnameMatches(hostname string, matchSpec string) bool {
-	return sets.New(HostnameMatchSpecCandidates(hostname)...).Has(matchSpec)
+	return slices.Contains(HostnameMatchSpecCandidates(hostname), matchSpec)
 }

--- a/pkg/controller/factory/controller_context.go
+++ b/pkg/controller/factory/controller_context.go
@@ -96,6 +96,7 @@ func (c syncContext) enqueueKeys(keys ...string) {
 // (or its tombstone) is a namespace  and it matches a name of any namespaces
 // that we are interested in
 func namespaceChecker(interestingNamespaces []string) func(obj interface{}) bool {
+	// This is used for quick lookups in informers
 	interestingNamespacesSet := sets.New(interestingNamespaces...)
 
 	return func(obj interface{}) bool {

--- a/pkg/oauth/tokenrequest/request_token.go
+++ b/pkg/oauth/tokenrequest/request_token.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 
 	"github.com/RangelReale/osincli"
@@ -192,7 +193,7 @@ func (o *RequestTokenOptions) SetDefaultOsinConfig(clientID string, redirectURL 
 		config.RedirectUrl = *redirectURL
 	}
 
-	if !o.TokenFlow && sets.New(metadata.CodeChallengeMethodsSupported...).Has(pkce_s256) {
+	if !o.TokenFlow && slices.Contains(metadata.CodeChallengeMethodsSupported, pkce_s256) {
 		if err := osincli.PopulatePKCE(config); err != nil {
 			return err
 		}

--- a/pkg/operator/configobserver/featuregates/observe_featuregates_test.go
+++ b/pkg/operator/configobserver/featuregates/observe_featuregates_test.go
@@ -3,6 +3,7 @@ package featuregates
 import (
 	"errors"
 	"reflect"
+	"slices"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -167,6 +168,8 @@ func TestObserveFeatureFlags(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
+			// Sort the result for comparison with the expected result
+			slices.Sort(actual)
 			if !reflect.DeepEqual(tc.expectedResult, actual) {
 				t.Errorf("Unexpected features gates\n  got:      %v\n  expected: %v", actual, tc.expectedResult)
 			}

--- a/pkg/operator/encryption/controllers/prune_controller.go
+++ b/pkg/operator/encryption/controllers/prune_controller.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"slices"
 	"sort"
 	"time"
 
@@ -10,7 +11,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/apimachinery/pkg/util/sets"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/klog/v2"
 
@@ -160,9 +160,9 @@ NextEncryptionSecret:
 
 		// remove our finalizer if it is present
 		secret := s.DeepCopy()
-		if finalizers := sets.New(secret.Finalizers...); finalizers.Has(secrets.EncryptionSecretFinalizer) {
-			delete(finalizers, secrets.EncryptionSecretFinalizer)
-			secret.Finalizers = sets.List(finalizers)
+		idx := slices.Index(secret.Finalizers, secrets.EncryptionSecretFinalizer)
+		if idx > -1 {
+			secret.Finalizers = slices.Delete(secret.Finalizers, idx, idx+1)
 			var updateErr error
 			secret, updateErr = c.secretClient.Secrets("openshift-config-managed").Update(ctx, secret, metav1.UpdateOptions{})
 			deleteErrs = append(deleteErrs, updateErr)

--- a/pkg/operator/staticpod/prune/cmd.go
+++ b/pkg/operator/staticpod/prune/cmd.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -13,8 +14,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"k8s.io/klog/v2"
-
-	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 type PruneOptions struct {
@@ -77,8 +76,6 @@ func (o *PruneOptions) Validate() error {
 }
 
 func (o *PruneOptions) Run() error {
-	protectedIDs := sets.New(o.ProtectedRevisions...)
-
 	files, err := os.ReadDir(o.ResourceDir)
 	if err != nil {
 		return err
@@ -102,7 +99,7 @@ func (o *PruneOptions) Run() error {
 		}
 
 		// And is not protected...
-		if protected := protectedIDs.Has(revisionID); protected {
+		if protected := slices.Contains(o.ProtectedRevisions, revisionID); protected {
 			continue
 		}
 		// And is less than or equal to the maxEligibleRevisionID


### PR DESCRIPTION
Now that Go includes slice operations such as slices.Contains, some uses of sets are no longer useful. In particular, creating a set using a slice just to check whether the slice contains a specific item is more expensive than checking the slice directly.