### PR TITLE
OCPBUGS-45321:enabling file protocol in git by default to fix command failures

### DIFF
--- a/pkg/git/repository.go
+++ b/pkg/git/repository.go
@@ -286,7 +286,7 @@ func (r *repository) AddGlobalConfig(name, value string) error {
 
 // CloneWithOptions clones a remote git repository to a local directory
 func (r *repository) CloneWithOptions(location string, url string, args ...string) error {
-	gitArgs := []string{"clone"}
+	gitArgs := []string{"-c","protocol.file.allow=always","clone"}
 	gitArgs = append(gitArgs, args...)
 	gitArgs = append(gitArgs, url)
 	gitArgs = append(gitArgs, location)
@@ -362,7 +362,7 @@ func (r *repository) Checkout(location string, ref string) error {
 
 // SubmoduleUpdate updates submodules, optionally recursively
 func (r *repository) SubmoduleUpdate(location string, init, recursive bool) error {
-	updateArgs := []string{"submodule", "update"}
+	updateArgs := []string{"-c","protocol.file.allow=always","submodule", "update"}
 	if init {
 		updateArgs = append(updateArgs, "--init")
 	}

--- a/pkg/git/repository.go
+++ b/pkg/git/repository.go
@@ -286,7 +286,7 @@ func (r *repository) AddGlobalConfig(name, value string) error {
 
 // CloneWithOptions clones a remote git repository to a local directory
 func (r *repository) CloneWithOptions(location string, url string, args ...string) error {
-	gitArgs := []string{"-c","protocol.file.allow=always","clone"}
+	gitArgs := []string{"-c", "protocol.file.allow=always", "clone"}
 	gitArgs = append(gitArgs, args...)
 	gitArgs = append(gitArgs, url)
 	gitArgs = append(gitArgs, location)
@@ -362,7 +362,7 @@ func (r *repository) Checkout(location string, ref string) error {
 
 // SubmoduleUpdate updates submodules, optionally recursively
 func (r *repository) SubmoduleUpdate(location string, init, recursive bool) error {
-	updateArgs := []string{"-c","protocol.file.allow=always","submodule", "update"}
+	updateArgs := []string{"-c", "protocol.file.allow=always", "submodule", "update"}
 	if init {
 		updateArgs = append(updateArgs, "--init")
 	}


### PR DESCRIPTION
git commands to create submodules and clones are failing because file protocol is not allowed in git by default. File protocol is required to be enabled in some unit test cases . Hence through this change its allowed by default . Changing this source package is a best approach in comparison to other complicated changes/ways of fixing it. OCPBUGS-44243 is the original bug raised in 4.18