### PR TITLE
OCPBUGS-44374: CSI controller conditions should provide reason and message

### DIFF
--- a/pkg/operator/csi/csidrivernodeservicecontroller/csi_driver_node_service_controller.go
+++ b/pkg/operator/csi/csidrivernodeservicecontroller/csi_driver_node_service_controller.go
@@ -197,7 +197,11 @@ func (c *CSIDriverNodeServiceController) syncManaged(ctx context.Context, opSpec
 		WithStatus(opv1.ConditionTrue)
 
 	if daemonSet.Status.NumberAvailable > 0 {
-		availableCondition = availableCondition.WithStatus(opv1.ConditionTrue)
+		availableCondition = availableCondition.
+			WithStatus(opv1.ConditionTrue).
+			WithMessage("DaemonSet is available").
+			WithReason("AsExpected")
+
 	} else {
 		availableCondition = availableCondition.
 			WithStatus(opv1.ConditionFalse).
@@ -209,7 +213,9 @@ func (c *CSIDriverNodeServiceController) syncManaged(ctx context.Context, opSpec
 	// Set Progressing condition
 	progressingCondition := applyoperatorv1.OperatorCondition().
 		WithType(c.instanceName + opv1.OperatorStatusTypeProgressing).
-		WithStatus(opv1.ConditionFalse)
+		WithStatus(opv1.ConditionFalse).
+		WithMessage("DaemonSet is not progressing").
+		WithReason("AsExpected")
 
 	if ok, msg := isProgressing(opStatus, daemonSet); ok {
 		progressingCondition = progressingCondition.

--- a/pkg/operator/deploymentcontroller/deployment_controller.go
+++ b/pkg/operator/deploymentcontroller/deployment_controller.go
@@ -272,7 +272,11 @@ func (c *DeploymentController) syncManaged(ctx context.Context, opSpec *opv1.Ope
 		availableCondition := applyoperatorv1.
 			OperatorCondition().WithType(c.instanceName + opv1.OperatorStatusTypeAvailable)
 		if deployment.Status.AvailableReplicas > 0 {
-			availableCondition = availableCondition.WithStatus(opv1.ConditionTrue)
+			availableCondition = availableCondition.
+				WithStatus(opv1.ConditionTrue).
+				WithMessage("Deployment is available").
+				WithReason("AsExpected")
+
 		} else {
 			availableCondition = availableCondition.
 				WithStatus(opv1.ConditionFalse).
@@ -286,7 +290,10 @@ func (c *DeploymentController) syncManaged(ctx context.Context, opSpec *opv1.Ope
 	if slices.Contains(c.conditions, opv1.OperatorStatusTypeProgressing) {
 		progressingCondition := applyoperatorv1.OperatorCondition().
 			WithType(c.instanceName + opv1.OperatorStatusTypeProgressing).
-			WithStatus(opv1.ConditionFalse)
+			WithStatus(opv1.ConditionFalse).
+			WithMessage("Deployment is not progressing").
+			WithReason("AsExpected")
+
 		if ok, msg := isProgressing(deployment); ok {
 			progressingCondition = progressingCondition.
 				WithStatus(opv1.ConditionTrue).


### PR DESCRIPTION
This change warns about `reason` and `message` fields in conditions being mandatory in the future: https://github.com/openshift/library-go/pull/1804/files#diff-49fde404f27181b69aea013be73a1439f91fcef3e1c11701f49fe01a5cef6268R351-R356

Causing overhaul of warning messages for controllers that don't set those:

```
W1125 12:50:39.932013   42393 dynamic_operator_client.go:352] .status.conditions["AWSEFSDriverControllerServiceControllerAvailable"].reason is missing; this will eventually be fatal
W1125 12:50:39.932042   42393 dynamic_operator_client.go:355] .status.conditions["AWSEFSDriverControllerServiceControllerAvailable"].message is missing; this will eventually be fatal
W1125 12:50:39.932047   42393 dynamic_operator_client.go:352] .status.conditions["AWSEFSDriverControllerServiceControllerProgressing"].reason is missing; this will eventually be fatal
W1125 12:50:39.932050   42393 dynamic_operator_client.go:355] .status.conditions["AWSEFSDriverControllerServiceControllerProgressing"].message is missing; this will eventually be fatal
```

```
W1125 14:48:15.962871   57793 dynamic_operator_client.go:352] .status.conditions["AWSEFSDriverNodeServiceControllerAvailable"].reason is missing; this will eventually be fatal
W1125 14:48:15.962883   57793 dynamic_operator_client.go:355] .status.conditions["AWSEFSDriverNodeServiceControllerAvailable"].message is missing; this will eventually be fatal
W1125 14:48:15.962887   57793 dynamic_operator_client.go:352] .status.conditions["AWSEFSDriverNodeServiceControllerProgressing"].reason is missing; this will eventually be fatal
W1125 14:48:15.962891   57793 dynamic_operator_client.go:355] .status.conditions["AWSEFSDriverNodeServiceControllerProgressing"].message is missing; this will eventually be fatal
```

With this patch the messages will always be set, although they're not very helpful:
```
  - lastTransitionTime: "2024-11-25T11:49:08Z"
    message: Deployment is available
    reason: AsExpected
    status: "True"
    type: AWSEFSDriverControllerServiceControllerAvailable
  - lastTransitionTime: "2024-11-25T11:50:06Z"
    message: Deployment is not progressing
    reason: AsExpected
    status: "False"
    type: AWSEFSDriverControllerServiceControllerProgressing
  - lastTransitionTime: "2024-11-25T11:49:08Z"
    message: DaemonSet is available
    reason: AsExpected
    status: "True"
    type: AWSEFSDriverNodeServiceControllerAvailable
  - lastTransitionTime: "2024-11-25T13:48:11Z"
    message: DaemonSet is not progressing
    reason: AsExpected
    status: "False"
    type: AWSEFSDriverNodeServiceControllerProgressing
```

cc @openshift/storage