### PR TITLE
API-1835: manifestclient/write_roundtripper: set the controller name in the annotation if specified in the ctx

### DIFF
--- a/pkg/manifestclient/context.go
+++ b/pkg/manifestclient/context.go
@@ -1,0 +1,18 @@
+package manifestclient
+
+import (
+	"context"
+)
+
+type ctxKey struct{}
+
+var controllerNameCtxKey = ctxKey{}
+
+func WithControllerNameInContext(ctx context.Context, name string) context.Context {
+	return context.WithValue(ctx, controllerNameCtxKey, name)
+}
+
+func ControllerNameFromContext(ctx context.Context) string {
+	val, _ := ctx.Value(controllerNameCtxKey).(string)
+	return val
+}

--- a/pkg/manifestclient/context_test.go
+++ b/pkg/manifestclient/context_test.go
@@ -1,0 +1,46 @@
+package manifestclient
+
+import (
+	"context"
+	"testing"
+)
+
+func TestWithControllerNameInContext(t *testing.T) {
+	scenarios := []struct {
+		name                   string
+		ctx                    context.Context
+		controllerNameToSet    string
+		expectedControllerName string
+	}{
+		{
+			name:                   "controller name is set in ctx",
+			ctx:                    context.Background(),
+			controllerNameToSet:    "fooController",
+			expectedControllerName: "fooController",
+		},
+		{
+			name:                   "empty controller name set in ctx",
+			ctx:                    context.Background(),
+			controllerNameToSet:    "",
+			expectedControllerName: "",
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			ctx := WithControllerNameInContext(scenario.ctx, scenario.controllerNameToSet)
+			retrievedControllerName := ControllerNameFromContext(ctx)
+			if retrievedControllerName != scenario.expectedControllerName {
+				t.Errorf("expected controller name: %q, got: %q", scenario.expectedControllerName, retrievedControllerName)
+			}
+		})
+	}
+}
+
+func TestControllerNameFromContext(t *testing.T) {
+	ctx := context.Background()
+	retrievedControllerName := ControllerNameFromContext(ctx)
+	if len(retrievedControllerName) != 0 {
+		t.Errorf("unexpected controller name: %q", retrievedControllerName)
+	}
+}

--- a/pkg/manifestclient/mutation_tracker.go
+++ b/pkg/manifestclient/mutation_tracker.go
@@ -6,6 +6,7 @@ import (
 )
 
 const DeletionNameAnnotation = "operator.openshift.io/deletion-name"
+const ControllerNameAnnotation = "operator.openshift.io/controller-name"
 
 type Action string
 

--- a/pkg/manifestclienttest/client_write_test.go
+++ b/pkg/manifestclienttest/client_write_test.go
@@ -92,6 +92,29 @@ func TestSimpleWritesChecks(t *testing.T) {
 			},
 		},
 		{
+			name: "UPDATE-crd-in-dataset-with-controller-name",
+			testFn: func(t *testing.T, httpClient *http.Client) {
+				configClient, err := configclient.NewForConfigAndClient(&rest.Config{}, httpClient)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				mutationObj := &configv1.FeatureGate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "new-item",
+					},
+				}
+				ctx := manifestclient.WithControllerNameInContext(context.TODO(), "fooController")
+				resultingObj, err := configClient.ConfigV1().FeatureGates().Update(ctx, mutationObj, metav1.UpdateOptions{})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(resultingObj.Name) == 0 {
+					t.Fatal(spew.Sdump(resultingObj))
+				}
+			},
+		},
+		{
 			name: "UPDATE-STATUS-crd-in-dataset-with-options",
 			testFn: func(t *testing.T, httpClient *http.Client) {
 				configClient, err := configclient.NewForConfigAndClient(&rest.Config{}, httpClient)

--- a/pkg/manifestclienttest/testdata/mutation-tests/UPDATE-crd-in-dataset-with-controller-name/Update/cluster-scoped-resources/config.openshift.io/featuregates/001-body-new-item.yaml
+++ b/pkg/manifestclienttest/testdata/mutation-tests/UPDATE-crd-in-dataset-with-controller-name/Update/cluster-scoped-resources/config.openshift.io/featuregates/001-body-new-item.yaml
@@ -1,0 +1,10 @@
+apiVersion: config.openshift.io/v1
+kind: FeatureGate
+metadata:
+  annotations:
+    operator.openshift.io/controller-name: fooController
+  creationTimestamp: null
+  name: new-item
+spec: {}
+status:
+  featureGates: null


### PR DESCRIPTION
requires https://github.com/openshift/library-go/pull/1860