### PR TITLE
OCPBUGS-42083: Include bootstrap IP in etcd endpoints list

### DIFF
--- a/pkg/operator/configobserver/etcd/observe_etcd_endpoints_test.go
+++ b/pkg/operator/configobserver/etcd/observe_etcd_endpoints_test.go
@@ -184,13 +184,13 @@ func TestInnerObserveStorageURLs(t *testing.T) {
 			expectErrors:      true,
 		},
 		{
-			name:             "IgnoreBootstrap",
+			name:             "BootstrapIncluded",
 			currentConfigFor: observedConfigFor(withStorageURLFor("https://previous.url:2379")),
 			endpoint: endpoints(
 				withBootstrap("10.0.0.2"),
 				withAddress("10.0.0.1"),
 			),
-			expectedConfigFor: observedConfigFor(withStorageURLFor("https://10.0.0.1:2379")),
+			expectedConfigFor: observedConfigFor(withStorageURLFor("https://10.0.0.1:2379"), withStorageURLFor("https://10.0.0.2:2379")),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
During bootstrap kube-apiserver points to master etcd instances. These instances are being added to etcd-servers list one by one, to ensure that if any master can't reach some other etcds this revision
 won't block the entire rollout.
 However, at some point the masters may end up with just one etcd
 (localhost and its IP), which makes it non-HA and apiserver may
 lose etcd connection if this etcd is being reconfigured.

This change updates the list to include bootstrap etcd so that any master would always have an etcd instance to connect to.

Tested in https://github.com/openshift/cluster-kube-apiserver-operator/pull/1745