### PR TITLE
HOSTEDCP-2207: Add filewatcher to library-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/distribution/distribution/v3 v3.0.0-20230511163743-f7717b7855ca
 	github.com/evanphx/json-patch v4.12.0+incompatible
+	github.com/fsnotify/fsnotify v1.7.0
 	github.com/fvbommel/sortorder v1.1.0
 	github.com/go-ldap/ldap/v3 v3.4.3
 	github.com/gonum/graph v0.0.0-20170401004347-50b27dea7ebb
@@ -66,7 +67,6 @@ require (
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/felixge/fgprof v0.9.4 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
 	github.com/go-asn1-ber/asn1-ber v1.5.4 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect

--- a/pkg/filewatcher/README.md
+++ b/pkg/filewatcher/README.md
@@ -1,0 +1,9 @@
+# General
+
+Filewatcher watches a file for changes within a pod. If the file contents have changed, the pod this function is running 
+within will be restarted. 
+
+Filewatcher was initially created during development of HyperShift's managed Azure service. Due to the Azure Cloud API 
+authentication type used by this service, client certificate, whenever the certificate rotates, the pod needs to 
+reauthenticate with Azure since Azure SDK for Go currently does not support re-authenticating with Azure with the new 
+certificate. 

--- a/pkg/filewatcher/filewatcher.go
+++ b/pkg/filewatcher/filewatcher.go
@@ -1,0 +1,68 @@
+package filewatcher
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/fsnotify/fsnotify"
+	"k8s.io/klog/v2"
+)
+
+var watchCertificateFileOnce sync.Once
+
+// WatchFileForChanges watches the file, fileToWatch, for changes. If the file contents have changed, the pod this
+// function is running within will be restarted.
+func WatchFileForChanges(fileToWatch string) error {
+	var err error
+
+	// This starts only one occurrence of the file watcher, which watches the file, fileToWatch.
+	watchCertificateFileOnce.Do(func() {
+		klog.Infof("Starting the file change watcher on file, %s", fileToWatch)
+
+		// Update the file path to watch in case this is a symlink
+		fileToWatch, err = filepath.EvalSymlinks(fileToWatch)
+		if err != nil {
+			return
+		}
+		klog.Infof("Watching file, %s", fileToWatch)
+
+		// Start the file watcher to monitor file changes
+		go func() {
+			err := checkForFileChanges(fileToWatch)
+			klog.Errorf("Error checking for file changes: %v", err)
+		}()
+	})
+	return err
+}
+
+// checkForFileChanges starts a new file watcher. If the file is changed, the pod running this function will exit.
+func checkForFileChanges(path string) error {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		for {
+			select {
+			case event, ok := <-watcher.Events:
+				if ok && (event.Has(fsnotify.Write) || event.Has(fsnotify.Chmod) || event.Has(fsnotify.Remove)) {
+					klog.Infof("file, %s, was modified, exiting...", event.Name)
+					os.Exit(0)
+				}
+			case err, ok := <-watcher.Errors:
+				if ok {
+					klog.Errorf("file watcher error: %v", err)
+				}
+			}
+		}
+	}()
+
+	err = watcher.Add(path)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
Filewatcher was initially created during development of HyperShift's managed Azure service. Due to the Azure Cloud API authentication type used by this service, client certificate, whenever the certificate rotates, the pod needs to reauthenticate with Azure since Azure SDK for Go currently does not support re-authenticating with Azure with the new certificate.
 
This functionality was individually added to several OpenShift repos - CNCC, CIO, and CIRO - through the PRs mentioned below:
- https://github.com/openshift/cloud-network-config-controller/pull/156
- https://github.com/openshift/cluster-ingress-operator/pull/1151 
- https://github.com/openshift/cluster-image-registry-operator/pull/1155 

These repos should use the same codebase for this functionality rather than having 3 different instances of filewatcher.