### PR TITLE
API-1825: revisioncontroller: add controller-instance-name label to secrets and configMaps

### DIFF
--- a/pkg/operator/revisioncontroller/revision_controller.go
+++ b/pkg/operator/revisioncontroller/revision_controller.go
@@ -253,6 +253,9 @@ func (c RevisionController) createNewRevision(ctx context.Context, recorder even
 			Annotations: map[string]string{
 				"operator.openshift.io/revision-ready": "false",
 			},
+			Labels: map[string]string{
+				"operator.openshift.io/controller-instance-name": c.controllerInstanceName,
+			},
 		},
 		Data: map[string]string{
 			"revision": fmt.Sprintf("%d", revision),
@@ -285,7 +288,17 @@ func (c RevisionController) createNewRevision(ctx context.Context, recorder even
 	}}
 
 	for _, cm := range c.configMaps {
-		obj, _, err := resourceapply.SyncConfigMap(ctx, c.configMapGetter, recorder, c.targetNamespace, cm.Name, c.targetNamespace, nameFor(cm.Name, revision), ownerRefs)
+		obj, _, err := resourceapply.SyncConfigMapWithLabels(
+			ctx,
+			c.configMapGetter,
+			recorder,
+			c.targetNamespace,
+			cm.Name,
+			c.targetNamespace,
+			nameFor(cm.Name, revision),
+			ownerRefs,
+			map[string]string{"operator.openshift.io/controller-instance-name": c.controllerInstanceName},
+		)
 		if err != nil {
 			return false, err
 		}
@@ -294,7 +307,17 @@ func (c RevisionController) createNewRevision(ctx context.Context, recorder even
 		}
 	}
 	for _, s := range c.secrets {
-		obj, _, err := resourceapply.SyncSecret(ctx, c.secretGetter, recorder, c.targetNamespace, s.Name, c.targetNamespace, nameFor(s.Name, revision), ownerRefs)
+		obj, _, err := resourceapply.SyncSecretWithLabels(
+			ctx,
+			c.secretGetter,
+			recorder,
+			c.targetNamespace,
+			s.Name,
+			c.targetNamespace,
+			nameFor(s.Name, revision),
+			ownerRefs,
+			map[string]string{"operator.openshift.io/controller-instance-name": c.controllerInstanceName},
+		)
 		if err != nil {
 			return false, err
 		}
@@ -306,7 +329,11 @@ func (c RevisionController) createNewRevision(ctx context.Context, recorder even
 	if createdStatus.Annotations == nil {
 		createdStatus.Annotations = map[string]string{}
 	}
+	if createdStatus.Labels == nil {
+		createdStatus.Labels = map[string]string{}
+	}
 	createdStatus.Annotations["operator.openshift.io/revision-ready"] = "true"
+	createdStatus.Labels["operator.openshift.io/controller-instance-name"] = c.controllerInstanceName
 	if _, err := c.configMapGetter.ConfigMaps(createdStatus.Namespace).Update(ctx, createdStatus, metav1.UpdateOptions{}); err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Proof: https://github.com/openshift/cluster-authentication-operator/pull/733

/hold