### PR TITLE
API-1802: certrotation: issue one Update request in cert rotation functions

### DIFF
--- a/pkg/operator/certrotation/signer.go
+++ b/pkg/operator/certrotation/signer.go
@@ -63,6 +63,7 @@ type RotatedSigningCASecret struct {
 // EnsureSigningCertKeyPair manages the entire lifecycle of a signer cert as a secret, from creation to continued rotation.
 // It always returns the currently used CA pair, a bool indicating whether it was created/updated within this function call and an error.
 func (c RotatedSigningCASecret) EnsureSigningCertKeyPair(ctx context.Context) (*crypto.CA, bool, error) {
+	modified := false
 	originalSigningCertKeyPairSecret, err := c.Lister.Secrets(c.Namespace).Get(c.Name)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return nil, false, err
@@ -78,6 +79,7 @@ func (c RotatedSigningCASecret) EnsureSigningCertKeyPair(ctx context.Context) (*
 			),
 			Type: corev1.SecretTypeTLS,
 		}
+		modified = true
 	}
 
 	applyFn := resourceapply.ApplySecret
@@ -87,13 +89,9 @@ func (c RotatedSigningCASecret) EnsureSigningCertKeyPair(ctx context.Context) (*
 
 	// apply necessary metadata (possibly via delete+recreate) if secret exists
 	// this is done before content update to prevent unexpected rollouts
-	if ensureMetadataUpdate(signingCertKeyPairSecret, c.Owner, c.AdditionalAnnotations) && ensureSecretTLSTypeSet(signingCertKeyPairSecret) {
-		actualSigningCertKeyPairSecret, _, err := applyFn(ctx, c.Client, c.EventRecorder, signingCertKeyPairSecret)
-		if err != nil {
-			return nil, false, err
-		}
-		signingCertKeyPairSecret = actualSigningCertKeyPairSecret
-	}
+	needsMetadataUpdate := ensureMetadataUpdate(signingCertKeyPairSecret, c.Owner, c.AdditionalAnnotations)
+	needsTypeChange := ensureSecretTLSTypeSet(signingCertKeyPairSecret)
+	modified = needsMetadataUpdate || needsTypeChange || modified
 
 	signerUpdated := false
 	if needed, reason := needNewSigningCertKeyPair(signingCertKeyPairSecret.Annotations, c.Refresh, c.RefreshOnlyWhenExpired); needed {
@@ -104,13 +102,18 @@ func (c RotatedSigningCASecret) EnsureSigningCertKeyPair(ctx context.Context) (*
 
 		LabelAsManagedSecret(signingCertKeyPairSecret, CertificateTypeSigner)
 
+		modified = true
+		signerUpdated = true
+	}
+
+	if modified {
 		actualSigningCertKeyPairSecret, _, err := applyFn(ctx, c.Client, c.EventRecorder, signingCertKeyPairSecret)
 		if err != nil {
 			return nil, false, err
 		}
 		signingCertKeyPairSecret = actualSigningCertKeyPairSecret
-		signerUpdated = true
 	}
+
 	// at this point, the secret has the correct signer, so we should read that signer to be able to sign
 	signingCertKeyPair, err := crypto.GetCAFromBytes(signingCertKeyPairSecret.Data["tls.crt"], signingCertKeyPairSecret.Data["tls.key"])
 	if err != nil {

--- a/pkg/operator/certrotation/signer_test.go
+++ b/pkg/operator/certrotation/signer_test.go
@@ -256,7 +256,7 @@ func operation(t *testing.T, options interface{}) string {
 	case metav1.GetOptions:
 		return "get"
 	case metav1.PatchOptions:
-		return "get"
+		return "patch"
 	}
 	t.Fatalf("wrong test setup: we shouldn't be here for this test")
 	return ""
@@ -371,7 +371,11 @@ func TestEnsureSigningCertKeyPair(t *testing.T) {
 						"auth.openshift.io/certificate-not-after":  "2108-09-08T22:47:31-07:00",
 						"auth.openshift.io/certificate-not-before": "2108-09-08T20:47:31-07:00",
 						annotations.OpenShiftComponent:             "test",
+					},
+					OwnerReferences: []metav1.OwnerReference{{
+						Name: "operator",
 					}},
+				},
 				Type: corev1.SecretTypeTLS,
 				Data: map[string][]byte{"tls.crt": {}, "tls.key": {}},
 			},

--- a/pkg/operator/certrotation/target_test.go
+++ b/pkg/operator/certrotation/target_test.go
@@ -246,9 +246,9 @@ func TestEnsureTargetCertKeyPair(t *testing.T) {
 				return caBundleSecret
 			},
 			verifyActions: func(t *testing.T, updateOnly bool, client *kubefake.Clientset) {
-				lengthWant := 5
+				lengthWant := 3
 				if updateOnly {
-					lengthWant = 4
+					lengthWant = 2
 				}
 				actions := client.Actions()
 				if len(actions) != lengthWant {
@@ -258,21 +258,15 @@ func TestEnsureTargetCertKeyPair(t *testing.T) {
 				var idx int
 				switch updateOnly {
 				case true:
-					idx = 3
+					idx = 1
 					if !actions[0].Matches("get", "secrets") {
 						t.Error(actions[0])
 					}
 					if !actions[1].Matches("update", "secrets") {
 						t.Error(actions[1])
 					}
-					if !actions[2].Matches("get", "secrets") {
-						t.Error(actions[2])
-					}
-					if !actions[3].Matches("update", "secrets") {
-						t.Error(actions[3])
-					}
 				default:
-					idx = 4
+					idx = 2
 					if !actions[0].Matches("get", "secrets") {
 						t.Error(actions[0])
 					}
@@ -281,12 +275,6 @@ func TestEnsureTargetCertKeyPair(t *testing.T) {
 					}
 					if !actions[2].Matches("create", "secrets") {
 						t.Error(actions[2])
-					}
-					if !actions[3].Matches("get", "secrets") {
-						t.Error(actions[3])
-					}
-					if !actions[4].Matches("update", "secrets") {
-						t.Error(actions[4])
 					}
 				}
 
@@ -332,9 +320,9 @@ func TestEnsureTargetCertKeyPair(t *testing.T) {
 				return caBundleSecret
 			},
 			verifyActions: func(t *testing.T, updateOnly bool, client *kubefake.Clientset) {
-				lengthWant := 5
+				lengthWant := 3
 				if updateOnly {
-					lengthWant = 4
+					lengthWant = 2
 				}
 
 				actions := client.Actions()
@@ -345,21 +333,15 @@ func TestEnsureTargetCertKeyPair(t *testing.T) {
 				var idx int
 				switch updateOnly {
 				case true:
-					idx = 3
+					idx = 1
 					if !actions[0].Matches("get", "secrets") {
 						t.Error(actions[0])
 					}
 					if !actions[1].Matches("update", "secrets") {
 						t.Error(actions[1])
 					}
-					if !actions[2].Matches("get", "secrets") {
-						t.Error(actions[2])
-					}
-					if !actions[3].Matches("update", "secrets") {
-						t.Error(actions[3])
-					}
 				default:
-					idx = 4
+					idx = 2
 					if !actions[0].Matches("get", "secrets") {
 						t.Error(actions[0])
 					}
@@ -368,12 +350,6 @@ func TestEnsureTargetCertKeyPair(t *testing.T) {
 					}
 					if !actions[2].Matches("create", "secrets") {
 						t.Error(actions[2])
-					}
-					if !actions[3].Matches("get", "secrets") {
-						t.Error(actions[3])
-					}
-					if !actions[4].Matches("update", "secrets") {
-						t.Error(actions[4])
 					}
 				}
 


### PR DESCRIPTION
Each function used in cert rotation controller should issue just one ApplySecret/ApplySecret per call. This call may  not be atomic, so running several replicas of this controller can cause unexpected races