### PR TITLE
OCPBUGS-37274: Replace FIPS_ENABLED string in assets for csi-driver

### DIFF
--- a/pkg/operator/csi/csidrivercontrollerservicecontroller/helpers.go
+++ b/pkg/operator/csi/csidrivercontrollerservicecontroller/helpers.go
@@ -215,6 +215,14 @@ func WithPlaceholdersHook(configInformer configinformers.SharedInformerFactory) 
 		logLevel := loglevel.LogLevelToVerbosity(spec.LogLevel)
 		pairs = append(pairs, []string{"${LOG_LEVEL}", strconv.Itoa(logLevel)}...)
 
+		// FIPS
+		fipsEnabled := "\"false\""
+		contents, err := os.ReadFile("/proc/sys/crypto/fips_enabled")
+		if err == nil && string(contents) == "1\n" {
+			fipsEnabled = "\"true\""
+		}
+		pairs = append(pairs, []string{"${FIPS_ENABLED}", fipsEnabled}...)
+
 		replaced := strings.NewReplacer(pairs...).Replace(string(manifest))
 		return []byte(replaced), nil
 	}

--- a/pkg/operator/csi/csidrivernodeservicecontroller/csi_driver_node_service_controller.go
+++ b/pkg/operator/csi/csidrivernodeservicecontroller/csi_driver_node_service_controller.go
@@ -276,6 +276,14 @@ func replacePlaceholders(manifest []byte, spec *opv1.OperatorSpec) []byte {
 	logLevel := loglevel.LogLevelToVerbosity(spec.LogLevel)
 	pairs = append(pairs, []string{"${LOG_LEVEL}", strconv.Itoa(logLevel)}...)
 
+	// FIPS
+	fipsEnabled := "\"false\""
+	contents, err := os.ReadFile("/proc/sys/crypto/fips_enabled")
+	if err == nil && string(contents) == "1\n" {
+		fipsEnabled = "\"true\""
+	}
+	pairs = append(pairs, []string{"${FIPS_ENABLED}", fipsEnabled}...)
+
 	replaced := strings.NewReplacer(pairs...).Replace(string(manifest))
 	return []byte(replaced)
 }


### PR DESCRIPTION
AWS-EFS CSi driver needs to know whether FIPS is enabled: https://github.com/openshift/aws-efs-csi-driver/pull/80 The operator sets FIPS_ENABLED in assets: https://github.com/openshift/aws-efs-csi-driver-operator/pull/144 , https://github.com/openshift/csi-operator/pull/245 This patch makes sure that the string `$(FIPS_ENABLED)` is substituted with true or false dependently on `/proc/sys/crypto/fips_enabled`. Other users of library-go must not notice this change because they do not use FIPS_ENABLED in asset yamls.