### PR TITLE
operator/certrotation: introduce an optional lock to CABundleConfigMap and RotatedSigningCASecret

### DIFF
--- a/pkg/operator/certrotation/signer.go
+++ b/pkg/operator/certrotation/signer.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/openshift/library-go/pkg/crypto"
@@ -47,6 +48,10 @@ type RotatedSigningCASecret struct {
 	// AdditionalAnnotations is a collection of annotations set for the secret
 	AdditionalAnnotations AdditionalAnnotations
 
+	// Lock is an optional mutex that protects the EnsureSigningCertKeyPair method.
+	// Use it only when this instance is shared across multiple controllers.
+	Lock *sync.Mutex
+
 	// Plumbing:
 	Informer      corev1informers.SecretInformer
 	Lister        corev1listers.SecretLister
@@ -63,6 +68,10 @@ type RotatedSigningCASecret struct {
 // EnsureSigningCertKeyPair manages the entire lifecycle of a signer cert as a secret, from creation to continued rotation.
 // It always returns the currently used CA pair, a bool indicating whether it was created/updated within this function call and an error.
 func (c RotatedSigningCASecret) EnsureSigningCertKeyPair(ctx context.Context) (*crypto.CA, bool, error) {
+	if c.Lock != nil {
+		c.Lock.Lock()
+		defer c.Lock.Unlock()
+	}
 	modified := false
 	originalSigningCertKeyPairSecret, err := c.Lister.Secrets(c.Namespace).Get(c.Name)
 	if err != nil && !apierrors.IsNotFound(err) {


### PR DESCRIPTION
To preserve the current behaviour and make the controllers thread safe
I've decided to introduce an optional mutex which can be used when the instance
is shared across multiple controllers.

This approach requires the fewest changes and resolves the race condition.

Perhaps the best approach would be to create separate controllers for `CABundleConfigMap` and `RotatedSigningCASecret.`

proof: https://gist.github.com/p0lyn0mial/176bece543907dbd9ac6b5306a170eda

a simpler version of https://github.com/openshift/library-go/pull/1752

Alternative for https://github.com/openshift/library-go/pull/1722