### PR TITLE
OCPBUGS-43509: add resourceread functions for ValidatingAdmissionPolicyV1

### DIFF
--- a/pkg/operator/resource/resourceread/admission.go
+++ b/pkg/operator/resource/resourceread/admission.go
@@ -53,3 +53,21 @@ func ReadValidatingAdmissionPolicyBindingV1beta1OrDie(objBytes []byte) *admissio
 
 	return requiredObj.(*admissionv1beta1.ValidatingAdmissionPolicyBinding)
 }
+
+func ReadValidatingAdmissionPolicyV1OrDie(objBytes []byte) *admissionv1.ValidatingAdmissionPolicy {
+	requiredObj, err := runtime.Decode(admissionCodecs.UniversalDecoder(admissionv1.SchemeGroupVersion), objBytes)
+	if err != nil {
+		panic(err)
+	}
+
+	return requiredObj.(*admissionv1.ValidatingAdmissionPolicy)
+}
+
+func ReadValidatingAdmissionPolicyBindingV1OrDie(objBytes []byte) *admissionv1.ValidatingAdmissionPolicyBinding {
+	requiredObj, err := runtime.Decode(admissionCodecs.UniversalDecoder(admissionv1.SchemeGroupVersion), objBytes)
+	if err != nil {
+		panic(err)
+	}
+
+	return requiredObj.(*admissionv1.ValidatingAdmissionPolicyBinding)
+}

--- a/pkg/operator/resource/resourceread/admission_test.go
+++ b/pkg/operator/resource/resourceread/admission_test.go
@@ -102,3 +102,49 @@ webhooks:
 		t.Errorf("Expected a webhook, got nil")
 	}
 }
+
+func TestValidatingAdmissionPolicies(t *testing.T) {
+	validValidatingAdmissionPolicy := `
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "machine-configuration-guards"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    matchPolicy: Equivalent
+    namespaceSelector: {}
+    objectSelector: {}
+    resourceRules:
+    - apiGroups:   ["operator.openshift.io"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE","UPDATE"]
+      resources:   ["machineconfigurations"]
+      scope: "*"
+  validations:
+    - expression: "object.metadata.name=='cluster'"
+      message: "Only a single object of MachineConfiguration is allowed and it must be named cluster."
+`
+	obj := ReadValidatingAdmissionPolicyV1OrDie([]byte(validValidatingAdmissionPolicy))
+	if obj == nil {
+		t.Errorf("Expected a validatingadmissionpolicy, got nil")
+	}
+
+}
+
+func TestValidatingAdmissionPolicyBindings(t *testing.T) {
+	validValidatingAdmissionPolicyBinding := `
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: "machine-configuration-guards-binding"
+spec:
+  policyName: "machine-configuration-guards"
+  validationActions: [Deny]
+`
+	obj := ReadValidatingAdmissionPolicyBindingV1OrDie([]byte(validValidatingAdmissionPolicyBinding))
+	if obj == nil {
+		t.Errorf("Expected a validatingadmissionpolicybinding, got nil")
+	}
+
+}


### PR DESCRIPTION
This is required for the [MCO to use ValidatingAdmissionPolicyV1](https://issues.redhat.com/browse/OCPBUGS-43509). We currently use ValidatingAdmissionPolicyV1Beta1 which has been deprecated.