### PR TITLE
STOR-1767: Support deletion of ValidatingWebhookConfiguration

### DIFF
--- a/pkg/operator/resource/resourceapply/admissionregistration.go
+++ b/pkg/operator/resource/resourceapply/admissionregistration.go
@@ -152,6 +152,18 @@ func ApplyValidatingWebhookConfigurationImproved(ctx context.Context, client adm
 	return actual, true, nil
 }
 
+func DeleteValidatingWebhookConfiguration(ctx context.Context, client admissionregistrationclientv1.ValidatingWebhookConfigurationsGetter, recorder events.Recorder, required *admissionregistrationv1.ValidatingWebhookConfiguration) (*admissionregistrationv1.ValidatingWebhookConfiguration, bool, error) {
+	err := client.ValidatingWebhookConfigurations().Delete(ctx, required.Name, metav1.DeleteOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	reportDeleteEvent(recorder, required, err)
+	return nil, true, nil
+}
+
 // copyValidatingWebhookCABundle populates webhooks[].clientConfig.caBundle fields from existing resource if it was set before
 // and is not set in present. This provides upgrade compatibility with service-ca-bundle operator.
 func copyValidatingWebhookCABundle(from, to *admissionregistrationv1.ValidatingWebhookConfiguration) {

--- a/pkg/operator/resource/resourceapply/generic.go
+++ b/pkg/operator/resource/resourceapply/generic.go
@@ -335,6 +335,12 @@ func DeleteAll(ctx context.Context, clients *ClientHolder, recorder events.Recor
 			} else {
 				_, result.Changed, result.Error = DeleteStorageClass(ctx, clients.kubeClient.StorageV1(), recorder, t)
 			}
+		case *admissionregistrationv1.ValidatingWebhookConfiguration:
+			if clients.kubeClient == nil {
+				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				_, result.Changed, result.Error = DeleteValidatingWebhookConfiguration(ctx, clients.kubeClient.AdmissionregistrationV1(), recorder, t)
+			}
 		case *storagev1.CSIDriver:
 			if clients.kubeClient == nil {
 				result.Error = fmt.Errorf("missing kubeClient")


### PR DESCRIPTION
The [PR](https://github.com/openshift/vmware-vsphere-csi-driver-operator/pull/233) needs to delete static resources conditionally, including [webhook/configuration.yaml](https://github.com/openshift/vmware-vsphere-csi-driver-operator/blob/master/assets/webhook/configuration.yaml) which is of `ValidatingWebhookConfiguration` type.

`ApplyDirectly()` from [generic.go](https://github.com/mpatlasov/library-go/blob/master/pkg/operator/resource/resourceapply/generic.go) already knows how to apply this type. This PR lets it delete it in `DeleteAll()`.