### PR TITLE
ETCD-519: add helper pods same revision

### DIFF
--- a/test/library/pod_same_revision.go
+++ b/test/library/pod_same_revision.go
@@ -3,6 +3,7 @@ package library
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -11,6 +12,24 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 )
+
+const revisionLabel = "revision"
+
+func WaitForPodsToStabilizeOnTheSameNewRevision(t LoggingT, podClient corev1client.PodInterface, podLabelSelector string, waitForRevisionSuccessThreshold int, waitForRevisionSuccessInterval, waitForRevisionPollInterval, waitForRevisionTimeout time.Duration) error {
+	pods, err := podClient.List(context.TODO(), metav1.ListOptions{LabelSelector: podLabelSelector})
+	if err != nil {
+		return fmt.Errorf("failed to list pods with selector '%v': %w", podLabelSelector, err)
+	}
+
+	currentRevision, err := getCurrenRevision(revisionLabel, pods.Items)
+	if err != nil {
+		return fmt.Errorf("failed to get current revision for pods with selector '%v': %w", podLabelSelector, err)
+	}
+
+	return wait.Poll(waitForRevisionPollInterval, waitForRevisionTimeout, mustSucceedMultipleTimes(waitForRevisionSuccessThreshold, waitForRevisionSuccessInterval, func() (bool, error) {
+		return arePodsOnTheSameNewRevision(t, podClient, podLabelSelector, currentRevision)
+	}))
+}
 
 // WaitForPodsToStabilizeOnTheSameRevision waits until all Pods with the given selector are running at the same revision.
 // The Pods must stay on the same revision for at least waitForRevisionSuccessThreshold * waitForRevisionSuccessInterval.
@@ -27,13 +46,24 @@ func WaitForPodsToStabilizeOnTheSameRevision(t LoggingT, podClient corev1client.
 	}))
 }
 
