### PR TITLE
OCPBUGS-36233: Replicas hook consider Control plane topology

### DIFF
--- a/pkg/operator/csi/csidrivercontrollerservicecontroller/helpers.go
+++ b/pkg/operator/csi/csidrivercontrollerservicecontroller/helpers.go
@@ -12,9 +12,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/labels"
 	corev1 "k8s.io/client-go/informers/core/v1"
-	corev1listers "k8s.io/client-go/listers/core/v1"
 
 	configv1 "github.com/openshift/api/config/v1"
 	opv1 "github.com/openshift/api/operator/v1"
@@ -121,22 +119,20 @@ func WithSecretHashAnnotationHook(
 	}
 }
 
-// WithReplicasHook sets the deployment.Spec.Replicas field according to the number
-// of available nodes. If the number of available nodes is bigger than one, then the
-// number of replicas will be two. The number of nodes is determined by the node
-// selector specified in the field deployment.Spec.Templates.NodeSelector.
-// When node ports or hostNetwork are used, maxSurge=0 should be set in the
+// WithReplicasHook sets the deployment.Spec.Replicas field according to the ControlPlaneTopology
+// mode. If the topology is set to 'HighlyAvailable' then the number of replicas will be two.
+// Else it will be one. When node ports or hostNetwork are used, maxSurge=0 should be set in the
 // Deployment RollingUpdate strategy to prevent the new pod from getting stuck
 // waiting for a node with free ports.
-func WithReplicasHook(nodeLister corev1listers.NodeLister) dc.DeploymentHookFunc {
+func WithReplicasHook(configInformer configinformers.SharedInformerFactory) dc.DeploymentHookFunc {
 	return func(_ *opv1.OperatorSpec, deployment *appsv1.Deployment) error {
-		nodeSelector := deployment.Spec.Template.Spec.NodeSelector
-		nodes, err := nodeLister.List(labels.SelectorFromSet(nodeSelector))
+		infra, err := configInformer.Config().V1().Infrastructures().Lister().Get(infraConfigName)
 		if err != nil {
 			return err
 		}
+
 		replicas := int32(1)
-		if len(nodes) > 1 {
+		if infra.Status.ControlPlaneTopology == configv1.HighlyAvailableTopologyMode {
 			replicas = int32(2)
 		}
 		deployment.Spec.Replicas = &replicas


### PR DESCRIPTION
If ControlPlaneTopology is set to `HighlyAvailable` return pod count 2 else 1.

backporting from #1796 