### PR TITLE
API-1835: demonstrate how we will store desired mutations

### DIFF
--- a/pkg/manifestclient/mutation_directory_reader.go
+++ b/pkg/manifestclient/mutation_directory_reader.go
@@ -141,6 +141,11 @@ func serializedRequestFromFile(action Action, bodyFilename string) (*FileOrigina
 		groupName = ""
 	}
 
+	metadataName := retObj.(*unstructured.Unstructured).GetName()
+	if action == ActionDelete {
+		metadataName = retObj.(*unstructured.Unstructured).GetAnnotations()[DeletionNameAnnotation]
+	}
+
 	ret := &FileOriginatedSerializedRequest{
 		BodyFilename: bodyFilename,
 		SerializedRequest: SerializedRequest{
@@ -152,7 +157,7 @@ func serializedRequestFromFile(action Action, bodyFilename string) (*FileOrigina
 			},
 			KindType:  retObj.(*unstructured.Unstructured).GroupVersionKind(),
 			Namespace: retObj.(*unstructured.Unstructured).GetNamespace(),
-			Name:      retObj.(*unstructured.Unstructured).GetName(),
+			Name:      metadataName,
 			Body:      bodyContent,
 		},
 	}

--- a/pkg/manifestclient/mutation_directory_reader.go
+++ b/pkg/manifestclient/mutation_directory_reader.go
@@ -1,0 +1,139 @@
+package manifestclient
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/yaml"
+)
+
+func ReadMutationDirectory(mutationDirectory string) (*AllActionsTracker[FileOriginatedSerializedRequest], error) {
+	ret := NewAllActionsTracker[FileOriginatedSerializedRequest]()
+	errs := []error{}
+
+	for _, action := range sets.List(AllActions) {
+		actionDir := filepath.Join(mutationDirectory, string(action))
+
+		currResourceList, err := readSerializedRequestsFromActionDirectory(action, actionDir)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("unable to read %q content in %q: %w", action, actionDir, err))
+		}
+		ret.AddRequests(currResourceList...)
+	}
+
+	return nil, nil
+}
+
+func readSerializedRequestsFromActionDirectory(action Action, mustGatherDir string) ([]FileOriginatedSerializedRequest, error) {
+	currResourceList := []FileOriginatedSerializedRequest{}
+	errs := []error{}
+	err := filepath.WalkDir(mustGatherDir, func(currLocation string, currFile fs.DirEntry, err error) error {
+		if err != nil {
+			errs = append(errs, err)
+		}
+
+		if currFile.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(currFile.Name(), ".yaml") && !strings.HasSuffix(currFile.Name(), ".json") {
+			return nil
+		}
+		currResource, err := serializedRequestFromFile(action, currLocation)
+		if err != nil {
+			return fmt.Errorf("error deserializing %q: %w", currLocation, err)
+		}
+		if currResource == nil { // not all file are body files, so those can be nil
+			return nil
+		}
+		currResourceList = append(currResourceList, *currResource)
+
+		return nil
+	})
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	return currResourceList, errors.Join(errs...)
+}
+
+var (
+	bodyRegex    = regexp.MustCompile(`(\d\d\d)-body-(.+).yaml`)
+	optionsRegex = regexp.MustCompile(`(\d\d\d)-options-(.+).yaml`)
+)
+
+func serializedRequestFromFile(action Action, bodyFilename string) (*FileOriginatedSerializedRequest, error) {
+	bodyBasename := filepath.Base(bodyFilename)
+	if !bodyRegex.MatchString(bodyBasename) {
+		return nil, nil
+	}
+	optionsBaseName := strings.Replace(bodyBasename, "body", "options", 1)
+	optionsFilename := filepath.Join(filepath.Dir(bodyFilename), optionsBaseName)
+
+	bodyContent, err := os.ReadFile(bodyFilename)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %q: %w", bodyFilename, err)
+	}
+
+	optionsExist := false
+	optionsContent, err := os.ReadFile(optionsFilename)
+	switch {
+	case os.IsNotExist(err):
+	// not required, do nothing
+	case err != nil:
+		return nil, fmt.Errorf("failed to read %q: %w", optionsFilename, err)
+	case err == nil:
+		optionsExist = true
+	}
+
+	// parse to discover bits of the serialized request
+	retObj, _, jsonErr := unstructured.UnstructuredJSONScheme.Decode(bodyContent, nil, &unstructured.Unstructured{})
+	if jsonErr != nil {
+		// try to see if it's yaml
+		jsonString, err := yaml.YAMLToJSON(bodyContent)
+		if err != nil {
+			return nil, fmt.Errorf("unable to decode %q as json: %w", bodyFilename, jsonErr)
+		}
+		retObj, _, err = unstructured.UnstructuredJSONScheme.Decode(jsonString, nil, &unstructured.Unstructured{})
+		if err != nil {
+			return nil, fmt.Errorf("unable to decode %q as yaml: %w", bodyFilename, err)
+		}
+	}
+
+	// stepping backwards in the filename we can determine resource and group since we're using individual files, not lists
+	resourceName := filepath.Base(filepath.Dir(bodyFilename))
+	versionName := retObj.(*unstructured.Unstructured).GroupVersionKind().Version // not always correct, but nearly always correct. When/if we get to scale this will be interesting
+	groupName := filepath.Base(filepath.Dir(filepath.Dir(bodyFilename)))
+	if groupName == "core" {
+		groupName = ""
+	}
+
+	ret := &FileOriginatedSerializedRequest{
+		BodyFilename: bodyFilename,
+		SerializedRequest: SerializedRequest{
+			Action: action,
+			ResourceType: schema.GroupVersionResource{
+				Group:    groupName,
+				Version:  versionName,
+				Resource: resourceName,
+			},
+			KindType:  retObj.(*unstructured.Unstructured).GroupVersionKind(),
+			Namespace: retObj.(*unstructured.Unstructured).GetNamespace(),
+			Name:      retObj.(*unstructured.Unstructured).GetName(),
+			Body:      bodyContent,
+		},
+	}
+	if optionsExist {
+		ret.OptionsFilename = optionsFilename
+		ret.SerializedRequest.Options = optionsContent
+	}
+
+	return ret, nil
+}

--- a/pkg/manifestclient/mutation_directory_writer.go
+++ b/pkg/manifestclient/mutation_directory_writer.go
@@ -1,0 +1,35 @@
+package manifestclient
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func WriteMutationDirectory[T SerializedRequestish](mutationDirectory string, requests ...T) error {
+	errs := []error{}
+
+	for _, request := range requests {
+		bodyFilename, optionsFilename := request.SuggestedFilenames()
+		bodyPath := filepath.Join(mutationDirectory, bodyFilename)
+
+		parentDir := filepath.Dir(bodyPath)
+		if err := os.MkdirAll(parentDir, 0755); err != nil {
+			errs = append(errs, fmt.Errorf("unable to create parentDir %q: %w", parentDir, err))
+			continue
+		}
+		if err := os.WriteFile(bodyPath, request.GetSerializedRequest().Body, 0644); err != nil {
+			errs = append(errs, fmt.Errorf("unable to write body %v: %w", request, err))
+		}
+		if len(request.GetSerializedRequest().Options) > 0 {
+			optionsPath := filepath.Join(mutationDirectory, optionsFilename)
+			if err := os.WriteFile(optionsPath, request.GetSerializedRequest().Options, 0644); err != nil {
+				errs = append(errs, fmt.Errorf("unable to write options %v: %w", request, err))
+			}
+		}
+
+	}
+
+	return errors.Join(errs...)
+}

--- a/pkg/manifestclient/mutation_tracker.go
+++ b/pkg/manifestclient/mutation_tracker.go
@@ -5,6 +5,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
+const DeletionNameAnnotation = "operator.openshift.io/deletion-name"
+
 type Action string
 
 const (

--- a/pkg/manifestclient/mutation_tracker.go
+++ b/pkg/manifestclient/mutation_tracker.go
@@ -3,27 +3,34 @@ package manifestclient
 import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"sync"
 )
-
-type AllActionsTracker struct {
-	lock sync.RWMutex
-
-	NextRequestNumber int
-	ActionToTracker   map[Action]*ActionTracker
-}
 
 type Action string
 
 const (
 	// this is really a subset of patch, but we treat it separately because it is useful to do so
-	ActionApply        Action = "server-side-apply"
-	ActionApplyStatus  Action = "server-side-apply-status"
-	ActionUpdate       Action = "update"
-	ActionUpdateStatus Action = "update-status"
-	ActionCreate       Action = "create"
-	ActionDelete       Action = "delete"
+	ActionApply        Action = "Apply"
+	ActionApplyStatus  Action = "ApplyStatus"
+	ActionUpdate       Action = "Update"
+	ActionUpdateStatus Action = "UpdateStatus"
+	ActionCreate       Action = "Create"
+	ActionDelete       Action = "Delete"
 )
