### PR TITLE
OCPBUGS-42535-prime: prevent conditions missing information

### DIFF
--- a/pkg/operator/genericoperatorclient/dynamic_operator_client.go
+++ b/pkg/operator/genericoperatorclient/dynamic_operator_client.go
@@ -192,6 +192,18 @@ func (c dynamicOperatorClient) UpdateOperatorSpec(ctx context.Context, resourceV
 // in operatorv1.OperatorStatus while preserving pre-existing status fields that have
 // no correspondence in operatorv1.OperatorStatus.
 func (c dynamicOperatorClient) UpdateOperatorStatus(ctx context.Context, resourceVersion string, status *operatorv1.OperatorStatus) (*operatorv1.OperatorStatus, error) {
+	if status != nil {
+		for i, curr := range status.Conditions {
+			// panicking so we can quickly find it and fix the source
+			if len(curr.Type) == 0 {
+				panic(fmt.Sprintf(".status.conditions[%d].type is missing", i))
+			}
+			if len(curr.Status) == 0 {
+				panic(fmt.Sprintf(".status.conditions[%q].status is missing", curr.Type))
+			}
+		}
+	}
+
 	uncastOriginal, err := c.informer.Lister().Get(c.configName)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This is catching them.  We need to 
1. identify the problems in openshift-apiserver and authentication (two cases the validation caught)
2. add a condition remover for these empties
3. backport
4. merge this and revendor
5. watch for fireworkds
6. backport this
