### PR TITLE
NO-JIRA: add test-e2e-monitoring placeholder test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,5 +26,6 @@ verify-podnetworkconnectivitychecks:
 test-e2e-encryption: GO_TEST_PACKAGES :=./test/e2e-encryption/...
 .PHONY: test-e2e-encryption
 
-test-e2e-monitoring:
+test-e2e-monitoring: GO_TEST_PACKAGES :=./test/e2e-monitoring/...
+test-e2e-monitoring: test-unit
 .PHONY: test-e2e-monitoring

--- a/test/e2e-monitoring/monitoring_test.go
+++ b/test/e2e-monitoring/monitoring_test.go
@@ -1,0 +1,7 @@
+package e2e_monitoring
+
+import "testing"
+
+func TestResourceVersionApplication(t *testing.T) {
+	// TODO: implement me!
+}


### PR DESCRIPTION
should unblock https://github.com/openshift/library-go/pull/1823

it works on my local machine:
```
make test-e2e-monitoring
go test -mod=vendor -race ./test/e2e-monitoring/...
ok  	github.com/openshift/library-go/test/e2e-monitoring	(cached)
```