### PR TITLE
Ensure static pod controller informers sync

### DIFF
--- a/pkg/operator/staticpod/controller/installer/installer_controller.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller.go
@@ -189,7 +189,12 @@ func NewInstallerController(
 	}
 
 	c.ownerRefsFn = c.setOwnerRefs
-	c.factory = factory.New().WithInformers(operatorClient.Informer(), kubeInformersForTargetNamespace.Core().V1().Pods().Informer())
+	c.factory = factory.New().WithInformers(
+		operatorClient.Informer(),
+		// informers are needed here because their Getter are cached lister based
+		kubeInformersForTargetNamespace.Core().V1().Pods().Informer(),
+		kubeInformersForTargetNamespace.Core().V1().ConfigMaps().Informer(),
+		kubeInformersForTargetNamespace.Core().V1().Secrets().Informer())
 
 	return c
 }

--- a/pkg/operator/staticpod/controller/prune/prune_controller_test.go
+++ b/pkg/operator/staticpod/controller/prune/prune_controller_test.go
@@ -313,7 +313,6 @@ func TestSync(t *testing.T) {
 				podResourcePrefix: "test-pod",
 				command:           []string{"/bin/true"},
 				configMapGetter:   kubeClient.CoreV1(),
-				secretGetter:      kubeClient.CoreV1(),
 				podGetter:         kubeClient.CoreV1(),
 				operatorClient:    fakeStaticPodOperatorClient,
 			}

--- a/pkg/operator/staticpod/controller/staticpodstate/staticpodstate_controller.go
+++ b/pkg/operator/staticpod/controller/staticpodstate/staticpodstate_controller.go
@@ -30,7 +30,6 @@ type StaticPodStateController struct {
 	operandName     string
 
 	operatorClient  v1helpers.StaticPodOperatorClient
-	configMapGetter corev1client.ConfigMapsGetter
 	podsGetter      corev1client.PodsGetter
 	versionRecorder status.VersionGetter
 }
@@ -41,7 +40,6 @@ func NewStaticPodStateController(
 	targetNamespace, staticPodName, operandName string,
 	kubeInformersForTargetNamespace informers.SharedInformerFactory,
 	operatorClient v1helpers.StaticPodOperatorClient,
-	configMapGetter corev1client.ConfigMapsGetter,
 	podsGetter corev1client.PodsGetter,
 	versionRecorder status.VersionGetter,
 	eventRecorder events.Recorder,
@@ -51,7 +49,6 @@ func NewStaticPodStateController(
 		staticPodName:   staticPodName,
 		operandName:     operandName,
 		operatorClient:  operatorClient,
-		configMapGetter: configMapGetter,
 		podsGetter:      podsGetter,
 		versionRecorder: versionRecorder,
 	}

--- a/pkg/operator/staticpod/controllers.go
+++ b/pkg/operator/staticpod/controllers.go
@@ -208,6 +208,8 @@ func (b *staticPodOperatorControllerBuilder) ToControllers() (manager.Controller
 		versionRecorder = status.NewVersionGetter()
 	}
 
+	// ensure that all controllers that need the secret/configmap informer-based clients
+	// need to wait for their synchronization before starting using WithInformer
 	configMapClient := v1helpers.CachedConfigMapGetter(b.kubeClient.CoreV1(), b.kubeInformers)
 	secretClient := v1helpers.CachedSecretGetter(b.kubeClient.CoreV1(), b.kubeInformers)
 	podClient := b.kubeClient.CoreV1()
@@ -277,7 +279,6 @@ func (b *staticPodOperatorControllerBuilder) ToControllers() (manager.Controller
 			b.operandName,
 			operandInformers,
 			b.staticPodOperatorClient,
-			configMapClient,
 			podClient,
 			versionRecorder,
 			eventRecorder,
@@ -293,9 +294,9 @@ func (b *staticPodOperatorControllerBuilder) ToControllers() (manager.Controller
 			b.certDir,
 			b.pruneCommand,
 			configMapClient,
-			secretClient,
 			podClient,
 			b.staticPodOperatorClient,
+			operandInformers,
 			eventRecorder,
 		), 1)
 	} else {


### PR DESCRIPTION
Some static pod controllers use cached listing clients and they were not properly synchronized.