+
+var (
+	AllActions = sets.New[Action](
+		ActionApply,
+		ActionApplyStatus,
+		ActionUpdate,
+		ActionUpdateStatus,
+		ActionCreate,
+		ActionDelete,
+	)
+)
+
+type AllActionsTracker[T SerializedRequestish] struct {
+	actionToTracker map[Action]*actionTracker[T]
+}
 
 type ActionMetadata struct {
 	Action    Action
@@ -32,139 +39,81 @@ type ActionMetadata struct {
 	Name      string
 }
 
-type ActionTracker struct {
-	Action            Action
-	ResourceToTracker map[schema.GroupVersionResource]*ResourceTracker
+type actionTracker[T SerializedRequestish] struct {
+	action Action
+
+	requests []T
 }
 
-type ResourceTracker struct {
-	GVR                schema.GroupVersionResource
-	NamespaceToTracker map[string]*NamespaceTracker
-}
-
-type NamespaceTracker struct {
-	Namespace     string
-	NameToTracker map[string]*NameTracker
-}
-
-type NameTracker struct {
-	Name               string
-	SerializedRequests []TrackedSerializedRequest
-}
-
-func (a *AllActionsTracker) AddRequest(metadata ActionMetadata, request SerializedRequest) {
-	a.lock.Lock()
-	defer a.lock.Unlock()
-
-	trackedRequest := TrackedSerializedRequest{
-		RequestNumber:     a.NextRequestNumber,
-		SerializedRequest: request,
+func NewAllActionsTracker[T SerializedRequestish]() *AllActionsTracker[T] {
+	return &AllActionsTracker[T]{
+		actionToTracker: make(map[Action]*actionTracker[T]),
 	}
-	a.NextRequestNumber++
-
-	if a.ActionToTracker == nil {
-		a.ActionToTracker = map[Action]*ActionTracker{}
-	}
-	if _, ok := a.ActionToTracker[metadata.Action]; !ok {
-		a.ActionToTracker[metadata.Action] = &ActionTracker{Action: metadata.Action}
-	}
-	a.ActionToTracker[metadata.Action].AddRequest(metadata, trackedRequest)
 }
 
-func (a *AllActionsTracker) ListActions() []Action {
-	a.lock.Lock()
-	defer a.lock.Unlock()
-
-	return sets.KeySet(a.ActionToTracker).UnsortedList()
-}
-
-func (a *AllActionsTracker) MutationsForAction(action Action) *ActionTracker {
-	a.lock.RLock()
-	defer a.lock.RUnlock()
-
-	return a.ActionToTracker[action]
-}
-
-func (a *AllActionsTracker) MutationsForMetadata(metadata ActionMetadata) []TrackedSerializedRequest {
-	a.lock.RLock()
-	defer a.lock.RUnlock()
-
-	actionTracker := a.MutationsForAction(metadata.Action)
-	if actionTracker == nil {
-		return nil
+func (a *AllActionsTracker[T]) AddRequests(requests ...T) {
+	for _, request := range requests {
+		a.AddRequest(request)
 	}
-	resourceTracker := actionTracker.MutationsForResource(metadata.GVR)
-	if resourceTracker == nil {
-		return nil
-	}
-	namespaceTracker := resourceTracker.MutationsForNamespace(metadata.Namespace)
-	if namespaceTracker == nil {
-		return nil
-	}
-	nameTracker := namespaceTracker.MutationsForName(metadata.Name)
-	if nameTracker == nil {
-		return nil
-	}
-	return nameTracker.SerializedRequests
 }
 
-func (a *ActionTracker) AddRequest(metadata ActionMetadata, request TrackedSerializedRequest) {
-	if a.ResourceToTracker == nil {
-		a.ResourceToTracker = map[schema.GroupVersionResource]*ResourceTracker{}
+func (a *AllActionsTracker[T]) AddRequest(request T) {
+	if a.actionToTracker == nil {
+		a.actionToTracker = map[Action]*actionTracker[T]{}
 	}
-	if _, ok := a.ResourceToTracker[metadata.GVR]; !ok {
-		a.ResourceToTracker[metadata.GVR] = &ResourceTracker{GVR: metadata.GVR}
+	action := request.GetSerializedRequest().Action
+	if _, ok := a.actionToTracker[action]; !ok {
+		a.actionToTracker[action] = &actionTracker[T]{action: action}
 	}
-	a.ResourceToTracker[metadata.GVR].AddRequest(metadata, request)
+	a.actionToTracker[action].AddRequest(request)
 }
 
-func (a *ActionTracker) ListResources() []schema.GroupVersionResource {
-	return sets.KeySet(a.ResourceToTracker).UnsortedList()
+func (a *AllActionsTracker[T]) ListActions() []Action {
+	return sets.List(sets.KeySet(a.actionToTracker))
 }
 
-func (a *ActionTracker) MutationsForResource(gvr schema.GroupVersionResource) *ResourceTracker {
-	return a.ResourceToTracker[gvr]
+func (a *AllActionsTracker[T]) RequestsForAction(action Action) []T {
+	return a.actionToTracker[action].Mutations()
 }
 
-func (a *ResourceTracker) AddRequest(metadata ActionMetadata, request TrackedSerializedRequest) {
-	if a.NamespaceToTracker == nil {
-		a.NamespaceToTracker = map[string]*NamespaceTracker{}
+func (a *AllActionsTracker[T]) AllRequests() []T {
+	ret := []T{}
+	for _, currActionTracker := range a.actionToTracker {
+		ret = append(ret, currActionTracker.Mutations()...)
 	}
-	if _, ok := a.NamespaceToTracker[metadata.Namespace]; !ok {
-		a.NamespaceToTracker[metadata.Namespace] = &NamespaceTracker{Namespace: metadata.Namespace}
+	return ret
+}
+
+func (a *AllActionsTracker[T]) DeepCopy() *AllActionsTracker[T] {
+	ret := &AllActionsTracker[T]{
+		actionToTracker: make(map[Action]*actionTracker[T]),
 	}
-	a.NamespaceToTracker[metadata.Namespace].AddRequest(metadata, request)
-}
 
-func (a *ResourceTracker) ListNamespaces() []string {
-	return sets.KeySet(a.NamespaceToTracker).UnsortedList()
-}
-
-func (a *ResourceTracker) MutationsForNamespace(namespace string) *NamespaceTracker {
-	return a.NamespaceToTracker[namespace]
-}
-
-func (a *NamespaceTracker) AddRequest(metadata ActionMetadata, request TrackedSerializedRequest) {
-	if a.NameToTracker == nil {
-		a.NameToTracker = map[string]*NameTracker{}
+	for k, v := range a.actionToTracker {
+		ret.actionToTracker[k] = v.DeepCopy()
 	}
-	if _, ok := a.NameToTracker[metadata.Name]; !ok {
-		a.NameToTracker[metadata.Name] = &NameTracker{Name: metadata.Name}
+	return ret
+}
+
+func (a *actionTracker[T]) AddRequest(request T) {
+	if a.action != request.GetSerializedRequest().Action {
+		panic("coding error")
 	}
-	a.NameToTracker[metadata.Name].AddRequest(request)
+	a.requests = append(a.requests, request)
 }
 
-func (a *NamespaceTracker) ListNames() []string {
-	return sets.KeySet(a.NameToTracker).UnsortedList()
+func (a *actionTracker[T]) Mutations() []T {
+	return a.requests
 }
 
-func (a *NamespaceTracker) MutationsForName(name string) *NameTracker {
-	return a.NameToTracker[name]
-}
-
-func (a *NameTracker) AddRequest(request TrackedSerializedRequest) {
-	if a.SerializedRequests == nil {
-		a.SerializedRequests = []TrackedSerializedRequest{}
+func (a *actionTracker[T]) DeepCopy() *actionTracker[T] {
+	ret := &actionTracker[T]{
+		action:   a.action,
+		requests: make([]T, 0),
 	}
-	a.SerializedRequests = append(a.SerializedRequests, request)
+
+	for _, v := range a.requests {
+		ret.requests = append(ret.requests, v.DeepCopy().(T))
+	}
+	return ret
 }

--- a/pkg/manifestclient/readwrite_roundtripper.go
+++ b/pkg/manifestclient/readwrite_roundtripper.go
@@ -52,7 +52,7 @@ type readWriteRoundTripper struct {
 
 type MutationTrackingRoundTripper interface {
 	http.RoundTripper
-	GetMutations() *AllActionsTracker
+	GetMutations() *AllActionsTracker[TrackedSerializedRequest]
 }
 
 type mutationTrackingClient struct {
@@ -65,13 +65,13 @@ func (m mutationTrackingClient) GetHTTPClient() *http.Client {
 	return m.httpClient
 }
 
-func (m mutationTrackingClient) GetMutations() *AllActionsTracker {
+func (m mutationTrackingClient) GetMutations() *AllActionsTracker[TrackedSerializedRequest] {
 	return m.mutationTrackingRoundTripper.GetMutations()
 }
 
 type MutationTrackingClient interface {
 	GetHTTPClient() *http.Client
-	GetMutations() *AllActionsTracker
+	GetMutations() *AllActionsTracker[TrackedSerializedRequest]
 }
 
 func (rt *readWriteRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -89,6 +89,6 @@ func (rt *readWriteRoundTripper) RoundTrip(req *http.Request) (*http.Response, e
 	}
 }
 
-func (rt *readWriteRoundTripper) GetMutations() *AllActionsTracker {
-	return rt.writeDelegate.actionTracker
+func (rt *readWriteRoundTripper) GetMutations() *AllActionsTracker[TrackedSerializedRequest] {
+	return rt.writeDelegate.GetMutations()
 }

--- a/pkg/manifestclient/serialized_request.go
+++ b/pkg/manifestclient/serialized_request.go
@@ -1,0 +1,220 @@
+package manifestclient
+
+import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type SerializedRequestish interface {
+	GetSerializedRequest() *SerializedRequest
+}
+
+type FileOriginatedSerializedRequest struct {
+	BodyFilename    string
+	OptionsFilename string
+
+	SerializedRequest SerializedRequest
+}
+
+type TrackedSerializedRequest struct {
+	RequestNumber int
+
+	SerializedRequest SerializedRequest
+}
+
+type SerializedRequest struct {
+	ResourceType schema.GroupVersionResource
+	KindType     schema.GroupVersionKind
+	Namespace    string
+	Name         string
+
+	Options []byte
+	Body    []byte
+}
+
+// Difference returns a set of objects that are not in s2.
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.Difference(s2) = {a3}
+// s2.Difference(s1) = {a4, a5}
+func DifferenceOfSerializedRequests[S ~[]E, E SerializedRequestish, T ~[]F, F SerializedRequestish](lhs S, rhs T) S {
+	ret := S{}
+
+	for i, currLHS := range lhs {
+		found := false
+		for _, currRHS := range rhs {
+			if EquivalentSerializedRequests(currLHS, currRHS) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			ret = append(ret, lhs[i])
+		}
+	}
+	return ret
+}
+
+func AreAllSerializedRequestsEquivalent[S ~[]E, E SerializedRequestish, T ~[]F, F SerializedRequestish](lhs S, rhs T) bool {
+	if len(DifferenceOfSerializedRequests(lhs, rhs)) != 0 {
+		return false
+	}
+	if len(DifferenceOfSerializedRequests(rhs, lhs)) != 0 {
+		return false
+	}
+	return true
+}
+
+func EquivalentSerializedRequests(lhs, rhs SerializedRequestish) bool {
+	return lhs.GetSerializedRequest().Equals(rhs.GetSerializedRequest())
+}
+
+//func SuggestedFilenamesForSerializedRequest(in SerializedRequest) (string, string) {
+//	groupName := in.ResourceType.Group
+//	if len(groupName) == 0 {
+//		groupName = "core"
+//	}
+//
+//	if len(in.Namespace) > 0 {
+//		bodyFilename := filepath.Join("namespaces", in.Namespace, groupName, in.ResourceType.Resource, fmt.Sprintf("%03d-%s.yaml", in.RequestNumber, in.Name))
+//		optionsFilename := filepath.Join("namespaces", in.Namespace, groupName, in.ResourceType.Resource, fmt.Sprintf("%03d-%s-options.yaml", in.RequestNumber, in.Name))
+//		return bodyFilename, optionsFilename
+//	}
+//	bodyFilename := filepath.Join("cluster-scoped", in.Namespace, groupName, in.ResourceType.Resource, fmt.Sprintf("%03d-%s.yaml", in.RequestNumber, in.Name))
+//	optionsFilename := filepath.Join("cluster-scoped", in.Namespace, groupName, in.ResourceType.Resource, fmt.Sprintf("%03d-%s-options.yaml", in.RequestNumber, in.Name))
+//	return bodyFilename, optionsFilename
+//}
+
+func SuggestedFilenameForTrackedSerializedRequest(in TrackedSerializedRequest) (string, string) {
+	groupName := in.SerializedRequest.ResourceType.Group
+	if len(groupName) == 0 {
+		groupName = "core"
+	}
+
+	if len(in.SerializedRequest.Namespace) > 0 {
+		bodyFilename := filepath.Join("namespaces", in.SerializedRequest.Namespace, groupName, in.SerializedRequest.ResourceType.Resource, fmt.Sprintf("%03d-%s.yaml", in.RequestNumber, in.SerializedRequest.Name))
+		optionsFilename := filepath.Join("namespaces", in.SerializedRequest.Namespace, groupName, in.SerializedRequest.ResourceType.Resource, fmt.Sprintf("%03d-%s-options.yaml", in.RequestNumber, in.SerializedRequest.Name))
+		return bodyFilename, optionsFilename
+	}
+	bodyFilename := filepath.Join("cluster-scoped", in.SerializedRequest.Namespace, groupName, in.SerializedRequest.ResourceType.Resource, fmt.Sprintf("%03d-%s.yaml", in.RequestNumber, in.SerializedRequest.Name))
+	optionsFilename := filepath.Join("cluster-scoped", in.SerializedRequest.Namespace, groupName, in.SerializedRequest.ResourceType.Resource, fmt.Sprintf("%03d-%s-options.yaml", in.RequestNumber, in.SerializedRequest.Name))
+	return bodyFilename, optionsFilename
+}
+
+func (lhs *FileOriginatedSerializedRequest) Equals(rhs *FileOriginatedSerializedRequest) bool {
+	return CompareFileOriginatedSerializedRequest(lhs, rhs) == 0
+}
+
+func CompareFileOriginatedSerializedRequest(lhs, rhs *FileOriginatedSerializedRequest) int {
+	switch {
+	case lhs == nil && rhs == nil:
+		return 0
+	case lhs == nil && rhs != nil:
+		return 1
+	case lhs != nil && rhs == nil:
+		return -1
+	}
+
+	if cmp := CompareSerializedRequest(&lhs.SerializedRequest, &rhs.SerializedRequest); cmp != 0 {
+		return cmp
+	}
+	if cmp := strings.Compare(lhs.BodyFilename, rhs.BodyFilename); cmp != 0 {
+		return cmp
+	}
+	if cmp := strings.Compare(lhs.OptionsFilename, rhs.OptionsFilename); cmp != 0 {
+		return cmp
+	}
+
+	return 0
+}
+
+func (lhs *TrackedSerializedRequest) Equals(rhs *TrackedSerializedRequest) bool {
+	return CompareTrackedSerializedRequest(lhs, rhs) == 0
+}
+
+func CompareTrackedSerializedRequest(lhs, rhs *TrackedSerializedRequest) int {
+	switch {
+	case lhs == nil && rhs == nil:
+		return 0
+	case lhs == nil && rhs != nil:
+		return 1
+	case lhs != nil && rhs == nil:
+		return -1
+	}
+
+	if lhs.RequestNumber < rhs.RequestNumber {
+		return -1
+	} else if lhs.RequestNumber > rhs.RequestNumber {
+		return 1
+	}
+
+	return CompareSerializedRequest(&lhs.SerializedRequest, &rhs.SerializedRequest)
+}
+
+func (lhs *SerializedRequest) Equals(rhs *SerializedRequest) bool {
+	return CompareSerializedRequest(lhs, rhs) == 0
+}
+
+func CompareSerializedRequest(lhs, rhs *SerializedRequest) int {
+	switch {
+	case lhs == nil && rhs == nil:
+		return 0
+	case lhs == nil && rhs != nil:
+		return 1
+	case lhs != nil && rhs == nil:
+		return -1
+	}
+
+	if cmp := strings.Compare(lhs.ResourceType.Group, rhs.ResourceType.Group); cmp != 0 {
+		return cmp
+	}
+	if cmp := strings.Compare(lhs.ResourceType.Version, rhs.ResourceType.Version); cmp != 0 {
+		return cmp
+	}
+	if cmp := strings.Compare(lhs.ResourceType.Resource, rhs.ResourceType.Resource); cmp != 0 {
+		return cmp
+	}
+
+	if cmp := strings.Compare(lhs.KindType.Group, rhs.KindType.Group); cmp != 0 {
+		return cmp
+	}
+	if cmp := strings.Compare(lhs.KindType.Version, rhs.KindType.Version); cmp != 0 {
+		return cmp
+	}
+	if cmp := strings.Compare(lhs.KindType.Kind, rhs.KindType.Kind); cmp != 0 {
+		return cmp
+	}
+
+	if cmp := strings.Compare(lhs.Namespace, rhs.Namespace); cmp != 0 {
+		return cmp
+	}
+	if cmp := strings.Compare(lhs.Name, rhs.Name); cmp != 0 {
+		return cmp
+	}
+
+	if cmp := bytes.Compare(lhs.Body, rhs.Body); cmp != 0 {
+		return cmp
+	}
+	if cmp := bytes.Compare(lhs.Options, rhs.Options); cmp != 0 {
+		return cmp
+	}
+
+	return 0
+}
+
+func (a FileOriginatedSerializedRequest) GetSerializedRequest() *SerializedRequest {
+	return &a.SerializedRequest
+}
+
+func (a TrackedSerializedRequest) GetSerializedRequest() *SerializedRequest {
+	return &a.SerializedRequest
+}
+
+func (a SerializedRequest) GetSerializedRequest() *SerializedRequest {
+	return &a
+}

--- a/pkg/manifestclient/serialized_request_test.go
+++ b/pkg/manifestclient/serialized_request_test.go
@@ -1,0 +1,95 @@
+package manifestclient
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDifferenceOfSerializedRequests(t *testing.T) {
+	type args struct {
+		lhs []FileOriginatedSerializedRequest
+		rhs []TrackedSerializedRequest
+	}
+	tests := []struct {
+		name string
+		args args
+		want []FileOriginatedSerializedRequest
+	}{
+		{
+			name: "different types, no diff",
+			args: args{
+				lhs: []FileOriginatedSerializedRequest{
+					{
+						BodyFilename:    "foo.yaml",
+						OptionsFilename: "foo-options.yaml",
+						SerializedRequest: SerializedRequest{
+							Namespace: "foo-ns",
+							Name:      "bar",
+							Options:   nil,
+							Body:      []byte("content"),
+						},
+					},
+				},
+				rhs: []TrackedSerializedRequest{
+					{
+						RequestNumber: 6,
+						SerializedRequest: SerializedRequest{
+							Namespace: "foo-ns",
+							Name:      "bar",
+							Options:   nil,
+							Body:      []byte("content"),
+						},
+					},
+				},
+			},
+			want: []FileOriginatedSerializedRequest{},
+		},
+		{
+			name: "different types with diff",
+			args: args{
+				lhs: []FileOriginatedSerializedRequest{
+					{
+						BodyFilename:    "foo.yaml",
+						OptionsFilename: "foo-options.yaml",
+						SerializedRequest: SerializedRequest{
+							Namespace: "foo-ns",
+							Name:      "bar",
+							Options:   []byte("options!"),
+							Body:      []byte("content"),
+						},
+					},
+				},
+				rhs: []TrackedSerializedRequest{
+					{
+						RequestNumber: 6,
+						SerializedRequest: SerializedRequest{
+							Namespace: "foo-ns",
+							Name:      "bar",
+							Options:   nil,
+							Body:      []byte("content"),
+						},
+					},
+				},
+			},
+			want: []FileOriginatedSerializedRequest{
+				{
+					BodyFilename:    "foo.yaml",
+					OptionsFilename: "foo-options.yaml",
+					SerializedRequest: SerializedRequest{
+						Namespace: "foo-ns",
+						Name:      "bar",
+						Options:   []byte("options!"),
+						Body:      []byte("content"),
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DifferenceOfSerializedRequests(tt.args.lhs, tt.args.rhs); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("DifferenceOfSerializedRequests() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/manifestclienttest/client_test.go
+++ b/pkg/manifestclienttest/client_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 //go:embed testdata
-var mustGather01 embed.FS
+var packageTestData embed.FS
 
 func TestSimpleChecks(t *testing.T) {
 	tests := []struct {
@@ -181,7 +181,7 @@ func defaultRoundTrippers(t *testing.T) []*testRoundTrippers {
 		{
 			name: "embed read",
 			newClientFn: func() manifestclient.MutationTrackingClient {
-				return manifestclient.NewTestingHTTPClient(mustGather01, "testdata/must-gather-01")
+				return manifestclient.NewTestingHTTPClient(packageTestData, "testdata/must-gather-01")
 			},
 		},
 	}

--- a/pkg/manifestclienttest/client_write_test.go
+++ b/pkg/manifestclienttest/client_write_test.go
@@ -99,6 +99,7 @@ func TestSimpleWritesChecks(t *testing.T) {
 				return manifestclient.ActionCreate,
 					[]manifestclient.SerializedRequestish{
 						manifestclient.SerializedRequest{
+							Action:       manifestclient.ActionCreate,
 							ResourceType: featureGateGVR,
 							KindType:     featureGateGVK,
 							Namespace:    "",
@@ -133,6 +134,7 @@ func TestSimpleWritesChecks(t *testing.T) {
 				return manifestclient.ActionCreate,
 					[]manifestclient.SerializedRequestish{
 						manifestclient.SerializedRequest{
+							Action:       manifestclient.ActionCreate,
 							ResourceType: apiserverGVR,
 							KindType:     apiserverGVK,
 							Namespace:    "",
@@ -167,6 +169,7 @@ func TestSimpleWritesChecks(t *testing.T) {
 				return manifestclient.ActionUpdate,
 					[]manifestclient.SerializedRequestish{
 						manifestclient.SerializedRequest{
+							Action:       manifestclient.ActionUpdate,
 							ResourceType: featureGateGVR,
 							KindType:     featureGateGVK,
 							Namespace:    "",
@@ -201,6 +204,7 @@ func TestSimpleWritesChecks(t *testing.T) {
 				return manifestclient.ActionUpdateStatus,
 					[]manifestclient.SerializedRequestish{
 						manifestclient.SerializedRequest{
+							Action:       manifestclient.ActionUpdateStatus,
 							ResourceType: featureGateGVR,
 							KindType:     featureGateGVK,
 							Namespace:    "",
@@ -240,6 +244,7 @@ func TestSimpleWritesChecks(t *testing.T) {
 				return manifestclient.ActionApply,
 					[]manifestclient.SerializedRequestish{
 						manifestclient.SerializedRequest{
+							Action:       manifestclient.ActionApply,
 							ResourceType: featureGateGVR,
 							KindType:     featureGateGVK,
 							Namespace:    "",
@@ -286,6 +291,7 @@ func TestSimpleWritesChecks(t *testing.T) {
 				return manifestclient.ActionApplyStatus,
 					[]manifestclient.SerializedRequestish{
 						manifestclient.SerializedRequest{
+							Action:       manifestclient.ActionApplyStatus,
 							ResourceType: featureGateGVR,
 							KindType:     featureGateGVK,
 							Namespace:    "",
@@ -314,6 +320,7 @@ func TestSimpleWritesChecks(t *testing.T) {
 				return manifestclient.ActionDelete,
 					[]manifestclient.SerializedRequestish{
 						manifestclient.SerializedRequest{
+							Action:       manifestclient.ActionDelete,
 							ResourceType: featureGateGVR,
 							KindType: schema.GroupVersionKind{
 								Group:   "config.openshift.io",
@@ -337,19 +344,10 @@ func TestSimpleWritesChecks(t *testing.T) {
 					mutationTrackingClient := roundTripperTest.getClient()
 					expectedAction, expectedSerializedRequests := test.testFn(t, mutationTrackingClient.GetHTTPClient())
 					mutations := mutationTrackingClient.GetMutations()
-					actualSerializedRequestsForAction := mutations.MutationsForAction(expectedAction)
+					actualSerializedRequestsForAction := mutations.RequestsForAction(expectedAction)
 
-					actualSerializedRequests := []manifestclient.TrackedSerializedRequest{}
-					for _, resourceActions := range actualSerializedRequestsForAction.ResourceToTracker {
-						for _, namespaceActions := range resourceActions.NamespaceToTracker {
-							for _, nameActions := range namespaceActions.NameToTracker {
-								actualSerializedRequests = append(actualSerializedRequests, nameActions.SerializedRequests...)
-							}
-						}
-					}
-
-					if !manifestclient.AreAllSerializedRequestsEquivalent(actualSerializedRequests, expectedSerializedRequests) {
-						t.Fatal(cmp.Diff(actualSerializedRequests, expectedSerializedRequests))
+					if !manifestclient.AreAllSerializedRequestsEquivalent(actualSerializedRequestsForAction, expectedSerializedRequests) {
+						t.Fatal(cmp.Diff(actualSerializedRequestsForAction, expectedSerializedRequests))
 					}
 				})
 			}

--- a/pkg/manifestclienttest/client_write_test.go
+++ b/pkg/manifestclienttest/client_write_test.go
@@ -11,74 +11,21 @@ import (
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/openshift/library-go/pkg/manifestclient"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	applymetav1 "k8s.io/client-go/applyconfigurations/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/utils/ptr"
 	"net/http"
-	"sigs.k8s.io/yaml"
 	"testing"
 )
 
-var (
-	featureGateGVR = schema.GroupVersionResource{
-		Group:    "config.openshift.io",
-		Version:  "v1",
-		Resource: "featuregates",
-	}
-	featureGateGVK = schema.GroupVersionKind{
-		Group:   "config.openshift.io",
-		Version: "v1",
-		Kind:    "FeatureGate",
-	}
-	apiserverGVR = schema.GroupVersionResource{
-		Group:    "config.openshift.io",
-		Version:  "v1",
-		Resource: "apiservers",
-	}
-	apiserverGVK = schema.GroupVersionKind{
-		Group:   "config.openshift.io",
-		Version: "v1",
-		Kind:    "APIServer",
-	}
-)
-
-func featureGateYAMLBytesOrDie(obj *configv1.FeatureGate) []byte {
-	unstructuredObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
-	if err != nil {
-		panic(err)
-	}
-	unstructuredObj["apiVersion"] = "config.openshift.io/v1"
-	unstructuredObj["kind"] = "FeatureGate"
-	retBytes, err := yaml.Marshal(unstructuredObj)
-	if err != nil {
-		panic(err)
-	}
-	return retBytes
-}
-
-func apiserverYAMLBytesOrDie(obj *configv1.APIServer) []byte {
-	unstructuredObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
-	if err != nil {
-		panic(err)
-	}
-	unstructuredObj["apiVersion"] = "config.openshift.io/v1"
-	unstructuredObj["kind"] = "APIServer"
-	retBytes, err := yaml.Marshal(unstructuredObj)
-	if err != nil {
-		panic(err)
-	}
-	return retBytes
-}
 func TestSimpleWritesChecks(t *testing.T) {
 	tests := []struct {
 		name   string
-		testFn func(*testing.T, *http.Client) (action manifestclient.Action, serializedRequests []manifestclient.SerializedRequestish)
+		testFn func(*testing.T, *http.Client)
 	}{
 		{
 			name: "CREATE-crd-in-dataset",
-			testFn: func(t *testing.T, httpClient *http.Client) (manifestclient.Action, []manifestclient.SerializedRequestish) {
+			testFn: func(t *testing.T, httpClient *http.Client) {
 				configClient, err := configclient.NewForConfigAndClient(&rest.Config{}, httpClient)
 				if err != nil {
 					t.Fatal(err)
@@ -96,24 +43,11 @@ func TestSimpleWritesChecks(t *testing.T) {
 				if len(resultingObj.Name) == 0 {
 					t.Fatal(spew.Sdump(resultingObj))
 				}
-
-				return manifestclient.ActionCreate,
-					[]manifestclient.SerializedRequestish{
-						manifestclient.SerializedRequest{
-							Action:       manifestclient.ActionCreate,
-							ResourceType: featureGateGVR,
-							KindType:     featureGateGVK,
-							Namespace:    "",
-							Name:         "new-item",
-							Options:      []byte("{}\n"),
-							Body:         featureGateYAMLBytesOrDie(mutationObj),
-						},
-					}
 			},
 		},
 		{
 			name: "CREATE-crd-not-in-dataset",
-			testFn: func(t *testing.T, httpClient *http.Client) (manifestclient.Action, []manifestclient.SerializedRequestish) {
+			testFn: func(t *testing.T, httpClient *http.Client) {
 				configClient, err := configclient.NewForConfigAndClient(&rest.Config{}, httpClient)
 				if err != nil {
 					t.Fatal(err)
@@ -131,24 +65,11 @@ func TestSimpleWritesChecks(t *testing.T) {
 				if len(resultingObj.Name) == 0 {
 					t.Fatal(spew.Sdump(resultingObj))
 				}
-
-				return manifestclient.ActionCreate,
-					[]manifestclient.SerializedRequestish{
-						manifestclient.SerializedRequest{
-							Action:       manifestclient.ActionCreate,
-							ResourceType: apiserverGVR,
-							KindType:     apiserverGVK,
-							Namespace:    "",
-							Name:         "new-item",
-							Options:      []byte("{}\n"),
-							Body:         apiserverYAMLBytesOrDie(mutationObj),
-						},
-					}
 			},
 		},
 		{
 			name: "UPDATE-crd-in-dataset",
-			testFn: func(t *testing.T, httpClient *http.Client) (manifestclient.Action, []manifestclient.SerializedRequestish) {
+			testFn: func(t *testing.T, httpClient *http.Client) {
 				configClient, err := configclient.NewForConfigAndClient(&rest.Config{}, httpClient)
 				if err != nil {
 					t.Fatal(err)
@@ -166,24 +87,11 @@ func TestSimpleWritesChecks(t *testing.T) {
 				if len(resultingObj.Name) == 0 {
 					t.Fatal(spew.Sdump(resultingObj))
 				}
-
-				return manifestclient.ActionUpdate,
-					[]manifestclient.SerializedRequestish{
-						manifestclient.SerializedRequest{
-							Action:       manifestclient.ActionUpdate,
-							ResourceType: featureGateGVR,
-							KindType:     featureGateGVK,
-							Namespace:    "",
-							Name:         "new-item",
-							Options:      []byte("{}\n"),
-							Body:         featureGateYAMLBytesOrDie(mutationObj),
-						},
-					}
 			},
 		},
 		{
 			name: "UPDATE-STATUS-crd-in-dataset-with-options",
-			testFn: func(t *testing.T, httpClient *http.Client) (manifestclient.Action, []manifestclient.SerializedRequestish) {
+			testFn: func(t *testing.T, httpClient *http.Client) {
 				configClient, err := configclient.NewForConfigAndClient(&rest.Config{}, httpClient)
 				if err != nil {
 					t.Fatal(err)
@@ -201,25 +109,11 @@ func TestSimpleWritesChecks(t *testing.T) {
 				if len(resultingObj.Name) == 0 {
 					t.Fatal(spew.Sdump(resultingObj))
 				}
-
-				return manifestclient.ActionUpdateStatus,
-					[]manifestclient.SerializedRequestish{
-						manifestclient.SerializedRequest{
-							Action:       manifestclient.ActionUpdateStatus,
-							ResourceType: featureGateGVR,
-							KindType:     featureGateGVK,
-							Namespace:    "",
-							Name:         "new-item",
-							Options:      []byte("fieldValidation: Strict\n"),
-							Body:         featureGateYAMLBytesOrDie(mutationObj),
-						},
-					}
-
 			},
 		},
 		{
 			name: "APPLY-crd-in-dataset",
-			testFn: func(t *testing.T, httpClient *http.Client) (manifestclient.Action, []manifestclient.SerializedRequestish) {
+			testFn: func(t *testing.T, httpClient *http.Client) {
 				configClient, err := configclient.NewForConfigAndClient(&rest.Config{}, httpClient)
 				if err != nil {
 					t.Fatal(err)
@@ -236,29 +130,11 @@ func TestSimpleWritesChecks(t *testing.T) {
 				if len(resultingObj.Name) == 0 {
 					t.Fatal(spew.Sdump(resultingObj))
 				}
-
-				applyBytes, err := yaml.Marshal(applyConfig)
-				if err != nil {
-					t.Fatal(err)
-				}
-
-				return manifestclient.ActionApply,
-					[]manifestclient.SerializedRequestish{
-						manifestclient.SerializedRequest{
-							Action:       manifestclient.ActionApply,
-							ResourceType: featureGateGVR,
-							KindType:     featureGateGVK,
-							Namespace:    "",
-							Name:         "new-item",
-							Options:      []byte("fieldManager: the-client\nforce: true\n"),
-							Body:         applyBytes,
-						},
-					}
 			},
 		},
 		{
 			name: "APPLY-STATUS-crd-in-dataset-with-options",
-			testFn: func(t *testing.T, httpClient *http.Client) (manifestclient.Action, []manifestclient.SerializedRequestish) {
+			testFn: func(t *testing.T, httpClient *http.Client) {
 				configClient, err := configclient.NewForConfigAndClient(&rest.Config{}, httpClient)
 				if err != nil {
 					t.Fatal(err)
@@ -283,29 +159,11 @@ func TestSimpleWritesChecks(t *testing.T) {
 				if len(resultingObj.Name) == 0 {
 					t.Fatal(spew.Sdump(resultingObj))
 				}
-
-				applyBytes, err := yaml.Marshal(applyConfig)
-				if err != nil {
-					t.Fatal(err)
-				}
-
-				return manifestclient.ActionApplyStatus,
-					[]manifestclient.SerializedRequestish{
-						manifestclient.SerializedRequest{
-							Action:       manifestclient.ActionApplyStatus,
-							ResourceType: featureGateGVR,
-							KindType:     featureGateGVK,
-							Namespace:    "",
-							Name:         "new-item",
-							Options:      []byte("fieldManager: the-client\nforce: true\n"),
-							Body:         applyBytes,
-						},
-					}
 			},
 		},
 		{
 			name: "DELETE-crd-in-dataset",
-			testFn: func(t *testing.T, httpClient *http.Client) (manifestclient.Action, []manifestclient.SerializedRequestish) {
+			testFn: func(t *testing.T, httpClient *http.Client) {
 				configClient, err := configclient.NewForConfigAndClient(&rest.Config{}, httpClient)
 				if err != nil {
 					t.Fatal(err)
@@ -317,23 +175,6 @@ func TestSimpleWritesChecks(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-
-				return manifestclient.ActionDelete,
-					[]manifestclient.SerializedRequestish{
-						manifestclient.SerializedRequest{
-							Action:       manifestclient.ActionDelete,
-							ResourceType: featureGateGVR,
-							KindType: schema.GroupVersionKind{
-								Group:   "config.openshift.io",
-								Version: "v1",
-								Kind:    "DeleteOptions",
-							},
-							Namespace: "",
-							Name:      "cluster",
-							Options:   []byte("{}\n"),
-							Body:      []byte("apiVersion: config.openshift.io/v1\nkind: DeleteOptions\npropagationPolicy: Foreground\n"),
-						},
-					}
 			},
 		},
 	}
@@ -343,18 +184,24 @@ func TestSimpleWritesChecks(t *testing.T) {
 			for _, test := range tests {
 				t.Run(test.name, func(t *testing.T) {
 					mutationTrackingClient := roundTripperTest.getClient()
-					expectedAction, expectedSerializedRequests := test.testFn(t, mutationTrackingClient.GetHTTPClient())
+					test.testFn(t, mutationTrackingClient.GetHTTPClient())
 					mutations := mutationTrackingClient.GetMutations()
-					actualSerializedRequestsForAction := mutations.RequestsForAction(expectedAction)
+					actualSerializedRequestsForAction := mutations.AllRequests()
 
-					mutationDir := filepath.Join(`/home/deads/workspaces/library-go/src/github.com/openshift/library-go/pkg/manifestclienttest/testdata`, test.name)
-					err := manifestclient.WriteMutationDirectory(mutationDir, mutations.AllRequests()...)
+					expectedRequests, err := manifestclient.ReadEmbeddedMutationDirectory(packageTestData, filepath.Join("testdata", "mutation-tests", test.name))
 					if err != nil {
 						t.Fatal(err)
 					}
 
-					if !manifestclient.AreAllSerializedRequestsEquivalent(actualSerializedRequestsForAction, expectedSerializedRequests) && false {
-						t.Fatal(cmp.Diff(actualSerializedRequestsForAction, expectedSerializedRequests))
+					//
+					//mutationDir := filepath.Join(`/home/deads/workspaces/library-go/src/github.com/openshift/library-go/pkg/manifestclienttest/testdata`, test.name)
+					//err := manifestclient.WriteMutationDirectory(mutationDir, mutations.AllRequests()...)
+					//if err != nil {
+					//	t.Fatal(err)
+					//}
+
+					if !manifestclient.AreAllSerializedRequestsEquivalent(actualSerializedRequestsForAction, expectedRequests.AllRequests()) {
+						t.Fatal(cmp.Diff(actualSerializedRequestsForAction[0].SerializedRequest, expectedRequests.AllRequests()[0].SerializedRequest))
 					}
 				})
 			}

--- a/pkg/manifestclienttest/client_write_test.go
+++ b/pkg/manifestclienttest/client_write_test.go
@@ -2,6 +2,7 @@ package manifestclienttest
 
 import (
 	"context"
+	"path/filepath"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/google/go-cmp/cmp"
@@ -346,7 +347,13 @@ func TestSimpleWritesChecks(t *testing.T) {
 					mutations := mutationTrackingClient.GetMutations()
 					actualSerializedRequestsForAction := mutations.RequestsForAction(expectedAction)
 
-					if !manifestclient.AreAllSerializedRequestsEquivalent(actualSerializedRequestsForAction, expectedSerializedRequests) {
+					mutationDir := filepath.Join(`/home/deads/workspaces/library-go/src/github.com/openshift/library-go/pkg/manifestclienttest/testdata`, test.name)
+					err := manifestclient.WriteMutationDirectory(mutationDir, mutations.AllRequests()...)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					if !manifestclient.AreAllSerializedRequestsEquivalent(actualSerializedRequestsForAction, expectedSerializedRequests) && false {
 						t.Fatal(cmp.Diff(actualSerializedRequestsForAction, expectedSerializedRequests))
 					}
 				})

--- a/pkg/manifestclienttest/testdata/mutation-tests/APPLY-STATUS-crd-in-dataset-with-options/ApplyStatus/cluster-scoped/config.openshift.io/featuregates/001-body-new-item.yaml
+++ b/pkg/manifestclienttest/testdata/mutation-tests/APPLY-STATUS-crd-in-dataset-with-options/ApplyStatus/cluster-scoped/config.openshift.io/featuregates/001-body-new-item.yaml
@@ -1,0 +1,8 @@
+apiVersion: config.openshift.io/v1
+kind: FeatureGate
+metadata:
+  name: new-item
+status:
+  conditions:
+  - status: "True"
+    type: condition-foo

--- a/pkg/manifestclienttest/testdata/mutation-tests/APPLY-STATUS-crd-in-dataset-with-options/ApplyStatus/cluster-scoped/config.openshift.io/featuregates/001-options-new-item.yaml
+++ b/pkg/manifestclienttest/testdata/mutation-tests/APPLY-STATUS-crd-in-dataset-with-options/ApplyStatus/cluster-scoped/config.openshift.io/featuregates/001-options-new-item.yaml
@@ -1,0 +1,2 @@
+fieldManager: the-client
+force: true

--- a/pkg/manifestclienttest/testdata/mutation-tests/APPLY-crd-in-dataset/Apply/cluster-scoped/config.openshift.io/featuregates/001-body-new-item.yaml
+++ b/pkg/manifestclienttest/testdata/mutation-tests/APPLY-crd-in-dataset/Apply/cluster-scoped/config.openshift.io/featuregates/001-body-new-item.yaml
@@ -1,0 +1,4 @@
+apiVersion: config.openshift.io/v1
+kind: FeatureGate
+metadata:
+  name: new-item

--- a/pkg/manifestclienttest/testdata/mutation-tests/APPLY-crd-in-dataset/Apply/cluster-scoped/config.openshift.io/featuregates/001-options-new-item.yaml
+++ b/pkg/manifestclienttest/testdata/mutation-tests/APPLY-crd-in-dataset/Apply/cluster-scoped/config.openshift.io/featuregates/001-options-new-item.yaml
@@ -1,0 +1,2 @@
+fieldManager: the-client
+force: true

--- a/pkg/manifestclienttest/testdata/mutation-tests/CREATE-crd-in-dataset/Create/cluster-scoped/config.openshift.io/featuregates/001-body-new-item.yaml
+++ b/pkg/manifestclienttest/testdata/mutation-tests/CREATE-crd-in-dataset/Create/cluster-scoped/config.openshift.io/featuregates/001-body-new-item.yaml
@@ -1,0 +1,8 @@
+apiVersion: config.openshift.io/v1
+kind: FeatureGate
+metadata:
+  creationTimestamp: null
+  name: new-item
+spec: {}
+status:
+  featureGates: null

--- a/pkg/manifestclienttest/testdata/mutation-tests/CREATE-crd-not-in-dataset/Create/cluster-scoped/config.openshift.io/apiservers/001-body-new-item.yaml
+++ b/pkg/manifestclienttest/testdata/mutation-tests/CREATE-crd-not-in-dataset/Create/cluster-scoped/config.openshift.io/apiservers/001-body-new-item.yaml
@@ -1,0 +1,12 @@
+apiVersion: config.openshift.io/v1
+kind: APIServer
+metadata:
+  creationTimestamp: null
+  name: new-item
+spec:
+  audit: {}
+  clientCA:
+    name: ""
+  encryption: {}
+  servingCerts: {}
+status: {}

--- a/pkg/manifestclienttest/testdata/mutation-tests/DELETE-crd-in-dataset/Delete/cluster-scoped/config.openshift.io/featuregates/001-body-cluster.yaml
+++ b/pkg/manifestclienttest/testdata/mutation-tests/DELETE-crd-in-dataset/Delete/cluster-scoped/config.openshift.io/featuregates/001-body-cluster.yaml
@@ -1,3 +1,6 @@
 apiVersion: config.openshift.io/v1
 kind: DeleteOptions
+metadata:
+  annotations:
+    operator.openshift.io/deletion-name: cluster
 propagationPolicy: Foreground

--- a/pkg/manifestclienttest/testdata/mutation-tests/DELETE-crd-in-dataset/Delete/cluster-scoped/config.openshift.io/featuregates/001-body-cluster.yaml
+++ b/pkg/manifestclienttest/testdata/mutation-tests/DELETE-crd-in-dataset/Delete/cluster-scoped/config.openshift.io/featuregates/001-body-cluster.yaml
@@ -1,0 +1,3 @@
+apiVersion: config.openshift.io/v1
+kind: DeleteOptions
+propagationPolicy: Foreground

--- a/pkg/manifestclienttest/testdata/mutation-tests/UPDATE-STATUS-crd-in-dataset-with-options/UpdateStatus/cluster-scoped/config.openshift.io/featuregates/001-body-new-item.yaml
+++ b/pkg/manifestclienttest/testdata/mutation-tests/UPDATE-STATUS-crd-in-dataset-with-options/UpdateStatus/cluster-scoped/config.openshift.io/featuregates/001-body-new-item.yaml
@@ -1,0 +1,8 @@
+apiVersion: config.openshift.io/v1
+kind: FeatureGate
+metadata:
+  creationTimestamp: null
+  name: new-item
+spec: {}
+status:
+  featureGates: null

--- a/pkg/manifestclienttest/testdata/mutation-tests/UPDATE-STATUS-crd-in-dataset-with-options/UpdateStatus/cluster-scoped/config.openshift.io/featuregates/001-options-new-item.yaml
+++ b/pkg/manifestclienttest/testdata/mutation-tests/UPDATE-STATUS-crd-in-dataset-with-options/UpdateStatus/cluster-scoped/config.openshift.io/featuregates/001-options-new-item.yaml
@@ -1,0 +1,1 @@
+fieldValidation: Strict

--- a/pkg/manifestclienttest/testdata/mutation-tests/UPDATE-crd-in-dataset/Update/cluster-scoped/config.openshift.io/featuregates/001-body-new-item.yaml
+++ b/pkg/manifestclienttest/testdata/mutation-tests/UPDATE-crd-in-dataset/Update/cluster-scoped/config.openshift.io/featuregates/001-body-new-item.yaml
@@ -1,0 +1,8 @@
+apiVersion: config.openshift.io/v1
+kind: FeatureGate
+metadata:
+  creationTimestamp: null
+  name: new-item
+spec: {}
+status:
+  featureGates: null

--- a/pkg/operator/genericoperatorclient/dynamic_operator_client.go
+++ b/pkg/operator/genericoperatorclient/dynamic_operator_client.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
 )
 
@@ -32,7 +33,7 @@ type StaticPodOperatorStatusExtractorFunc func(obj *unstructured.Unstructured, f
 type OperatorSpecExtractorFunc func(obj *unstructured.Unstructured, fieldManager string) (*applyoperatorv1.OperatorSpecApplyConfiguration, error)
 type OperatorStatusExtractorFunc func(obj *unstructured.Unstructured, fieldManager string) (*applyoperatorv1.OperatorStatusApplyConfiguration, error)
 
-func newClusterScopedOperatorClient(dynamicClient dynamic.Interface, gvr schema.GroupVersionResource, gvk schema.GroupVersionKind, instanceName string, extractApplySpec StaticPodOperatorSpecExtractorFunc, extractApplyStatus StaticPodOperatorStatusExtractorFunc) (*dynamicOperatorClient, dynamicinformer.DynamicSharedInformerFactory, error) {
+func newClusterScopedOperatorClient(clock clock.PassiveClock, dynamicClient dynamic.Interface, gvr schema.GroupVersionResource, gvk schema.GroupVersionKind, instanceName string, extractApplySpec StaticPodOperatorSpecExtractorFunc, extractApplyStatus StaticPodOperatorStatusExtractorFunc) (*dynamicOperatorClient, dynamicinformer.DynamicSharedInformerFactory, error) {
 	if len(instanceName) < 1 {
 		return nil, nil, fmt.Errorf("config name cannot be empty")
 	}
@@ -43,6 +44,7 @@ func newClusterScopedOperatorClient(dynamicClient dynamic.Interface, gvr schema.
 	informer := informers.ForResource(gvr)
 
 	return &dynamicOperatorClient{
+		clock:              clock,
 		gvk:                gvk,
 		informer:           informer,
 		client:             client,
@@ -82,22 +84,26 @@ func convertOperatorStatusToStaticPodOperatorStatus(extractApplyStatus OperatorS
 	}
 }
 
-func NewClusterScopedOperatorClient(config *rest.Config, gvr schema.GroupVersionResource, gvk schema.GroupVersionKind, extractApplySpec OperatorSpecExtractorFunc, extractApplyStatus OperatorStatusExtractorFunc) (v1helpers.OperatorClientWithFinalizers, dynamicinformer.DynamicSharedInformerFactory, error) {
-	return NewClusterScopedOperatorClientWithConfigName(config, gvr, gvk, defaultConfigName, extractApplySpec, extractApplyStatus)
+func NewClusterScopedOperatorClient(clock clock.PassiveClock, config *rest.Config, gvr schema.GroupVersionResource, gvk schema.GroupVersionKind, extractApplySpec OperatorSpecExtractorFunc, extractApplyStatus OperatorStatusExtractorFunc) (v1helpers.OperatorClientWithFinalizers, dynamicinformer.DynamicSharedInformerFactory, error) {
+	return NewClusterScopedOperatorClientWithConfigName(clock, config, gvr, gvk, defaultConfigName, extractApplySpec, extractApplyStatus)
 
 }
 
-func NewClusterScopedOperatorClientWithConfigName(config *rest.Config, gvr schema.GroupVersionResource, gvk schema.GroupVersionKind, configName string, extractApplySpec OperatorSpecExtractorFunc, extractApplyStatus OperatorStatusExtractorFunc) (v1helpers.OperatorClientWithFinalizers, dynamicinformer.DynamicSharedInformerFactory, error) {
+func NewClusterScopedOperatorClientWithConfigName(clock clock.PassiveClock, config *rest.Config, gvr schema.GroupVersionResource, gvk schema.GroupVersionKind, configName string, extractApplySpec OperatorSpecExtractorFunc, extractApplyStatus OperatorStatusExtractorFunc) (v1helpers.OperatorClientWithFinalizers, dynamicinformer.DynamicSharedInformerFactory, error) {
 	dynamicClient, err := dynamic.NewForConfig(config)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return newClusterScopedOperatorClient(dynamicClient, gvr, gvk, configName,
+	return newClusterScopedOperatorClient(clock, dynamicClient, gvr, gvk, configName,
 		convertOperatorSpecToStaticPodOperatorSpec(extractApplySpec), convertOperatorStatusToStaticPodOperatorStatus(extractApplyStatus))
 }
 
 type dynamicOperatorClient struct {
+	// clock is used to allow apply-configuration to choose a fixed, "execute as though time/X", which is needed for stable
+	// testing output.
+	clock clock.PassiveClock
+
 	gvk        schema.GroupVersionKind
 	configName string
 	informer   informers.GenericInformer
@@ -289,7 +295,7 @@ func (c dynamicOperatorClient) applyOperatorStatus(ctx context.Context, fieldMan
 		// set last transitionTimes and then apply
 		// If our cache improperly 404's (the lister wasn't synchronized), then we will improperly reset all the last transition times.
 		// This isn't ideal, but we shouldn't hit this case unless a loop isn't waiting for HasSynced.
-		v1helpers.SetApplyConditionsLastTransitionTime(&desiredConfiguration.Conditions, nil)
+		v1helpers.SetApplyConditionsLastTransitionTime(c.clock, &desiredConfiguration.Conditions, nil)
 
 	case err != nil:
 		return fmt.Errorf("unable to read existing %q: %w", c.configName, err)
@@ -316,9 +322,9 @@ func (c dynamicOperatorClient) applyOperatorStatus(ctx context.Context, fieldMan
 		// This only becomes pathological if the condition is also flapping, but if that happens the time should also update.
 		switch {
 		case desiredConfiguration != nil && desiredConfiguration.Conditions != nil && previouslyDesiredConfiguration != nil:
-			v1helpers.SetApplyConditionsLastTransitionTime(&desiredConfiguration.Conditions, previouslyDesiredConfiguration.Conditions)
+			v1helpers.SetApplyConditionsLastTransitionTime(c.clock, &desiredConfiguration.Conditions, previouslyDesiredConfiguration.Conditions)
 		case desiredConfiguration != nil && desiredConfiguration.Conditions != nil && previouslyDesiredConfiguration == nil:
-			v1helpers.SetApplyConditionsLastTransitionTime(&desiredConfiguration.Conditions, nil)
+			v1helpers.SetApplyConditionsLastTransitionTime(c.clock, &desiredConfiguration.Conditions, nil)
 		}
 
 		// canonicalize so the DeepEqual works consistently

--- a/pkg/operator/genericoperatorclient/dynamic_staticpod_operator_client.go
+++ b/pkg/operator/genericoperatorclient/dynamic_staticpod_operator_client.go
@@ -2,29 +2,28 @@ package genericoperatorclient
 
 import (
 	"context"
-	applyoperatorv1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
 
 	"github.com/imdario/mergo"
-
-	"k8s.io/apimachinery/pkg/runtime"
-
 	operatorv1 "github.com/openshift/api/operator/v1"
+	applyoperatorv1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/rest"
+	"k8s.io/utils/clock"
 )
 
-func NewStaticPodOperatorClient(config *rest.Config, gvr schema.GroupVersionResource, gvk schema.GroupVersionKind, extractApplySpec StaticPodOperatorSpecExtractorFunc, extractApplyStatus StaticPodOperatorStatusExtractorFunc) (v1helpers.StaticPodOperatorClient, dynamicinformer.DynamicSharedInformerFactory, error) {
+func NewStaticPodOperatorClient(clock clock.PassiveClock, config *rest.Config, gvr schema.GroupVersionResource, gvk schema.GroupVersionKind, extractApplySpec StaticPodOperatorSpecExtractorFunc, extractApplyStatus StaticPodOperatorStatusExtractorFunc) (v1helpers.StaticPodOperatorClient, dynamicinformer.DynamicSharedInformerFactory, error) {
 	dynamicClient, err := dynamic.NewForConfig(config)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return newClusterScopedOperatorClient(dynamicClient, gvr, gvk, defaultConfigName,
+	return newClusterScopedOperatorClient(clock, dynamicClient, gvr, gvk, defaultConfigName,
 		extractApplySpec, extractApplyStatus)
 }
 

--- a/pkg/operator/genericoperatorclient/test_operator_client.go
+++ b/pkg/operator/genericoperatorclient/test_operator_client.go
@@ -1,35 +1,37 @@
 package genericoperatorclient
 
 import (
+	"net/http"
+
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/rest"
-	"net/http"
+	"k8s.io/utils/clock"
 )
 
-func NewOperatorClientWithClient(httpClient *http.Client, gvr schema.GroupVersionResource, gvk schema.GroupVersionKind, extractApplySpec OperatorSpecExtractorFunc, extractApplyStatus OperatorStatusExtractorFunc) (v1helpers.OperatorClientWithFinalizers, dynamicinformer.DynamicSharedInformerFactory, error) {
-	return NewOperatorClientWithConfigNameWithClient(httpClient, gvr, gvk, defaultConfigName, extractApplySpec, extractApplyStatus)
+func NewOperatorClientWithClient(clock clock.PassiveClock, httpClient *http.Client, gvr schema.GroupVersionResource, gvk schema.GroupVersionKind, extractApplySpec OperatorSpecExtractorFunc, extractApplyStatus OperatorStatusExtractorFunc) (v1helpers.OperatorClientWithFinalizers, dynamicinformer.DynamicSharedInformerFactory, error) {
+	return NewOperatorClientWithConfigNameWithClient(clock, httpClient, gvr, gvk, defaultConfigName, extractApplySpec, extractApplyStatus)
 
 }
 
-func NewOperatorClientWithConfigNameWithClient(httpClient *http.Client, gvr schema.GroupVersionResource, gvk schema.GroupVersionKind, configName string, extractApplySpec OperatorSpecExtractorFunc, extractApplyStatus OperatorStatusExtractorFunc) (v1helpers.OperatorClientWithFinalizers, dynamicinformer.DynamicSharedInformerFactory, error) {
+func NewOperatorClientWithConfigNameWithClient(clock clock.PassiveClock, httpClient *http.Client, gvr schema.GroupVersionResource, gvk schema.GroupVersionKind, configName string, extractApplySpec OperatorSpecExtractorFunc, extractApplyStatus OperatorStatusExtractorFunc) (v1helpers.OperatorClientWithFinalizers, dynamicinformer.DynamicSharedInformerFactory, error) {
 	dynamicClient, err := dynamic.NewForConfigAndClient(&rest.Config{}, httpClient)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return newClusterScopedOperatorClient(dynamicClient, gvr, gvk, configName,
+	return newClusterScopedOperatorClient(clock, dynamicClient, gvr, gvk, configName,
 		convertOperatorSpecToStaticPodOperatorSpec(extractApplySpec), convertOperatorStatusToStaticPodOperatorStatus(extractApplyStatus))
 }
 
-func NewStaticPodOperatorClientWithConfigNameWithClient(httpClient *http.Client, gvr schema.GroupVersionResource, gvk schema.GroupVersionKind, configName string, extractApplySpec OperatorSpecExtractorFunc, extractApplyStatus OperatorStatusExtractorFunc) (v1helpers.StaticPodOperatorClient, dynamicinformer.DynamicSharedInformerFactory, error) {
+func NewStaticPodOperatorClientWithConfigNameWithClient(clock clock.PassiveClock, httpClient *http.Client, gvr schema.GroupVersionResource, gvk schema.GroupVersionKind, configName string, extractApplySpec StaticPodOperatorSpecExtractorFunc, extractApplyStatus StaticPodOperatorStatusExtractorFunc) (v1helpers.StaticPodOperatorClient, dynamicinformer.DynamicSharedInformerFactory, error) {
 	dynamicClient, err := dynamic.NewForConfigAndClient(&rest.Config{}, httpClient)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return newClusterScopedOperatorClient(dynamicClient, gvr, gvk, configName,
-		convertOperatorSpecToStaticPodOperatorSpec(extractApplySpec), convertOperatorStatusToStaticPodOperatorStatus(extractApplyStatus))
+	return newClusterScopedOperatorClient(clock, dynamicClient, gvr, gvk, configName,
+		extractApplySpec, extractApplyStatus)
 }

--- a/pkg/operator/v1helpers/canonicalize.go
+++ b/pkg/operator/v1helpers/canonicalize.go
@@ -2,14 +2,15 @@ package v1helpers
 
 import (
 	"fmt"
-	operatorv1 "github.com/openshift/api/operator/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/json"
-	"k8s.io/utils/ptr"
 	"slices"
 	"strings"
 
+	operatorv1 "github.com/openshift/api/operator/v1"
 	applyoperatorv1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/json"
+	"k8s.io/utils/clock"
+	"k8s.io/utils/ptr"
 )
 
 // ToStaticPodOperator returns the equivalent typed kind for the applyconfiguration. Due to differences in serialization like
@@ -32,12 +33,12 @@ func ToStaticPodOperator(in *applyoperatorv1.StaticPodOperatorStatusApplyConfigu
 	return ret, nil
 }
 
-func SetApplyConditionsLastTransitionTime(newConditions *[]applyoperatorv1.OperatorConditionApplyConfiguration, oldConditions []applyoperatorv1.OperatorConditionApplyConfiguration) {
+func SetApplyConditionsLastTransitionTime(clock clock.PassiveClock, newConditions *[]applyoperatorv1.OperatorConditionApplyConfiguration, oldConditions []applyoperatorv1.OperatorConditionApplyConfiguration) {
 	if newConditions == nil {
 		return
 	}
 
-	now := metav1.Now()
+	now := metav1.NewTime(clock.Now())
 	for i := range *newConditions {
 		newCondition := (*newConditions)[i]
 


### PR DESCRIPTION
1. adds ability to write recorded mutation requests to disk
2. adds ability to read recorded mutation requests from disk
3. adds ability to compare various mutation requests for equivalence
4. adds test that can record mutation requests to a testdata location.  this tests 1 and we need it for real operators
5. adds test that reads the tesdata location. this tests 2 and 3
6. adds a fake annotation to deletion request bodies so that we know which instance was being deleted
7. adds function to make filenames go.mod friendly