+func arePodsOnTheSameNewRevision(t LoggingT, podClient corev1client.PodInterface, podLabelSelector string, oldRevision string) (bool, error) {
+	pods, err := podClient.List(context.TODO(), metav1.ListOptions{LabelSelector: podLabelSelector})
+	if err != nil {
+		return false, fmt.Errorf("failed to list pods with selector '%v': %w", podLabelSelector, err)
+	}
+
+	currentRevision, err := getCurrenRevision(revisionLabel, pods.Items)
+	if strings.Compare(currentRevision, oldRevision) != 1 {
+		return false, fmt.Errorf("current revision is not newer than old revision")
+	}
+	return true, nil
+}
+
 // arePodsOnTheSameRevision tries to find the current revision that the pods are running at.
 // The number of instances is calculated based on the number of running pods in a namespace.
 // This should be okay because this function is meant to be used by WaitForPodsToStabilizeOnTheSameRevision which will wait at least waitForRevisionSuccessThreshold * waitForRevisionSuccessInterval
 // The number of pods should stabilize in that period of time.
 func arePodsOnTheSameRevision(t LoggingT, podClient corev1client.PodInterface, podLabelSelector string) (bool, error) {
-	revisionLabel := "revision"
-
 	// do a live list so we never get confused about what revision we are on
 	apiServerPods, err := podClient.List(context.TODO(), metav1.ListOptions{LabelSelector: podLabelSelector})
 	if err != nil {
@@ -52,6 +82,25 @@ func arePodsOnTheSameRevision(t LoggingT, podClient corev1client.PodInterface, p
 	}
 
 	return true, nil
+}
+
+func getCurrenRevision(revisionLabel string, pods []corev1.Pod) (string, error) {
+	goodRevisions, failingRevisions, progressing, err := getRevisions(revisionLabel, pods)
+	if err != nil || progressing {
+		return "", err
+	}
+
+	// all pods must have the same revision
+	if goodRevisions.Len() != 1 {
+		return "", fmt.Errorf("pods has different revisions, expected all to have the same revision")
+	}
+
+	currentRevision, _ := goodRevisions.PopAny()
+	if failingRevisions.Has(currentRevision) {
+		return "", fmt.Errorf("pods has both running and failed pods")
+	}
+
+	return currentRevision, nil
 }
 
 func getRevisions(revisionLabel string, pods []corev1.Pod) (sets.Set[string], sets.Set[string], bool, error) {

--- a/test/library/pod_same_revision_test.go
+++ b/test/library/pod_same_revision_test.go
@@ -1,13 +1,62 @@
 package library
 
 import (
+	"fmt"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/stretchr/testify/require"
 )
+
+const (
+	testNamespaceName = "test-ns"
+	podsLabelSelector = "apiserver=true"
+)
+
+func TestArePodsOnTheSameNewRevision(t *testing.T) {
+	testCases := []struct {
+		name           string
+		oldRevision    string
+		initialObjects []runtime.Object
+		exp            bool
+		expErr         error
+	}{
+		{
+			name:           "happy path",
+			oldRevision:    "3",
+			initialObjects: []runtime.Object{newPod(corev1.PodRunning, corev1.ConditionTrue, "4", "node1"), newPod(corev1.PodRunning, corev1.ConditionTrue, "4", "node2"), newPod(corev1.PodRunning, corev1.ConditionTrue, "4", "node3")},
+			exp:            true,
+			expErr:         nil,
+		},
+		{
+			name:           "one pod is failing",
+			oldRevision:    "3",
+			initialObjects: []runtime.Object{newPod(corev1.PodRunning, corev1.ConditionTrue, "4", "node1"), newPod(corev1.PodRunning, corev1.ConditionTrue, "4", "node2"), newPod(corev1.PodFailed, corev1.ConditionTrue, "4", "node3")},
+			exp:            false,
+			expErr:         fmt.Errorf("current revision is not newer than old revision"),
+		},
+		{
+			name:           "one pod on previous revision",
+			oldRevision:    "3",
+			initialObjects: []runtime.Object{newPod(corev1.PodRunning, corev1.ConditionTrue, "3", "node1"), newPod(corev1.PodRunning, corev1.ConditionTrue, "4", "node2"), newPod(corev1.PodRunning, corev1.ConditionTrue, "4", "node3")},
+			exp:            false,
+			expErr:         fmt.Errorf("current revision is not newer than old revision"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeKubeClient := fake.NewSimpleClientset(tc.initialObjects...)
+			isSameRevision, err := arePodsOnTheSameNewRevision(t, fakeKubeClient.CoreV1().Pods(testNamespaceName), podsLabelSelector, tc.oldRevision)
+			require.Equal(t, tc.expErr, err)
+			require.Equal(t, tc.exp, isSameRevision)
+		})
+	}
+}
 
 func TestArePodsOnTheSameRevision(t *testing.T) {
 	scenarios := []struct {
@@ -25,7 +74,7 @@ func TestArePodsOnTheSameRevision(t *testing.T) {
 	for _, scenario := range scenarios {
 		t.Run(scenario.name, func(t *testing.T) {
 			fakeKubeClient := fake.NewSimpleClientset(scenario.initialObjects...)
-			sameRevision, err := arePodsOnTheSameRevision(t, fakeKubeClient.CoreV1().Pods("test-ns"), "apiserver=true")
+			sameRevision, err := arePodsOnTheSameRevision(t, fakeKubeClient.CoreV1().Pods(testNamespaceName), podsLabelSelector)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -40,7 +89,8 @@ func newPod(phase corev1.PodPhase, ready corev1.ConditionStatus, revision, nodeN
 	pod := corev1.Pod{
 		TypeMeta: v1.TypeMeta{Kind: "Pod"},
 		ObjectMeta: v1.ObjectMeta{
-			Namespace: "test-ns",
+			Name:      "pod" + nodeName,
+			Namespace: testNamespaceName,
 			Labels: map[string]string{
 				"revision":  revision,
 				"apiserver": "true",


### PR DESCRIPTION
This PR adds a helper that poll one pods have the same `new` revision. 

This is needed by https://github.com/openshift/cluster-etcd-operator/pull/1248#

cc @openshift/openshift-team-etcd @soltysh @JoelSpeed @p0lyn0mial 