### PR TITLE
certgraphanalysis: update bootstrap name lookup

### DIFF
--- a/pkg/certs/cert-inspection/certgraphanalysis/collector.go
+++ b/pkg/certs/cert-inspection/certgraphanalysis/collector.go
@@ -289,17 +289,11 @@ func GetBootstrapIPAndHostname(ctx context.Context, kubeClient kubernetes.Interf
 		if !ok || !strings.Contains(certHostNames, bootstrapIP) {
 			continue
 		}
-		// Node name is stored as last word in the secret description
-		description, ok := secret.Annotations[annotations.OpenShiftDescription]
-		if !ok {
-			continue
+		// Extract bootstrap name from etcd secret name
+		if result, found := strings.CutPrefix(secret.Name, "etcd-peer-"); found {
+			bootstrapHostname = result
+			break
 		}
-		descriptionWords := strings.Split(description, " ")
-		if len(descriptionWords) < 1 {
-			continue
-		}
-		bootstrapHostname = descriptionWords[len(descriptionWords)-1]
-		break
 	}
 
 	return bootstrapIP, bootstrapHostname, nil


### PR DESCRIPTION
Bootstrap node name is no longer the last word in the description, instead the name should be extracted from the secret name.

Testing this in https://github.com/openshift/origin/pull/28868