### PR TITLE
API-1835: fix initialization of variable in deployment controller

### DIFF
--- a/pkg/operator/deploymentcontroller/deployment_controller.go
+++ b/pkg/operator/deploymentcontroller/deployment_controller.go
@@ -124,12 +124,13 @@ func NewDeploymentControllerBuilder(
 	deployInformer appsinformersv1.DeploymentInformer,
 ) *DeploymentController {
 	return &DeploymentController{
-		instanceName:   instanceName,
-		manifest:       manifest,
-		operatorClient: operatorClient,
-		kubeClient:     kubeClient,
-		deployInformer: deployInformer,
-		recorder:       recorder,
+		instanceName:           instanceName,
+		controllerInstanceName: factory.ControllerInstanceName(instanceName, "Deployment"),
+		manifest:               manifest,
+		operatorClient:         operatorClient,
+		kubeClient:             kubeClient,
+		deployInformer:         deployInformer,
+		recorder:               recorder,
 	}
 }
 


### PR DESCRIPTION
Failure:

```
{Operator degraded (GCPPDCSIDriverOperatorCR_GCPPDDriverControllerServiceController_SyncError): GCPPDCSIDriverOperatorCRDegraded: GCPPDDriverControllerServiceControllerDegraded: unable to ApplyStatus for operator using fieldManager "": PatchOptions.meta.k8s.io "" is invalid: fieldManager: Required value: is required for apply patch  Operator degraded (GCPPDCSIDriverOperatorCR_GCPPDDriverControllerServiceController_SyncError): GCPPDCSIDriverOperatorCRDegraded: GCPPDDriverControllerServiceControllerDegraded: unable to ApplyStatus for operator using fieldManager "": PatchOptions.meta.k8s.io "" is invalid: fieldManager: Required value: is required for apply patch}
```

xref: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_gcp-pd-csi-driver-operator/127/pull-ci-openshift-gcp-pd-csi-driver-operator-master-e2e-gcp-csi/1840730610318970880

Introduced in https://github.com/openshift/library-go/pull/1794/files#diff-abb679a52a6ea86c466b84d87793ee37682c0e4b6a111234e69cb684d7ec3157.

/assign @deads2k @p0lyn0mial 