### PR TITLE
OCPBUGS-24588: degrade when deployment progressing too long

### DIFF
--- a/pkg/operator/apiserver/controller/workload/workload.go
+++ b/pkg/operator/apiserver/controller/workload/workload.go
@@ -291,7 +291,7 @@ func (c *Controller) updateOperatorStatus(ctx context.Context, previousStatus *o
 	// Update is done when all pods have been updated to the latest revision
 	// and the deployment controller has reported NewReplicaSetAvailable
 	workloadIsBeingUpdated := !workloadAtHighestGeneration || !hasDeploymentProgressed(workload.Status)
-	workloadIsBeingUpdatedTooLong, err := v1helpers.IsUpdatingTooLong(previousStatus, *deploymentProgressingCondition.Type)
+	workloadIsBeingUpdatedTooLong := v1helpers.IsUpdatingTooLong(previousStatus, *deploymentProgressingCondition.Type)
 	if !workloadAtHighestGeneration {
 		deploymentProgressingCondition = deploymentProgressingCondition.
 			WithStatus(operatorv1.ConditionTrue).

--- a/pkg/operator/deploymentcontroller/deployment_controller.go
+++ b/pkg/operator/deploymentcontroller/deployment_controller.go
@@ -300,6 +300,11 @@ func (c *DeploymentController) syncManaged(ctx context.Context, opSpec *opv1.Ope
 				WithMessage(msg).
 				WithReason("Deploying")
 		}
+
+		// Degrade when operator is progressing too long.
+		if v1helpers.IsUpdatingTooLong(opStatus, c.instanceName+opv1.OperatorStatusTypeProgressing) {
+			return fmt.Errorf("Deployment was progressing too long")
+		}
 		status = status.WithConditions(progressingCondition)
 	}
 

--- a/pkg/operator/v1helpers/helpers.go
+++ b/pkg/operator/v1helpers/helpers.go
@@ -23,6 +23,10 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+const (
+	progressingConditionTimeout = 15 * time.Minute
+)
+
 // SetOperandVersion sets the new version and returns the previous value.
 func SetOperandVersion(versions *[]configv1.OperandVersion, operandVersion configv1.OperandVersion) string {
 	if versions == nil {
@@ -555,5 +559,5 @@ func IsConditionPresentAndEqual(conditions []metav1.Condition, conditionType str
 // it returns true if the progressing condition has been set to True for at least 15 minutes
 func IsUpdatingTooLong(operatorStatus *operatorv1.OperatorStatus, progressingConditionType string) (bool, error) {
 	progressing := FindOperatorCondition(operatorStatus.Conditions, progressingConditionType)
-	return progressing != nil && progressing.Status == operatorv1.ConditionTrue && time.Now().After(progressing.LastTransitionTime.Add(15*time.Minute)), nil
+	return progressing != nil && progressing.Status == operatorv1.ConditionTrue && time.Now().After(progressing.LastTransitionTime.Add(progressingConditionTimeout)), nil
 }

--- a/pkg/operator/v1helpers/helpers.go
+++ b/pkg/operator/v1helpers/helpers.go
@@ -555,9 +555,9 @@ func IsConditionPresentAndEqual(conditions []metav1.Condition, conditionType str
 	return false
 }
 
-// IsUpdatingTooLong determines if updating operands takes too long.
-// it returns true if the progressing condition has been set to True for at least 15 minutes
-func IsUpdatingTooLong(operatorStatus *operatorv1.OperatorStatus, progressingConditionType string) (bool, error) {
+// IsUpdatingTooLong determines if updating operands condition takes too long.
+// It returns true if the given condition was found and has been set to True longer than progressingConditionTimeout.
+func IsUpdatingTooLong(operatorStatus *operatorv1.OperatorStatus, progressingConditionType string) bool {
 	progressing := FindOperatorCondition(operatorStatus.Conditions, progressingConditionType)
-	return progressing != nil && progressing.Status == operatorv1.ConditionTrue && time.Now().After(progressing.LastTransitionTime.Add(progressingConditionTimeout)), nil
+	return progressing != nil && progressing.Status == operatorv1.ConditionTrue && time.Now().After(progressing.LastTransitionTime.Add(progressingConditionTimeout))
 }

--- a/pkg/operator/v1helpers/helpers.go
+++ b/pkg/operator/v1helpers/helpers.go
@@ -550,3 +550,10 @@ func IsConditionPresentAndEqual(conditions []metav1.Condition, conditionType str
 	}
 	return false
 }
+
+// IsUpdatingTooLong determines if updating operands takes too long.
+// it returns true if the progressing condition has been set to True for at least 15 minutes
+func IsUpdatingTooLong(operatorStatus *operatorv1.OperatorStatus, progressingConditionType string) (bool, error) {
+	progressing := FindOperatorCondition(operatorStatus.Conditions, progressingConditionType)
+	return progressing != nil && progressing.Status == operatorv1.ConditionTrue && time.Now().After(progressing.LastTransitionTime.Add(15*time.Minute)), nil
+}


### PR DESCRIPTION
Patch deployment controller so it transitions to Degraded=True when it's been in progressing state for 15 minutes or longer.

- this does not provide any hints about what requirement of the controller was not met, this would require further refactoring and using preconditions similar to workload controller - we decided not to address this issue in scope of this bug
- the controller can not set Degraded=True condition directly because it gets immediately [overwritten](https://github.com/openshift/library-go/blob/b06fb9d374b312718c7d28f01c740ebed985a0c5/pkg/controller/factory/base_controller.go#L250) to Degraded=False due to usage of `WithSyncDegradedOnError` so we just return error from sync and let base controller handle it

## Reproducer

- we leave CSO running to update storage operator status

Remove secret and prevent recreation:
``` 
oc scale --replicas=0 deploy/cluster-version-operator -n openshift-cluster-version
oc -n openshift-cloud-credential-operator scale --replicas=0 deployment/cloud-credential-operator
oc -n openshift-cluster-csi-drivers delete secret/gcp-pd-cloud-credentials
```

Check controller pod events about secret not found:
```
$ oc -n openshift-cluster-csi-drivers describe pod/gcp-pd-csi-driver-controller-67d7bdc778-8xd5z
...
Warning  FailedMount  119s (x11 over 8m11s)  kubelet            MountVolume.SetUp failed for volume "cloud-sa-volume" : secret "gcp-pd-cloud-credentials" not found
```

Observe cluster operator status which will never change from Progressing=True:
```
$ oc get clusteroperator/storage
NAME      VERSION                              AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
storage   4.15.0-0.nightly-2023-12-21-050324   True        True          False      37m     GCPPDCSIDriverOperatorCRProgressing: GCPPDDriverControllerServiceControllerProgressing: Waiting for Deployment to deploy pods
```

## Patch verification

Scale down CVO and CSO:
```
oc scale --replicas=0 deploy/cluster-version-operator -n openshift-cluster-version
oc scale --replicas=0 deploy/cluster-storage-operator -n openshift-cluster-storage-operator
```

Remove secret to force operator into progressing condition:
``` 
oc scale --replicas=0 deploy/cluster-version-operator -n openshift-cluster-version
oc -n openshift-cloud-credential-operator scale --replicas=0 deployment/cloud-credential-operator
oc -n openshift-cluster-csi-drivers delete secret/gcp-pd-cloud-credentials
```

Build and run operator with patched library-go locally:
```
./gcp-pd-csi-driver-operator start --kubeconfig $KUBECONFIG --namespace openshift-cluster-csi-drivers
```

Start CSO again so it can update cluster storage operator status, the operator running locally should maintain it's lock:
```
oc scale --replicas=1 deploy/cluster-storage-operator -n openshift-cluster-storage-operator
```

Get cluster and CSI operator status:
```
$ oc get clusteroperator/storage
NAME      VERSION                              AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
storage   4.18.0-0.nightly-2025-01-08-044301   True        True          False      4h54m   GCPPDCSIDriverOperatorCRProgressing: GCPPDDriverControllerServiceControllerProgressing: Waiting for Deployment to deploy pods

$ oc get clustercsidriver/pd.csi.storage.gke.io -o json | jq '.status.conditions[11]'
{
  "lastTransitionTime": "2025-01-09T13:44:25Z",
  "message": "Waiting for Deployment to deploy pods",
  "reason": "Deploying",
  "status": "True",
  "type": "GCPPDDriverControllerServiceControllerProgressing"
}
```

Wait 15 minutes and check CSI operator condition is degraded:
```
$ oc get clustercsidriver/pd.csi.storage.gke.io -o json | jq '.status.conditions[9]'
{
  "lastTransitionTime": "2025-01-09T15:44:20Z",
  "message": "deployment was progressing too long",
  "reason": "SyncError",
  "status": "True",
  "type": "GCPPDDriverControllerServiceControllerDegraded"
}
```

Check that the condition propagated to cluster operator:
```
oc get clusteroperator/storage
NAME      VERSION                              AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
storage   4.18.0-0.nightly-2025-01-08-044301   False       True          True       68m     GCPPDCSIDriverOperatorCRAvailable: GCPPDDriverControllerServiceControllerAvailable: Waiting for Deployment
```