### PR TITLE
STOR-1767: Delete resources if spec.ManagementState is equal to Removed for removable CSI drivers

### DIFF
--- a/pkg/operator/csi/csidrivernodeservicecontroller/csi_driver_node_service_controller.go
+++ b/pkg/operator/csi/csidrivernodeservicecontroller/csi_driver_node_service_controller.go
@@ -131,6 +131,10 @@ func (c *CSIDriverNodeServiceController) sync(ctx context.Context, syncContext f
 		return err
 	}
 
+	if opSpec.ManagementState == opv1.Removed && management.IsOperatorRemovable() {
+		return c.syncDeleting(ctx, opSpec, opStatus, syncContext)
+	}
+
 	if opSpec.ManagementState != opv1.Managed {
 		return nil
 	}

--- a/pkg/operator/deploymentcontroller/deployment_controller.go
+++ b/pkg/operator/deploymentcontroller/deployment_controller.go
@@ -209,6 +209,10 @@ func (c *DeploymentController) sync(ctx context.Context, syncContext factory.Syn
 		return err
 	}
 
+	if opSpec.ManagementState == opv1.Removed && management.IsOperatorRemovable() {
+		return c.syncDeleting(ctx, opSpec, opStatus, syncContext)
+	}
+
 	if opSpec.ManagementState != opv1.Managed {
 		return nil
 	}

--- a/pkg/operator/staticresourcecontroller/static_resource_controller.go
+++ b/pkg/operator/staticresourcecontroller/static_resource_controller.go
@@ -282,7 +282,7 @@ func (c *StaticResourceController) Sync(ctx context.Context, syncContext factory
 	if err != nil {
 		return err
 	}
-	if !management.IsOperatorManaged(operatorSpec.ManagementState) {
+	if !management.IsOperatorManaged(operatorSpec.ManagementState) && (operatorSpec.ManagementState != operatorv1.Removed || management.IsOperatorNotRemovable()) {
 		return nil
 	}
 


### PR DESCRIPTION
We want to disable storage if system administrator sets `spec.ManagementState` of ClusterCSIDriver to `Removed`. This PR ensures that NodeService and Deployment controllers delete resources when `spec.ManagementState` is `Removed`.

Also, it patches `StaticResourceController` Sync() to call `DeleteAll()` if the ManagementState is Removed, and implements support of multiple conditional StaticResourceControllers.

/cc @openshift/storage @jsafrane