### PR TITLE
csi: Add Deployment, DaemonSet hooks for config map hash annotations

### DIFF
--- a/pkg/operator/csi/csidrivercontrollerservicecontroller/helpers.go
+++ b/pkg/operator/csi/csidrivercontrollerservicecontroller/helpers.go
@@ -102,6 +102,25 @@ func WithCABundleDeploymentHook(
 	}
 }
 
+// WithConfigMapHashAnnotationHook creates a deployment hook that annotates a Deployment with a config map's hash.
+func WithConfigMapHashAnnotationHook(
+	namespace string,
+	configMapName string,
+	configMapInformer corev1.ConfigMapInformer,
+) dc.DeploymentHookFunc {
+	return func(opSpec *opv1.OperatorSpec, deployment *appsv1.Deployment) error {
+		inputHashes, err := resourcehash.MultipleObjectHashStringMapForObjectReferenceFromLister(
+			configMapInformer.Lister(),
+			nil,
+			resourcehash.NewObjectRef().ForConfigMap().InNamespace(namespace).Named(configMapName),
+		)
+		if err != nil {
+			return fmt.Errorf("invalid dependency reference: %w", err)
+		}
+		return addObjectHash(deployment, inputHashes)
+	}
+}
+
 // WithSecretHashAnnotationHook creates a deployment hook that annotates a Deployment with a secret's hash.
 func WithSecretHashAnnotationHook(
 	namespace string,

--- a/pkg/operator/csi/csidrivernodeservicecontroller/helpers.go
+++ b/pkg/operator/csi/csidrivernodeservicecontroller/helpers.go
@@ -74,6 +74,26 @@ func WithCABundleDaemonSetHook(
 	}
 }
 
+// WithConfigMapHashAnnotationHook creates a DaemonSet hook that annotates a DaemonSet with a config map's hash.
+func WithConfigMapHashAnnotationHook(
+	namespace string,
+	configMapName string,
+	configMapInformer corev1.ConfigMapInformer,
+) DaemonSetHookFunc {
+	return func(_ *opv1.OperatorSpec, ds *appsv1.DaemonSet) error {
+		inputHashes, err := resourcehash.MultipleObjectHashStringMapForObjectReferenceFromLister(
+			configMapInformer.Lister(),
+			nil,
+			resourcehash.NewObjectRef().ForConfigMap().InNamespace(namespace).Named(configMapName),
+		)
+		if err != nil {
+			return fmt.Errorf("invalid dependency reference: %w", err)
+		}
+
+		return addObjectHash(ds, inputHashes)
+	}
+}
+
 // WithSecretHashAnnotationHook creates a DaemonSet hook that annotates a DaemonSet with a secret's hash.
 func WithSecretHashAnnotationHook(
 	namespace string,


### PR DESCRIPTION
We already have these for secrets. Add them for config maps.

This is needed for the OpenStack Cinder CSI Driver Operator. See https://github.com/openshift/openstack-cinder-csi-driver-operator/pull/168/ for more information.
