### PR TITLE
NO-JIRA: certgraphanalysis: save not-before and not-after, don't export to JSON

### DIFF
--- a/pkg/certs/cert-inspection/certgraphanalysis/certkeypair.go
+++ b/pkg/certs/cert-inspection/certgraphanalysis/certkeypair.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/openshift/library-go/pkg/certs/cert-inspection/certgraphapi"
 	"k8s.io/apimachinery/pkg/util/duration"
@@ -108,6 +109,8 @@ func toCertKeyMetadata(certificate *x509.Certificate) certgraphapi.CertKeyMetada
 		},
 		SignatureAlgorithm: certificate.SignatureAlgorithm.String(),
 		PublicKeyAlgorithm: certificate.PublicKeyAlgorithm.String(),
+		NotBefore:          certificate.NotBefore.Format(time.RFC3339),
+		NotAfter:           certificate.NotAfter.Format(time.RFC3339),
 		ValidityDuration:   duration.HumanDuration(certificate.NotAfter.Sub(certificate.NotBefore)),
 	}
 

--- a/pkg/certs/cert-inspection/certgraphapi/types.go
+++ b/pkg/certs/cert-inspection/certgraphapi/types.go
@@ -157,6 +157,8 @@ type CertKeyMetadata struct {
 	SignatureAlgorithm string
 	PublicKeyAlgorithm string
 	PublicKeyBitSize   string
+	NotBefore          string `json:"-"`
+	NotAfter           string `json:"-"`
 	ValidityDuration   string
 	Usages             []string
 	ExtendedUsages     []string


### PR DESCRIPTION
This is useful for cluster-debug-tools - https://github.com/vrutkovs/cluster-debug-tools/commit/ac958fff43542cdc5c02bdc04933714cc24465fa specifically. Alongside the time secret was created we also log timestamps when certificate is valid for 

These fields are not exported to JSON to avoid leaking these values to TLS registry exports. Tested in https://github.com/openshift/cluster-kube-apiserver-operator/pull/1785