### PR TITLE
AUTH-543: Add optional operand deletion condition

### DIFF
--- a/pkg/apiserver/jsonpatch/jsonpatch.go
+++ b/pkg/apiserver/jsonpatch/jsonpatch.go
@@ -26,6 +26,22 @@ func New() *PatchSet {
 	return &PatchSet{}
 }
 
+func Merge(patches ...*PatchSet) *PatchSet {
+	merged := New()
+
+	if len(patches) == 0 {
+		return merged
+	}
+
+	for _, p := range patches {
+		if p != nil && !p.IsEmpty() {
+			merged.patches = append(merged.patches, p.patches...)
+		}
+	}
+
+	return merged
+}
+
 func (p *PatchSet) WithRemove(path string, test TestCondition) *PatchSet {
 	p.WithTest(test.path, test.value)
 	p.addOperation(patchRemoveOperation, path, nil)


### PR DESCRIPTION
There might be cases (as demonstrated in [OCPBUGS-44937](https://issues.redhat.com/browse/OCPBUGS-44937)) where we might want to gracefully delete the operand workload of the workload controller, and keep the operator status available (instead of unavailable or degraded).

This PR adds an optional way of specifying a deletion condition which will trigger the deletion of the operand gracefully, keeping the operator's status as `Available=True`. To avoid breaking changes, I've added new setup functions to be used for wiring this particular case.

This is needed in the scope of https://github.com/openshift/cluster-authentication-operator/pull/740.

Proof PRs:
- https://github.com/openshift/cluster-authentication-operator/pull/772 (incl. usage demo for external OIDC usecase)
- https://github.com/openshift/cluster-openshift-apiserver-operator/pull/618