### PR TITLE
API-1835: track patches in mutation client

### DIFF
--- a/pkg/manifestclient/mutation_directory_writer.go
+++ b/pkg/manifestclient/mutation_directory_writer.go
@@ -5,19 +5,31 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sigs.k8s.io/yaml"
 )
 
 func WriteMutationDirectory[T SerializedRequestish](mutationDirectory string, requests ...T) error {
 	errs := []error{}
 
 	for _, request := range requests {
-		bodyFilename, optionsFilename := request.SuggestedFilenames()
+		metadataFilename, bodyFilename, optionsFilename := request.SuggestedFilenames()
 		bodyPath := filepath.Join(mutationDirectory, bodyFilename)
+		metadataPath := filepath.Join(mutationDirectory, metadataFilename)
+
+		metadataBytes, err := yaml.Marshal(request.GetSerializedRequest().GetLookupMetadata())
+		if err != nil {
+			errs = append(errs, fmt.Errorf("unable to serialize metadata %v: %w", request.GetSerializedRequest().ActionMetadata, err))
+			continue
+		}
 
 		parentDir := filepath.Dir(bodyPath)
 		if err := os.MkdirAll(parentDir, 0755); err != nil {
 			errs = append(errs, fmt.Errorf("unable to create parentDir %q: %w", parentDir, err))
 			continue
+		}
+
+		if err := os.WriteFile(metadataPath, metadataBytes, 0644); err != nil {
+			errs = append(errs, fmt.Errorf("unable to write body %v: %w", request, err))
 		}
 		if err := os.WriteFile(bodyPath, request.GetSerializedRequest().Body, 0644); err != nil {
 			errs = append(errs, fmt.Errorf("unable to write body %v: %w", request, err))

--- a/pkg/manifestclient/mutation_tracker.go
+++ b/pkg/manifestclient/mutation_tracker.go
@@ -12,6 +12,8 @@ type Action string
 
 const (
 	// this is really a subset of patch, but we treat it separately because it is useful to do so
+	ActionPatch        Action = "Patch"
+	ActionPatchStatus  Action = "PatchStatus"
 	ActionApply        Action = "Apply"
 	ActionApplyStatus  Action = "ApplyStatus"
 	ActionUpdate       Action = "Update"
@@ -36,11 +38,11 @@ type AllActionsTracker[T SerializedRequestish] struct {
 }
 
 type ActionMetadata struct {
-	Action       Action
-	GVR          schema.GroupVersionResource
-	Namespace    string
-	Name         string
-	GenerateName string
+	Action       Action                      `json:"action"`
+	ResourceType schema.GroupVersionResource `json:"resourceType"`
+	Namespace    string                      `json:"namespace"`
+	Name         string                      `json:"mame"`
+	GenerateName string                      `json:"generateName"`
 }
 
 type actionTracker[T SerializedRequestish] struct {

--- a/pkg/manifestclient/mutation_tracker.go
+++ b/pkg/manifestclient/mutation_tracker.go
@@ -43,6 +43,7 @@ type ActionMetadata struct {
 	Action           Action `json:"action"`
 	ResourceMetadata `json:",inline"`
 
+	PatchType              string `json:"patchType,omitempty"`
 	FieldManager           string `json:"fieldManager,omitempty"`
 	ControllerInstanceName string `json:"controllerInstanceName"`
 }

--- a/pkg/manifestclient/mutation_tracker.go
+++ b/pkg/manifestclient/mutation_tracker.go
@@ -24,6 +24,8 @@ const (
 
 var (
 	AllActions = sets.New[Action](
+		ActionPatch,
+		ActionPatchStatus,
 		ActionApply,
 		ActionApplyStatus,
 		ActionUpdate,

--- a/pkg/manifestclient/mutation_tracker.go
+++ b/pkg/manifestclient/mutation_tracker.go
@@ -38,9 +38,18 @@ type AllActionsTracker[T SerializedRequestish] struct {
 }
 
 type ActionMetadata struct {
-	Action       Action                      `json:"action"`
+	Action           Action `json:"action"`
+	ResourceMetadata `json:",inline"`
+
+	FieldManager           string `json:"fieldManager,omitempty"`
+	ControllerInstanceName string `json:"controllerInstanceName"`
+}
+
+// ResourceMetadata uniquely identifies an item in the API
+// This is probably shareable across multiple packages.
+type ResourceMetadata struct {
 	ResourceType schema.GroupVersionResource `json:"resourceType"`
-	Namespace    string                      `json:"namespace"`
+	Namespace    string                      `json:"namespace,omitempty"`
 	Name         string                      `json:"mame"`
 	GenerateName string                      `json:"generateName"`
 }

--- a/pkg/manifestclient/serialized_request.go
+++ b/pkg/manifestclient/serialized_request.go
@@ -180,6 +180,12 @@ func CompareSerializedRequest(lhs, rhs *SerializedRequest) int {
 	if cmp := strings.Compare(string(lhs.Action), string(rhs.Action)); cmp != 0 {
 		return cmp
 	}
+	if cmp := strings.Compare(lhs.FieldManager, rhs.FieldManager); cmp != 0 {
+		return cmp
+	}
+	if cmp := strings.Compare(lhs.ControllerInstanceName, rhs.ControllerInstanceName); cmp != 0 {
+		return cmp
+	}
 
 	if cmp := strings.Compare(lhs.ResourceType.Group, rhs.ResourceType.Group); cmp != 0 {
 		return cmp
@@ -312,11 +318,15 @@ func (a TrackedSerializedRequest) DeepCopy() SerializedRequestish {
 func (a SerializedRequest) DeepCopy() SerializedRequestish {
 	return SerializedRequest{
 		ActionMetadata: ActionMetadata{
-			Action:       a.Action,
-			ResourceType: a.ResourceType,
-			Namespace:    a.Namespace,
-			Name:         a.Name,
-			GenerateName: a.GenerateName,
+			Action: a.Action,
+			ResourceMetadata: ResourceMetadata{
+				ResourceType: a.ResourceType,
+				Namespace:    a.Namespace,
+				Name:         a.Name,
+				GenerateName: a.GenerateName,
+			},
+			FieldManager:           a.FieldManager,
+			ControllerInstanceName: a.ControllerInstanceName,
 		},
 		KindType: a.KindType,
 		Options:  bytes.Clone(a.Options),
@@ -329,11 +339,5 @@ func (a SerializedRequest) StringID() string {
 }
 
 func (a SerializedRequest) GetLookupMetadata() ActionMetadata {
-	return ActionMetadata{
-		Action:       a.Action,
-		ResourceType: a.ResourceType,
-		Namespace:    a.Namespace,
-		Name:         a.Name,
-		GenerateName: a.GenerateName,
-	}
+	return a.ActionMetadata
 }

--- a/pkg/manifestclient/serialized_request.go
+++ b/pkg/manifestclient/serialized_request.go
@@ -180,6 +180,9 @@ func CompareSerializedRequest(lhs, rhs *SerializedRequest) int {
 	if cmp := strings.Compare(string(lhs.Action), string(rhs.Action)); cmp != 0 {
 		return cmp
 	}
+	if cmp := strings.Compare(lhs.PatchType, rhs.PatchType); cmp != 0 {
+		return cmp
+	}
 	if cmp := strings.Compare(lhs.FieldManager, rhs.FieldManager); cmp != 0 {
 		return cmp
 	}
@@ -325,6 +328,7 @@ func (a SerializedRequest) DeepCopy() SerializedRequestish {
 				Name:         a.Name,
 				GenerateName: a.GenerateName,
 			},
+			PatchType:              a.PatchType,
 			FieldManager:           a.FieldManager,
 			ControllerInstanceName: a.ControllerInstanceName,
 		},

--- a/pkg/manifestclient/serialized_request_test.go
+++ b/pkg/manifestclient/serialized_request_test.go
@@ -23,10 +23,12 @@ func TestDifferenceOfSerializedRequests(t *testing.T) {
 						BodyFilename:    "foo.yaml",
 						OptionsFilename: "foo-options.yaml",
 						SerializedRequest: SerializedRequest{
-							Namespace: "foo-ns",
-							Name:      "bar",
-							Options:   nil,
-							Body:      []byte("content"),
+							ActionMetadata: ActionMetadata{
+								Namespace: "foo-ns",
+								Name:      "bar",
+							},
+							Options: nil,
+							Body:    []byte("content"),
 						},
 					},
 				},
@@ -34,10 +36,12 @@ func TestDifferenceOfSerializedRequests(t *testing.T) {
 					{
 						RequestNumber: 6,
 						SerializedRequest: SerializedRequest{
-							Namespace: "foo-ns",
-							Name:      "bar",
-							Options:   nil,
-							Body:      []byte("content"),
+							ActionMetadata: ActionMetadata{
+								Namespace: "foo-ns",
+								Name:      "bar",
+							},
+							Options: nil,
+							Body:    []byte("content"),
 						},
 					},
 				},
@@ -52,10 +56,12 @@ func TestDifferenceOfSerializedRequests(t *testing.T) {
 						BodyFilename:    "foo.yaml",
 						OptionsFilename: "foo-options.yaml",
 						SerializedRequest: SerializedRequest{
-							Namespace: "foo-ns",
-							Name:      "bar",
-							Options:   []byte("options!"),
-							Body:      []byte("content"),
+							ActionMetadata: ActionMetadata{
+								Namespace: "foo-ns",
+								Name:      "bar",
+							},
+							Options: []byte("options!"),
+							Body:    []byte("content"),
 						},
 					},
 				},
@@ -63,10 +69,12 @@ func TestDifferenceOfSerializedRequests(t *testing.T) {
 					{
 						RequestNumber: 6,
 						SerializedRequest: SerializedRequest{
-							Namespace: "foo-ns",
-							Name:      "bar",
-							Options:   nil,
-							Body:      []byte("content"),
+							ActionMetadata: ActionMetadata{
+								Namespace: "foo-ns",
+								Name:      "bar",
+							},
+							Options: nil,
+							Body:    []byte("content"),
 						},
 					},
 				},
@@ -76,10 +84,12 @@ func TestDifferenceOfSerializedRequests(t *testing.T) {
 					BodyFilename:    "foo.yaml",
 					OptionsFilename: "foo-options.yaml",
 					SerializedRequest: SerializedRequest{
-						Namespace: "foo-ns",
-						Name:      "bar",
-						Options:   []byte("options!"),
-						Body:      []byte("content"),
+						ActionMetadata: ActionMetadata{
+							Namespace: "foo-ns",
+							Name:      "bar",
+						},
+						Options: []byte("options!"),
+						Body:    []byte("content"),
 					},
 				},
 			},
@@ -92,10 +102,12 @@ func TestDifferenceOfSerializedRequests(t *testing.T) {
 						BodyFilename:    "foo.yaml",
 						OptionsFilename: "foo-options.yaml",
 						SerializedRequest: SerializedRequest{
-							Namespace:    "foo-ns",
-							GenerateName: "bar-",
-							Options:      nil,
-							Body:         []byte("content"),
+							ActionMetadata: ActionMetadata{
+								Namespace:    "foo-ns",
+								GenerateName: "bar-",
+							},
+							Options: nil,
+							Body:    []byte("content"),
 						},
 					},
 				},
@@ -103,10 +115,12 @@ func TestDifferenceOfSerializedRequests(t *testing.T) {
 					{
 						RequestNumber: 6,
 						SerializedRequest: SerializedRequest{
-							Namespace: "foo-ns",
-							Name:      "bar",
-							Options:   nil,
-							Body:      []byte("content"),
+							ActionMetadata: ActionMetadata{
+								Namespace: "foo-ns",
+								Name:      "bar",
+							},
+							Options: nil,
+							Body:    []byte("content"),
 						},
 					},
 				},
@@ -116,10 +130,12 @@ func TestDifferenceOfSerializedRequests(t *testing.T) {
 					BodyFilename:    "foo.yaml",
 					OptionsFilename: "foo-options.yaml",
 					SerializedRequest: SerializedRequest{
-						Namespace:    "foo-ns",
-						GenerateName: "bar-",
-						Options:      nil,
-						Body:         []byte("content"),
+						ActionMetadata: ActionMetadata{
+							Namespace:    "foo-ns",
+							GenerateName: "bar-",
+						},
+						Options: nil,
+						Body:    []byte("content"),
 					},
 				},
 			},
@@ -132,11 +148,13 @@ func TestDifferenceOfSerializedRequests(t *testing.T) {
 						BodyFilename:    "foo.yaml",
 						OptionsFilename: "foo-options.yaml",
 						SerializedRequest: SerializedRequest{
-							Namespace:    "foo-ns",
-							Name:         "bar-2", // this happens on updates for instance
-							GenerateName: "bar-",
-							Options:      nil,
-							Body:         []byte("content"),
+							ActionMetadata: ActionMetadata{
+								Namespace:    "foo-ns",
+								Name:         "bar-2", // this happens on updates for instance
+								GenerateName: "bar-",
+							},
+							Options: nil,
+							Body:    []byte("content"),
 						},
 					},
 				},
@@ -144,10 +162,12 @@ func TestDifferenceOfSerializedRequests(t *testing.T) {
 					{
 						RequestNumber: 6,
 						SerializedRequest: SerializedRequest{
-							Namespace: "foo-ns",
-							Name:      "bar-2",
-							Options:   nil,
-							Body:      []byte("content"),
+							ActionMetadata: ActionMetadata{
+								Namespace: "foo-ns",
+								Name:      "bar-2",
+							},
+							Options: nil,
+							Body:    []byte("content"),
 						},
 					},
 				},
@@ -157,11 +177,13 @@ func TestDifferenceOfSerializedRequests(t *testing.T) {
 					BodyFilename:    "foo.yaml",
 					OptionsFilename: "foo-options.yaml",
 					SerializedRequest: SerializedRequest{
-						Namespace:    "foo-ns",
-						Name:         "bar-2", // this happens on updates for instance
-						GenerateName: "bar-",
-						Options:      nil,
-						Body:         []byte("content"),
+						ActionMetadata: ActionMetadata{
+							Namespace:    "foo-ns",
+							Name:         "bar-2", // this happens on updates for instance
+							GenerateName: "bar-",
+						},
+						Options: nil,
+						Body:    []byte("content"),
 					},
 				},
 			},

--- a/pkg/manifestclient/write_roundtripper.go
+++ b/pkg/manifestclient/write_roundtripper.go
@@ -90,6 +90,10 @@ func (mrt *writeTrackingRoundTripper) roundTrip(req *http.Request) ([]byte, erro
 		action = ActionApply
 	case requestInfo.Verb == "patch" && req.Header.Get("Content-Type") == string(types.ApplyPatchType) && requestInfo.Subresource == "status":
 		action = ActionApplyStatus
+	case requestInfo.Verb == "patch" && len(requestInfo.Subresource) == 0:
+		action = ActionPatch
+	case requestInfo.Verb == "patch" && requestInfo.Subresource == "status":
+		action = ActionPatchStatus
 	case requestInfo.Verb == "delete" && len(requestInfo.Subresource) == 0:
 		action = ActionDelete
 	default:
@@ -98,6 +102,8 @@ func (mrt *writeTrackingRoundTripper) roundTrip(req *http.Request) ([]byte, erro
 
 	var opts runtime.Object
 	switch action {
+	case ActionPatch, ActionPatchStatus:
+		opts = &metav1.PatchOptions{}
 	case ActionApply, ActionApplyStatus:
 		opts = &metav1.PatchOptions{}
 	case ActionUpdate, ActionUpdateStatus:
@@ -126,15 +132,20 @@ func (mrt *writeTrackingRoundTripper) roundTrip(req *http.Request) ([]byte, erro
 			return nil, fmt.Errorf("failed to read body: %w", err)
 		}
 	}
-	bodyObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, bodyContent)
-	if err != nil {
-		return nil, fmt.Errorf("unable to decode body: %w", err)
-	}
-	if requestInfo.Namespace != bodyObj.(*unstructured.Unstructured).GetNamespace() {
-		return nil, fmt.Errorf("request namespace %q does not equal body namespace %q", requestInfo.Namespace, bodyObj.(*unstructured.Unstructured).GetNamespace())
-	}
-	if action != ActionCreate && action != ActionDelete && requestInfo.Name != bodyObj.(*unstructured.Unstructured).GetName() {
-		return nil, fmt.Errorf("request name %q does not equal body name %q", requestInfo.Namespace, bodyObj.(*unstructured.Unstructured).GetNamespace())
+
+	var bodyObj runtime.Object
+	actionHasRuntimeObjectBody := action != ActionPatch && action != ActionPatchStatus
+	if actionHasRuntimeObjectBody {
+		bodyObj, err = runtime.Decode(unstructured.UnstructuredJSONScheme, bodyContent)
+		if err != nil {
+			return nil, fmt.Errorf("unable to decode body: %w", err)
+		}
+		if requestInfo.Namespace != bodyObj.(*unstructured.Unstructured).GetNamespace() {
+			return nil, fmt.Errorf("request namespace %q does not equal body namespace %q", requestInfo.Namespace, bodyObj.(*unstructured.Unstructured).GetNamespace())
+		}
+		if action != ActionCreate && action != ActionDelete && requestInfo.Name != bodyObj.(*unstructured.Unstructured).GetName() {
+			return nil, fmt.Errorf("request name %q does not equal body name %q", requestInfo.Namespace, bodyObj.(*unstructured.Unstructured).GetNamespace())
+		}
 	}
 
 	gvr := schema.GroupVersionResource{
@@ -148,9 +159,16 @@ func (mrt *writeTrackingRoundTripper) roundTrip(req *http.Request) ([]byte, erro
 		metadataName = bodyObj.(*unstructured.Unstructured).GetName()
 	}
 
-	bodyYAMLBytes, err := yaml.Marshal(bodyObj.(*unstructured.Unstructured).Object)
-	if err != nil {
-		return nil, fmt.Errorf("unable to encode body: %w", err)
+	bodyOutputBytes := bodyContent
+	generatedName := ""
+	kindType := schema.GroupVersionKind{}
+	if actionHasRuntimeObjectBody {
+		bodyOutputBytes, err = yaml.Marshal(bodyObj.(*unstructured.Unstructured).Object)
+		if err != nil {
+			return nil, fmt.Errorf("unable to encode body: %w", err)
+		}
+		generatedName = bodyObj.(*unstructured.Unstructured).GetGenerateName()
+		kindType = bodyObj.GetObjectKind().GroupVersionKind()
 	}
 
 	fieldManagerName := ""
@@ -165,14 +183,14 @@ func (mrt *writeTrackingRoundTripper) roundTrip(req *http.Request) ([]byte, erro
 				ResourceType: gvr,
 				Namespace:    requestInfo.Namespace,
 				Name:         metadataName,
-				GenerateName: bodyObj.(*unstructured.Unstructured).GetGenerateName(),
+				GenerateName: generatedName,
 			},
 			FieldManager:           fieldManagerName,
 			ControllerInstanceName: ControllerInstanceNameFromContext(req.Context()),
 		},
-		KindType: bodyObj.GetObjectKind().GroupVersionKind(),
+		KindType: kindType,
 		Options:  optionsBytes,
-		Body:     bodyYAMLBytes,
+		Body:     bodyOutputBytes,
 	}
 
 	// this lock also protects the access to actionTracker
@@ -189,9 +207,11 @@ func (mrt *writeTrackingRoundTripper) roundTrip(req *http.Request) ([]byte, erro
 	// returning a value that will probably not cause the wrapping client to fail, but isn't very useful.
 	// this keeps calling code from depending on the return value.
 	ret := &unstructured.Unstructured{Object: map[string]interface{}{}}
-	ret.SetGroupVersionKind(bodyObj.GetObjectKind().GroupVersionKind())
-	ret.SetName(bodyObj.(*unstructured.Unstructured).GetName())
-	ret.SetNamespace(bodyObj.(*unstructured.Unstructured).GetNamespace())
+	ret.SetName(serializedRequest.ActionMetadata.Name)
+	ret.SetNamespace(serializedRequest.ActionMetadata.Namespace)
+	if actionHasRuntimeObjectBody { // TODO might be able to do something generally based on discovery if absolutely necessary
+		ret.SetGroupVersionKind(bodyObj.GetObjectKind().GroupVersionKind())
+	}
 	retBytes, err := json.Marshal(ret.Object)
 	if err != nil {
 		return nil, fmt.Errorf("unable to encode body: %w", err)

--- a/pkg/manifestclient/write_roundtripper.go
+++ b/pkg/manifestclient/write_roundtripper.go
@@ -78,6 +78,7 @@ func (mrt *writeTrackingRoundTripper) roundTrip(req *http.Request) ([]byte, erro
 		return nil, fmt.Errorf("subresource %v is not supported by this implementation", requestInfo.Subresource)
 	}
 
+	patchType := ""
 	var action Action
 	switch {
 	case requestInfo.Verb == "create" && len(requestInfo.Subresource) == 0:
@@ -92,8 +93,10 @@ func (mrt *writeTrackingRoundTripper) roundTrip(req *http.Request) ([]byte, erro
 		action = ActionApplyStatus
 	case requestInfo.Verb == "patch" && len(requestInfo.Subresource) == 0:
 		action = ActionPatch
+		patchType = req.Header.Get("Content-Type")
 	case requestInfo.Verb == "patch" && requestInfo.Subresource == "status":
 		action = ActionPatchStatus
+		patchType = req.Header.Get("Content-Type")
 	case requestInfo.Verb == "delete" && len(requestInfo.Subresource) == 0:
 		action = ActionDelete
 	default:
@@ -185,6 +188,7 @@ func (mrt *writeTrackingRoundTripper) roundTrip(req *http.Request) ([]byte, erro
 				Name:         metadataName,
 				GenerateName: generatedName,
 			},
+			PatchType:              patchType,
 			FieldManager:           fieldManagerName,
 			ControllerInstanceName: ControllerInstanceNameFromContext(req.Context()),
 		},

--- a/pkg/manifestclient/write_roundtripper.go
+++ b/pkg/manifestclient/write_roundtripper.go
@@ -161,14 +161,16 @@ func (mrt *writeTrackingRoundTripper) roundTrip(req *http.Request) ([]byte, erro
 	}
 
 	serializedRequest := SerializedRequest{
-		Action:       action,
-		ResourceType: gvr,
-		KindType:     bodyObj.GetObjectKind().GroupVersionKind(),
-		Namespace:    requestInfo.Namespace,
-		Name:         metadataName,
-		GenerateName: bodyObj.(*unstructured.Unstructured).GetGenerateName(),
-		Options:      optionsBytes,
-		Body:         bodyYAMLBytes,
+		ActionMetadata: ActionMetadata{
+			Action:       action,
+			ResourceType: gvr,
+			Namespace:    requestInfo.Namespace,
+			Name:         metadataName,
+			GenerateName: bodyObj.(*unstructured.Unstructured).GetGenerateName(),
+		},
+		KindType: bodyObj.GetObjectKind().GroupVersionKind(),
+		Options:  optionsBytes,
+		Body:     bodyYAMLBytes,
 	}
 
 	// this lock also protects the access to actionTracker

--- a/pkg/manifestclienttest/client_write_test.go
+++ b/pkg/manifestclienttest/client_write_test.go
@@ -217,10 +217,6 @@ func TestSimpleWritesChecks(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
-					expectedRequests, err := manifestclient.ReadEmbeddedMutationDirectory(testFS)
-					if err != nil {
-						t.Fatal(err)
-					}
 
 					const updateEnvVar = "UPDATE_MUTATION_TEST_DATA"
 					if os.Getenv(updateEnvVar) == "true" {
@@ -231,6 +227,12 @@ func TestSimpleWritesChecks(t *testing.T) {
 						} else {
 							t.Logf("Updated data")
 						}
+						t.Errorf("updated. now re-run your test")
+					}
+
+					expectedRequests, err := manifestclient.ReadEmbeddedMutationDirectory(testFS)
+					if err != nil {
+						t.Fatal(err)
 					}
 
 					if !manifestclient.AreAllSerializedRequestsEquivalent(actualRequests, expectedRequests.AllRequests()) {

--- a/pkg/manifestclienttest/testdata/mutation-tests/APPLY-STATUS-crd-in-dataset-with-options/ApplyStatus/cluster-scoped-resources/config.openshift.io/featuregates/001-metadata-new-item.yaml
+++ b/pkg/manifestclienttest/testdata/mutation-tests/APPLY-STATUS-crd-in-dataset-with-options/ApplyStatus/cluster-scoped-resources/config.openshift.io/featuregates/001-metadata-new-item.yaml
@@ -1,7 +1,8 @@
 action: ApplyStatus
+controllerInstanceName: ""
+fieldManager: the-client
 generateName: ""
 mame: new-item
-namespace: ""
 resourceType:
   Group: config.openshift.io
   Resource: featuregates

--- a/pkg/manifestclienttest/testdata/mutation-tests/APPLY-STATUS-crd-in-dataset-with-options/ApplyStatus/cluster-scoped-resources/config.openshift.io/featuregates/001-metadata-new-item.yaml
+++ b/pkg/manifestclienttest/testdata/mutation-tests/APPLY-STATUS-crd-in-dataset-with-options/ApplyStatus/cluster-scoped-resources/config.openshift.io/featuregates/001-metadata-new-item.yaml
@@ -1,0 +1,8 @@
+action: ApplyStatus
+generateName: ""
+mame: new-item
+namespace: ""
+resourceType:
+  Group: config.openshift.io
+  Resource: featuregates
+  Version: v1

--- a/pkg/manifestclienttest/testdata/mutation-tests/APPLY-crd-in-dataset/Apply/cluster-scoped-resources/config.openshift.io/featuregates/001-metadata-new-item.yaml
+++ b/pkg/manifestclienttest/testdata/mutation-tests/APPLY-crd-in-dataset/Apply/cluster-scoped-resources/config.openshift.io/featuregates/001-metadata-new-item.yaml
@@ -1,0 +1,8 @@
+action: Apply
+generateName: ""
+mame: new-item
+namespace: ""
+resourceType:
+  Group: config.openshift.io
+  Resource: featuregates
+  Version: v1

--- a/pkg/manifestclienttest/testdata/mutation-tests/APPLY-crd-in-dataset/Apply/cluster-scoped-resources/config.openshift.io/featuregates/001-metadata-new-item.yaml
+++ b/pkg/manifestclienttest/testdata/mutation-tests/APPLY-crd-in-dataset/Apply/cluster-scoped-resources/config.openshift.io/featuregates/001-metadata-new-item.yaml
@@ -1,7 +1,8 @@
 action: Apply
+controllerInstanceName: ""
+fieldManager: the-client
 generateName: ""
 mame: new-item
-namespace: ""
 resourceType:
   Group: config.openshift.io
   Resource: featuregates

--- a/pkg/manifestclienttest/testdata/mutation-tests/CREATE-crd-in-dataset/Create/cluster-scoped-resources/config.openshift.io/featuregates/001-metadata-new-item.yaml
+++ b/pkg/manifestclienttest/testdata/mutation-tests/CREATE-crd-in-dataset/Create/cluster-scoped-resources/config.openshift.io/featuregates/001-metadata-new-item.yaml
@@ -1,0 +1,8 @@
+action: Create
+generateName: ""
+mame: new-item
+namespace: ""
+resourceType:
+  Group: config.openshift.io
+  Resource: featuregates
+  Version: v1

--- a/pkg/manifestclienttest/testdata/mutation-tests/CREATE-crd-in-dataset/Create/cluster-scoped-resources/config.openshift.io/featuregates/001-metadata-new-item.yaml
+++ b/pkg/manifestclienttest/testdata/mutation-tests/CREATE-crd-in-dataset/Create/cluster-scoped-resources/config.openshift.io/featuregates/001-metadata-new-item.yaml
@@ -1,7 +1,7 @@
 action: Create
+controllerInstanceName: ""
 generateName: ""
 mame: new-item
-namespace: ""
 resourceType:
   Group: config.openshift.io
   Resource: featuregates

--- a/pkg/manifestclienttest/testdata/mutation-tests/CREATE-crd-not-in-dataset/Create/cluster-scoped-resources/config.openshift.io/apiservers/001-metadata-new-item.yaml
+++ b/pkg/manifestclienttest/testdata/mutation-tests/CREATE-crd-not-in-dataset/Create/cluster-scoped-resources/config.openshift.io/apiservers/001-metadata-new-item.yaml
@@ -1,0 +1,8 @@
+action: Create
+generateName: ""
+mame: new-item
+namespace: ""
+resourceType:
+  Group: config.openshift.io
+  Resource: apiservers
+  Version: v1

--- a/pkg/manifestclienttest/testdata/mutation-tests/CREATE-crd-not-in-dataset/Create/cluster-scoped-resources/config.openshift.io/apiservers/001-metadata-new-item.yaml
+++ b/pkg/manifestclienttest/testdata/mutation-tests/CREATE-crd-not-in-dataset/Create/cluster-scoped-resources/config.openshift.io/apiservers/001-metadata-new-item.yaml
@@ -1,7 +1,7 @@
 action: Create
+controllerInstanceName: ""
 generateName: ""
 mame: new-item
-namespace: ""
 resourceType:
   Group: config.openshift.io
   Resource: apiservers

--- a/pkg/manifestclienttest/testdata/mutation-tests/DELETE-crd-in-dataset/Delete/cluster-scoped-resources/config.openshift.io/featuregates/001-body-cluster.yaml
+++ b/pkg/manifestclienttest/testdata/mutation-tests/DELETE-crd-in-dataset/Delete/cluster-scoped-resources/config.openshift.io/featuregates/001-body-cluster.yaml
@@ -1,6 +1,3 @@
 apiVersion: config.openshift.io/v1
 kind: DeleteOptions
-metadata:
-  annotations:
-    operator.openshift.io/deletion-name: cluster
 propagationPolicy: Foreground

--- a/pkg/manifestclienttest/testdata/mutation-tests/DELETE-crd-in-dataset/Delete/cluster-scoped-resources/config.openshift.io/featuregates/001-metadata-cluster.yaml
+++ b/pkg/manifestclienttest/testdata/mutation-tests/DELETE-crd-in-dataset/Delete/cluster-scoped-resources/config.openshift.io/featuregates/001-metadata-cluster.yaml
@@ -1,0 +1,8 @@
+action: Delete
+generateName: ""
+mame: cluster
+namespace: ""
+resourceType:
+  Group: config.openshift.io
+  Resource: featuregates
+  Version: v1

--- a/pkg/manifestclienttest/testdata/mutation-tests/DELETE-crd-in-dataset/Delete/cluster-scoped-resources/config.openshift.io/featuregates/001-metadata-cluster.yaml
+++ b/pkg/manifestclienttest/testdata/mutation-tests/DELETE-crd-in-dataset/Delete/cluster-scoped-resources/config.openshift.io/featuregates/001-metadata-cluster.yaml
@@ -1,7 +1,7 @@
 action: Delete
+controllerInstanceName: ""
 generateName: ""
 mame: cluster
-namespace: ""
 resourceType:
   Group: config.openshift.io
   Resource: featuregates

--- a/pkg/manifestclienttest/testdata/mutation-tests/PATCH-crd-in-dataset/Patch/cluster-scoped-resources/config.openshift.io/featuregates/001-body-instance-name.yaml
+++ b/pkg/manifestclienttest/testdata/mutation-tests/PATCH-crd-in-dataset/Patch/cluster-scoped-resources/config.openshift.io/featuregates/001-body-instance-name.yaml
@@ -1,0 +1,1 @@
+json-patch

--- a/pkg/manifestclienttest/testdata/mutation-tests/PATCH-crd-in-dataset/Patch/cluster-scoped-resources/config.openshift.io/featuregates/001-metadata-instance-name.yaml
+++ b/pkg/manifestclienttest/testdata/mutation-tests/PATCH-crd-in-dataset/Patch/cluster-scoped-resources/config.openshift.io/featuregates/001-metadata-instance-name.yaml
@@ -1,0 +1,8 @@
+action: Patch
+controllerInstanceName: fooController
+generateName: ""
+mame: instance-name
+resourceType:
+  Group: config.openshift.io
+  Resource: featuregates
+  Version: v1

--- a/pkg/manifestclienttest/testdata/mutation-tests/PATCH-crd-in-dataset/Patch/cluster-scoped-resources/config.openshift.io/featuregates/001-metadata-instance-name.yaml
+++ b/pkg/manifestclienttest/testdata/mutation-tests/PATCH-crd-in-dataset/Patch/cluster-scoped-resources/config.openshift.io/featuregates/001-metadata-instance-name.yaml
@@ -2,6 +2,7 @@ action: Patch
 controllerInstanceName: fooController
 generateName: ""
 mame: instance-name
+patchType: application/json-patch+json
 resourceType:
   Group: config.openshift.io
   Resource: featuregates

--- a/pkg/manifestclienttest/testdata/mutation-tests/PATCH-crd-in-dataset/PatchStatus/cluster-scoped-resources/config.openshift.io/featuregates/002-body-instance-name.yaml
+++ b/pkg/manifestclienttest/testdata/mutation-tests/PATCH-crd-in-dataset/PatchStatus/cluster-scoped-resources/config.openshift.io/featuregates/002-body-instance-name.yaml
@@ -1,0 +1,1 @@
+json-patch

--- a/pkg/manifestclienttest/testdata/mutation-tests/PATCH-crd-in-dataset/PatchStatus/cluster-scoped-resources/config.openshift.io/featuregates/002-metadata-instance-name.yaml
+++ b/pkg/manifestclienttest/testdata/mutation-tests/PATCH-crd-in-dataset/PatchStatus/cluster-scoped-resources/config.openshift.io/featuregates/002-metadata-instance-name.yaml
@@ -1,0 +1,8 @@
+action: PatchStatus
+controllerInstanceName: fooController
+generateName: ""
+mame: instance-name
+resourceType:
+  Group: config.openshift.io
+  Resource: featuregates
+  Version: v1

--- a/pkg/manifestclienttest/testdata/mutation-tests/PATCH-crd-in-dataset/PatchStatus/cluster-scoped-resources/config.openshift.io/featuregates/002-metadata-instance-name.yaml
+++ b/pkg/manifestclienttest/testdata/mutation-tests/PATCH-crd-in-dataset/PatchStatus/cluster-scoped-resources/config.openshift.io/featuregates/002-metadata-instance-name.yaml
@@ -2,6 +2,7 @@ action: PatchStatus
 controllerInstanceName: fooController
 generateName: ""
 mame: instance-name
+patchType: application/json-patch+json
 resourceType:
   Group: config.openshift.io
   Resource: featuregates

--- a/pkg/manifestclienttest/testdata/mutation-tests/UPDATE-STATUS-crd-in-dataset-with-options/UpdateStatus/cluster-scoped-resources/config.openshift.io/featuregates/001-metadata-new-item.yaml
+++ b/pkg/manifestclienttest/testdata/mutation-tests/UPDATE-STATUS-crd-in-dataset-with-options/UpdateStatus/cluster-scoped-resources/config.openshift.io/featuregates/001-metadata-new-item.yaml
@@ -1,0 +1,8 @@
+action: UpdateStatus
+generateName: ""
+mame: new-item
+namespace: ""
+resourceType:
+  Group: config.openshift.io
+  Resource: featuregates
+  Version: v1

--- a/pkg/manifestclienttest/testdata/mutation-tests/UPDATE-STATUS-crd-in-dataset-with-options/UpdateStatus/cluster-scoped-resources/config.openshift.io/featuregates/001-metadata-new-item.yaml
+++ b/pkg/manifestclienttest/testdata/mutation-tests/UPDATE-STATUS-crd-in-dataset-with-options/UpdateStatus/cluster-scoped-resources/config.openshift.io/featuregates/001-metadata-new-item.yaml
@@ -1,7 +1,7 @@
 action: UpdateStatus
+controllerInstanceName: ""
 generateName: ""
 mame: new-item
-namespace: ""
 resourceType:
   Group: config.openshift.io
   Resource: featuregates

--- a/pkg/manifestclienttest/testdata/mutation-tests/UPDATE-crd-in-dataset-with-controller-name/Update/cluster-scoped-resources/config.openshift.io/featuregates/001-body-new-item.yaml
+++ b/pkg/manifestclienttest/testdata/mutation-tests/UPDATE-crd-in-dataset-with-controller-name/Update/cluster-scoped-resources/config.openshift.io/featuregates/001-body-new-item.yaml
@@ -1,8 +1,6 @@
 apiVersion: config.openshift.io/v1
 kind: FeatureGate
 metadata:
-  annotations:
-    synthetic.mom.openshift.io/controller-instance-name: fooController
   creationTimestamp: null
   name: new-item
 spec: {}

--- a/pkg/manifestclienttest/testdata/mutation-tests/UPDATE-crd-in-dataset-with-controller-name/Update/cluster-scoped-resources/config.openshift.io/featuregates/001-metadata-new-item.yaml
+++ b/pkg/manifestclienttest/testdata/mutation-tests/UPDATE-crd-in-dataset-with-controller-name/Update/cluster-scoped-resources/config.openshift.io/featuregates/001-metadata-new-item.yaml
@@ -1,0 +1,8 @@
+action: Update
+generateName: ""
+mame: new-item
+namespace: ""
+resourceType:
+  Group: config.openshift.io
+  Resource: featuregates
+  Version: v1

--- a/pkg/manifestclienttest/testdata/mutation-tests/UPDATE-crd-in-dataset-with-controller-name/Update/cluster-scoped-resources/config.openshift.io/featuregates/001-metadata-new-item.yaml
+++ b/pkg/manifestclienttest/testdata/mutation-tests/UPDATE-crd-in-dataset-with-controller-name/Update/cluster-scoped-resources/config.openshift.io/featuregates/001-metadata-new-item.yaml
@@ -1,7 +1,7 @@
 action: Update
+controllerInstanceName: fooController
 generateName: ""
 mame: new-item
-namespace: ""
 resourceType:
   Group: config.openshift.io
   Resource: featuregates

--- a/pkg/manifestclienttest/testdata/mutation-tests/UPDATE-crd-in-dataset/Update/cluster-scoped-resources/config.openshift.io/featuregates/001-metadata-new-item.yaml
+++ b/pkg/manifestclienttest/testdata/mutation-tests/UPDATE-crd-in-dataset/Update/cluster-scoped-resources/config.openshift.io/featuregates/001-metadata-new-item.yaml
@@ -1,0 +1,8 @@
+action: Update
+generateName: ""
+mame: new-item
+namespace: ""
+resourceType:
+  Group: config.openshift.io
+  Resource: featuregates
+  Version: v1

--- a/pkg/manifestclienttest/testdata/mutation-tests/UPDATE-crd-in-dataset/Update/cluster-scoped-resources/config.openshift.io/featuregates/001-metadata-new-item.yaml
+++ b/pkg/manifestclienttest/testdata/mutation-tests/UPDATE-crd-in-dataset/Update/cluster-scoped-resources/config.openshift.io/featuregates/001-metadata-new-item.yaml
@@ -1,7 +1,7 @@
 action: Update
+controllerInstanceName: ""
 generateName: ""
 mame: new-item
-namespace: ""
 resourceType:
   Group: config.openshift.io
   Resource: featuregates


### PR DESCRIPTION
This required several changes

1. metadata file to track the patch type
2. this metadata file is a natural place to store our general metadata to avoid mutating user input
3. the body content isn't necessarily yaml anymore, but most of it is so I didn't change the file format
4. keeping the patch content "natural" allows us to easily test using kubectl
5. pulled controllerInstanceName and fieldManager into metadata to avoid that mutation above


/assign @bertinatto @p0lyn0mial 