### PR TITLE
certrotation: return err if the secret/configmap already has an owner

### DIFF
--- a/pkg/operator/certrotation/metadata.go
+++ b/pkg/operator/certrotation/metadata.go
@@ -5,14 +5,18 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func ensureMetadataUpdate(secret *corev1.Secret, owner *metav1.OwnerReference, additionalAnnotations AdditionalAnnotations) bool {
+func ensureMetadataUpdate(secret *corev1.Secret, owner *metav1.OwnerReference, additionalAnnotations AdditionalAnnotations) (bool, error) {
+	var err error
 	needsMetadataUpdate := false
 	// no ownerReference set
 	if owner != nil {
-		needsMetadataUpdate = ensureOwnerReference(&secret.ObjectMeta, owner)
+		needsMetadataUpdate, err = ensureOwnerReference(&secret.ObjectMeta, owner)
+		if err != nil {
+			return true, err
+		}
 	}
 	// ownership annotations not set
-	return additionalAnnotations.EnsureTLSMetadataUpdate(&secret.ObjectMeta) || needsMetadataUpdate
+	return additionalAnnotations.EnsureTLSMetadataUpdate(&secret.ObjectMeta) || needsMetadataUpdate, nil
 }
 
 func ensureSecretTLSTypeSet(secret *corev1.Secret) bool {

--- a/pkg/operator/certrotation/target.go
+++ b/pkg/operator/certrotation/target.go
@@ -125,7 +125,10 @@ func (c RotatedSelfSignedCertKeySecret) EnsureTargetCertKeyPair(ctx context.Cont
 
 	// apply necessary metadata (possibly via delete+recreate) if secret exists
 	// this is done before content update to prevent unexpected rollouts
-	needsMetadataUpdate := ensureMetadataUpdate(targetCertKeyPairSecret, c.Owner, c.AdditionalAnnotations)
+	needsMetadataUpdate, err := ensureMetadataUpdate(targetCertKeyPairSecret, c.Owner, c.AdditionalAnnotations)
+	if err != nil {
+		return nil, err
+	}
 	needsSecretTypeUpdate := ensureSecretTLSTypeSet(targetCertKeyPairSecret)
 	modified = needsMetadataUpdate || needsSecretTypeUpdate || modified
 


### PR DESCRIPTION
Ensure that all signer/ca bundles/targets are owned by only one controller