### PR TITLE
API-1802: cert-rotation: allow specifying multiple target certs in CertRotationController

### DIFF
--- a/pkg/operator/certrotation/client_cert_rotation_controller.go
+++ b/pkg/operator/certrotation/client_cert_rotation_controller.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
+	"k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/openshift/library-go/pkg/controller/factory"
@@ -65,9 +67,8 @@ type CertRotationController struct {
 	RotatedSigningCASecret RotatedSigningCASecret
 	// CABundleConfigMap maintains a CA bundle config map, by adding new CA certs coming from rotatedSigningCASecret, and by removing expired old ones.
 	CABundleConfigMap CABundleConfigMap
-	// RotatedSelfSignedCertKeySecret rotates a key and cert signed by a signing CA and stores it in a secret.
-	RotatedSelfSignedCertKeySecret RotatedSelfSignedCertKeySecret
-
+	// RotatedTargetSecrets contains a list of key and cert signed by a signing CA to rotate.
+	RotatedTargetSecrets []RotatedSelfSignedCertKeySecret
 	// Plumbing:
 	StatusReporter StatusReporter
 }
@@ -81,11 +82,11 @@ func NewCertRotationController(
 	reporter StatusReporter,
 ) factory.Controller {
 	c := &CertRotationController{
-		Name:                           name,
-		RotatedSigningCASecret:         rotatedSigningCASecret,
-		CABundleConfigMap:              caBundleConfigMap,
-		RotatedSelfSignedCertKeySecret: rotatedSelfSignedCertKeySecret,
-		StatusReporter:                 reporter,
+		Name:                   name,
+		RotatedSigningCASecret: rotatedSigningCASecret,
+		CABundleConfigMap:      caBundleConfigMap,
+		RotatedTargetSecrets:   []RotatedSelfSignedCertKeySecret{rotatedSelfSignedCertKeySecret},
+		StatusReporter:         reporter,
 	}
 	return factory.New().
 		ResyncEvery(time.Minute).
@@ -102,6 +103,42 @@ func NewCertRotationController(
 			"CertRotationController", // don't change what is passed here unless you also remove the old FooDegraded condition
 			recorder.WithComponentSuffix("cert-rotation-controller").WithComponentSuffix(name),
 		)
+}
+
+func NewCertRotationControllerMultipleTargets(
+	name string,
+	rotatedSigningCASecret RotatedSigningCASecret,
+	caBundleConfigMap CABundleConfigMap,
+	rotatedTargetSecrets []RotatedSelfSignedCertKeySecret,
+	recorder events.Recorder,
+	reporter StatusReporter,
+) factory.Controller {
+	informers := sets.New[factory.Informer](
+		rotatedSigningCASecret.Informer.Informer(),
+		caBundleConfigMap.Informer.Informer(),
+	)
+
+	for _, target := range rotatedTargetSecrets {
+		informers = informers.Insert(target.Informer.Informer())
+	}
+
+	c := &CertRotationController{
+		Name:                   name,
+		RotatedSigningCASecret: rotatedSigningCASecret,
+		CABundleConfigMap:      caBundleConfigMap,
+		RotatedTargetSecrets:   rotatedTargetSecrets,
+		StatusReporter:         reporter,
+	}
+	return factory.New().
+		ResyncEvery(time.Minute).
+		WithSync(c.Sync).
+		WithInformers(
+			informers.UnsortedList()...,
+		).
+		WithPostStartHooks(
+			c.targetCertRecheckerPostRunHook,
+		).
+		ToController("MultipleTargetCertRotationController", recorder.WithComponentSuffix("cert-rotation-controller").WithComponentSuffix(name))
 }
 
 func (c CertRotationController) Sync(ctx context.Context, syncCtx factory.SyncContext) error {
@@ -125,7 +162,15 @@ func (c CertRotationController) Sync(ctx context.Context, syncCtx factory.SyncCo
 }
 
 func (c CertRotationController) getSigningCertKeyPairLocation() string {
-	return fmt.Sprintf("%s/%s", c.RotatedSelfSignedCertKeySecret.Namespace, c.RotatedSelfSignedCertKeySecret.Name)
+	var firstSecret RotatedSelfSignedCertKeySecret
+	if c.RotatedTargetSecrets == nil {
+		return ""
+	}
+	if len(c.RotatedTargetSecrets) == 0 {
+		return ""
+	}
+	firstSecret = c.RotatedTargetSecrets[0]
+	return fmt.Sprintf("%s/%s", firstSecret.Namespace, firstSecret.Name)
 }
 
 func (c CertRotationController) SyncWorker(ctx context.Context) error {
@@ -139,8 +184,14 @@ func (c CertRotationController) SyncWorker(ctx context.Context) error {
 		return err
 	}
 
-	if _, err := c.RotatedSelfSignedCertKeySecret.EnsureTargetCertKeyPair(ctx, signingCertKeyPair, cabundleCerts); err != nil {
-		return err
+	var errs []error
+	for _, secret := range c.RotatedTargetSecrets {
+		if _, err := secret.EnsureTargetCertKeyPair(ctx, signingCertKeyPair, cabundleCerts); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) != 0 {
+		return errors.NewAggregate(errs)
 	}
 
 	return nil
@@ -148,21 +199,20 @@ func (c CertRotationController) SyncWorker(ctx context.Context) error {
 
 func (c CertRotationController) targetCertRecheckerPostRunHook(ctx context.Context, syncCtx factory.SyncContext) error {
 	// If we have a need to force rechecking the cert, use this channel to do it.
-	refresher, ok := c.RotatedSelfSignedCertKeySecret.CertCreator.(TargetCertRechecker)
-	if !ok {
-		return nil
-	}
-	targetRefresh := refresher.RecheckChannel()
-	go wait.Until(func() {
-		for {
-			select {
-			case <-targetRefresh:
-				syncCtx.Queue().Add(factory.DefaultQueueKey)
-			case <-ctx.Done():
-				return
-			}
+	for _, target := range c.RotatedTargetSecrets {
+		if refresher, ok := target.CertCreator.(TargetCertRechecker); ok {
+			go wait.Until(func() {
+				for {
+					select {
+					case <-refresher.RecheckChannel():
+						syncCtx.Queue().Add(factory.DefaultQueueKey)
+					case <-ctx.Done():
+						return
+					}
+				}
+			}, time.Minute, ctx.Done())
 		}
-	}, time.Minute, ctx.Done())
+	}
 
 	<-ctx.Done()
 	return nil

--- a/pkg/operator/certrotation/client_cert_rotation_controller_test.go
+++ b/pkg/operator/certrotation/client_cert_rotation_controller_test.go
@@ -1,0 +1,419 @@
+package certrotation
+
+import (
+	"context"
+	"crypto/x509"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/crypto"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/events/eventstesting"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	clienttesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+)
+
+type fakeStatusReporter struct{}
+
+func (f *fakeStatusReporter) Report(ctx context.Context, controllerName string, syncErr error) (updated bool, updateErr error) {
+	return false, nil
+}
+
+type fakeTargetCertCreator struct {
+	name             string
+	hostnamesChanged chan struct{}
+	channelClosed    bool
+	callCount        int
+}
+
+func (f *fakeTargetCertCreator) NewCertificate(signer *crypto.CA, validity time.Duration) (*crypto.TLSCertificateConfig, error) {
+	return nil, nil
+}
+
+func (f *fakeTargetCertCreator) NeedNewTargetCertKeyPair(currentCertSecret *corev1.Secret, signer *crypto.CA, caBundleCerts []*x509.Certificate, refresh time.Duration, refreshOnlyWhenExpired bool, _ bool) string {
+	f.callCount += 1
+	return ""
+}
+
+func (f *fakeTargetCertCreator) SetAnnotations(cert *crypto.TLSCertificateConfig, annotations map[string]string) map[string]string {
+	return map[string]string{}
+}
+
+func (f *fakeTargetCertCreator) RecheckChannel() <-chan struct{} {
+	if !f.channelClosed {
+		return f.hostnamesChanged
+	} else {
+		f.channelClosed = true
+		close(f.hostnamesChanged)
+		return nil
+	}
+}
+
+func (f *fakeTargetCertCreator) triggerSync() {
+	f.hostnamesChanged <- struct{}{}
+}
+
+func TestCertRotationController(t *testing.T) {
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	client := kubefake.NewSimpleClientset()
+	controllerCtx, cancel := context.WithCancel(context.Background())
+
+	ns, signerName, caName, targetName := "ns", "test-signer", "test-ca", "test-target"
+	eventRecorder := events.NewInMemoryRecorder("test")
+	eventRecorder := events.NewInMemoryRecorder("test", clock.RealClock{})
+		JiraComponent: "test",
+	}
+	owner := &metav1.OwnerReference{
+		Name: "operator",
+	}
+
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(client, 1*time.Minute, informers.WithNamespace(ns))
+
+	signerSecret := RotatedSigningCASecret{
+		Namespace:             ns,
+		Name:                  signerName,
+		Validity:              24 * time.Hour,
+		Refresh:               12 * time.Hour,
+		Client:                client.CoreV1(),
+		Lister:                corev1listers.NewSecretLister(indexer),
+		Informer:              informerFactory.Core().V1().Secrets(),
+		EventRecorder:         eventRecorder,
+		AdditionalAnnotations: additionalAnnotations,
+		Owner:                 owner,
+		UseSecretUpdateOnly:   true,
+	caBundleConfigMap := CABundleConfigMap{
+		Namespace:             ns,
+		Name:                  caName,
+		Client:                client.CoreV1(),
+		Lister:                corev1listers.NewConfigMapLister(indexer),
+		EventRecorder:         eventRecorder,
+		Informer:              informerFactory.Core().V1().ConfigMaps(),
+		AdditionalAnnotations: additionalAnnotations,
+		Owner:                 owner,
+	}
+	targetSecret := RotatedSelfSignedCertKeySecret{
+		Name:      targetName,
+		Namespace: ns,
+		Validity:  24 * time.Hour,
+		Refresh:   12 * time.Hour,
+		CertCreator: &ServingRotation{
+			Hostnames: func() []string { return []string{"foo", "bar"} },
+		},
+		Client:                client.CoreV1(),
+		Informer:              informerFactory.Core().V1().Secrets(),
+		Lister:                corev1listers.NewSecretLister(indexer),
+		EventRecorder:         eventRecorder,
+		AdditionalAnnotations: additionalAnnotations,
+		Owner:                 owner,
+		UseSecretUpdateOnly:   true,
+
+	c := NewCertRotationController("operator", signerSecret, caBundleConfigMap, targetSecret, eventRecorder, &fakeStatusReporter{})
+
+	time.AfterFunc(1*time.Second, func() {
+		cancel()
+	})
+	c.Run(controllerCtx, 1)
+
+	syncCtx := factory.NewSyncContext("test", eventstesting.NewTestingEventRecorder(t))
+	err := c.Sync(controllerCtx, syncCtx)
+	if err != nil {
+		t.Errorf("sync error: %v", err)
+	}
+
+	if len(actions) != 3 {
+	if len(actions) != 6 {
+		t.Fatal(spew.Sdump(actions))
+	}
+	if !actions[0].Matches("create", "secrets") {
+	if !actions[0].Matches("get", "secrets") {
+		t.Error(actions[0])
+	if !actions[1].Matches("create", "configmaps") {
+	if !actions[1].Matches("create", "secrets") {
+		t.Error(actions[1])
+	if !actions[2].Matches("create", "secrets") {
+	if !actions[2].Matches("get", "configmaps") {
+		t.Error(actions[2])
+	actualSignerSecret := actions[0].(clienttesting.CreateAction).GetObject().(*corev1.Secret)
+	actualSignerSecret := actions[1].(clienttesting.CreateAction).GetObject().(*corev1.Secret)
+	if actualSignerSecret.Name != signerName {
+		t.Errorf("expected signer secret name to be %s, got %s", signerName, actualSignerSecret.Name)
+	}
+	actualCABundleConfigMap := actions[3].(clienttesting.CreateAction).GetObject().(*corev1.ConfigMap)
+	if actualCABundleConfigMap.Name != caName {
+		t.Errorf("expected CA bundle configmap name to be %s, got %s", signerName, actualCABundleConfigMap.Name)
+	}
+	actualTargetSecret := actions[5].(clienttesting.CreateAction).GetObject().(*corev1.Secret)
+	if actualTargetSecret.Name != targetName {
+		t.Errorf("expected target secret name to be %s, got %s", signerName, actualTargetSecret.Name)
+	}
+}
+	eventRecorder := events.NewInMemoryRecorder("test", clock.RealClock{})
+func TestCertRotationControllerMultipleTargets(t *testing.T) {
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	client := kubefake.NewSimpleClientset()
+	controllerCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ns, signerName, caName, targetFirstName, targetSecondName := "ns", "test-signer", "test-ca", "test-target-one", "test-target-two"
+	eventRecorder := events.NewInMemoryRecorder("test")
+	additionalAnnotations := AdditionalAnnotations{
+		JiraComponent: "test",
+	}
+	owner := &metav1.OwnerReference{
+		Name: "operator",
+	}
+
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(client, 1*time.Minute, informers.WithNamespace(ns))
+
+	signerSecret := RotatedSigningCASecret{
+		Namespace:             ns,
+		Name:                  signerName,
+		Refresh:               12 * time.Hour,
+		Client:                client.CoreV1(),
+		Lister:                corev1listers.NewSecretLister(indexer),
+		Informer:              informerFactory.Core().V1().Secrets(),
+		EventRecorder:         eventRecorder,
+		AdditionalAnnotations: additionalAnnotations,
+		Owner:                 owner,
+		UseSecretUpdateOnly:   true,
+	}
+	caBundleConfigMap := CABundleConfigMap{
+		Namespace:             ns,
+		Name:                  caName,
+		Client:                client.CoreV1(),
+		Lister:                corev1listers.NewConfigMapLister(indexer),
+		EventRecorder:         eventRecorder,
+		Informer:              informerFactory.Core().V1().ConfigMaps(),
+		AdditionalAnnotations: additionalAnnotations,
+		Owner:                 owner,
+	}
+	targetFirstSecret := RotatedSelfSignedCertKeySecret{
+		Name:      targetFirstName,
+		Namespace: ns,
+		Validity:  24 * time.Hour,
+		Refresh:   12 * time.Hour,
+		CertCreator: &ServingRotation{
+		},
+		Client:                client.CoreV1(),
+		Informer:              informerFactory.Core().V1().Secrets(),
+		Lister:                corev1listers.NewSecretLister(indexer),
+		EventRecorder:         eventRecorder,
+		AdditionalAnnotations: additionalAnnotations,
+		Owner:                 owner,
+		UseSecretUpdateOnly:   true,
+	}
+	targetSecondSecret := RotatedSelfSignedCertKeySecret{
+		Name:      targetSecondName,
+		Namespace: ns,
+		Validity:  24 * time.Hour,
+		Refresh:   12 * time.Hour,
+		CertCreator: &ServingRotation{
+		},
+		Client:                client.CoreV1(),
+		Informer:              informerFactory.Core().V1().Secrets(),
+		Lister:                corev1listers.NewSecretLister(indexer),
+		EventRecorder:         eventRecorder,
+		AdditionalAnnotations: additionalAnnotations,
+		Owner:                 owner,
+		UseSecretUpdateOnly:   true,
+	}
+
+	c := NewCertRotationControllerMultipleTargets("operator", signerSecret, caBundleConfigMap, []RotatedSelfSignedCertKeySecret{targetFirstSecret, targetSecondSecret}, eventRecorder, &fakeStatusReporter{})
+
+	time.AfterFunc(1*time.Second, func() {
+		cancel()
+	})
+	c.Run(controllerCtx, 1)
+
+	// Ensure we don't leak goroutines
+	initialNumGoroutine := runtime.NumGoroutine()
+
+	syncCtx := factory.NewSyncContext("test", eventstesting.NewTestingEventRecorder(t))
+	err := c.Sync(controllerCtx, syncCtx)
+	if err != nil {
+		t.Errorf("sync error: %v", err)
+	}
+
+	actions := client.Actions()
+	if len(actions) != 8 {
+		t.Fatal(spew.Sdump(actions))
+	}
+
+	if !actions[0].Matches("get", "secrets") {
+		t.Error(actions[0])
+	}
+	if len(actions) != 4 {
+		t.Error(actions[1])
+	}
+	if !actions[2].Matches("get", "configmaps") {
+	if !actions[0].Matches("create", "secrets") {
+	}
+	if !actions[3].Matches("create", "configmaps") {
+	if !actions[1].Matches("create", "configmaps") {
+	}
+	if !actions[4].Matches("get", "secrets") {
+	if !actions[2].Matches("create", "secrets") {
+	}
+	if !actions[5].Matches("create", "secrets") {
+	if !actions[3].Matches("create", "secrets") {
+	}
+	if !actions[6].Matches("get", "secrets") {
+<<<<<<< HEAD
+		t.Error(actions[6])
+	}
+	if !actions[7].Matches("create", "secrets") {
+		t.Error(actions[7])
+	}
+	actualSignerSecret := actions[1].(clienttesting.CreateAction).GetObject().(*corev1.Secret)
+	if actualSignerSecret.Name != signerName {
+		t.Errorf("expected signer secret name to be %s, got %s", signerName, actualSignerSecret.Name)
+	}
+	actualCABundleConfigMap := actions[3].(clienttesting.CreateAction).GetObject().(*corev1.ConfigMap)
+	if actualCABundleConfigMap.Name != caName {
+		t.Errorf("expected CA bundle configmap name to be %s, got %s", signerName, actualCABundleConfigMap.Name)
+	}
+	actualFirstTargetSecret := actions[5].(clienttesting.CreateAction).GetObject().(*corev1.Secret)
+	if actualFirstTargetSecret.Name != targetFirstName {
+		t.Errorf("expected first target secret name to be %s, got %s", signerName, actualFirstTargetSecret.Name)
+	}
+	actualSecondTargetSecret := actions[7].(clienttesting.CreateAction).GetObject().(*corev1.Secret)
+	if actualSecondTargetSecret.Name != targetSecondName {
+		t.Errorf("expected second target secret name to be %s, got %s", signerName, actualFirstTargetSecret.Name)
+	}
+	currentNumGoroutine := runtime.NumGoroutine()
+	if currentNumGoroutine != initialNumGoroutine {
+		t.Errorf("Goroutine leak detected, expected %d but was %d", initialNumGoroutine, currentNumGoroutine)
+	}
+}
+	eventRecorder := events.NewInMemoryRecorder("test", clock.RealClock{})
+func TestCertRotationControllerMultipleTargetsPostRunHooks(t *testing.T) {
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	client := kubefake.NewSimpleClientset()
+	controllerCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ns, signerName, caName, targetFirstName, targetSecondName := "ns", "test-signer", "test-ca", "test-target-one", "test-target-two"
+	eventRecorder := events.NewInMemoryRecorder("test")
+	additionalAnnotations := AdditionalAnnotations{
+		JiraComponent: "test",
+	}
+	owner := &metav1.OwnerReference{
+		Name: "operator",
+	}
+
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(client, 1*time.Minute, informers.WithNamespace(ns))
+
+	firstTargetCertCreator := &fakeTargetCertCreator{name: "first", hostnamesChanged: make(chan struct{}, 1)}
+	secondTargetCertCreator := &fakeTargetCertCreator{name: "second", hostnamesChanged: make(chan struct{}, 1)}
+
+	signerSecret := RotatedSigningCASecret{
+		Namespace:             ns,
+		Name:                  signerName,
+		Refresh:               12 * time.Hour,
+		Client:                client.CoreV1(),
+		Lister:                corev1listers.NewSecretLister(indexer),
+		Informer:              informerFactory.Core().V1().Secrets(),
+		EventRecorder:         eventRecorder,
+		AdditionalAnnotations: additionalAnnotations,
+		Owner:                 owner,
+		UseSecretUpdateOnly:   true,
+	}
+	caBundleConfigMap := CABundleConfigMap{
+		Namespace:             ns,
+		Name:                  caName,
+		Client:                client.CoreV1(),
+		Lister:                corev1listers.NewConfigMapLister(indexer),
+		EventRecorder:         eventRecorder,
+		Informer:              informerFactory.Core().V1().ConfigMaps(),
+		AdditionalAnnotations: additionalAnnotations,
+		Owner:                 owner,
+	}
+	targetFirstSecret := RotatedSelfSignedCertKeySecret{
+		Name:                  targetFirstName,
+		Namespace:             ns,
+		Validity:              24 * time.Hour,
+		CertCreator:           firstTargetCertCreator,
+		Client:                client.CoreV1(),
+		Informer:              informerFactory.Core().V1().Secrets(),
+		Lister:                corev1listers.NewSecretLister(indexer),
+		EventRecorder:         eventRecorder,
+		AdditionalAnnotations: additionalAnnotations,
+		Owner:                 owner,
+		UseSecretUpdateOnly:   true,
+	}
+	targetSecondSecret := RotatedSelfSignedCertKeySecret{
+		Name:                  targetSecondName,
+		Namespace:             ns,
+		Validity:              24 * time.Hour,
+		CertCreator:           secondTargetCertCreator,
+		Client:                client.CoreV1(),
+		Informer:              informerFactory.Core().V1().Secrets(),
+		Lister:                corev1listers.NewSecretLister(indexer),
+		EventRecorder:         eventRecorder,
+		AdditionalAnnotations: additionalAnnotations,
+		Owner:                 owner,
+		UseSecretUpdateOnly:   true,
+	}
+
+	// Ensure we don't leak goroutines
+	initialNumGoroutine := runtime.NumGoroutine()
+
+	c := NewCertRotationControllerMultipleTargets("operator", signerSecret, caBundleConfigMap, []RotatedSelfSignedCertKeySecret{targetFirstSecret, targetSecondSecret}, eventRecorder, &fakeStatusReporter{})
+
+	informerFactory.Start(controllerCtx.Done())
+	hasSecretSynced := cache.WaitForCacheSync(controllerCtx.Done(), informerFactory.Core().V1().Secrets().Informer().HasSynced)
+	if hasSecretSynced != true {
+		t.Errorf("caches for secrets didn't sync")
+	}
+	hasConfigMapsSynced := cache.WaitForCacheSync(controllerCtx.Done(), informerFactory.Core().V1().ConfigMaps().Informer().HasSynced)
+	if hasConfigMapsSynced != true {
+		t.Errorf("caches for configmap didn't sync")
+	}
+
+	time.AfterFunc(1*time.Second, func() {
+		cancel()
+	})
+	firstTargetCertCreator.triggerSync()
+	secondTargetCertCreator.triggerSync()
+	c.Run(controllerCtx, 1)
+
+	// Ensure both target certs have been called exactly three times
+	// initial sync and two hook calls for target certs
+||||||| parent of f7056aa9b (fixup! cert-rotation: allow specifying multiple target certs in CertRotationController)
+		t.Error(actions[6])
+	}
+	if !actions[7].Matches("create", "secrets") {
+		t.Error(actions[7])
+	}
+	actualSignerSecret := actions[1].(clienttesting.CreateAction).GetObject().(*corev1.Secret)
+	if actualSignerSecret.Name != signerName {
+		t.Errorf("expected signer secret name to be %s, got %s", signerName, actualSignerSecret.Name)
+	}
+	actualCABundleConfigMap := actions[3].(clienttesting.CreateAction).GetObject().(*corev1.ConfigMap)
+	if actualCABundleConfigMap.Name != caName {
+		t.Errorf("expected CA bundle configmap name to be %s, got %s", signerName, actualCABundleConfigMap.Name)
+	// initial sync and two hook calls for target certs
+=======
+	actualSignerSecret := actions[0].(clienttesting.CreateAction).GetObject().(*corev1.Secret)
+>>>>>>> f7056aa9b (fixup! cert-rotation: allow specifying multiple target certs in CertRotationController)
+	// TODO[vrutkovs]: informers make unpredictable number of calls
+	if firstTargetCertCreator.callCount < 3 {
+		t.Errorf("first target cert was expected to be synced three times but was called %d times", firstTargetCertCreator.callCount)
+	actualCABundleConfigMap := actions[1].(clienttesting.CreateAction).GetObject().(*corev1.ConfigMap)
+	if secondTargetCertCreator.callCount < 3 {
+		t.Errorf("second target cert was expected to be synced three times but was called %d times", secondTargetCertCreator.callCount)
+	}
+	actualFirstTargetSecret := actions[2].(clienttesting.CreateAction).GetObject().(*corev1.Secret)
+	currentNumGoroutine := runtime.NumGoroutine()
+	if currentNumGoroutine != initialNumGoroutine {
+		t.Errorf("Goroutine leak detected, expected %d but was %d", initialNumGoroutine, currentNumGoroutine)
+	actualSecondTargetSecret := actions[3].(clienttesting.CreateAction).GetObject().(*corev1.Secret)
+}

--- a/pkg/operator/certrotation/client_cert_rotation_controller_test.go
+++ b/pkg/operator/certrotation/client_cert_rotation_controller_test.go
@@ -119,7 +119,9 @@ func TestCertRotationController(t *testing.T) {
 		Owner:                 owner,
 	}
 
-	c := NewCertRotationController("operator", signerSecret, caBundleConfigMap, targetSecret, eventRecorder, &fakeStatusReporter{})
+	controlledSecrets := []metav1.ObjectMeta{}
+	controlledConfigMaps := []metav1.ObjectMeta{}
+	c := NewCertRotationController("operator", signerSecret, caBundleConfigMap, targetSecret, eventRecorder, &fakeStatusReporter{}, &controlledSecrets, &controlledConfigMaps)
 
 	time.AfterFunc(1*time.Second, func() {
 		cancel()
@@ -220,8 +222,10 @@ func TestCertRotationControllerIdempotent(t *testing.T) {
 		Owner:                 owner,
 	}
 
+	controlledSecrets := []metav1.ObjectMeta{}
+	controlledConfigMaps := []metav1.ObjectMeta{}
 	// Run sync once to get signer / cabundle / target filled up
-	c := NewCertRotationController("operator", signerSecret, caBundleConfigMap, targetSecret, eventRecorder, &fakeStatusReporter{})
+	c := NewCertRotationController("operator", signerSecret, caBundleConfigMap, targetSecret, eventRecorder, &fakeStatusReporter{}, &controlledSecrets, &controlledConfigMaps)
 	syncCtx := factory.NewSyncContext("test", eventstesting.NewTestingEventRecorder(t))
 	err := c.Sync(controllerCtx, syncCtx)
 	if err != nil {
@@ -319,8 +323,10 @@ func TestCertRotationControllerSignerUpdate(t *testing.T) {
 		Owner:                 owner,
 	}
 
+	controlledSecrets := []metav1.ObjectMeta{}
+	controlledConfigMaps := []metav1.ObjectMeta{}
 	// Run sync once to get signer / cabundle / target filled up
-	c := NewCertRotationController("operator", signerSecret, caBundleConfigMap, targetSecret, eventRecorder, &fakeStatusReporter{})
+	c := NewCertRotationController("operator", signerSecret, caBundleConfigMap, targetSecret, eventRecorder, &fakeStatusReporter{}, &controlledSecrets, &controlledConfigMaps)
 	syncCtx := factory.NewSyncContext("test", eventstesting.NewTestingEventRecorder(t))
 	err := c.Sync(controllerCtx, syncCtx)
 	if err != nil {
@@ -460,8 +466,10 @@ func TestCertRotationControllerFilterExpiredSigners(t *testing.T) {
 		Owner:                 owner,
 	}
 
+	controlledSecrets := []metav1.ObjectMeta{}
+	controlledConfigMaps := []metav1.ObjectMeta{}
 	// Run sync once to get signer / cabundle / target filled up
-	c := NewCertRotationController("operator", signerSecret, caBundleConfigMap, targetSecret, eventRecorder, &fakeStatusReporter{})
+	c := NewCertRotationController("operator", signerSecret, caBundleConfigMap, targetSecret, eventRecorder, &fakeStatusReporter{}, &controlledSecrets, &controlledConfigMaps)
 	syncCtx := factory.NewSyncContext("test", eventstesting.NewTestingEventRecorder(t))
 	err := c.Sync(controllerCtx, syncCtx)
 	if err != nil {
@@ -602,8 +610,10 @@ func TestCertRotationControllerParallelUpdate(t *testing.T) {
 		Owner:                 owner,
 	}
 
+	controlledSecrets := []metav1.ObjectMeta{}
+	controlledConfigMaps := []metav1.ObjectMeta{}
 	syncCtx := factory.NewSyncContext("test", eventstesting.NewTestingEventRecorder(t))
-	c1 := NewCertRotationController("c1", signerSecret, caBundleConfigMap, targetSecret, eventRecorder, &fakeStatusReporter{})
+	c1 := NewCertRotationController("c1", signerSecret, caBundleConfigMap, targetSecret, eventRecorder, &fakeStatusReporter{}, &controlledSecrets, &controlledConfigMaps)
 
 	// Sync first controller to get first copy of signer/cabundle
 	err := c1.Sync(controllerCtx, syncCtx)
@@ -672,7 +682,9 @@ func TestCertRotationControllerParallelUpdate(t *testing.T) {
 			Owner:                 owner,
 		}
 		name := fmt.Sprintf("c%d", i)
-		ctrl := NewCertRotationController(name, signerSecret, caBundleConfigMap, targetNewSecret, eventRecorder, &fakeStatusReporter{})
+		controlledSecrets := []metav1.ObjectMeta{}
+		controlledConfigMaps := []metav1.ObjectMeta{}
+		ctrl := NewCertRotationController(name, signerSecret, caBundleConfigMap, targetNewSecret, eventRecorder, &fakeStatusReporter{}, &controlledSecrets, &controlledConfigMaps)
 		controllers[name] = ctrl
 	}
 
@@ -797,7 +809,9 @@ func TestCertRotationControllerMultipleTargets(t *testing.T) {
 		Owner:                 owner,
 	}
 
-	c := NewCertRotationControllerMultipleTargets("operator", signerSecret, caBundleConfigMap, []RotatedSelfSignedCertKeySecret{targetFirstSecret, targetSecondSecret}, eventRecorder, &fakeStatusReporter{})
+	controlledSecrets := []metav1.ObjectMeta{}
+	controlledConfigMaps := []metav1.ObjectMeta{}
+	c := NewCertRotationControllerMultipleTargets("operator", signerSecret, caBundleConfigMap, []RotatedSelfSignedCertKeySecret{targetFirstSecret, targetSecondSecret}, eventRecorder, &fakeStatusReporter{}, &controlledSecrets, &controlledConfigMaps)
 
 	time.AfterFunc(1*time.Second, func() {
 		cancel()

--- a/pkg/operator/certrotation/client_cert_rotation_controller_test.go
+++ b/pkg/operator/certrotation/client_cert_rotation_controller_test.go
@@ -3,7 +3,10 @@ package certrotation
 import (
 	"context"
 	"crypto/x509"
+	"fmt"
 	"runtime"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -19,6 +22,7 @@ import (
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/clock"
 )
 
 type fakeStatusReporter struct{}
@@ -67,8 +71,8 @@ func TestCertRotationController(t *testing.T) {
 	controllerCtx, cancel := context.WithCancel(context.Background())
 
 	ns, signerName, caName, targetName := "ns", "test-signer", "test-ca", "test-target"
-	eventRecorder := events.NewInMemoryRecorder("test")
 	eventRecorder := events.NewInMemoryRecorder("test", clock.RealClock{})
+	additionalAnnotations := AdditionalAnnotations{
 		JiraComponent: "test",
 	}
 	owner := &metav1.OwnerReference{
@@ -88,7 +92,7 @@ func TestCertRotationController(t *testing.T) {
 		EventRecorder:         eventRecorder,
 		AdditionalAnnotations: additionalAnnotations,
 		Owner:                 owner,
-		UseSecretUpdateOnly:   true,
+	}
 	caBundleConfigMap := CABundleConfigMap{
 		Namespace:             ns,
 		Name:                  caName,
@@ -113,14 +117,13 @@ func TestCertRotationController(t *testing.T) {
 		EventRecorder:         eventRecorder,
 		AdditionalAnnotations: additionalAnnotations,
 		Owner:                 owner,
-		UseSecretUpdateOnly:   true,
+	}
 
 	c := NewCertRotationController("operator", signerSecret, caBundleConfigMap, targetSecret, eventRecorder, &fakeStatusReporter{})
 
 	time.AfterFunc(1*time.Second, func() {
 		cancel()
 	})
-	c.Run(controllerCtx, 1)
 
 	syncCtx := factory.NewSyncContext("test", eventstesting.NewTestingEventRecorder(t))
 	err := c.Sync(controllerCtx, syncCtx)
@@ -128,42 +131,48 @@ func TestCertRotationController(t *testing.T) {
 		t.Errorf("sync error: %v", err)
 	}
 
+	actions := client.Actions()
 	if len(actions) != 3 {
-	if len(actions) != 6 {
 		t.Fatal(spew.Sdump(actions))
 	}
+
 	if !actions[0].Matches("create", "secrets") {
-	if !actions[0].Matches("get", "secrets") {
 		t.Error(actions[0])
+	}
 	if !actions[1].Matches("create", "configmaps") {
-	if !actions[1].Matches("create", "secrets") {
 		t.Error(actions[1])
+	}
 	if !actions[2].Matches("create", "secrets") {
-	if !actions[2].Matches("get", "configmaps") {
 		t.Error(actions[2])
+	}
 	actualSignerSecret := actions[0].(clienttesting.CreateAction).GetObject().(*corev1.Secret)
-	actualSignerSecret := actions[1].(clienttesting.CreateAction).GetObject().(*corev1.Secret)
 	if actualSignerSecret.Name != signerName {
 		t.Errorf("expected signer secret name to be %s, got %s", signerName, actualSignerSecret.Name)
 	}
-	actualCABundleConfigMap := actions[3].(clienttesting.CreateAction).GetObject().(*corev1.ConfigMap)
+	actualSignerContent := actualSignerSecret.Data["tls.crt"]
+	actualCABundleConfigMap := actions[1].(clienttesting.CreateAction).GetObject().(*corev1.ConfigMap)
 	if actualCABundleConfigMap.Name != caName {
-		t.Errorf("expected CA bundle configmap name to be %s, got %s", signerName, actualCABundleConfigMap.Name)
+		t.Errorf("expected CA bundle configmap name to be %s, got %s", caName, actualCABundleConfigMap.Name)
 	}
-	actualTargetSecret := actions[5].(clienttesting.CreateAction).GetObject().(*corev1.Secret)
+	actualCABundleContent := actualCABundleConfigMap.Data["ca-bundle.crt"]
+	actualTargetSecret := actions[2].(clienttesting.CreateAction).GetObject().(*corev1.Secret)
 	if actualTargetSecret.Name != targetName {
-		t.Errorf("expected target secret name to be %s, got %s", signerName, actualTargetSecret.Name)
+		t.Errorf("expected target secret name to be %s, got %s", targetName, actualTargetSecret.Name)
+	}
+	// Verify that CA bundle is equivalent to the signer
+	if string(actualSignerContent) != actualCABundleContent {
+		t.Errorf("expected CA bundle to be equivalent to the signer\n signer:\n%s\n, ca bundle:\n %s", string(actualSignerContent), actualCABundleContent)
 	}
 }
-	eventRecorder := events.NewInMemoryRecorder("test", clock.RealClock{})
-func TestCertRotationControllerMultipleTargets(t *testing.T) {
+
+func TestCertRotationControllerIdempotent(t *testing.T) {
 	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	client := kubefake.NewSimpleClientset()
 	controllerCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ns, signerName, caName, targetFirstName, targetSecondName := "ns", "test-signer", "test-ca", "test-target-one", "test-target-two"
-	eventRecorder := events.NewInMemoryRecorder("test")
+	ns, signerName, caName, targetName := "ns", "test-signer", "test-ca", "test-target"
+	eventRecorder := events.NewInMemoryRecorder("test", clock.RealClock{})
 	additionalAnnotations := AdditionalAnnotations{
 		JiraComponent: "test",
 	}
@@ -176,6 +185,7 @@ func TestCertRotationControllerMultipleTargets(t *testing.T) {
 	signerSecret := RotatedSigningCASecret{
 		Namespace:             ns,
 		Name:                  signerName,
+		Validity:              24 * time.Hour,
 		Refresh:               12 * time.Hour,
 		Client:                client.CoreV1(),
 		Lister:                corev1listers.NewSecretLister(indexer),
@@ -183,7 +193,568 @@ func TestCertRotationControllerMultipleTargets(t *testing.T) {
 		EventRecorder:         eventRecorder,
 		AdditionalAnnotations: additionalAnnotations,
 		Owner:                 owner,
-		UseSecretUpdateOnly:   true,
+	}
+	caBundleConfigMap := CABundleConfigMap{
+		Namespace:             ns,
+		Name:                  caName,
+		Client:                client.CoreV1(),
+		Lister:                corev1listers.NewConfigMapLister(indexer),
+		EventRecorder:         eventRecorder,
+		Informer:              informerFactory.Core().V1().ConfigMaps(),
+		AdditionalAnnotations: additionalAnnotations,
+		Owner:                 owner,
+	}
+	targetSecret := RotatedSelfSignedCertKeySecret{
+		Name:      targetName,
+		Namespace: ns,
+		Validity:  24 * time.Hour,
+		Refresh:   12 * time.Hour,
+		CertCreator: &ServingRotation{
+			Hostnames: func() []string { return []string{"foo", "bar"} },
+		},
+		Client:                client.CoreV1(),
+		Informer:              informerFactory.Core().V1().Secrets(),
+		Lister:                corev1listers.NewSecretLister(indexer),
+		EventRecorder:         eventRecorder,
+		AdditionalAnnotations: additionalAnnotations,
+		Owner:                 owner,
+	}
+
+	// Run sync once to get signer / cabundle / target filled up
+	c := NewCertRotationController("operator", signerSecret, caBundleConfigMap, targetSecret, eventRecorder, &fakeStatusReporter{})
+	syncCtx := factory.NewSyncContext("test", eventstesting.NewTestingEventRecorder(t))
+	err := c.Sync(controllerCtx, syncCtx)
+	if err != nil {
+		t.Errorf("sync error: %v", err)
+	}
+
+	actions := client.Actions()
+	if len(actions) != 3 {
+		t.Fatal(spew.Sdump(actions))
+	}
+	// Extract signer / cabundle / target certs from actions
+	previousSignerSecret := actions[0].(clienttesting.CreateAction).GetObject().(*corev1.Secret)
+	if previousSignerSecret.Name != signerName {
+		t.Fatalf("expected signer secret name to be %s, got %s", signerName, previousSignerSecret.Name)
+	}
+	previousCABundleConfigMap := actions[1].(clienttesting.CreateAction).GetObject().(*corev1.ConfigMap)
+	if previousCABundleConfigMap.Name != caName {
+		t.Fatalf("expected CA bundle configmap name to be %s, got %s", caName, previousCABundleConfigMap.Name)
+	}
+	previousTargetSecret := actions[2].(clienttesting.CreateAction).GetObject().(*corev1.Secret)
+	if previousTargetSecret.Name != targetName {
+		t.Fatalf("expected target secret name to be %s, got %s", targetName, previousTargetSecret.Name)
+	}
+	client.ClearActions()
+
+	// Cache generated resources
+	indexer.Add(previousSignerSecret)
+	indexer.Add(previousCABundleConfigMap)
+	indexer.Add(previousTargetSecret)
+
+	// Run a sync and make sure no changes were performed
+	err = c.Sync(controllerCtx, syncCtx)
+	if err != nil {
+		t.Errorf("sync error: %v", err)
+	}
+
+	actions = client.Actions()
+	if len(actions) != 0 {
+		t.Fatal(spew.Sdump(actions))
+	}
+}
+
+func TestCertRotationControllerSignerUpdate(t *testing.T) {
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	client := kubefake.NewSimpleClientset()
+	controllerCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ns, signerName, caName, targetName := "ns", "test-signer", "test-ca", "test-target"
+	eventRecorder := events.NewInMemoryRecorder("test", clock.RealClock{})
+	additionalAnnotations := AdditionalAnnotations{
+		JiraComponent: "test",
+	}
+	owner := &metav1.OwnerReference{
+		Name: "operator",
+	}
+
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(client, 1*time.Minute, informers.WithNamespace(ns))
+
+	signerSecret := RotatedSigningCASecret{
+		Namespace:             ns,
+		Name:                  signerName,
+		Validity:              24 * time.Hour,
+		Refresh:               12 * time.Hour,
+		Client:                client.CoreV1(),
+		Lister:                corev1listers.NewSecretLister(indexer),
+		Informer:              informerFactory.Core().V1().Secrets(),
+		EventRecorder:         eventRecorder,
+		AdditionalAnnotations: additionalAnnotations,
+		Owner:                 owner,
+	}
+	caBundleConfigMap := CABundleConfigMap{
+		Namespace:             ns,
+		Name:                  caName,
+		Client:                client.CoreV1(),
+		Lister:                corev1listers.NewConfigMapLister(indexer),
+		EventRecorder:         eventRecorder,
+		Informer:              informerFactory.Core().V1().ConfigMaps(),
+		AdditionalAnnotations: additionalAnnotations,
+		Owner:                 owner,
+	}
+	targetSecret := RotatedSelfSignedCertKeySecret{
+		Name:      targetName,
+		Namespace: ns,
+		Validity:  24 * time.Hour,
+		Refresh:   12 * time.Hour,
+		CertCreator: &ServingRotation{
+			Hostnames: func() []string { return []string{"foo", "bar"} },
+		},
+		Client:                client.CoreV1(),
+		Informer:              informerFactory.Core().V1().Secrets(),
+		Lister:                corev1listers.NewSecretLister(indexer),
+		EventRecorder:         eventRecorder,
+		AdditionalAnnotations: additionalAnnotations,
+		Owner:                 owner,
+	}
+
+	// Run sync once to get signer / cabundle / target filled up
+	c := NewCertRotationController("operator", signerSecret, caBundleConfigMap, targetSecret, eventRecorder, &fakeStatusReporter{})
+	syncCtx := factory.NewSyncContext("test", eventstesting.NewTestingEventRecorder(t))
+	err := c.Sync(controllerCtx, syncCtx)
+	if err != nil {
+		t.Errorf("sync error: %v", err)
+	}
+
+	actions := client.Actions()
+	if len(actions) != 3 {
+		t.Fatal(spew.Sdump(actions))
+	}
+	// Extract signer / cabundle / target certs from actions
+	previousSignerSecret := actions[0].(clienttesting.CreateAction).GetObject().(*corev1.Secret)
+	if previousSignerSecret.Name != signerName {
+		t.Fatalf("expected signer secret name to be %s, got %s", signerName, previousSignerSecret.Name)
+	}
+	previousSignerContent := previousSignerSecret.Data["tls.crt"]
+	previousCABundleConfigMap := actions[1].(clienttesting.CreateAction).GetObject().(*corev1.ConfigMap)
+	if previousCABundleConfigMap.Name != caName {
+		t.Fatalf("expected CA bundle configmap name to be %s, got %s", caName, previousCABundleConfigMap.Name)
+	}
+	previousCABundleContent := previousCABundleConfigMap.Data["ca-bundle.crt"]
+	previousTargetSecret := actions[2].(clienttesting.CreateAction).GetObject().(*corev1.Secret)
+	if previousTargetSecret.Name != targetName {
+		t.Fatalf("expected target secret name to be %s, got %s", targetName, previousTargetSecret.Name)
+	}
+	client.ClearActions()
+
+	// Cache all created objects
+	indexer.Add(previousSignerSecret)
+	indexer.Add(previousCABundleConfigMap)
+	indexer.Add(previousTargetSecret)
+
+	// Remove annotations to trigger signer regeneration
+	newSignerSecret := previousSignerSecret.DeepCopy()
+	newSignerSecret.Annotations = map[string]string{}
+	updatedSignerSecret, err := client.CoreV1().Secrets(ns).Update(controllerCtx, newSignerSecret, metav1.UpdateOptions{})
+	if err != nil {
+		t.Errorf("signer update error: %v", err)
+	}
+	indexer.Update(updatedSignerSecret)
+	client.ClearActions()
+
+	// Run a sync and make sure signer and CA bundle were regenerated
+	err = c.Sync(controllerCtx, syncCtx)
+	if err != nil {
+		t.Errorf("sync error: %v", err)
+	}
+
+	actions = client.Actions()
+	if len(actions) != 2 {
+		t.Fatal(spew.Sdump(actions))
+	}
+	if !actions[0].Matches("update", "secrets") {
+		t.Error(actions[0])
+	}
+	actualSignerSecret := actions[0].(clienttesting.UpdateAction).GetObject().(*corev1.Secret)
+	if actualSignerSecret.Name != signerName {
+		t.Fatalf("expected signer secret name to be %s, got %s", signerName, previousSignerSecret.Name)
+	}
+	actualSignerContents := actualSignerSecret.Data["tls.crt"]
+	if string(actualSignerContents) == string(previousSignerContent) {
+		t.Fatalf("new signer content is equivalent to the previous")
+	}
+
+	if !actions[1].Matches("update", "configmaps") {
+		t.Error(actions[1])
+	}
+	actualCABundleConfigMap := actions[1].(clienttesting.UpdateAction).GetObject().(*corev1.ConfigMap)
+	if actualCABundleConfigMap.Name != caName {
+		t.Fatalf("expected CA bundle configmap name to be %s, got %s", caName, previousCABundleConfigMap.Name)
+	}
+	actualCABundleContent := actualCABundleConfigMap.Data["ca-bundle.crt"]
+	if string(actualCABundleContent) == string(previousCABundleContent) {
+		t.Fatalf("CA bundle was not regenerated")
+	}
+	if !strings.Contains(actualCABundleContent, string(previousSignerContent)) {
+		t.Fatalf("New CA bundle doesn't contain previous CA bundle\n expected\n%s\n to contain\n%s", actualCABundleContent, string(previousSignerContent))
+	}
+	if !strings.Contains(actualCABundleContent, string(actualSignerContents)) {
+		t.Fatalf("New CA bundle doesn't contain new CA bundle\n expected\n%s\n to contain\n%s", actualCABundleContent, string(actualSignerContents))
+	}
+}
+
+func TestCertRotationControllerFilterExpiredSigners(t *testing.T) {
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	client := kubefake.NewSimpleClientset()
+	controllerCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ns, signerName, caName, targetName := "ns", "test-signer", "test-ca", "test-target"
+	eventRecorder := events.NewInMemoryRecorder("test", clock.RealClock{})
+	additionalAnnotations := AdditionalAnnotations{
+		JiraComponent: "test",
+	}
+	owner := &metav1.OwnerReference{
+		Name: "operator",
+	}
+
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(client, 1*time.Minute, informers.WithNamespace(ns))
+	const validity = time.Second
+
+	signerSecret := RotatedSigningCASecret{
+		Namespace:             ns,
+		Name:                  signerName,
+		Validity:              validity,
+		Refresh:               validity / 2,
+		Client:                client.CoreV1(),
+		Lister:                corev1listers.NewSecretLister(indexer),
+		Informer:              informerFactory.Core().V1().Secrets(),
+		EventRecorder:         eventRecorder,
+		AdditionalAnnotations: additionalAnnotations,
+		Owner:                 owner,
+	}
+	caBundleConfigMap := CABundleConfigMap{
+		Namespace:             ns,
+		Name:                  caName,
+		Client:                client.CoreV1(),
+		Lister:                corev1listers.NewConfigMapLister(indexer),
+		EventRecorder:         eventRecorder,
+		Informer:              informerFactory.Core().V1().ConfigMaps(),
+		AdditionalAnnotations: additionalAnnotations,
+		Owner:                 owner,
+	}
+	targetSecret := RotatedSelfSignedCertKeySecret{
+		Name:      targetName,
+		Namespace: ns,
+		Validity:  validity,
+		Refresh:   validity / 2,
+		CertCreator: &ServingRotation{
+			Hostnames: func() []string { return []string{"foo", "bar"} },
+		},
+		Client:                client.CoreV1(),
+		Informer:              informerFactory.Core().V1().Secrets(),
+		Lister:                corev1listers.NewSecretLister(indexer),
+		EventRecorder:         eventRecorder,
+		AdditionalAnnotations: additionalAnnotations,
+		Owner:                 owner,
+	}
+
+	// Run sync once to get signer / cabundle / target filled up
+	c := NewCertRotationController("operator", signerSecret, caBundleConfigMap, targetSecret, eventRecorder, &fakeStatusReporter{})
+	syncCtx := factory.NewSyncContext("test", eventstesting.NewTestingEventRecorder(t))
+	err := c.Sync(controllerCtx, syncCtx)
+	if err != nil {
+		t.Errorf("sync error: %v", err)
+	}
+
+	actions := client.Actions()
+	if len(actions) != 3 {
+		t.Fatal(spew.Sdump(actions))
+	}
+	// Extract signer / cabundle / target certs from actions
+	previousSignerSecret := actions[0].(clienttesting.CreateAction).GetObject().(*corev1.Secret)
+	if previousSignerSecret.Name != signerName {
+		t.Fatalf("expected signer secret name to be %s, got %s", signerName, previousSignerSecret.Name)
+	}
+	previousSignerContent := previousSignerSecret.Data["tls.crt"]
+	previousCABundleConfigMap := actions[1].(clienttesting.CreateAction).GetObject().(*corev1.ConfigMap)
+	if previousCABundleConfigMap.Name != caName {
+		t.Fatalf("expected CA bundle configmap name to be %s, got %s", caName, previousCABundleConfigMap.Name)
+	}
+	previousCABundleContent := previousCABundleConfigMap.Data["ca-bundle.crt"]
+	previousTargetSecret := actions[2].(clienttesting.CreateAction).GetObject().(*corev1.Secret)
+	if previousTargetSecret.Name != targetName {
+		t.Fatalf("expected target secret name to be %s, got %s", targetName, previousTargetSecret.Name)
+	}
+	client.ClearActions()
+
+	// Cache all created objects
+	indexer.Add(previousSignerSecret)
+	indexer.Add(previousCABundleConfigMap)
+	indexer.Add(previousTargetSecret)
+
+	// Run a sync and make sure signer has expired
+	targetSecret.Validity = time.Minute * 5
+	time.AfterFunc(validity, func() {
+		cancel()
+	})
+	c.Run(controllerCtx, 1)
+	err = c.Sync(controllerCtx, syncCtx)
+	if err != nil {
+		t.Errorf("sync error: %v", err)
+	}
+
+	actions = client.Actions()
+	if len(actions) != 3 {
+		t.Fatal(spew.Sdump(actions))
+	}
+	if !actions[0].Matches("update", "secrets") {
+		t.Error(actions[0])
+	}
+	actualSignerSecret := actions[0].(clienttesting.UpdateAction).GetObject().(*corev1.Secret)
+	if actualSignerSecret.Name != signerName {
+		t.Fatalf("expected signer secret name to be %s, got %s", signerName, actualSignerSecret.Name)
+	}
+	actualSignerContents := actualSignerSecret.Data["tls.crt"]
+	if string(actualSignerContents) == string(previousSignerContent) {
+		t.Fatalf("new signer content is equivalent to the previous")
+	}
+
+	if !actions[1].Matches("update", "configmaps") {
+		t.Error(actions[1])
+	}
+	actualCABundleConfigMap := actions[1].(clienttesting.UpdateAction).GetObject().(*corev1.ConfigMap)
+	if actualCABundleConfigMap.Name != caName {
+		t.Fatalf("expected CA bundle configmap name to be %s, got %s", caName, actualCABundleConfigMap.Name)
+	}
+	actualCABundleContent := actualCABundleConfigMap.Data["ca-bundle.crt"]
+	if string(actualCABundleContent) == string(previousCABundleContent) {
+		t.Fatalf("CA bundle was not regenerated")
+	}
+	if strings.Contains(actualCABundleContent, string(previousSignerContent)) {
+		t.Fatalf("New CA bundle still contains previous CA bundle\n expected\n%s\n to contain\n%s", actualCABundleContent, string(previousSignerContent))
+	}
+	if !strings.Contains(actualCABundleContent, string(actualSignerContents)) {
+		t.Fatalf("New CA bundle doesn't contain new CA bundle\n expected\n%s\n to contain\n%s", actualCABundleContent, string(actualSignerContents))
+	}
+	if !actions[2].Matches("update", "secrets") {
+		t.Error(actions[2])
+	}
+	actualTargetSecret := actions[2].(clienttesting.UpdateAction).GetObject().(*corev1.Secret)
+	if actualTargetSecret.Name != targetName {
+		t.Fatalf("expected target secret name to be %s, got %s", signerName, actualTargetSecret.Name)
+	}
+}
+
+func TestCertRotationControllerParallelUpdate(t *testing.T) {
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	client := kubefake.NewSimpleClientset()
+	controllerCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ns, signerName, caName, targetName := "ns", "test-signer", "test-ca", "test-target"
+	eventRecorder := events.NewInMemoryRecorder("test", clock.RealClock{})
+	additionalAnnotations := AdditionalAnnotations{
+		JiraComponent: "test",
+	}
+	owner := &metav1.OwnerReference{
+		Name: "operator",
+	}
+
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(client, 1*time.Minute, informers.WithNamespace(ns))
+
+	signerSecret := RotatedSigningCASecret{
+		Namespace:             ns,
+		Name:                  signerName,
+		Validity:              24 * time.Hour,
+		Refresh:               12 * time.Hour,
+		Client:                client.CoreV1(),
+		Lister:                corev1listers.NewSecretLister(indexer),
+		Informer:              informerFactory.Core().V1().Secrets(),
+		EventRecorder:         eventRecorder,
+		AdditionalAnnotations: additionalAnnotations,
+		Owner:                 owner,
+	}
+	caBundleConfigMap := CABundleConfigMap{
+		Namespace:             ns,
+		Name:                  caName,
+		Client:                client.CoreV1(),
+		Lister:                corev1listers.NewConfigMapLister(indexer),
+		EventRecorder:         eventRecorder,
+		Informer:              informerFactory.Core().V1().ConfigMaps(),
+		AdditionalAnnotations: additionalAnnotations,
+		Owner:                 owner,
+	}
+	targetSecret := RotatedSelfSignedCertKeySecret{
+		Name:      targetName,
+		Namespace: ns,
+		Validity:  24 * time.Hour,
+		Refresh:   12 * time.Hour,
+		CertCreator: &ServingRotation{
+			Hostnames: func() []string { return []string{"first"} },
+		},
+		Client:                client.CoreV1(),
+		Informer:              informerFactory.Core().V1().Secrets(),
+		Lister:                corev1listers.NewSecretLister(indexer),
+		EventRecorder:         eventRecorder,
+		AdditionalAnnotations: additionalAnnotations,
+		Owner:                 owner,
+	}
+
+	syncCtx := factory.NewSyncContext("test", eventstesting.NewTestingEventRecorder(t))
+	c1 := NewCertRotationController("c1", signerSecret, caBundleConfigMap, targetSecret, eventRecorder, &fakeStatusReporter{})
+
+	// Sync first controller to get first copy of signer/cabundle
+	err := c1.Sync(controllerCtx, syncCtx)
+	if err != nil {
+		t.Errorf("c1 sync error: %v", err)
+	}
+
+	actions := client.Actions()
+	if len(actions) != 3 {
+		t.Fatal(spew.Sdump(actions))
+	}
+	// Extract signer / cabundle / target certs from actions
+	previousSignerSecret := actions[0].(clienttesting.CreateAction).GetObject().(*corev1.Secret)
+	if previousSignerSecret.Name != signerName {
+		t.Fatalf("expected signer secret name to be %s, got %s", signerName, previousSignerSecret.Name)
+	}
+	firstSignerContent := previousSignerSecret.Data["tls.crt"]
+	previousCABundleConfigMap := actions[1].(clienttesting.CreateAction).GetObject().(*corev1.ConfigMap)
+	if previousCABundleConfigMap.Name != caName {
+		t.Fatalf("expected CA bundle configmap name to be %s, got %s", caName, previousCABundleConfigMap.Name)
+	}
+	previousTargetSecret := actions[2].(clienttesting.CreateAction).GetObject().(*corev1.Secret)
+	if previousTargetSecret.Name != targetName {
+		t.Fatalf("expected target secret name to be %s, got %s", targetName, previousTargetSecret.Name)
+	}
+	previousCABundleContent := previousCABundleConfigMap.Data["ca-bundle.crt"]
+	client.ClearActions()
+
+	// Cache all created resources
+	indexer.Add(previousSignerSecret)
+	indexer.Add(previousCABundleConfigMap)
+	indexer.Add(previousTargetSecret)
+
+	// Remove annotations to trigger signer regeneration
+	newSignerSecret := previousSignerSecret.DeepCopy()
+	newSignerSecret.Annotations = map[string]string{}
+	updatedSignerSecret, err := client.CoreV1().Secrets(ns).Update(controllerCtx, newSignerSecret, metav1.UpdateOptions{})
+	if err != nil {
+		t.Errorf("signer update error: %v", err)
+	}
+	indexer.Update(updatedSignerSecret)
+	client.ClearActions()
+
+	// Run multiple controllers in parallel
+	var workerWg sync.WaitGroup
+	var controllers = map[string]factory.Controller{
+		"c1": c1,
+	}
+	const nParallelControllers = 4
+
+	for i := 1; i <= nParallelControllers; i++ {
+		// Create second controller reusing signer / cabundle but creating second target cert
+		targetNewSecret := RotatedSelfSignedCertKeySecret{
+			Name:      fmt.Sprintf("%s-%d", targetName, i),
+			Namespace: ns,
+			Validity:  24 * time.Hour,
+			Refresh:   12 * time.Hour,
+			CertCreator: &ServingRotation{
+				Hostnames: func() []string { return []string{"second"} },
+			},
+			Client:                client.CoreV1(),
+			Informer:              informerFactory.Core().V1().Secrets(),
+			Lister:                corev1listers.NewSecretLister(indexer),
+			EventRecorder:         eventRecorder,
+			AdditionalAnnotations: additionalAnnotations,
+			Owner:                 owner,
+		}
+		name := fmt.Sprintf("c%d", i)
+		ctrl := NewCertRotationController(name, signerSecret, caBundleConfigMap, targetNewSecret, eventRecorder, &fakeStatusReporter{})
+		controllers[name] = ctrl
+	}
+
+	// Sync informers
+	informerFactory.Start(controllerCtx.Done())
+	hasSecretSynced := cache.WaitForCacheSync(controllerCtx.Done(), informerFactory.Core().V1().Secrets().Informer().HasSynced)
+	if hasSecretSynced != true {
+		t.Errorf("caches for secrets didn't sync")
+	}
+	hasConfigMapsSynced := cache.WaitForCacheSync(controllerCtx.Done(), informerFactory.Core().V1().ConfigMaps().Informer().HasSynced)
+	if hasConfigMapsSynced != true {
+		t.Errorf("caches for configmap didn't sync")
+	}
+
+	// Start parallel controllers
+	time.AfterFunc(time.Second, func() {
+		cancel()
+	})
+	for name, ctrl := range controllers {
+		t.Logf("Starting %s controller ...", name)
+		workerWg.Add(1)
+		go func() {
+			ctrl.Run(controllerCtx, 1)
+			t.Logf("Shutting down %s controller ...", name)
+			workerWg.Done()
+		}()
+	}
+	workerWg.Wait()
+
+	var action clienttesting.Action
+	actions = client.Actions()
+	// Find last configmap update
+	for i := len(actions) - 1; i > 0; i-- {
+		if actions[i].Matches("update", "configmaps") {
+			action = actions[i]
+			break
+		}
+	}
+	if action == nil {
+		t.Fatal(spew.Sdump(actions))
+	}
+	actualCABundleConfigMap := action.(clienttesting.UpdateAction).GetObject().(*corev1.ConfigMap)
+	if actualCABundleConfigMap.Name != caName {
+		t.Fatalf("expected CA bundle configmap name to be %s, got %s", caName, previousCABundleConfigMap.Name)
+	}
+	actualCABundleContent := actualCABundleConfigMap.Data["ca-bundle.crt"]
+	if string(actualCABundleContent) == string(previousCABundleContent) {
+		t.Fatalf("CA bundle was not regenerated")
+	}
+	if !strings.Contains(actualCABundleContent, string(firstSignerContent)) {
+		t.Fatalf("New CA bundle doesn't contain previous CA bundle\n expected %s\n to contain %s", actualCABundleContent, string(firstSignerContent))
+	}
+}
+
+func TestCertRotationControllerMultipleTargets(t *testing.T) {
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	client := kubefake.NewSimpleClientset()
+	controllerCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ns, signerName, caName, targetFirstName, targetSecondName := "ns", "test-signer", "test-ca", "test-target-one", "test-target-two"
+	eventRecorder := events.NewInMemoryRecorder("test", clock.RealClock{})
+	additionalAnnotations := AdditionalAnnotations{
+		JiraComponent: "test",
+	}
+	owner := &metav1.OwnerReference{
+		Name: "operator",
+	}
+
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(client, 1*time.Minute, informers.WithNamespace(ns))
+
+	signerSecret := RotatedSigningCASecret{
+		Namespace:             ns,
+		Name:                  signerName,
+		Validity:              24 * time.Hour,
+		Refresh:               12 * time.Hour,
+		Client:                client.CoreV1(),
+		Lister:                corev1listers.NewSecretLister(indexer),
+		Informer:              informerFactory.Core().V1().Secrets(),
+		EventRecorder:         eventRecorder,
+		AdditionalAnnotations: additionalAnnotations,
+		Owner:                 owner,
 	}
 	caBundleConfigMap := CABundleConfigMap{
 		Namespace:             ns,
@@ -201,6 +772,7 @@ func TestCertRotationControllerMultipleTargets(t *testing.T) {
 		Validity:  24 * time.Hour,
 		Refresh:   12 * time.Hour,
 		CertCreator: &ServingRotation{
+			Hostnames: func() []string { return []string{"foo", "bar"} },
 		},
 		Client:                client.CoreV1(),
 		Informer:              informerFactory.Core().V1().Secrets(),
@@ -208,7 +780,6 @@ func TestCertRotationControllerMultipleTargets(t *testing.T) {
 		EventRecorder:         eventRecorder,
 		AdditionalAnnotations: additionalAnnotations,
 		Owner:                 owner,
-		UseSecretUpdateOnly:   true,
 	}
 	targetSecondSecret := RotatedSelfSignedCertKeySecret{
 		Name:      targetSecondName,
@@ -216,6 +787,7 @@ func TestCertRotationControllerMultipleTargets(t *testing.T) {
 		Validity:  24 * time.Hour,
 		Refresh:   12 * time.Hour,
 		CertCreator: &ServingRotation{
+			Hostnames: func() []string { return []string{"foo", "bar"} },
 		},
 		Client:                client.CoreV1(),
 		Informer:              informerFactory.Core().V1().Secrets(),
@@ -223,7 +795,6 @@ func TestCertRotationControllerMultipleTargets(t *testing.T) {
 		EventRecorder:         eventRecorder,
 		AdditionalAnnotations: additionalAnnotations,
 		Owner:                 owner,
-		UseSecretUpdateOnly:   true,
 	}
 
 	c := NewCertRotationControllerMultipleTargets("operator", signerSecret, caBundleConfigMap, []RotatedSelfSignedCertKeySecret{targetFirstSecret, targetSecondSecret}, eventRecorder, &fakeStatusReporter{})
@@ -243,48 +814,35 @@ func TestCertRotationControllerMultipleTargets(t *testing.T) {
 	}
 
 	actions := client.Actions()
-	if len(actions) != 8 {
+	if len(actions) != 4 {
 		t.Fatal(spew.Sdump(actions))
 	}
 
-	if !actions[0].Matches("get", "secrets") {
+	if !actions[0].Matches("create", "secrets") {
 		t.Error(actions[0])
 	}
-	if len(actions) != 4 {
+	if !actions[1].Matches("create", "configmaps") {
 		t.Error(actions[1])
 	}
-	if !actions[2].Matches("get", "configmaps") {
-	if !actions[0].Matches("create", "secrets") {
-	}
-	if !actions[3].Matches("create", "configmaps") {
-	if !actions[1].Matches("create", "configmaps") {
-	}
-	if !actions[4].Matches("get", "secrets") {
 	if !actions[2].Matches("create", "secrets") {
+		t.Error(actions[2])
 	}
-	if !actions[5].Matches("create", "secrets") {
 	if !actions[3].Matches("create", "secrets") {
+		t.Error(actions[3])
 	}
-	if !actions[6].Matches("get", "secrets") {
-<<<<<<< HEAD
-		t.Error(actions[6])
-	}
-	if !actions[7].Matches("create", "secrets") {
-		t.Error(actions[7])
-	}
-	actualSignerSecret := actions[1].(clienttesting.CreateAction).GetObject().(*corev1.Secret)
+	actualSignerSecret := actions[0].(clienttesting.CreateAction).GetObject().(*corev1.Secret)
 	if actualSignerSecret.Name != signerName {
 		t.Errorf("expected signer secret name to be %s, got %s", signerName, actualSignerSecret.Name)
 	}
-	actualCABundleConfigMap := actions[3].(clienttesting.CreateAction).GetObject().(*corev1.ConfigMap)
+	actualCABundleConfigMap := actions[1].(clienttesting.CreateAction).GetObject().(*corev1.ConfigMap)
 	if actualCABundleConfigMap.Name != caName {
 		t.Errorf("expected CA bundle configmap name to be %s, got %s", signerName, actualCABundleConfigMap.Name)
 	}
-	actualFirstTargetSecret := actions[5].(clienttesting.CreateAction).GetObject().(*corev1.Secret)
+	actualFirstTargetSecret := actions[2].(clienttesting.CreateAction).GetObject().(*corev1.Secret)
 	if actualFirstTargetSecret.Name != targetFirstName {
 		t.Errorf("expected first target secret name to be %s, got %s", signerName, actualFirstTargetSecret.Name)
 	}
-	actualSecondTargetSecret := actions[7].(clienttesting.CreateAction).GetObject().(*corev1.Secret)
+	actualSecondTargetSecret := actions[3].(clienttesting.CreateAction).GetObject().(*corev1.Secret)
 	if actualSecondTargetSecret.Name != targetSecondName {
 		t.Errorf("expected second target secret name to be %s, got %s", signerName, actualFirstTargetSecret.Name)
 	}
@@ -292,128 +850,4 @@ func TestCertRotationControllerMultipleTargets(t *testing.T) {
 	if currentNumGoroutine != initialNumGoroutine {
 		t.Errorf("Goroutine leak detected, expected %d but was %d", initialNumGoroutine, currentNumGoroutine)
 	}
-}
-	eventRecorder := events.NewInMemoryRecorder("test", clock.RealClock{})
-func TestCertRotationControllerMultipleTargetsPostRunHooks(t *testing.T) {
-	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-	client := kubefake.NewSimpleClientset()
-	controllerCtx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	ns, signerName, caName, targetFirstName, targetSecondName := "ns", "test-signer", "test-ca", "test-target-one", "test-target-two"
-	eventRecorder := events.NewInMemoryRecorder("test")
-	additionalAnnotations := AdditionalAnnotations{
-		JiraComponent: "test",
-	}
-	owner := &metav1.OwnerReference{
-		Name: "operator",
-	}
-
-	informerFactory := informers.NewSharedInformerFactoryWithOptions(client, 1*time.Minute, informers.WithNamespace(ns))
-
-	firstTargetCertCreator := &fakeTargetCertCreator{name: "first", hostnamesChanged: make(chan struct{}, 1)}
-	secondTargetCertCreator := &fakeTargetCertCreator{name: "second", hostnamesChanged: make(chan struct{}, 1)}
-
-	signerSecret := RotatedSigningCASecret{
-		Namespace:             ns,
-		Name:                  signerName,
-		Refresh:               12 * time.Hour,
-		Client:                client.CoreV1(),
-		Lister:                corev1listers.NewSecretLister(indexer),
-		Informer:              informerFactory.Core().V1().Secrets(),
-		EventRecorder:         eventRecorder,
-		AdditionalAnnotations: additionalAnnotations,
-		Owner:                 owner,
-		UseSecretUpdateOnly:   true,
-	}
-	caBundleConfigMap := CABundleConfigMap{
-		Namespace:             ns,
-		Name:                  caName,
-		Client:                client.CoreV1(),
-		Lister:                corev1listers.NewConfigMapLister(indexer),
-		EventRecorder:         eventRecorder,
-		Informer:              informerFactory.Core().V1().ConfigMaps(),
-		AdditionalAnnotations: additionalAnnotations,
-		Owner:                 owner,
-	}
-	targetFirstSecret := RotatedSelfSignedCertKeySecret{
-		Name:                  targetFirstName,
-		Namespace:             ns,
-		Validity:              24 * time.Hour,
-		CertCreator:           firstTargetCertCreator,
-		Client:                client.CoreV1(),
-		Informer:              informerFactory.Core().V1().Secrets(),
-		Lister:                corev1listers.NewSecretLister(indexer),
-		EventRecorder:         eventRecorder,
-		AdditionalAnnotations: additionalAnnotations,
-		Owner:                 owner,
-		UseSecretUpdateOnly:   true,
-	}
-	targetSecondSecret := RotatedSelfSignedCertKeySecret{
-		Name:                  targetSecondName,
-		Namespace:             ns,
-		Validity:              24 * time.Hour,
-		CertCreator:           secondTargetCertCreator,
-		Client:                client.CoreV1(),
-		Informer:              informerFactory.Core().V1().Secrets(),
-		Lister:                corev1listers.NewSecretLister(indexer),
-		EventRecorder:         eventRecorder,
-		AdditionalAnnotations: additionalAnnotations,
-		Owner:                 owner,
-		UseSecretUpdateOnly:   true,
-	}
-
-	// Ensure we don't leak goroutines
-	initialNumGoroutine := runtime.NumGoroutine()
-
-	c := NewCertRotationControllerMultipleTargets("operator", signerSecret, caBundleConfigMap, []RotatedSelfSignedCertKeySecret{targetFirstSecret, targetSecondSecret}, eventRecorder, &fakeStatusReporter{})
-
-	informerFactory.Start(controllerCtx.Done())
-	hasSecretSynced := cache.WaitForCacheSync(controllerCtx.Done(), informerFactory.Core().V1().Secrets().Informer().HasSynced)
-	if hasSecretSynced != true {
-		t.Errorf("caches for secrets didn't sync")
-	}
-	hasConfigMapsSynced := cache.WaitForCacheSync(controllerCtx.Done(), informerFactory.Core().V1().ConfigMaps().Informer().HasSynced)
-	if hasConfigMapsSynced != true {
-		t.Errorf("caches for configmap didn't sync")
-	}
-
-	time.AfterFunc(1*time.Second, func() {
-		cancel()
-	})
-	firstTargetCertCreator.triggerSync()
-	secondTargetCertCreator.triggerSync()
-	c.Run(controllerCtx, 1)
-
-	// Ensure both target certs have been called exactly three times
-	// initial sync and two hook calls for target certs
-||||||| parent of f7056aa9b (fixup! cert-rotation: allow specifying multiple target certs in CertRotationController)
-		t.Error(actions[6])
-	}
-	if !actions[7].Matches("create", "secrets") {
-		t.Error(actions[7])
-	}
-	actualSignerSecret := actions[1].(clienttesting.CreateAction).GetObject().(*corev1.Secret)
-	if actualSignerSecret.Name != signerName {
-		t.Errorf("expected signer secret name to be %s, got %s", signerName, actualSignerSecret.Name)
-	}
-	actualCABundleConfigMap := actions[3].(clienttesting.CreateAction).GetObject().(*corev1.ConfigMap)
-	if actualCABundleConfigMap.Name != caName {
-		t.Errorf("expected CA bundle configmap name to be %s, got %s", signerName, actualCABundleConfigMap.Name)
-	// initial sync and two hook calls for target certs
-=======
-	actualSignerSecret := actions[0].(clienttesting.CreateAction).GetObject().(*corev1.Secret)
->>>>>>> f7056aa9b (fixup! cert-rotation: allow specifying multiple target certs in CertRotationController)
-	// TODO[vrutkovs]: informers make unpredictable number of calls
-	if firstTargetCertCreator.callCount < 3 {
-		t.Errorf("first target cert was expected to be synced three times but was called %d times", firstTargetCertCreator.callCount)
-	actualCABundleConfigMap := actions[1].(clienttesting.CreateAction).GetObject().(*corev1.ConfigMap)
-	if secondTargetCertCreator.callCount < 3 {
-		t.Errorf("second target cert was expected to be synced three times but was called %d times", secondTargetCertCreator.callCount)
-	}
-	actualFirstTargetSecret := actions[2].(clienttesting.CreateAction).GetObject().(*corev1.Secret)
-	currentNumGoroutine := runtime.NumGoroutine()
-	if currentNumGoroutine != initialNumGoroutine {
-		t.Errorf("Goroutine leak detected, expected %d but was %d", initialNumGoroutine, currentNumGoroutine)
-	actualSecondTargetSecret := actions[3].(clienttesting.CreateAction).GetObject().(*corev1.Secret)
 }


### PR DESCRIPTION
Instead of defining several controllers managing the same signer/CA bundle pair and different target certs the same controller can accept a list of target certs to create.

Tested with
* [`workflow-test openshift-e2e-cert-rotation-suspend-sno 4.17,https://github.com/openshift/cluster-kube-apiserver-operator/pull/1669,https://github.com/openshift/cluster-etcd-operator/pull/1284 "CLUSTER_AGE_DAYS=300","CLUSTER_AGE_STEP=300","PACKET_OS=rocky_9"`](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/release-openshift-origin-installer-launch-assisted-modern/1806403521822593024)
* [`workflow-test openshift-e2e-cert-rotation-suspend-sno 4.17,https://github.com/openshift/cluster-kube-apiserver-operator/pull/1669,https://github.com/openshift/cluster-etcd-operator/pull/1284 "CLUSTER_AGE_DAYS=600","CLUSTER_AGE_STEP=300","PACKET_OS=rocky_9"`](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/release-openshift-origin-installer-launch-assisted-modern/1806454959277871104)
* [`workflow-test openshift-e2e-cert-rotation-suspend-sno 4.17,https://github.com/openshift/cluster-kube-apiserver-operator/pull/1669,https://github.com/openshift/cluster-etcd-operator/pull/1284 "CLUSTER_AGE_DAYS=900","CLUSTER_AGE_STEP=300","PACKET_OS=rocky_9"`](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/release-openshift-origin-installer-launch-assisted-modern/1806455065116938240)
* [`workflow-test openshift-e2e-cert-rotation-suspend-sno 4.17,https://github.com/openshift/cluster-kube-apiserver-operator/pull/1669,https://github.com/openshift/cluster-etcd-operator/pull/1284 "CLUSTER_AGE_DAYS=1200","CLUSTER_AGE_STEP=300","PACKET_OS=rocky_9"`](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/release-openshift-origin-installer-launch-assisted-modern/1806455176609927168)
* [`workflow-test openshift-e2e-cert-rotation-suspend-sno 4.17,https://github.com/openshift/cluster-kube-apiserver-operator/pull/1669,https://github.com/openshift/cluster-etcd-operator/pull/1284 "CLUSTER_AGE_DAYS=1500","CLUSTER_AGE_STEP=300","PACKET_OS=rocky_9"`](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/release-openshift-origin-installer-launch-assisted-modern/1806455276568580096)
* [`workflow-test openshift-e2e-cert-rotation-suspend-sno 4.17,https://github.com/openshift/cluster-kube-apiserver-operator/pull/1669,https://github.com/openshift/cluster-etcd-operator/pull/1284 "CLUSTER_AGE_DAYS=1800","CLUSTER_AGE_STEP=300","PACKET_OS=rocky_9"`](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/release-openshift-origin-installer-launch-assisted-modern/1806455378926374912)
* [`workflow-test openshift-e2e-cert-rotation-suspend-sno 4.17,https://github.com/openshift/cluster-kube-apiserver-operator/pull/1669,https://github.com/openshift/cluster-etcd-operator/pull/1284 "CLUSTER_AGE_DAYS=2100","CLUSTER_AGE_STEP=300","PACKET_OS=rocky_9"`](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/release-openshift-origin-installer-launch-assisted-modern/1806455474938187776)
* [`workflow-test openshift-e2e-cert-rotation-suspend-sno 4.17,https://github.com/openshift/cluster-kube-apiserver-operator/pull/1669,https://github.com/openshift/cluster-etcd-operator/pull/1284 "CLUSTER_AGE_DAYS=2400","CLUSTER_AGE_STEP=300","PACKET_OS=rocky_9"`](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/release-openshift-origin-installer-launch-assisted-modern/1806455571197464576)