### PR TITLE
remove warning messages about missing reason and message in conditions

### DIFF
--- a/pkg/operator/genericoperatorclient/dynamic_operator_client.go
+++ b/pkg/operator/genericoperatorclient/dynamic_operator_client.go
@@ -347,15 +347,6 @@ func (c dynamicOperatorClient) applyOperatorStatus(ctx context.Context, fieldMan
 		}
 	}
 
-	for _, curr := range desiredConfiguration.Conditions {
-		if len(ptr.Deref(curr.Reason, "")) == 0 {
-			klog.Warningf(".status.conditions[%q].reason is missing; this will eventually be fatal", *curr.Type)
-		}
-		if len(ptr.Deref(curr.Message, "")) == 0 {
-			klog.Warningf(".status.conditions[%q].message is missing; this will eventually be fatal", *curr.Type)
-		}
-	}
-
 	desiredStatus, err := runtime.DefaultUnstructuredConverter.ToUnstructured(desiredConfiguration)
 	if err != nil {
 		return fmt.Errorf("failed to convert to unstructured: %w", err)


### PR DESCRIPTION
This is a followup for https://github.com/openshift/library-go/pull/1900 which covers only certain controllers. However operators can set conditions themselves which would make this warning show up when reason or message is omitted.

The warning is not relevant at this moment and we want to remove it in 4.18. 