### PR TITLE
OCPBUGS-35528: pkg/verify/configmap: Aggregate errors in loadArmoredOrUnarmoredGPGKeyRing

### DIFF
--- a/pkg/verify/configmap.go
+++ b/pkg/verify/configmap.go
@@ -172,5 +172,9 @@ func loadArmoredOrUnarmoredGPGKeyRing(data []byte) (openpgp.EntityList, error) {
 	if err == nil {
 		return keyring, nil
 	}
-	return openpgp.ReadKeyRing(bytes.NewReader(data))
+	keyring, err2 := openpgp.ReadKeyRing(bytes.NewReader(data))
+	if err2 == nil {
+		return keyring, nil
+	}
+	return nil, fmt.Errorf("unable to read keyring with armor (%w) or without armor (%w)", err, err2)
 }


### PR DESCRIPTION
Previously, when both `ReadArmoredKeyRing` and `ReadKeyRing` failed, we'd only return the latter error.  But in [OCPBUGS-35528][1], `ReadArmoredKeyRing` errors like:

    openpgp: invalid data: user ID self-signature invalid: openpgp: invalid signature: RSA verification failure

pointed at the SHA-1 self-signature issue, but were masked by `ReadKeyRing`'s:

    openpgp: invalid data: tag byte does not have MSB set

and required additional work on out-of-cluster reproducers.  With this commit, we'll return an error aggregating both underlying errors on failure, to make future debugging easier.

[1]: https://issues.redhat.com/browse/OCPBUGS-35528