### PR TITLE
API-1835: Apply operator status

### DIFF
--- a/pkg/controller/factory/base_controller.go
+++ b/pkg/controller/factory/base_controller.go
@@ -217,10 +217,6 @@ func (c *baseController) degradedPanicHandler(panicVal interface{}) {
 	_ = c.reportDegraded(context.TODO(), fmt.Errorf("panic caught:\n%v", panicVal))
 }
 
-func (c *baseController) ControllerFieldManager(usageName string) string {
-	return ControllerFieldManager(c.name, usageName)
-}
-
 // reportDegraded updates status with an indication of degraded-ness
 func (c *baseController) reportDegraded(ctx context.Context, reportedError error) error {
 	if c.syncDegradedClient == nil {
@@ -233,7 +229,7 @@ func (c *baseController) reportDegraded(ctx context.Context, reportedError error
 				WithStatus(operatorv1.ConditionTrue).
 				WithReason("SyncError").
 				WithMessage(reportedError.Error()))
-		updateErr := c.syncDegradedClient.ApplyOperatorStatus(ctx, c.ControllerFieldManager("reportDegraded"), condition)
+		updateErr := c.syncDegradedClient.ApplyOperatorStatus(ctx, ControllerFieldManager(c.name, "reportDegraded"), condition)
 		if updateErr != nil {
 			klog.Warningf("Updating status of %q failed: %v", c.Name(), updateErr)
 		}
@@ -245,7 +241,7 @@ func (c *baseController) reportDegraded(ctx context.Context, reportedError error
 			WithType(c.name + "Degraded").
 			WithStatus(operatorv1.ConditionFalse).
 			WithReason("AsExpected"))
-	updateErr := c.syncDegradedClient.ApplyOperatorStatus(ctx, c.ControllerFieldManager("reportDegraded"), condition)
+	updateErr := c.syncDegradedClient.ApplyOperatorStatus(ctx, ControllerFieldManager(c.name, "reportDegraded"), condition)
 	return updateErr
 }
 

--- a/pkg/controller/factory/base_controller.go
+++ b/pkg/controller/factory/base_controller.go
@@ -216,6 +216,10 @@ func (c *baseController) degradedPanicHandler(panicVal interface{}) {
 	_ = c.reportDegraded(context.TODO(), fmt.Errorf("panic caught:\n%v", panicVal))
 }
 
+func (c *baseController) ControllerFieldManager(usageName string) string {
+	return ControllerFieldManager(c.name, usageName)
+}
+
 // reportDegraded updates status with an indication of degraded-ness
 func (c *baseController) reportDegraded(ctx context.Context, reportedError error) error {
 	if c.syncDegradedClient == nil {

--- a/pkg/controller/factory/base_controller.go
+++ b/pkg/controller/factory/base_controller.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 	"time"
 
+	applyoperatorv1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
+
 	"github.com/robfig/cron"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -17,7 +19,6 @@ import (
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/library-go/pkg/operator/management"
-	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
 )
 
@@ -226,23 +227,25 @@ func (c *baseController) reportDegraded(ctx context.Context, reportedError error
 		return reportedError
 	}
 	if reportedError != nil {
-		_, _, updateErr := v1helpers.UpdateStatus(ctx, c.syncDegradedClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
-			Type:    c.name + "Degraded",
-			Status:  operatorv1.ConditionTrue,
-			Reason:  "SyncError",
-			Message: reportedError.Error(),
-		}))
+		condition := applyoperatorv1.OperatorStatus().
+			WithConditions(applyoperatorv1.OperatorCondition().
+				WithType(c.name + "Degraded").
+				WithStatus(operatorv1.ConditionTrue).
+				WithReason("SyncError").
+				WithMessage(reportedError.Error()))
+		updateErr := c.syncDegradedClient.ApplyOperatorStatus(ctx, c.ControllerFieldManager("reportDegraded"), condition)
 		if updateErr != nil {
 			klog.Warningf("Updating status of %q failed: %v", c.Name(), updateErr)
 		}
 		return reportedError
 	}
-	_, _, updateErr := v1helpers.UpdateStatus(ctx, c.syncDegradedClient,
-		v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
-			Type:   c.name + "Degraded",
-			Status: operatorv1.ConditionFalse,
-			Reason: "AsExpected",
-		}))
+
+	condition := applyoperatorv1.OperatorStatus().
+		WithConditions(applyoperatorv1.OperatorCondition().
+			WithType(c.name + "Degraded").
+			WithStatus(operatorv1.ConditionFalse).
+			WithReason("AsExpected"))
+	updateErr := c.syncDegradedClient.ApplyOperatorStatus(ctx, c.ControllerFieldManager("reportDegraded"), condition)
 	return updateErr
 }
 

