### PR TITLE
OCPBUGS-46372: Prevent node controller from stomping NodeStatus fields owned by installer controller

### DIFF
--- a/pkg/operator/staticpod/controller/node/node_controller.go
+++ b/pkg/operator/staticpod/controller/node/node_controller.go
@@ -96,18 +96,7 @@ func (c *NodeController) sync(ctx context.Context, syncCtx factory.SyncContext) 
 			}
 		}
 		if found {
-			newTargetNodeState := applyoperatorv1.NodeStatus().
-				WithNodeName(originalOperatorStatus.NodeStatuses[i].NodeName).
-				WithCurrentRevision(originalOperatorStatus.NodeStatuses[i].CurrentRevision).
-				WithTargetRevision(originalOperatorStatus.NodeStatuses[i].TargetRevision).
-				WithLastFailedRevision(originalOperatorStatus.NodeStatuses[i].LastFailedRevision).
-				WithLastFailedReason(originalOperatorStatus.NodeStatuses[i].LastFailedReason).
-				WithLastFailedCount(originalOperatorStatus.NodeStatuses[i].LastFailedCount).
-				WithLastFallbackCount(originalOperatorStatus.NodeStatuses[i].LastFallbackCount).
-				WithLastFailedRevisionErrors(originalOperatorStatus.NodeStatuses[i].LastFailedRevisionErrors...)
-			if originalOperatorStatus.NodeStatuses[i].LastFailedTime != nil {
-				newTargetNodeState = newTargetNodeState.WithLastFailedTime(*originalOperatorStatus.NodeStatuses[i].LastFailedTime)
-			}
+			newTargetNodeState := applyoperatorv1.NodeStatus().WithNodeName(originalOperatorStatus.NodeStatuses[i].NodeName)
 			newTargetNodeStates = append(newTargetNodeStates, newTargetNodeState)
 		} else {
 			syncCtx.Recorder().Warningf("MasterNodeRemoved", "Observed removal of master node %s", nodeState.NodeName)


### PR DESCRIPTION
If the operator status retrieved from the lister has not observed the most recent NodeStatus write from the installer controller, the node controller will overwrite it with stale information. This would have returned a 409 and retried using update, but it's now a forced apply. The node controller is only concerned that there exists a node status entry per node and not with their actual statuses.