### PR TITLE
OCPBUGS-33958: retrieve registered secret name from secretManager

### DIFF
--- a/pkg/route/secretmanager/fake/fake_manager.go
+++ b/pkg/route/secretmanager/fake/fake_manager.go
@@ -9,9 +9,10 @@ import (
 )
 
 type SecretManager struct {
-	Err          error
-	Secret       *corev1.Secret
-	IsRegistered bool
+	Err        error
+	Secret     *corev1.Secret
+	IsPresent  bool
+	SecretName string
 }
 
 func (m *SecretManager) RegisterRoute(ctx context.Context, namespace string, routeName string, secretName string, handler cache.ResourceEventHandlerFuncs) error {
@@ -24,8 +25,9 @@ func (m *SecretManager) UnregisterRoute(namespace string, routeName string) erro
 func (m *SecretManager) GetSecret(ctx context.Context, namespace string, routeName string) (*corev1.Secret, error) {
 	return m.Secret, m.Err
 }
-func (m *SecretManager) IsRouteRegistered(namespace string, routeName string) bool {
-	return m.IsRegistered
+
+func (m *SecretManager) LookupRouteSecret(namespace string, routeName string) (string, bool) {
+	return m.SecretName, m.IsPresent
 }
 
 func (m *SecretManager) Queue() workqueue.RateLimitingInterface {


### PR DESCRIPTION
Update `IsRouteRegistered()` to `LookupRouteSecret()` which will also return the registered secret name from secretManager.

```
LookupRouteSecret returns the secret name associated with a route,
and true indicating if the route is registered with manager.
If the route is not registered, an empty string and false are returned.
```

Related to [OCPBUGS-33958](https://issues.redhat.com/browse/OCPBUGS-33958)