--- a/pkg/controller/factory/interfaces.go
+++ b/pkg/controller/factory/interfaces.go
@@ -2,6 +2,7 @@ package factory
 
 import (
 	"context"
+	"fmt"
 
 	"k8s.io/client-go/util/workqueue"
 
@@ -45,3 +46,7 @@ type SyncContext interface {
 // The syncContext.syncContext passed is the main controller syncContext, when cancelled it means the controller is being shut down.
 // The syncContext provides access to controller name, queue and event recorder.
 type SyncFunc func(ctx context.Context, controllerContext SyncContext) error
+
+func ControllerFieldManager(controllerName, usageName string) string {
+	return fmt.Sprintf("%s-%s", controllerName, usageName)
+}

--- a/pkg/operator/README.md
+++ b/pkg/operator/README.md
@@ -4,9 +4,15 @@
 
 Creates and maintains an `apiservices.apiregistration.k8s.io`.
 
+### ResourceSyncController
+**Location** [resourcesynccontroller](https://github.com/openshift/library-go/tree/master/pkg/operator/resourcesynccontroller)
+
+Copies a ConfigMap or Secret from one location to another.
+Can copy partial ConfigMaps or Secrets.
 
 ### StaticResourceController
 **Location** [staticresourcecontroller](https://github.com/openshift/library-go/tree/master/pkg/operator/staticresourcecontroller)
 
 Creates, maintains, and deletes resources that need little to no customization.
 Has precondition capability for things like FeatureGates, platforms, or whatever you want.
+

--- a/pkg/operator/README.md
+++ b/pkg/operator/README.md
@@ -1,0 +1,12 @@
+
+### APIService
+**Location** [apiserver/controller/apiservice](https://github.com/openshift/library-go/tree/master/pkg/operator/apiserver/controller/apiservice)
+
+Creates and maintains an `apiservices.apiregistration.k8s.io`.
+
+
+### StaticResourceController
+**Location** [staticresourcecontroller](https://github.com/openshift/library-go/tree/master/pkg/operator/staticresourcecontroller)
+
+Creates, maintains, and deletes resources that need little to no customization.
+Has precondition capability for things like FeatureGates, platforms, or whatever you want.

--- a/pkg/operator/apiserver/controller/apiservice/apiservice_controller.go
+++ b/pkg/operator/apiserver/controller/apiservice/apiservice_controller.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	applyoperatorv1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/errors"
@@ -32,6 +34,7 @@ type GetAPIServicesToMangeFunc func() (enabled []*apiregistrationv1.APIService, 
 type apiServicesPreconditionFuncType func([]*apiregistrationv1.APIService) (bool, error)
 
 type APIServiceController struct {
+	name                     string
 	getAPIServicesToManageFn GetAPIServicesToMangeFunc
 	// preconditionsForEnabledAPIServices must return true before the apiservices will be created
 	preconditionsForEnabledAPIServices apiServicesPreconditionFuncType
@@ -54,6 +57,7 @@ func NewAPIServiceController(
 	informers ...factory.Informer,
 ) factory.Controller {
 	c := &APIServiceController{
+		name: "APIServiceController_" + name,
 		preconditionsForEnabledAPIServices: preconditionsForEnabledAPIServices(
 			kubeInformersForNamespaces.InformersFor(targetNamespace).Core().V1().Endpoints().Lister(),
 			kubeInformersForNamespaces.InformersFor(metav1.NamespaceSystem).Core().V1().ConfigMaps().Lister(),
@@ -73,7 +77,7 @@ func NewAPIServiceController(
 			kubeInformersForNamespaces.InformersFor(metav1.NamespaceSystem).Core().V1().ConfigMaps().Informer(),
 			apiregistrationInformers.Apiregistration().V1().APIServices().Informer(),
 		)...,
-	).ToController("APIServiceController_"+name, eventRecorder.WithComponentSuffix("apiservice-"+name+"-controller"))
+	).ToController(c.name, eventRecorder.WithComponentSuffix("apiservice-"+name+"-controller"))
 }
 
 func (c *APIServiceController) updateOperatorStatus(
@@ -84,14 +88,13 @@ func (c *APIServiceController) updateOperatorStatus(
 	syncEnabledAPIServicesErr error,
 ) (err error) {
 	errs := []error{}
-	conditionAPIServicesDegraded := operatorv1.OperatorCondition{
-		Type:   "APIServicesDegraded",
-		Status: operatorv1.ConditionFalse,
-	}
-	conditionAPIServicesAvailable := operatorv1.OperatorCondition{
-		Type:   "APIServicesAvailable",
-		Status: operatorv1.ConditionTrue,
-	}
+	conditionAPIServicesDegraded := applyoperatorv1.OperatorCondition().
+		WithType("APIServicesDegraded").
+		WithStatus(operatorv1.ConditionFalse)
+
+	conditionAPIServicesAvailable := applyoperatorv1.OperatorCondition().
+		WithType("APIServicesAvailable").
+		WithStatus(operatorv1.ConditionTrue)
 
 	if syncDisabledAPIServicesErr != nil || preconditionReadyErr != nil || syncEnabledAPIServicesErr != nil {
 		// a closed context indicates that the process has been requested to shutdown
@@ -116,40 +119,42 @@ func (c *APIServiceController) updateOperatorStatus(
 	}
 
 	defer func() {
-		updates := []v1helpers.UpdateStatusFunc{
-			v1helpers.UpdateConditionFn(conditionAPIServicesDegraded),
-			v1helpers.UpdateConditionFn(conditionAPIServicesAvailable),
-		}
-
-		if _, _, updateError := v1helpers.UpdateStatus(ctx, c.operatorClient, updates...); updateError != nil {
+		status := applyoperatorv1.OperatorStatus().
+			WithConditions(conditionAPIServicesDegraded, conditionAPIServicesAvailable)
+		updateError := c.operatorClient.ApplyOperatorStatus(ctx, factory.ControllerFieldManager(c.name, "updateOperatorStatus"), status)
+		if updateError != nil {
 			// overrides error returned through 'return <ERROR>' statement
 			err = updateError
 		}
 	}()
 
 	if syncDisabledAPIServicesErr != nil {
-		conditionAPIServicesDegraded.Status = operatorv1.ConditionTrue
-		conditionAPIServicesDegraded.Reason = "DisabledAPIServicesPresent"
-		conditionAPIServicesDegraded.Message = syncDisabledAPIServicesErr.Error()
+		conditionAPIServicesDegraded = conditionAPIServicesDegraded.
+			WithStatus(operatorv1.ConditionTrue).
+			WithReason("DisabledAPIServicesPresent").
+			WithMessage(syncDisabledAPIServicesErr.Error())
 		errs = append(errs, syncDisabledAPIServicesErr)
 	}
 
 	if preconditionReadyErr != nil {
-		conditionAPIServicesAvailable.Status = operatorv1.ConditionFalse
-		conditionAPIServicesAvailable.Reason = "ErrorCheckingPrecondition"
-		conditionAPIServicesAvailable.Message = preconditionReadyErr.Error()
+		conditionAPIServicesAvailable = conditionAPIServicesAvailable.
+			WithStatus(operatorv1.ConditionFalse).
+			WithReason("ErrorCheckingPrecondition").
+			WithMessage(preconditionReadyErr.Error())
 		errs = append(errs, preconditionReadyErr)
 	} else if !preconditionsReady {
-		conditionAPIServicesAvailable.Status = operatorv1.ConditionFalse
-		conditionAPIServicesAvailable.Reason = "PreconditionNotReady"
-		conditionAPIServicesAvailable.Message = "PreconditionNotReady"
+		conditionAPIServicesAvailable = conditionAPIServicesAvailable.
+			WithStatus(operatorv1.ConditionFalse).
+			WithReason("PreconditionNotReady").
+			WithMessage("PreconditionNotReady")
 		return errors.NewAggregate(errs)
 	}
 
 	if syncEnabledAPIServicesErr != nil {
-		conditionAPIServicesAvailable.Status = operatorv1.ConditionFalse
-		conditionAPIServicesAvailable.Reason = "Error"
-		conditionAPIServicesAvailable.Message = syncEnabledAPIServicesErr.Error()
+		conditionAPIServicesAvailable = conditionAPIServicesAvailable.
+			WithStatus(operatorv1.ConditionFalse).
+			WithReason("Error").
+			WithMessage(syncEnabledAPIServicesErr.Error())
 		return errors.NewAggregate(append(errs, syncEnabledAPIServicesErr))
 	}
 

--- a/pkg/operator/configobserver/config_observer_controller_test.go
+++ b/pkg/operator/configobserver/config_observer_controller_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	applyoperatorv1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
+
 	"github.com/davecgh/go-spew/spew"
 	"github.com/imdario/mergo"
 	"sigs.k8s.io/yaml"
@@ -57,6 +59,18 @@ func (c *fakeOperatorClient) UpdateOperatorSpec(ctx context.Context, rv string, 
 func (c *fakeOperatorClient) UpdateOperatorStatus(ctx context.Context, rv string, in *operatorv1.OperatorStatus) (status *operatorv1.OperatorStatus, err error) {
 	c.status = in
 	return in, nil
+}
+
+func (c *fakeOperatorClient) ApplyOperator(ctx context.Context, fieldManager string, applyConfiguration *applyoperatorv1.OperatorSpecApplyConfiguration) (err error) {
+	if c.specUpdateFailure != nil {
+		return c.specUpdateFailure
+	}
+
+	return nil
+}
+
+func (c *fakeOperatorClient) ApplyOperatorStatus(ctx context.Context, fieldManager string, applyConfiguration *applyoperatorv1.OperatorStatusApplyConfiguration) (err error) {
+	return nil
 }
 
 type fakeOperatorClient struct {

--- a/pkg/operator/configobserver/config_observer_controller_test.go
+++ b/pkg/operator/configobserver/config_observer_controller_test.go
@@ -61,7 +61,7 @@ func (c *fakeOperatorClient) UpdateOperatorStatus(ctx context.Context, rv string
 	return in, nil
 }
 
-func (c *fakeOperatorClient) ApplyOperator(ctx context.Context, fieldManager string, applyConfiguration *applyoperatorv1.OperatorSpecApplyConfiguration) (err error) {
+func (c *fakeOperatorClient) ApplyOperatorSpec(ctx context.Context, fieldManager string, applyConfiguration *applyoperatorv1.OperatorSpecApplyConfiguration) (err error) {
 	if c.specUpdateFailure != nil {
 		return c.specUpdateFailure
 	}

--- a/pkg/operator/genericoperatorclient/dynamic_operator_client.go
+++ b/pkg/operator/genericoperatorclient/dynamic_operator_client.go
@@ -7,26 +7,31 @@ import (
 	"strings"
 	"time"
 
-	applyoperatorv1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
-
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/klog/v2"
-
 	operatorv1 "github.com/openshift/api/operator/v1"
+	applyoperatorv1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
 )
 
 const defaultConfigName = "cluster"
 
-func newClusterScopedOperatorClient(config *rest.Config, gvr schema.GroupVersionResource, gvk schema.GroupVersionKind) (*dynamicOperatorClient, dynamicinformer.DynamicSharedInformerFactory, error) {
+type StaticPodOperatorSpecExtractorFunc func(obj *unstructured.Unstructured, fieldManager string) (*applyoperatorv1.StaticPodOperatorSpecApplyConfiguration, error)
+type StaticPodOperatorStatusExtractorFunc func(obj *unstructured.Unstructured, fieldManager string) (*applyoperatorv1.StaticPodOperatorStatusApplyConfiguration, error)
+type OperatorSpecExtractorFunc func(obj *unstructured.Unstructured, fieldManager string) (*applyoperatorv1.OperatorSpecApplyConfiguration, error)
+type OperatorStatusExtractorFunc func(obj *unstructured.Unstructured, fieldManager string) (*applyoperatorv1.OperatorStatusApplyConfiguration, error)
+
+func newClusterScopedOperatorClient(config *rest.Config, gvr schema.GroupVersionResource, gvk schema.GroupVersionKind, extractApplySpec StaticPodOperatorSpecExtractorFunc, extractApplyStatus StaticPodOperatorStatusExtractorFunc) (*dynamicOperatorClient, dynamicinformer.DynamicSharedInformerFactory, error) {
 	dynamicClient, err := dynamic.NewForConfig(config)
 	if err != nil {
 		return nil, nil, err
@@ -37,14 +42,47 @@ func newClusterScopedOperatorClient(config *rest.Config, gvr schema.GroupVersion
 	informer := informers.ForResource(gvr)
 
 	return &dynamicOperatorClient{
-		kind:     gvk,
-		informer: informer,
-		client:   client,
+		gvk:                gvk,
+		informer:           informer,
+		client:             client,
+		extractApplySpec:   extractApplySpec,
+		extractApplyStatus: extractApplyStatus,
 	}, informers, nil
 }
 
-func NewClusterScopedOperatorClient(config *rest.Config, gvr schema.GroupVersionResource, gvk schema.GroupVersionKind) (v1helpers.OperatorClientWithFinalizers, dynamicinformer.DynamicSharedInformerFactory, error) {
-	d, informers, err := newClusterScopedOperatorClient(config, gvr, gvk)
+func convertOperatorSpecToStaticPodOperatorSpec(extractApplySpec OperatorSpecExtractorFunc) StaticPodOperatorSpecExtractorFunc {
+	return func(obj *unstructured.Unstructured, fieldManager string) (*applyoperatorv1.StaticPodOperatorSpecApplyConfiguration, error) {
+		operatorSpec, err := extractApplySpec(obj, fieldManager)
+		if err != nil {
+			return nil, err
+		}
+		if operatorSpec == nil {
+			return nil, nil
+		}
+		return &applyoperatorv1.StaticPodOperatorSpecApplyConfiguration{
+			OperatorSpecApplyConfiguration: *operatorSpec,
+		}, nil
+	}
+}
+
+func convertOperatorStatusToStaticPodOperatorStatus(extractApplyStatus OperatorStatusExtractorFunc) StaticPodOperatorStatusExtractorFunc {
+	return func(obj *unstructured.Unstructured, fieldManager string) (*applyoperatorv1.StaticPodOperatorStatusApplyConfiguration, error) {
+		operatorStatus, err := extractApplyStatus(obj, fieldManager)
+		if err != nil {
+			return nil, err
+		}
+		if operatorStatus == nil {
+			return nil, nil
+		}
+		return &applyoperatorv1.StaticPodOperatorStatusApplyConfiguration{
+			OperatorStatusApplyConfiguration: *operatorStatus,
+		}, nil
+	}
+}
+
+func NewClusterScopedOperatorClient(config *rest.Config, gvr schema.GroupVersionResource, gvk schema.GroupVersionKind, extractApplySpec OperatorSpecExtractorFunc, extractApplyStatus OperatorStatusExtractorFunc) (v1helpers.OperatorClientWithFinalizers, dynamicinformer.DynamicSharedInformerFactory, error) {
+	d, informers, err := newClusterScopedOperatorClient(config, gvr, gvk,
+		convertOperatorSpecToStaticPodOperatorSpec(extractApplySpec), convertOperatorStatusToStaticPodOperatorStatus(extractApplyStatus))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -53,11 +91,12 @@ func NewClusterScopedOperatorClient(config *rest.Config, gvr schema.GroupVersion
 
 }
 
-func NewClusterScopedOperatorClientWithConfigName(config *rest.Config, gvr schema.GroupVersionResource, gvk schema.GroupVersionKind, configName string) (v1helpers.OperatorClientWithFinalizers, dynamicinformer.DynamicSharedInformerFactory, error) {
+func NewClusterScopedOperatorClientWithConfigName(config *rest.Config, gvr schema.GroupVersionResource, gvk schema.GroupVersionKind, configName string, extractApplySpec OperatorSpecExtractorFunc, extractApplyStatus OperatorStatusExtractorFunc) (v1helpers.OperatorClientWithFinalizers, dynamicinformer.DynamicSharedInformerFactory, error) {
 	if len(configName) < 1 {
 		return nil, nil, fmt.Errorf("config name cannot be empty")
 	}
-	d, informers, err := newClusterScopedOperatorClient(config, gvr, gvk)
+	d, informers, err := newClusterScopedOperatorClient(config, gvr, gvk,
+		convertOperatorSpecToStaticPodOperatorSpec(extractApplySpec), convertOperatorStatusToStaticPodOperatorStatus(extractApplyStatus))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -67,10 +106,13 @@ func NewClusterScopedOperatorClientWithConfigName(config *rest.Config, gvr schem
 }
 
 type dynamicOperatorClient struct {
-	kind       schema.GroupVersionKind
+	gvk        schema.GroupVersionKind
 	configName string
 	informer   informers.GenericInformer
 	client     dynamic.ResourceInterface
+
+	extractApplySpec   StaticPodOperatorSpecExtractorFunc
+	extractApplyStatus StaticPodOperatorStatusExtractorFunc
 }
 
 func (c dynamicOperatorClient) Informer() cache.SharedIndexInformer {
@@ -174,49 +216,120 @@ func (c dynamicOperatorClient) UpdateOperatorStatus(ctx context.Context, resourc
 	return retStatus, nil
 }
 
-func (c dynamicOperatorClient) ApplyOperator(ctx context.Context, fieldManager string, applyConfiguration *applyoperatorv1.OperatorSpecApplyConfiguration) (err error) {
-	applyMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(applyConfiguration)
+func (c dynamicOperatorClient) ApplyOperatorSpec(ctx context.Context, fieldManager string, desiredConfiguration *applyoperatorv1.OperatorSpecApplyConfiguration) (err error) {
+	if desiredConfiguration == nil {
+		return fmt.Errorf("desiredConfiguration must have value")
+	}
+	desiredConfigurationAsStaticPod := applyoperatorv1.StaticPodOperatorSpec()
+	desiredConfigurationAsStaticPod.OperatorSpecApplyConfiguration = *desiredConfiguration
+	return c.applyOperatorSpec(ctx, fieldManager, desiredConfigurationAsStaticPod)
+}
+
+func (c dynamicOperatorClient) applyOperatorSpec(ctx context.Context, fieldManager string, desiredConfiguration *applyoperatorv1.StaticPodOperatorSpecApplyConfiguration) (err error) {
+	uncastOriginal, err := c.informer.Lister().Get(c.configName)
+	switch {
+	case apierrors.IsNotFound(err):
+		// do nothing and proceed with the apply
+	case err != nil:
+		return fmt.Errorf("unable to read existing %q: %w", c.configName, err)
+	default:
+		original := uncastOriginal.(*unstructured.Unstructured)
+		if c.extractApplySpec == nil {
+			return fmt.Errorf("extractApplySpec is nil")
+		}
+		previouslyDesiredConfiguration, err := c.extractApplySpec(original, fieldManager)
+		if err != nil {
+			return fmt.Errorf("unable to extract status for %q: %w", fieldManager, err)
+		}
+		if equality.Semantic.DeepEqual(previouslyDesiredConfiguration, desiredConfiguration) {
+			// nothing to apply, so return early
+			return nil
+		}
+	}
+
+	desiredSpec, err := runtime.DefaultUnstructuredConverter.ToUnstructured(desiredConfiguration)
 	if err != nil {
 		return fmt.Errorf("failed to convert to unstructured: %w", err)
 	}
-	applyUnstructured := &unstructured.Unstructured{
+	desiredConfigurationAsUnstructured := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"spec": applyMap,
+			"spec": desiredSpec,
 		},
 	}
-	applyUnstructured.SetGroupVersionKind(c.kind)
-	applyUnstructured.SetName(c.configName)
-
-	_, err = c.client.Apply(ctx, c.configName, applyUnstructured, metav1.ApplyOptions{
+	desiredConfigurationAsUnstructured.SetGroupVersionKind(c.gvk)
+	desiredConfigurationAsUnstructured.SetName(c.configName)
+	_, err = c.client.Apply(ctx, c.configName, desiredConfigurationAsUnstructured, metav1.ApplyOptions{
 		Force:        true,
 		FieldManager: fieldManager,
 	})
 	if err != nil {
-		return fmt.Errorf("unable to ApplyStatus for operator: %w", err)
+		return fmt.Errorf("unable to Apply for operator using fieldManager %q: %w", fieldManager, err)
 	}
 
 	return nil
 }
 
-func (c dynamicOperatorClient) ApplyOperatorStatus(ctx context.Context, fieldManager string, applyConfiguration *applyoperatorv1.OperatorStatusApplyConfiguration) (err error) {
-	applyMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(applyConfiguration)
+func (c dynamicOperatorClient) ApplyOperatorStatus(ctx context.Context, fieldManager string, desiredConfiguration *applyoperatorv1.OperatorStatusApplyConfiguration) (err error) {
+	if desiredConfiguration == nil {
+		return fmt.Errorf("desiredConfiguration must have value")
+	}
+	desiredConfigurationAsStaticPod := applyoperatorv1.StaticPodOperatorStatus()
+	desiredConfigurationAsStaticPod.OperatorStatusApplyConfiguration = *desiredConfiguration
+	return c.applyOperatorStatus(ctx, fieldManager, desiredConfigurationAsStaticPod)
+}
+
+func (c dynamicOperatorClient) applyOperatorStatus(ctx context.Context, fieldManager string, desiredConfiguration *applyoperatorv1.StaticPodOperatorStatusApplyConfiguration) (err error) {
+	uncastOriginal, err := c.informer.Lister().Get(c.configName)
+	switch {
+	case apierrors.IsNotFound(err):
+		// do nothing and proceed with the apply
+	case err != nil:
+		return fmt.Errorf("unable to read existing %q: %w", c.configName, err)
+	default:
+		original := uncastOriginal.(*unstructured.Unstructured)
+		if c.extractApplyStatus == nil {
+			return fmt.Errorf("extractApplyStatus is nil")
+		}
+		previouslyDesiredConfiguration, err := c.extractApplyStatus(original, fieldManager)
+		if err != nil {
+			return fmt.Errorf("unable to extract status for %q: %w", fieldManager, err)
+		}
+
+		// canonicalize so the DeepEqual works consistently
+		v1helpers.CanonicalizeStaticPodOperatorStatus(previouslyDesiredConfiguration)
+		v1helpers.CanonicalizeStaticPodOperatorStatus(desiredConfiguration)
+		previouslyDesiredObj, err := v1helpers.ToStaticPodOperator(previouslyDesiredConfiguration)
+		if err != nil {
+			return err
+		}
+		desiredObj, err := v1helpers.ToStaticPodOperator(desiredConfiguration)
+		if err != nil {
+			return err
+		}
+		if equality.Semantic.DeepEqual(previouslyDesiredObj, desiredObj) {
+			// nothing to apply, so return early
+			return nil
+		}
+	}
+
+	desiredStatus, err := runtime.DefaultUnstructuredConverter.ToUnstructured(desiredConfiguration)
 	if err != nil {
 		return fmt.Errorf("failed to convert to unstructured: %w", err)
 	}
-	applyUnstructured := &unstructured.Unstructured{
+	desiredConfigurationAsUnstructured := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"status": applyMap,
+			"status": desiredStatus,
 		},
 	}
-	applyUnstructured.SetGroupVersionKind(c.kind)
-	applyUnstructured.SetName(c.configName)
+	desiredConfigurationAsUnstructured.SetGroupVersionKind(c.gvk)
+	desiredConfigurationAsUnstructured.SetName(c.configName)
 
-	_, err = c.client.ApplyStatus(ctx, c.configName, applyUnstructured, metav1.ApplyOptions{
+	_, err = c.client.ApplyStatus(ctx, c.configName, desiredConfigurationAsUnstructured, metav1.ApplyOptions{
 		Force:        true,
 		FieldManager: fieldManager,
 	})
 	if err != nil {
-		return fmt.Errorf("unable to ApplyStatus for operator: %w", err)
+		return fmt.Errorf("unable to ApplyStatus for operator using fieldManager %q: %w", fieldManager, err)
 	}
 
 	return nil

--- a/pkg/operator/managementstatecontroller/management_state_controller_test.go
+++ b/pkg/operator/managementstatecontroller/management_state_controller_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	applyoperatorv1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
+
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/library-go/pkg/operator/management"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -146,4 +148,12 @@ func (c *statusClient) UpdateOperatorSpec(context.Context, string, *operatorv1.O
 func (c *statusClient) UpdateOperatorStatus(ctx context.Context, version string, s *operatorv1.OperatorStatus) (status *operatorv1.OperatorStatus, err error) {
 	c.status = *s
 	return &c.status, nil
+}
+
+func (c *statusClient) ApplyOperator(ctx context.Context, fieldManager string, applyConfiguration *applyoperatorv1.OperatorSpecApplyConfiguration) (err error) {
+	return nil
+}
+
+func (c *statusClient) ApplyOperatorStatus(ctx context.Context, fieldManager string, applyConfiguration *applyoperatorv1.OperatorStatusApplyConfiguration) (err error) {
+	return nil
 }

--- a/pkg/operator/managementstatecontroller/management_state_controller_test.go
+++ b/pkg/operator/managementstatecontroller/management_state_controller_test.go
@@ -150,7 +150,7 @@ func (c *statusClient) UpdateOperatorStatus(ctx context.Context, version string,
 	return &c.status, nil
 }
 
-func (c *statusClient) ApplyOperator(ctx context.Context, fieldManager string, applyConfiguration *applyoperatorv1.OperatorSpecApplyConfiguration) (err error) {
+func (c *statusClient) ApplyOperatorSpec(ctx context.Context, fieldManager string, applyConfiguration *applyoperatorv1.OperatorSpecApplyConfiguration) (err error) {
 	return nil
 }
 

--- a/pkg/operator/resourcesynccontroller/resourcesync_controller.go
+++ b/pkg/operator/resourcesynccontroller/resourcesync_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	applyoperatorv1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
 	"net/http"
 	"sort"
 	"strings"
@@ -250,24 +251,26 @@ func (c *ResourceSyncController) Sync(ctx context.Context, syncCtx factory.SyncC
 	}
 
 	if len(errors) > 0 {
-		cond := operatorv1.OperatorCondition{
-			Type:    condition.ResourceSyncControllerDegradedConditionType,
-			Status:  operatorv1.ConditionTrue,
-			Reason:  "Error",
-			Message: v1helpers.NewMultiLineAggregate(errors).Error(),
-		}
-		if _, _, updateError := v1helpers.UpdateStatus(ctx, c.operatorConfigClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
-			return updateError
+		condition := applyoperatorv1.OperatorStatus().
+			WithConditions(applyoperatorv1.OperatorCondition().
+				WithType(condition.ResourceSyncControllerDegradedConditionType).
+				WithStatus(operatorv1.ConditionTrue).
+				WithReason("Error").
+				WithMessage(v1helpers.NewMultiLineAggregate(errors).Error()))
+		updateErr := c.operatorConfigClient.ApplyOperatorStatus(ctx, factory.ControllerFieldManager(c.name, "reportDegraded"), condition)
+		if updateErr != nil {
+			return updateErr
 		}
 		return nil
 	}
 
-	cond := operatorv1.OperatorCondition{
-		Type:   condition.ResourceSyncControllerDegradedConditionType,
-		Status: operatorv1.ConditionFalse,
-	}
-	if _, _, updateError := v1helpers.UpdateStatus(ctx, c.operatorConfigClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
-		return updateError
+	condition := applyoperatorv1.OperatorStatus().
+		WithConditions(applyoperatorv1.OperatorCondition().
+			WithType(condition.ResourceSyncControllerDegradedConditionType).
+			WithStatus(operatorv1.ConditionFalse))
+	updateErr := c.operatorConfigClient.ApplyOperatorStatus(ctx, factory.ControllerFieldManager(c.name, "reportDegraded"), condition)
+	if updateErr != nil {
+		return updateErr
 	}
 	return nil
 }

--- a/pkg/operator/status/status_controller_test.go
+++ b/pkg/operator/status/status_controller_test.go
@@ -621,7 +621,7 @@ func (c *statusClient) UpdateOperatorStatus(context.Context, string, *operatorv1
 	panic("missing")
 }
 
-func (c *statusClient) ApplyOperator(ctx context.Context, fieldManager string, applyConfiguration *applyoperatorv1.OperatorSpecApplyConfiguration) (err error) {
+func (c *statusClient) ApplyOperatorSpec(ctx context.Context, fieldManager string, applyConfiguration *applyoperatorv1.OperatorSpecApplyConfiguration) (err error) {
 	panic("missing")
 }
 

--- a/pkg/operator/status/status_controller_test.go
+++ b/pkg/operator/status/status_controller_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	applyoperatorv1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/client-go/tools/cache"
@@ -616,6 +618,14 @@ func (c *statusClient) UpdateOperatorSpec(context.Context, string, *operatorv1.O
 }
 
 func (c *statusClient) UpdateOperatorStatus(context.Context, string, *operatorv1.OperatorStatus) (status *operatorv1.OperatorStatus, err error) {
+	panic("missing")
+}
+
+func (c *statusClient) ApplyOperator(ctx context.Context, fieldManager string, applyConfiguration *applyoperatorv1.OperatorSpecApplyConfiguration) (err error) {
+	panic("missing")
+}
+
+func (c *statusClient) ApplyOperatorStatus(ctx context.Context, fieldManager string, applyConfiguration *applyoperatorv1.OperatorStatusApplyConfiguration) (err error) {
 	panic("missing")
 }
 

--- a/pkg/operator/v1helpers/canonicalize.go
+++ b/pkg/operator/v1helpers/canonicalize.go
@@ -1,0 +1,75 @@
+package v1helpers
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"k8s.io/apimachinery/pkg/util/json"
+
+	"k8s.io/utils/ptr"
+
+	applyoperatorv1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
+)
+
+// ToStaticPodOperator returns the equivalent typed kind for the applyconfiguration. Due to differences in serialization like
+// omitempty on strings versus pointers, the returned values can be slightly different.  This is an expensive way to diff the
+// result, but it is an effective one.
+func ToStaticPodOperator(in *applyoperatorv1.StaticPodOperatorStatusApplyConfiguration) (*operatorv1.StaticPodOperatorStatus, error) {
+	if in == nil {
+		return nil, nil
+	}
+	jsonBytes, err := json.Marshal(in)
+	if err != nil {
+		return nil, fmt.Errorf("unable to serialize: %w", err)
+	}
+
+	ret := &operatorv1.StaticPodOperatorStatus{}
+	if err := json.Unmarshal(jsonBytes, ret); err != nil {
+		return nil, fmt.Errorf("unable to deserialize: %w", err)
+	}
+
+	return ret, nil
+}
+
+func CanonicalizeStaticPodOperatorStatus(obj *applyoperatorv1.StaticPodOperatorStatusApplyConfiguration) {
+	if obj == nil {
+		return
+	}
+	CanonicalizeOperatorStatus(&obj.OperatorStatusApplyConfiguration)
+	slices.SortStableFunc(obj.NodeStatuses, CompareNodeStatusByNode)
+}
+
+func CanonicalizeOperatorStatus(obj *applyoperatorv1.OperatorStatusApplyConfiguration) {
+	if obj == nil {
+		return
+	}
+	slices.SortStableFunc(obj.Conditions, CompareOperatorConditionByType)
+	slices.SortStableFunc(obj.Generations, CompareGenerationStatusByKeys)
+}
+
+func CompareOperatorConditionByType(a, b applyoperatorv1.OperatorConditionApplyConfiguration) int {
+	return strings.Compare(ptr.Deref(a.Type, ""), ptr.Deref(b.Type, ""))
+}
+
+func CompareGenerationStatusByKeys(a, b applyoperatorv1.GenerationStatusApplyConfiguration) int {
+	if c := strings.Compare(ptr.Deref(a.Group, ""), ptr.Deref(b.Group, "")); c != 0 {
+		return c
+	}
+	if c := strings.Compare(ptr.Deref(a.Resource, ""), ptr.Deref(b.Resource, "")); c != 0 {
+		return c
+	}
+	if c := strings.Compare(ptr.Deref(a.Namespace, ""), ptr.Deref(b.Namespace, "")); c != 0 {
+		return c
+	}
+	if c := strings.Compare(ptr.Deref(a.Name, ""), ptr.Deref(b.Name, "")); c != 0 {
+		return c
+	}
+
+	return 0
+}
+
+func CompareNodeStatusByNode(a, b applyoperatorv1.NodeStatusApplyConfiguration) int {
+	return strings.Compare(ptr.Deref(a.NodeName, ""), ptr.Deref(b.NodeName, ""))
+}

--- a/pkg/operator/v1helpers/interfaces.go
+++ b/pkg/operator/v1helpers/interfaces.go
@@ -3,6 +3,8 @@ package v1helpers
 import (
 	"context"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
 	operatorv1 "github.com/openshift/api/operator/v1"
 	applyoperatorv1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,7 +24,7 @@ type OperatorClient interface {
 	// UpdateOperatorStatus updates the status of the operator, assuming the given resource version.
 	UpdateOperatorStatus(ctx context.Context, oldResourceVersion string, in *operatorv1.OperatorStatus) (out *operatorv1.OperatorStatus, err error)
 
-	ApplyOperator(ctx context.Context, fieldManager string, applyConfiguration *applyoperatorv1.OperatorSpecApplyConfiguration) (err error)
+	ApplyOperatorSpec(ctx context.Context, fieldManager string, applyConfiguration *applyoperatorv1.OperatorSpecApplyConfiguration) (err error)
 	ApplyOperatorStatus(ctx context.Context, fieldManager string, applyConfiguration *applyoperatorv1.OperatorStatusApplyConfiguration) (err error)
 }
 
@@ -39,7 +41,7 @@ type StaticPodOperatorClient interface {
 	// UpdateStaticPodOperatorSpec updates the spec, assuming the given resource  version.
 	UpdateStaticPodOperatorSpec(ctx context.Context, resourceVersion string, in *operatorv1.StaticPodOperatorSpec) (out *operatorv1.StaticPodOperatorSpec, newResourceVersion string, err error)
 
-	ApplyStaticPodOperator(ctx context.Context, fieldManager string, applyConfiguration *applyoperatorv1.StaticPodOperatorSpecApplyConfiguration) (err error)
+	ApplyStaticPodOperatorSpec(ctx context.Context, fieldManager string, applyConfiguration *applyoperatorv1.StaticPodOperatorSpecApplyConfiguration) (err error)
 	ApplyStaticPodOperatorStatus(ctx context.Context, fieldManager string, applyConfiguration *applyoperatorv1.StaticPodOperatorStatusApplyConfiguration) (err error)
 }
 
@@ -50,3 +52,11 @@ type OperatorClientWithFinalizers interface {
 	// RemoveFinalizer removes a finalizer from the operator CR, if it is there. No-op otherwise.
 	RemoveFinalizer(ctx context.Context, finalizer string) error
 }
+
+type Foo interface {
+	ExtractOperatorSpec(fieldManager string) (*applyoperatorv1.OperatorSpecApplyConfiguration, error)
+	ExtractOperatorStatus(fieldManager string) (*applyoperatorv1.OperatorStatusApplyConfiguration, error)
+}
+
+type OperatorSpecExtractor func(obj *unstructured.Unstructured, fieldManager string) (*applyoperatorv1.OperatorSpecApplyConfiguration, error)
+type OperatorStatusExtractor func(obj *unstructured.Unstructured, fieldManager string) (*applyoperatorv1.OperatorStatusApplyConfiguration, error)

--- a/pkg/operator/v1helpers/interfaces.go
+++ b/pkg/operator/v1helpers/interfaces.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
+	applyoperatorv1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -20,6 +21,9 @@ type OperatorClient interface {
 	UpdateOperatorSpec(ctx context.Context, oldResourceVersion string, in *operatorv1.OperatorSpec) (out *operatorv1.OperatorSpec, newResourceVersion string, err error)
 	// UpdateOperatorStatus updates the status of the operator, assuming the given resource version.
 	UpdateOperatorStatus(ctx context.Context, oldResourceVersion string, in *operatorv1.OperatorStatus) (out *operatorv1.OperatorStatus, err error)
+
+	ApplyOperator(ctx context.Context, fieldManager string, applyConfiguration *applyoperatorv1.OperatorSpecApplyConfiguration) (err error)
+	ApplyOperatorStatus(ctx context.Context, fieldManager string, applyConfiguration *applyoperatorv1.OperatorStatusApplyConfiguration) (err error)
 }
 
 type StaticPodOperatorClient interface {
@@ -34,6 +38,9 @@ type StaticPodOperatorClient interface {
 	UpdateStaticPodOperatorStatus(ctx context.Context, resourceVersion string, in *operatorv1.StaticPodOperatorStatus) (out *operatorv1.StaticPodOperatorStatus, err error)
 	// UpdateStaticPodOperatorSpec updates the spec, assuming the given resource  version.
 	UpdateStaticPodOperatorSpec(ctx context.Context, resourceVersion string, in *operatorv1.StaticPodOperatorSpec) (out *operatorv1.StaticPodOperatorSpec, newResourceVersion string, err error)
+
+	ApplyStaticPodOperator(ctx context.Context, fieldManager string, applyConfiguration *applyoperatorv1.StaticPodOperatorSpecApplyConfiguration) (err error)
+	ApplyStaticPodOperatorStatus(ctx context.Context, fieldManager string, applyConfiguration *applyoperatorv1.StaticPodOperatorStatusApplyConfiguration) (err error)
 }
 
 type OperatorClientWithFinalizers interface {

--- a/pkg/operator/v1helpers/test_helpers.go
+++ b/pkg/operator/v1helpers/test_helpers.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"time"
 
+	applyoperatorv1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -155,6 +156,22 @@ func (c *fakeStaticPodOperatorClient) UpdateStaticPodOperatorSpec(ctx context.Co
 	return c.fakeStaticPodOperatorSpec, c.resourceVersion, nil
 }
 
+func (c *fakeStaticPodOperatorClient) ApplyOperator(ctx context.Context, fieldManager string, applyConfiguration *applyoperatorv1.OperatorSpecApplyConfiguration) (err error) {
+	return nil
+}
+
+func (c *fakeStaticPodOperatorClient) ApplyOperatorStatus(ctx context.Context, fieldManager string, applyConfiguration *applyoperatorv1.OperatorStatusApplyConfiguration) (err error) {
+	return nil
+}
+
+func (c *fakeStaticPodOperatorClient) ApplyStaticPodOperator(ctx context.Context, fieldManager string, applyConfiguration *applyoperatorv1.StaticPodOperatorSpecApplyConfiguration) (err error) {
+	return nil
+}
+
+func (c *fakeStaticPodOperatorClient) ApplyStaticPodOperatorStatus(ctx context.Context, fieldManager string, applyConfiguration *applyoperatorv1.StaticPodOperatorStatusApplyConfiguration) (err error) {
+	return nil
+}
+
 func (c *fakeStaticPodOperatorClient) GetOperatorState() (*operatorv1.OperatorSpec, *operatorv1.OperatorStatus, string, error) {
 	return &c.fakeStaticPodOperatorSpec.OperatorSpec, &c.fakeStaticPodOperatorStatus.OperatorStatus, c.resourceVersion, nil
 }
@@ -281,6 +298,14 @@ func (c *fakeOperatorClient) UpdateOperatorSpec(ctx context.Context, resourceVer
 	c.resourceVersion = strconv.Itoa(rv + 1)
 	c.fakeOperatorSpec = spec
 	return c.fakeOperatorSpec, c.resourceVersion, nil
+}
+
+func (c *fakeOperatorClient) ApplyOperator(ctx context.Context, fieldManager string, applyConfiguration *applyoperatorv1.OperatorSpecApplyConfiguration) (err error) {
+	return nil
+}
+
+func (c *fakeOperatorClient) ApplyOperatorStatus(ctx context.Context, fieldManager string, applyConfiguration *applyoperatorv1.OperatorStatusApplyConfiguration) (err error) {
+	return nil
 }
 
 func (c *fakeOperatorClient) EnsureFinalizer(ctx context.Context, finalizer string) error {

--- a/pkg/operator/v1helpers/test_helpers.go
+++ b/pkg/operator/v1helpers/test_helpers.go
@@ -15,8 +15,10 @@ import (
 	"k8s.io/client-go/kubernetes"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/ptr"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
+	v1 "github.com/openshift/api/operator/v1"
 )
 
 // NewFakeSharedIndexInformer returns a fake shared index informer, suitable to use in static pod controller unit tests.
@@ -156,7 +158,7 @@ func (c *fakeStaticPodOperatorClient) UpdateStaticPodOperatorSpec(ctx context.Co
 	return c.fakeStaticPodOperatorSpec, c.resourceVersion, nil
 }
 
-func (c *fakeStaticPodOperatorClient) ApplyOperator(ctx context.Context, fieldManager string, applyConfiguration *applyoperatorv1.OperatorSpecApplyConfiguration) (err error) {
+func (c *fakeStaticPodOperatorClient) ApplyOperatorSpec(ctx context.Context, fieldManager string, applyConfiguration *applyoperatorv1.OperatorSpecApplyConfiguration) (err error) {
 	return nil
 }
 
@@ -164,7 +166,7 @@ func (c *fakeStaticPodOperatorClient) ApplyOperatorStatus(ctx context.Context, f
 	return nil
 }
 
-func (c *fakeStaticPodOperatorClient) ApplyStaticPodOperator(ctx context.Context, fieldManager string, applyConfiguration *applyoperatorv1.StaticPodOperatorSpecApplyConfiguration) (err error) {
+func (c *fakeStaticPodOperatorClient) ApplyStaticPodOperatorSpec(ctx context.Context, fieldManager string, applyConfiguration *applyoperatorv1.StaticPodOperatorSpecApplyConfiguration) (err error) {
 	return nil
 }
 
@@ -300,11 +302,12 @@ func (c *fakeOperatorClient) UpdateOperatorSpec(ctx context.Context, resourceVer
 	return c.fakeOperatorSpec, c.resourceVersion, nil
 }
 
-func (c *fakeOperatorClient) ApplyOperator(ctx context.Context, fieldManager string, applyConfiguration *applyoperatorv1.OperatorSpecApplyConfiguration) (err error) {
+func (c *fakeOperatorClient) ApplyOperatorSpec(ctx context.Context, fieldManager string, applyConfiguration *applyoperatorv1.OperatorSpecApplyConfiguration) (err error) {
 	return nil
 }
 
 func (c *fakeOperatorClient) ApplyOperatorStatus(ctx context.Context, fieldManager string, applyConfiguration *applyoperatorv1.OperatorStatusApplyConfiguration) (err error) {
+	c.fakeOperatorStatus = convertOperatorStatusApplyConfiguration(applyConfiguration)
 	return nil
 }
 
@@ -335,4 +338,36 @@ func (c *fakeOperatorClient) RemoveFinalizer(ctx context.Context, finalizer stri
 
 func (c *fakeOperatorClient) SetObjectMeta(meta *metav1.ObjectMeta) {
 	c.fakeObjectMeta = meta
+}
+
+func convertOperatorStatusApplyConfiguration(applyConfiguration *applyoperatorv1.OperatorStatusApplyConfiguration) *v1.OperatorStatus {
+	status := &v1.OperatorStatus{
+		ObservedGeneration: ptr.Deref(applyConfiguration.ObservedGeneration, 0),
+		Version:            ptr.Deref(applyConfiguration.Version, ""),
+		ReadyReplicas:      ptr.Deref(applyConfiguration.ReadyReplicas, 0),
+	}
+
+	for _, condition := range applyConfiguration.Conditions {
+		newCondition := operatorv1.OperatorCondition{
+			Type:    ptr.Deref(condition.Type, ""),
+			Status:  ptr.Deref(condition.Status, ""),
+			Reason:  ptr.Deref(condition.Reason, ""),
+			Message: ptr.Deref(condition.Message, ""),
+		}
+		status.Conditions = append(status.Conditions, newCondition)
+	}
+
+	for _, generation := range applyConfiguration.Generations {
+		newGeneration := operatorv1.GenerationStatus{
+			Group:          ptr.Deref(generation.Group, ""),
+			Resource:       ptr.Deref(generation.Resource, ""),
+			Namespace:      ptr.Deref(generation.Namespace, ""),
+			Name:           ptr.Deref(generation.Name, ""),
+			LastGeneration: ptr.Deref(generation.LastGeneration, 0),
+			Hash:           ptr.Deref(generation.Hash, ""),
+		}
+		status.Generations = append(status.Generations, newGeneration)
+	}
+
+	return status
 }


### PR DESCRIPTION
use apply in operator status instead of updates.  This will
1. eliminate unnecessary conflicts and repeated writes
2. eliminate retries in controller logic
3. make it easier to describe desired state from multiple different controllers
4. make it possible to locate conflicting writers in CI

Messing around with the core bits in this repo and will try revendoring into a couple.