### PR TITLE
NO-JIRA: operator/node-controller, guard-controller: parse the master node selector during construction

### DIFF
--- a/pkg/operator/staticpod/controller/guard/guard_controller_test.go
+++ b/pkg/operator/staticpod/controller/guard/guard_controller_test.go
@@ -635,6 +635,7 @@ func TestRenderGuardPod(t *testing.T) {
 				podResourcePrefix:       "operand",
 				operatorName:            "operator",
 				operandPodLabelSelector: labels.Set{"app": "operand"}.AsSelector(),
+				masterNodesSelector:     masterNodesSelector(t),
 				readyzPort:              "99999",
 				nodeLister:              kubeInformers.Core().V1().Nodes().Lister(),
 				podLister:               kubeInformers.Core().V1().Pods().Lister(),
@@ -772,6 +773,7 @@ func TestRenderGuardPodPortChanged(t *testing.T) {
 		targetNamespace:         "test",
 		podResourcePrefix:       "operand",
 		operandPodLabelSelector: labels.Set{"app": "operand"}.AsSelector(),
+		masterNodesSelector:     masterNodesSelector(t),
 		operatorName:            "operator",
 		readyzPort:              "99999",
 		readyzEndpoint:          "readyz",
@@ -862,4 +864,12 @@ func TestGuardPodTemplate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func masterNodesSelector(t *testing.T) labels.Selector {
+	selector, err := labels.Parse("node-role.kubernetes.io/master=")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return selector
 }

--- a/pkg/operator/staticpod/controller/node/node_controller.go
+++ b/pkg/operator/staticpod/controller/node/node_controller.go
@@ -7,7 +7,6 @@ import (
 
 	coreapiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/client-go/informers"
 	corelisterv1 "k8s.io/client-go/listers/core/v1"
 
@@ -26,6 +25,7 @@ type NodeController struct {
 	operatorClient         v1helpers.StaticPodOperatorClient
 	nodeLister             corelisterv1.NodeLister
 	extraNodeSelector      labels.Selector
+	masterNodesSelector    labels.Selector
 }
 
 // NewNodeController creates a new node controller.
@@ -42,6 +42,12 @@ func NewNodeController(
 		nodeLister:             kubeInformersClusterScoped.Core().V1().Nodes().Lister(),
 		extraNodeSelector:      extraNodeSelector,
 	}
+
+	masterNodesSelector, err := labels.Parse("node-role.kubernetes.io/master=")
+	if err != nil {
+		panic(err)
+	}
+	c.masterNodesSelector = masterNodesSelector
 
 	return factory.New().
 		WithInformers(
@@ -62,11 +68,7 @@ func (c *NodeController) sync(ctx context.Context, syncCtx factory.SyncContext) 
 		return err
 	}
 
-	selector, err := labels.NewRequirement("node-role.kubernetes.io/master", selection.Equals, []string{""})
-	if err != nil {
-		panic(err)
-	}
-	nodes, err := c.nodeLister.List(labels.NewSelector().Add(*selector))
+	nodes, err := c.nodeLister.List(c.masterNodesSelector)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
while reviewing https://github.com/openshift/library-go/pull/1882 I found that the master nodes selector is being parsed on each `sync` for some controllers.