### PR TITLE
audit: do not log requests to /livez

### DIFF
--- a/pkg/operator/apiserver/audit/manifests/base-policy.yaml
+++ b/pkg/operator/apiserver/audit/manifests/base-policy.yaml
@@ -14,6 +14,7 @@
       - "/version"
       - "/healthz"
       - "/readyz"
+      - "/livez"
     # Don't log requests by "system:apiserver" on apirequestcounts
     - level: None
       users: ["system:apiserver"]

--- a/pkg/operator/apiserver/audit/testdata/allrequestbodies.yaml
+++ b/pkg/operator/apiserver/audit/testdata/allrequestbodies.yaml
@@ -16,6 +16,7 @@ rules:
   - "/version"
   - "/healthz"
   - "/readyz"
+  - "/livez"
 # Don't log requests by "system:apiserver" on apirequestcounts
 - level: None
   users: ["system:apiserver"]

--- a/pkg/operator/apiserver/audit/testdata/default.yaml
+++ b/pkg/operator/apiserver/audit/testdata/default.yaml
@@ -16,6 +16,7 @@
       - "/version"
       - "/healthz"
       - "/readyz"
+      - "/livez"
       # Don't log requests by "system:apiserver" on apirequestcounts
     - level: None
       users: ["system:apiserver"]

--- a/pkg/operator/apiserver/audit/testdata/multipleCr.yaml
+++ b/pkg/operator/apiserver/audit/testdata/multipleCr.yaml
@@ -16,6 +16,7 @@ rules:
   - "/version"
   - "/healthz"
   - "/readyz"
+  - "/livez"
 # Don't log requests by "system:apiserver" on apirequestcounts
 - level: None
   users: ["system:apiserver"]

--- a/pkg/operator/apiserver/audit/testdata/none.yaml
+++ b/pkg/operator/apiserver/audit/testdata/none.yaml
@@ -16,6 +16,7 @@ rules:
   - "/version"
   - "/healthz"
   - "/readyz"
+  - "/livez"
 # Don't log requests by "system:apiserver" on apirequestcounts
 - level: None
   users: ["system:apiserver"]

--- a/pkg/operator/apiserver/audit/testdata/oauth.yaml
+++ b/pkg/operator/apiserver/audit/testdata/oauth.yaml
@@ -16,6 +16,7 @@ rules:
   - "/version"
   - "/healthz"
   - "/readyz"
+  - "/livez"
 # Don't log requests by "system:apiserver" on apirequestcounts
 - level: None
   users: ["system:apiserver"]

--- a/pkg/operator/apiserver/audit/testdata/writerequestbodies.yaml
+++ b/pkg/operator/apiserver/audit/testdata/writerequestbodies.yaml
@@ -16,6 +16,7 @@ rules:
   - "/version"
   - "/healthz"
   - "/readyz"
+  - "/livez"
 # Don't log requests by "system:apiserver" on apirequestcounts
 - level: None
   users: ["system:apiserver"]


### PR DESCRIPTION
when we switched the API [servers](https://github.com/openshift/cluster-openshift-apiserver-operator/pull/588) to use the /livez EP we forgot to update the audit policy.
this pr updates the base policy which stops logging request to the mentioned ep.

kudos to @deads2k for discovering this.


proof pr at https://github.com/openshift/cluster-kube-apiserver-operator/pull/1751