### PR TITLE
[NO-JIRA]: add readApiServerOrDieV1 for kueue-operator work

### DIFF
--- a/pkg/operator/resource/resourceread/apiregistration.go
+++ b/pkg/operator/resource/resourceread/apiregistration.go
@@ -1,0 +1,26 @@
+package resourceread
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+)
+
+var (
+	apiRegisterScheme = runtime.NewScheme()
+	apiRegisterCodec  = serializer.NewCodecFactory(apiRegisterScheme)
+)
+
+func init() {
+	if err := apiregistrationv1.AddToScheme(apiRegisterScheme); err != nil {
+		panic(err)
+	}
+}
+
+func ReadAPIServiceOrDie(objBytes []byte) *apiregistrationv1.APIService {
+	requiredObj, err := runtime.Decode(apiRegisterCodec.UniversalDecoder(apiregistrationv1.SchemeGroupVersion), objBytes)
+	if err != nil {
+		panic(err)
+	}
+	return requiredObj.(*apiregistrationv1.APIService)
+}


### PR DESCRIPTION
I am tasked with building a KueueOperator for installing upstream kueue into Openshift.

I want to follow an established pattern of having the operator install data in binData. This seems to require reading resources and applying those resources. I noticed that APIServer is not yet a function in resourceread.

Proposing this PR to add this as a function so I can apply APIService from upstream Kueue.