### PR TITLE
OCPBUGS-23435: Fix Progressing and Degraded condition during workload rollouts.

### DIFF
--- a/pkg/operator/apiserver/controller/workload/workload.go
+++ b/pkg/operator/apiserver/controller/workload/workload.go
@@ -289,7 +289,9 @@ func (c *Controller) updateOperatorStatus(ctx context.Context, previousStatus *o
 
 	// If the workload is up to date, then we are no longer progressing
 	workloadAtHighestGeneration := workload.ObjectMeta.Generation == workload.Status.ObservedGeneration
-	workloadIsBeingUpdated := workload.Status.UpdatedReplicas < desiredReplicas
+	// Update is done when all pods have been updated to the latest revision
+	// and the deployment controller has reported NewReplicaSetAvailable
+	workloadIsBeingUpdated := !workloadAtHighestGeneration || !hasDeploymentProgressed(workload.Status)
 	workloadIsBeingUpdatedTooLong, err := isUpdatingTooLong(previousStatus, *deploymentProgressingCondition.Type)
 	if !workloadAtHighestGeneration {
 		deploymentProgressingCondition = deploymentProgressingCondition.
@@ -300,8 +302,15 @@ func (c *Controller) updateOperatorStatus(ctx context.Context, previousStatus *o
 		deploymentProgressingCondition = deploymentProgressingCondition.
 			WithStatus(operatorv1.ConditionTrue).
 			WithReason("PodsUpdating").
-			WithMessage(fmt.Sprintf("deployment/%s.%s: %d/%d pods have been updated to the latest generation", workload.Name, c.targetNamespace, workload.Status.UpdatedReplicas, desiredReplicas))
+			WithMessage(fmt.Sprintf("deployment/%s.%s: %d/%d pods have been updated to the latest generation and %d/%d pods are available", workload.Name, c.targetNamespace, workload.Status.UpdatedReplicas, desiredReplicas, workload.Status.AvailableReplicas, desiredReplicas))
 	} else {
+		// Terminating pods don't account for any of the other status fields but
+		// still can exist in a state when they are accepting connections and would
+		// contribute to unexpected behavior when we report Progressing=False.
+		// The case of too many pods might occur for example if `TerminationGracePeriodSeconds` is set
+		//
+		// The workload should ensure this does not happen by using for example EnsureAtMostOnePodPerNode
+		// so that the old pods terminate before the new ones are started.
 		deploymentProgressingCondition = deploymentProgressingCondition.
 			WithStatus(operatorv1.ConditionFalse).
 			WithReason("AsExpected")
@@ -351,6 +360,17 @@ func (c *Controller) updateOperatorStatus(ctx context.Context, previousStatus *o
 func isUpdatingTooLong(operatorStatus *operatorv1.OperatorStatus, progressingConditionType string) (bool, error) {
 	progressing := v1helpers.FindOperatorCondition(operatorStatus.Conditions, progressingConditionType)
 	return progressing != nil && progressing.Status == operatorv1.ConditionTrue && time.Now().After(progressing.LastTransitionTime.Add(15*time.Minute)), nil
+}
+
+// hasDeploymentProgressed returns true if the deployment reports NewReplicaSetAvailable
+// via the DeploymentProgressing condition
+func hasDeploymentProgressed(status appsv1.DeploymentStatus) bool {
+	for _, cond := range status.Conditions {
+		if cond.Type == appsv1.DeploymentProgressing {
+			return cond.Status == corev1.ConditionTrue && cond.Reason == "NewReplicaSetAvailable"
+		}
+	}
+	return false
 }
 
 // EnsureAtMostOnePodPerNode updates the deployment spec to prevent more than


### PR DESCRIPTION
Deployment rollout should depend on the Deployment Progressing condition
to asses the state of the deployment as there can be unavailable pods
during the deployment. This is capped by a 15 minute deadline. As a result
- Degraded condition should be False during the deployment rollout.
- Progressing condition should be True  during the deployment rollout.

followup for https://github.com/openshift/library-go/pull/1732 


- fixes https://issues.redhat.com//browse/OCPBUGS-23435
- partially fixes https://issues.redhat.com/browse/OCPBUGS-38675