### PR TITLE
NO-ISSUE: pkg/manifest: Restore CustomNoUpgrade handling

### DIFF
--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -40,6 +40,7 @@ func init() {
 			knownFeatureSets.Insert(string(featureSet))
 		}
 	}
+	knownFeatureSets.Insert(string(configv1.CustomNoUpgrade))
 }
 
 // resourceId uniquely identifies a Kubernetes resource.

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -688,7 +688,7 @@ func Test_include(t *testing.T) {
 				"include.release.openshift.io/self-managed-high-availability": "true",
 				"release.openshift.io/feature-set":                            "Other",
 			},
-			expected: fmt.Errorf("unrecognized value \"Other\" in release.openshift.io/feature-set=Other; known values are: Default,DevPreviewNoUpgrade,TechPreviewNoUpgrade"),
+			expected: fmt.Errorf("unrecognized value \"Other\" in release.openshift.io/feature-set=Other; known values are: CustomNoUpgrade,Default,DevPreviewNoUpgrade,TechPreviewNoUpgrade"),
 		},
 		{
 			name:               "incorrect techpreview value is not excluded if techpreview on using feature-set",
@@ -698,7 +698,7 @@ func Test_include(t *testing.T) {
 				"include.release.openshift.io/self-managed-high-availability": "true",
 				"release.openshift.io/feature-set":                            "Other",
 			},
-			expected: fmt.Errorf("unrecognized value \"Other\" in release.openshift.io/feature-set=Other; known values are: Default,DevPreviewNoUpgrade,TechPreviewNoUpgrade"),
+			expected: fmt.Errorf("unrecognized value \"Other\" in release.openshift.io/feature-set=Other; known values are: CustomNoUpgrade,Default,DevPreviewNoUpgrade,TechPreviewNoUpgrade"),
 		},
 		{
 			name:        "default profile selection excludes without annotation",


### PR DESCRIPTION
Avoiding failures like:

```console
$ curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_cluster-capi-operator/181/pull-ci-openshift-cluster-capi-operator-main-e2e-aws-capi-techpreview/1806459134145466368/artifacts/e2e-aws-capi-techpreview/gather-extra/artifacts/pods/openshift-cluster-version_cluster-version-operator-85cdd86f99-nrqd6_cluster-version-operator_previous.log | grep '0000_30_cluster-api_00_namespace.yaml'
I0627 23:22:20.849886       1 payload.go:210] excluding Filename: "0000_30_cluster-api_00_namespace.yaml" Group: "" Kind: "Namespace" Name: "openshift-cluster-api": unrecognized value "CustomNoUpgrade" in release.openshift.io/feature-set=CustomNoUpgrade,TechPreviewNoUpgrade; known values are: Default,DevPreviewNoUpgrade,TechPreviewNoUpgrade
I0627 23:22:21.820724       1 payload.go:210] excluding Filename: "0000_30_cluster-api_00_namespace.yaml" Group: "" Kind: "Namespace" Name: "openshift-cluster-api": unrecognized value "CustomNoUpgrade" in release.openshift.io/feature-set=CustomNoUpgrade,TechPreviewNoUpgrade; known values are: Default,DevPreviewNoUpgrade,TechPreviewNoUpgrade
```

because 679dc9ff64 (#1711) accidentally dropped the set.

679dc9ff64 also removed `LatencySensitive`, although that is ok because [OCPBUGS-15877][1] intentionally pushed `LatencySensitive` clusters back into the default feature set in 4.14.

[1]: http://issues.redhat.com/browse/OCPBUGS-15877