### PR TITLE
audit/manifests: log requests to Events

### DIFF
--- a/pkg/operator/apiserver/audit/manifests/base-policy.yaml
+++ b/pkg/operator/apiserver/audit/manifests/base-policy.yaml
@@ -6,11 +6,6 @@
     omitStages:
     - "RequestReceived"
     rules:
-    # Don't log requests for events
-    - level: None
-      resources:
-      - group: ""
-        resources: ["events"]
     # Don't log authenticated requests to certain non-resource URL paths.
     - level: None
       userGroups: ["system:authenticated", "system:unauthenticated"]

--- a/pkg/operator/apiserver/audit/testdata/allrequestbodies.yaml
+++ b/pkg/operator/apiserver/audit/testdata/allrequestbodies.yaml
@@ -8,11 +8,6 @@ omitManagedFields: true
 omitStages:
 - "RequestReceived"
 rules:
-# Don't log requests for events
-- level: None
-  resources:
-  - group: ""
-    resources: ["events"]
 # Don't log authenticated requests to certain non-resource URL paths.
 - level: None
   userGroups: ["system:authenticated", "system:unauthenticated"]

--- a/pkg/operator/apiserver/audit/testdata/audit-policies-cm-scenario-1.yaml
+++ b/pkg/operator/apiserver/audit/testdata/audit-policies-cm-scenario-1.yaml
@@ -15,11 +15,6 @@ data:
     omitStages:
     - "RequestReceived"
     rules:
-    # Don't log requests for events
-    - level: None
-      resources:
-      - group: ""
-        resources: ["events"]
     # Don't log authenticated requests to certain non-resource URL paths.
     - level: None
       userGroups: ["system:authenticated", "system:unauthenticated"]

--- a/pkg/operator/apiserver/audit/testdata/default.yaml
+++ b/pkg/operator/apiserver/audit/testdata/default.yaml
@@ -8,11 +8,6 @@
     omitStages:
     - "RequestReceived"
     rules:
-    # Don't log requests for events
-    - level: None
-      resources:
-      - group: ""
-        resources: ["events"]
     # Don't log authenticated requests to certain non-resource URL paths.
     - level: None
       userGroups: ["system:authenticated", "system:unauthenticated"]

--- a/pkg/operator/apiserver/audit/testdata/multipleCr.yaml
+++ b/pkg/operator/apiserver/audit/testdata/multipleCr.yaml
@@ -8,11 +8,6 @@ omitManagedFields: true
 omitStages:
   - "RequestReceived"
 rules:
-# Don't log requests for events
-- level: None
-  resources:
-  - group: ""
-    resources: ["events"]
 # Don't log authenticated requests to certain non-resource URL paths.
 - level: None
   userGroups: ["system:authenticated", "system:unauthenticated"]

--- a/pkg/operator/apiserver/audit/testdata/none.yaml
+++ b/pkg/operator/apiserver/audit/testdata/none.yaml
@@ -8,11 +8,6 @@ omitManagedFields: true
 omitStages:
 - "RequestReceived"
 rules:
-# Don't log requests for events
-- level: None
-  resources:
-  - group: ""
-    resources: ["events"]
 # Don't log authenticated requests to certain non-resource URL paths.
 - level: None
   userGroups: ["system:authenticated", "system:unauthenticated"]

--- a/pkg/operator/apiserver/audit/testdata/oauth.yaml
+++ b/pkg/operator/apiserver/audit/testdata/oauth.yaml
@@ -8,11 +8,6 @@ omitManagedFields: true
 omitStages:
 - "RequestReceived"
 rules:
-# Don't log requests for events
-- level: None
-  resources:
-  - group: ""
-    resources: ["events"]
 # Don't log authenticated requests to certain non-resource URL paths.
 - level: None
   userGroups: ["system:authenticated", "system:unauthenticated"]

--- a/pkg/operator/apiserver/audit/testdata/writerequestbodies.yaml
+++ b/pkg/operator/apiserver/audit/testdata/writerequestbodies.yaml
@@ -8,11 +8,6 @@ omitManagedFields: true
 omitStages:
 - "RequestReceived"
 rules:
-# Don't log requests for events
-- level: None
-  resources:
-  - group: ""
-    resources: ["events"]
 # Don't log authenticated requests to certain non-resource URL paths.
 - level: None
   userGroups: ["system:authenticated", "system:unauthenticated"]


### PR DESCRIPTION
Re-enable audit logs about Events to be able to identify misconfigured clients.