### PR TITLE
CNTRLPLANE-190: Add support for modyfing asset object in StaticResourceController

### DIFF
--- a/pkg/operator/connectivitycheckcontroller/connectivity_check_controller.go
+++ b/pkg/operator/connectivitycheckcontroller/connectivity_check_controller.go
@@ -310,6 +310,7 @@ func ensureConnectivityCheckCRDExists(ctx context.Context, syncContext factory.S
 			syncContext.Recorder(),
 			nil,
 			assets.ReadFile,
+			nil,
 			"manifests/controlplane.operator.openshift.io_podnetworkconnectivitychecks.yaml",
 		)
 		if applyResults[0].Error != nil {

--- a/pkg/operator/csi/csicontrollerset/csi_controller_set.go
+++ b/pkg/operator/csi/csicontrollerset/csi_controller_set.go
@@ -95,11 +95,13 @@ func (c *CSIControllerSet) WithConditionalStaticResourcesController(
 	manifests resourceapply.AssetFunc,
 	files []string,
 	shouldCreateFnArg, shouldDeleteFnArg resourceapply.ConditionalFunction,
+	manifestObjModifier resourceapply.ObjectModifierFunc,
 ) *CSIControllerSet {
 	c.conditionalStaticResourcesControllers = append(c.conditionalStaticResourcesControllers, staticresourcecontroller.NewStaticResourceController(
 		name,
 		manifests,
-		[]string{},
+		nil,
+		nil,
 		(&resourceapply.ClientHolder{}).WithKubernetes(kubeClient).WithDynamicClient(dynamicClient),
 		c.operatorClient,
 		c.eventRecorder,
@@ -108,6 +110,7 @@ func (c *CSIControllerSet) WithConditionalStaticResourcesController(
 		files,
 		shouldCreateFnArg,
 		shouldDeleteFnArg,
+		manifestObjModifier,
 	).AddKubeInformers(kubeInformersForNamespace))
 	return c
 }
@@ -120,11 +123,13 @@ func (c *CSIControllerSet) WithStaticResourcesController(
 	kubeInformersForNamespace v1helpers.KubeInformersForNamespaces,
 	manifests resourceapply.AssetFunc,
 	files []string,
+	manifestObjModifier resourceapply.ObjectModifierFunc,
 ) *CSIControllerSet {
 	c.staticResourcesController = staticresourcecontroller.NewStaticResourceController(
 		name,
 		manifests,
 		files,
+		manifestObjModifier,
 		(&resourceapply.ClientHolder{}).WithKubernetes(kubeClient).WithDynamicClient(dynamicClient),
 		c.operatorClient,
 		c.eventRecorder,
@@ -232,6 +237,7 @@ func (c *CSIControllerSet) WithServiceMonitorController(
 	dynamicClient dynamic.Interface,
 	assetFunc resourceapply.AssetFunc,
 	file string,
+	manifestObjModifier resourceapply.ObjectModifierFunc,
 ) *CSIControllerSet {
 	// Use StaticResourceController to apply ServiceMonitors.
 	// Ensure that NotFound errors are ignored, e.g. when ServiceMonitor CRD missing.
@@ -239,6 +245,7 @@ func (c *CSIControllerSet) WithServiceMonitorController(
 		name,
 		assetFunc,
 		[]string{file},
+		manifestObjModifier,
 		(&resourceapply.ClientHolder{}).WithDynamicClient(dynamicClient),
 		c.operatorClient,
 		c.eventRecorder,

--- a/pkg/operator/resource/resourceapply/generic_test.go
+++ b/pkg/operator/resource/resourceapply/generic_test.go
@@ -2,11 +2,18 @@ package resourceapply
 
 import (
 	"context"
-	clocktesting "k8s.io/utils/clock/testing"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	clocktesting "k8s.io/utils/clock/testing"
 
 	"github.com/openshift/library-go/pkg/operator/events"
 )
@@ -23,10 +30,71 @@ metadata:
 `), nil
 	}
 	recorder := events.NewInMemoryRecorder("", clocktesting.NewFakePassiveClock(time.Now()))
-	ret := ApplyDirectly(context.TODO(), (&ClientHolder{}).WithKubernetes(fakeClient), recorder, nil, content, "pvc")
+	ret := ApplyDirectly(context.TODO(), (&ClientHolder{}).WithKubernetes(fakeClient), recorder, nil, content, nil, "pvc")
 	if ret[0].Error == nil {
 		t.Fatal("missing expected error")
 	} else if ret[0].Error.Error() != "unhandled type *v1.PersistentVolumeClaim" {
 		t.Fatal(ret[0].Error)
+	}
+}
+func TestApplyDirectlyWithCustomChanges(t *testing.T) {
+	fakeClient := fake.NewSimpleClientset()
+	content := func(name string) ([]byte, error) {
+		return []byte(`apiVersion: v1
+kind: Pod
+metadata:
+  name: sample-pod
+  ownerReferences:
+  - apiVersion: apps/v1
+    kind: ReplicaSet
+    name: rs-controller
+    uid: rs-uid
+spec:
+  containers:
+  - name: fedora
+    image: fedora
+`), nil
+	}
+	recorder := events.NewInMemoryRecorder("", clocktesting.NewFakePassiveClock(time.Now()))
+	extraOwnerReference := metav1.OwnerReference{
+		APIVersion: "test.openshift.io/v1",
+		Kind:       "Test",
+		Name:       "test-name",
+		UID:        "test-uid",
+	}
+	expectedOwnerReferences := []metav1.OwnerReference{
+		{
+			APIVersion: "apps/v1",
+			Kind:       "ReplicaSet",
+			Name:       "rs-controller",
+			UID:        "rs-uid",
+		},
+		extraOwnerReference,
+	}
+
+	objModifier := func(object runtime.Object) (runtime.Object, error) {
+		metadata, err := meta.Accessor(object)
+		if err != nil {
+			return nil, err
+		}
+		newOwnerRefs := append(metadata.GetOwnerReferences(), extraOwnerReference)
+		metadata.SetOwnerReferences(newOwnerRefs)
+		metadata.SetNamespace("custom-ns")
+		return object, nil
+	}
+
+	ret := ApplyDirectly(context.TODO(), (&ClientHolder{}).WithKubernetes(fakeClient), recorder, NewResourceCache(), content, objModifier, "pod")
+	if ret[0].Error != nil {
+		t.Fatalf("unexpected error %v", ret[0].Error)
+	}
+	if !ret[0].Changed {
+		t.Fatal("expected changed")
+	}
+	if pod, ok := ret[0].Result.(*v1.Pod); !ok {
+		t.Fatalf("expected pod, got %v", pod)
+	} else if !equality.Semantic.DeepEqual(pod.OwnerReferences, expectedOwnerReferences) {
+		t.Fatalf("expected resulting owner references to match : %s", cmp.Diff(pod.OwnerReferences, expectedOwnerReferences))
+	} else if pod.Namespace != "custom-ns" {
+		t.Fatalf("expected pod namespace: %s, got %s", pod.Namespace, "custom-ns")
 	}
 }

--- a/pkg/operator/staticpod/controller/backingresource/backing_resource_controller_test.go
+++ b/pkg/operator/staticpod/controller/backingresource/backing_resource_controller_test.go
@@ -184,6 +184,7 @@ func TestBackingResourceController(t *testing.T) {
 					"manifests/installer-sa.yaml",
 					"manifests/installer-cluster-rolebinding.yaml",
 				},
+				nil,
 				resourceapply.NewKubeClientHolder(kubeClient),
 				tc.operatorClient,
 				eventRecorder,

--- a/pkg/operator/staticpod/controllers.go
+++ b/pkg/operator/staticpod/controllers.go
@@ -373,6 +373,7 @@ func (b *staticPodOperatorControllerBuilder) ToControllers() (manager.Controller
 			"manifests/installer-sa.yaml",
 			"manifests/installer-cluster-rolebinding.yaml",
 		},
+		nil,
 		resourceapply.NewKubeClientHolder(b.kubeClient),
 		b.staticPodOperatorClient,
 		eventRecorder,

--- a/pkg/operator/staticresourcecontroller/static_resource_controller_test.go
+++ b/pkg/operator/staticresourcecontroller/static_resource_controller_test.go
@@ -54,7 +54,7 @@ metadata:
 		return []byte(assets[filename]), nil
 	}
 
-	src := NewStaticResourceController("", readBytesFromString, []string{"secret", "sa"}, nil, operatorClient, events.NewInMemoryRecorder("", clocktesting.NewFakePassiveClock(time.Now())))
+	src := NewStaticResourceController("", readBytesFromString, []string{"secret", "sa"}, nil, nil, operatorClient, events.NewInMemoryRecorder("", clocktesting.NewFakePassiveClock(time.Now())))
 	src = src.AddRESTMapper(restMapper).AddCategoryExpander(expander)
 	res, _ := src.RelatedObjects()
 	assert.ElementsMatch(t, expected, res)


### PR DESCRIPTION
- to allow setting e.g. dynamic namespace or owner references

This is needed for our new operators:
- https://github.com/openshift/jobset-operator/pull/1
- https://github.com/openshift/lws-operator/pull/9

To automatically set owner references to the managed objects, and have an option to deploy the operator in any namespace. Please see the usage in: https://github.com/atiratree/jobset-operator/blob/70a1985ed9814e0fd51c6326dbb176ab11628a15/pkg/operator/starter.go#L71-L103