### PR TITLE
operator/certrotation: introduce an optional lock to CABundleConfigMap and RotatedSigningCASecret

### DIFF
--- a/pkg/operator/certrotation/client_cert_rotation_controller.go
+++ b/pkg/operator/certrotation/client_cert_rotation_controller.go
@@ -62,9 +62,9 @@ type CertRotationController struct {
 	// controller name
 	Name string
 	// RotatedSigningCASecret rotates a self-signed signing CA stored in a secret.
-	RotatedSigningCASecret RotatedSigningCASecret
+	RotatedSigningCASecret *RotatedSigningCASecret
 	// CABundleConfigMap maintains a CA bundle config map, by adding new CA certs coming from rotatedSigningCASecret, and by removing expired old ones.
-	CABundleConfigMap CABundleConfigMap
+	CABundleConfigMap *CABundleConfigMap
 	// RotatedSelfSignedCertKeySecret rotates a key and cert signed by a signing CA and stores it in a secret.
 	RotatedSelfSignedCertKeySecret RotatedSelfSignedCertKeySecret
 
@@ -74,8 +74,8 @@ type CertRotationController struct {
 
 func NewCertRotationController(
 	name string,
-	rotatedSigningCASecret RotatedSigningCASecret,
-	caBundleConfigMap CABundleConfigMap,
+	rotatedSigningCASecret *RotatedSigningCASecret,
+	caBundleConfigMap *CABundleConfigMap,
 	rotatedSelfSignedCertKeySecret RotatedSelfSignedCertKeySecret,
 	recorder events.Recorder,
 	reporter StatusReporter,


### PR DESCRIPTION
To preserve the current behaviour and make the controllers thread safe
I've decided to introduce an optional mutex which can be used when the instance 
is shared across multiple controllers.
This approach requires the fewest changes and resolves the race condition.

I think even a simpler version of this approach would work: https://github.com/openshift/library-go/pull/1753

Perhaps the best approach would be to create separate controllers for `CABundleConfigMap` and `RotatedSigningCASecret`.

I've also opened a proof PR at https://github.com/openshift/cluster-kube-apiserver-operator/pull/1709

Alternative for https://github.com/openshift/library-go/pull/1722