### PR TITLE
Fix for issue 1775: in ldapquery, validation out of bounds query should be case insensitive as ldap is.

### DIFF
--- a/pkg/security/ldapquery/query.go
+++ b/pkg/security/ldapquery/query.go
@@ -112,9 +112,9 @@ func (o *LDAPQueryOnAttribute) NewSearchRequest(attributeValue string, attribute
 		if err != nil {
 			return nil, fmt.Errorf("could not search by dn, invalid dn value: %v", err)
 		}
-		if !baseDN.AncestorOf(dn) && !baseDN.Equal(dn) {
-			return nil, NewQueryOutOfBoundsError(attributeValue, o.BaseDN)
-		}
+                if !baseDN.AncestorOfFold(dn) && !baseDN.EqualFold(dn) {
+                        return nil, NewQueryOutOfBoundsError(attributeValue, o.BaseDN)
+                }
 		return o.buildDNQuery(attributeValue, attributes), nil
 
 	} else {

--- a/pkg/security/ldapquery/query.go
+++ b/pkg/security/ldapquery/query.go
@@ -112,9 +112,9 @@ func (o *LDAPQueryOnAttribute) NewSearchRequest(attributeValue string, attribute
 		if err != nil {
 			return nil, fmt.Errorf("could not search by dn, invalid dn value: %v", err)
 		}
-                if !baseDN.AncestorOfFold(dn) && !baseDN.EqualFold(dn) {
-                        return nil, NewQueryOutOfBoundsError(attributeValue, o.BaseDN)
-                }
+		if !baseDN.AncestorOfFold(dn) && !baseDN.EqualFold(dn) {
+			return nil, NewQueryOutOfBoundsError(attributeValue, o.BaseDN)
+		}
 		return o.buildDNQuery(attributeValue, attributes), nil
 
 	} else {

--- a/pkg/security/ldapquery/query_test.go
+++ b/pkg/security/ldapquery/query_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"strings"
 
 	"github.com/go-ldap/ldap/v3"
 	"github.com/openshift/library-go/pkg/security/ldapclient"
@@ -177,6 +178,33 @@ func TestNewSearchRequest(t *testing.T) {
 			attributes:      DefaultAttributes,
 			expectedRequest: nil,
 			expectedError:   true,
+		},
+		{
+			name: "dn query should not be out of bounds",
+			options: LDAPQueryOnAttribute{
+				LDAPQuery: LDAPQuery{
+					BaseDN:       strings.ToUpper(DefaultBaseDN),
+					Scope:        DefaultScope,
+					DerefAliases: DefaultDerefAliases,
+					TimeLimit:    DefaultTimeLimit,
+					Filter:       DefaultFilter,
+				},
+				QueryAttribute: "DN",
+			},
+			attributeValue:  "uid=john,o=users,dc=example,dc=com",
+			attributes:      DefaultAttributes,
+			expectedRequest: &ldap.SearchRequest{
+				BaseDN:       "uid=john,o=users,dc=example,dc=com",
+				Scope:        ldap.ScopeBaseObject,
+				DerefAliases: int(DefaultDerefAliases),
+				SizeLimit:    DefaultSizeLimit,
+				TimeLimit:    DefaultTimeLimit,
+				TypesOnly:    DefaultTypesOnly,
+				Filter:       "(objectClass=*)",
+				Attributes:   DefaultAttributes,
+				Controls:     DefaultControls,
+			},
+			expectedError:   false,
 		},
 		{
 			name: "attribute query no attributes with paging",

--- a/pkg/security/ldapquery/query_test.go
+++ b/pkg/security/ldapquery/query_test.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"testing"
 	"strings"
+	"testing"
 
 	"github.com/go-ldap/ldap/v3"
 	"github.com/openshift/library-go/pkg/security/ldapclient"
@@ -191,8 +191,8 @@ func TestNewSearchRequest(t *testing.T) {
 				},
 				QueryAttribute: "DN",
 			},
-			attributeValue:  "uid=john,o=users,dc=example,dc=com",
-			attributes:      DefaultAttributes,
+			attributeValue: "uid=john,o=users,dc=example,dc=com",
+			attributes:     DefaultAttributes,
 			expectedRequest: &ldap.SearchRequest{
 				BaseDN:       "uid=john,o=users,dc=example,dc=com",
 				Scope:        ldap.ScopeBaseObject,
@@ -204,7 +204,7 @@ func TestNewSearchRequest(t *testing.T) {
 				Attributes:   DefaultAttributes,
 				Controls:     DefaultControls,
 			},
-			expectedError:   false,
+			expectedError: false,
 		},
 		{
 			name: "attribute query no attributes with paging",


### PR DESCRIPTION
Any compare operation in ldap should be case insensitive. 

This is to fix a well known issue in oc groups sync command that is comparing base dn to a dn and showing out of bounds if the compare operation fails.