### PR TITLE
WIP: NO-JIRA: Remove empty message set for operator conditions

### DIFF
--- a/pkg/operator/staticresourcecontroller/static_resource_controller.go
+++ b/pkg/operator/staticresourcecontroller/static_resource_controller.go
@@ -350,8 +350,7 @@ func (c *StaticResourceController) Sync(ctx context.Context, syncContext factory
 	cnd := applyoperatorv1.OperatorCondition().
 		WithType(fmt.Sprintf("%sDegraded", c.instanceName)).
 		WithStatus(operatorv1.ConditionFalse).
-		WithReason("AsExpected").
-		WithMessage("")
+		WithReason("AsExpected")
 
 	if len(errors) > 0 {
 		message := ""


### PR DESCRIPTION
According to this comment https://github.com/openshift/library-go/blob/5e8bc563202897158370a76957da92155cf3cb2e/pkg/operator/genericoperatorclient/dynamic_operator_client.go#L355, setting empty string to `Message` field should not happen. 