### PR TITLE
OCPBUGS-39255: resourcehelper: handle nil object when guessing GVK

### DIFF
--- a/pkg/operator/resource/resourcehelper/resource_helpers.go
+++ b/pkg/operator/resource/resourcehelper/resource_helpers.go
@@ -63,6 +63,9 @@ func FormatResourceForCLI(obj runtime.Object) string {
 
 // GuessObjectGroupVersionKind returns a human readable for the passed runtime object.
 func GuessObjectGroupVersionKind(object runtime.Object) schema.GroupVersionKind {
+	if object == nil {
+		return schema.GroupVersionKind{Kind: "<unknown>"}
+	}
 	if gvk := object.GetObjectKind().GroupVersionKind(); len(gvk.Kind) > 0 {
 		return gvk
 	}


### PR DESCRIPTION
If Create/Update returns nil pointer `GuessObjectGroupVersionKind` should not panic and return `<unknown>` kind