### PR TITLE
OCPBUGS-27741: Reject Invalid Route Paths with Rewrite-Target Annotation

### DIFF
--- a/pkg/route/validation/validation.go
+++ b/pkg/route/validation/validation.go
@@ -60,6 +60,8 @@ const (
 	permittedResponseHeaderValueErrorMessage = "Either header value provided is not in correct format or the converter specified is not allowed. The dynamic header value  may use HAProxy's %[] syntax and otherwise must be a valid HTTP header value as defined in https://datatracker.ietf.org/doc/html/rfc7230#section-3.2 Sample fetchers allowed are res.hdr, ssl_c_der. Converters allowed are lower, base64."
 	// routerServiceAccount is used to validate RBAC permissions for externalCertificate
 	routerServiceAccount = "system:serviceaccount:openshift-ingress:router"
+	// rewriteTargetAnnotation is route annotation used to specify a rewrite target.
+	rewriteTargetAnnotation = "haproxy.router.openshift.io/rewrite-target"
 )
 
 var (
@@ -212,6 +214,47 @@ func validateRoute(ctx context.Context, route *routev1.Route, checkHostname bool
 		result = append(result, errs...)
 	}
 
+	if errs := ValidatePathWithRewriteTargetAnnotation(route, specPath.Child("path")); len(errs) != 0 {
+		result = append(result, errs...)
+	}
+
+	return result
+}
+
+// ValidatePathWithRewriteTargetAnnotation tests the spec.path field for invalid syntax when the
+// rewrite-target annotation is set. This addresses OCPBUGS-27741 by rejecting invalid spec.path
+// values, while preserving compatibility for users who may have depended on the unintended
+// behavior caused by the bug.
+func ValidatePathWithRewriteTargetAnnotation(route *routev1.Route, fldPath *field.Path) field.ErrorList {
+	result := field.ErrorList{}
+	if rewriteVal, ok := route.Annotations[rewriteTargetAnnotation]; ok {
+		// Since regex compilation is expensive, first determine if there are any regex meta characters in spec.path.
+		if containsRegexMetaChars(route.Spec.Path) {
+			// Replicate the regex used in the haproxy-config.template.
+			var regex string
+			if rewriteVal == "/" {
+				regex = fmt.Sprintf("^%s/?(.*)$", route.Spec.Path)
+			} else {
+				regex = fmt.Sprintf("^%s?(.*)$", route.Spec.Path)
+			}
+			if _, err := regexp.Compile(regex); err != nil {
+				result = append(result, field.Invalid(fldPath, route.Spec.Path, fmt.Sprintf("cannot contain invalid regex characters while %s is specified", rewriteTargetAnnotation)))
+			}
+		}
+		// These validations are to protect against HAProxy config file level errors.
+		if hasUnmatchedSingleQuotes(route.Spec.Path) {
+			result = append(result, field.Invalid(fldPath, route.Spec.Path, fmt.Sprintf("cannot contain unmatched ' while %s is specified", rewriteTargetAnnotation)))
+		}
+		if hasUnmatchedDoubleQuotes(route.Spec.Path) {
+			result = append(result, field.Invalid(fldPath, route.Spec.Path, fmt.Sprintf("cannot contain unmatched \" while %s is specified", rewriteTargetAnnotation)))
+		}
+		if strings.Contains(route.Spec.Path, "#") {
+			result = append(result, field.Invalid(fldPath, route.Spec.Path, fmt.Sprintf("cannot contain # while %s is specified", rewriteTargetAnnotation)))
+		}
+		if strings.Contains(route.Spec.Path, "\n") || strings.Contains(route.Spec.Path, "\r") {
+			result = append(result, field.Invalid(fldPath, route.Spec.Path, fmt.Sprintf("cannot contain newlines while %s is specified", rewriteTargetAnnotation)))
+		}
+	}
 	return result
 }
 
@@ -526,10 +569,59 @@ func validateKubeFinalizerName(stringValue string, fldPath *field.Path) field.Er
 }
 
 func Warnings(route *routev1.Route) []string {
+	var warnings []string
 	if len(route.Spec.Host) != 0 && len(route.Spec.Subdomain) != 0 {
-		var warnings []string
 		warnings = append(warnings, "spec.host is set; spec.subdomain may be ignored")
-		return warnings
 	}
-	return nil
+	warnings = append(warnings, warnPathWithRewriteTargetAnnotation(route)...)
+
+	return warnings
+}
+
+// warnPathWithRewriteTargetAnnotation returns warnings if a provided route has
+// the rewrite-target annotation set, and the spec.path contains invalid
+// values that, while valid, may lead to unintended behavior.
+func warnPathWithRewriteTargetAnnotation(route *routev1.Route) []string {
+	var warnings []string
+	if _, ok := route.Annotations[rewriteTargetAnnotation]; ok {
+		if containsRegexMetaChars(route.Spec.Path) {
+			warnings = append(warnings, fmt.Sprintf("spec.path contains regex meta characters which may lead to unexpected behavior using %s", rewriteTargetAnnotation))
+		}
+		if strings.Contains(route.Spec.Path, `'`) {
+			warnings = append(warnings, fmt.Sprintf("spec.path contains a ' which may lead to unexpected behavior using %s", rewriteTargetAnnotation))
+		}
+		if strings.Contains(route.Spec.Path, `"`) {
+			warnings = append(warnings, fmt.Sprintf("spec.path contains a \" which may lead to unexpected behavior using %s", rewriteTargetAnnotation))
+		}
+	}
+	return warnings
+}
+
+// hasUnmatchedSingleQuotes returns true if input string has unmatched single quotes.
+func hasUnmatchedSingleQuotes(input string) bool {
+	singleQuoteCount := strings.Count(input, `'`)
+	if singleQuoteCount%2 != 0 {
+		return true
+	}
+	return false
+}
+
+// hasUnmatchedDoubleQuotes returns true if input string has unmatched double quotes.
+func hasUnmatchedDoubleQuotes(input string) bool {
+	doubleQuoteCount := strings.Count(input, `"`)
+	if doubleQuoteCount%2 != 0 {
+		return true
+	}
+	return false
+}
+
+// containsRegexMetaChars returns true if the input string contains a regex meta character.
+func containsRegexMetaChars(input string) bool {
+	regexMetaChars := `.+*?^$()[]{}|\`
+	for _, char := range regexMetaChars {
+		if strings.ContainsRune(input, char) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Reject routes with the rewrite-target annotation set and a spec.path that would cause HAProxy startup failure. This solution maintains compatability for the rewrite-target annotation while only rejecting routes with problematic configuration. Additionally, add warnings to indicate to users that their route configuration with rewrite-target may produce unexpected results.