### PR TITLE
OCPBUGS-35102: certrotation: don't update metadata in RefreshOnlyWhenExpired mode

### DIFF
--- a/pkg/operator/certrotation/cabundle.go
+++ b/pkg/operator/certrotation/cabundle.go
@@ -30,6 +30,10 @@ type CABundleConfigMap struct {
 	Namespace string
 	// Name is the name of the ConfigMap to maintain.
 	Name string
+	// RefreshOnlyWhenExpired set to true means to ignore 80% of validity and the Refresh duration for rotation,
+	// but only rotate when the certificate expires. This is useful for auto-recovery when we want to enforce
+	// rotation on expiration only, but not interfere with the ordinary rotation controller.
+	RefreshOnlyWhenExpired bool
 	// Owner is an optional reference to add to the secret that this rotator creates.
 	Owner *metav1.OwnerReference
 	// AdditionalAnnotations is a collection of annotations set for the secret
@@ -62,12 +66,15 @@ func (c CABundleConfigMap) EnsureConfigMapCABundle(ctx context.Context, signingC
 		creationRequired = true
 	}
 
-	needsOwnerUpdate := false
-	if c.Owner != nil {
-		needsOwnerUpdate = ensureOwnerReference(&caBundleConfigMap.ObjectMeta, c.Owner)
+	// run Update if metadata needs changing unless running in RefreshOnlyWhenExpired mode
+	if !c.RefreshOnlyWhenExpired {
+		needsOwnerUpdate := false
+		if c.Owner != nil {
+			needsOwnerUpdate = ensureOwnerReference(&caBundleConfigMap.ObjectMeta, c.Owner)
+		}
+		needsMetadataUpdate := c.AdditionalAnnotations.EnsureTLSMetadataUpdate(&caBundleConfigMap.ObjectMeta)
+		updateRequired = needsOwnerUpdate || needsMetadataUpdate
 	}
-	needsMetadataUpdate := c.AdditionalAnnotations.EnsureTLSMetadataUpdate(&caBundleConfigMap.ObjectMeta)
-	updateRequired = needsOwnerUpdate || needsMetadataUpdate
 
 	updatedCerts, err := manageCABundleConfigMap(caBundleConfigMap, signingCertKeyPair.Config.Certs[0])
 	if err != nil {

--- a/pkg/operator/certrotation/signer.go
+++ b/pkg/operator/certrotation/signer.go
@@ -78,10 +78,12 @@ func (c RotatedSigningCASecret) EnsureSigningCertKeyPair(ctx context.Context) (*
 		creationRequired = true
 	}
 
-	// run Update if metadata needs changing
-	needsMetadataUpdate := ensureMetadataUpdate(signingCertKeyPairSecret, c.Owner, c.AdditionalAnnotations)
-	needsTypeChange := ensureSecretTLSTypeSet(signingCertKeyPairSecret)
-	updateRequired = needsMetadataUpdate || needsTypeChange
+	// run Update if metadata needs changing unless we're in RefreshOnlyWhenExpired mode
+	if !c.RefreshOnlyWhenExpired {
+		needsMetadataUpdate := ensureMetadataUpdate(signingCertKeyPairSecret, c.Owner, c.AdditionalAnnotations)
+		needsTypeChange := ensureSecretTLSTypeSet(signingCertKeyPairSecret)
+		updateRequired = needsMetadataUpdate || needsTypeChange
+	}
 
 	// run Update if signer content needs changing
 	signerUpdated := false

--- a/pkg/operator/certrotation/target.go
+++ b/pkg/operator/certrotation/target.go
@@ -112,9 +112,12 @@ func (c RotatedSelfSignedCertKeySecret) EnsureTargetCertKeyPair(ctx context.Cont
 		creationRequired = true
 	}
 
-	needsMetadataUpdate := ensureMetadataUpdate(targetCertKeyPairSecret, c.Owner, c.AdditionalAnnotations)
-	needsTypeChange := ensureSecretTLSTypeSet(targetCertKeyPairSecret)
-	updateRequired = needsMetadataUpdate || needsTypeChange
+	// run Update if metadata needs changing unless we're in RefreshOnlyWhenExpired mode
+	if !c.RefreshOnlyWhenExpired {
+		needsMetadataUpdate := ensureMetadataUpdate(targetCertKeyPairSecret, c.Owner, c.AdditionalAnnotations)
+		needsTypeChange := ensureSecretTLSTypeSet(targetCertKeyPairSecret)
+		updateRequired = needsMetadataUpdate || needsTypeChange
+	}
 
 	if reason := c.CertCreator.NeedNewTargetCertKeyPair(targetCertKeyPairSecret, signingCertKeyPair, caBundleCerts, c.Refresh, c.RefreshOnlyWhenExpired, creationRequired); len(reason) > 0 {
 		c.EventRecorder.Eventf("TargetUpdateRequired", "%q in %q requires a new target cert/key pair: %v", c.Name, c.Namespace, reason)


### PR DESCRIPTION
There are two copies of this controller running in the cluster: one in the operator with RefreshOnlyWhenExpired=false and one leader in kube-apiserver sidecar with RefreshOnlyWhenExpired=true. This method allows us to generate certs in operator before kube-apiserver pods are created - and regenerate expired certs after the cluster was shutdown.

However, regardless of the mode, this controller applies metadata changes.

So if an update introduces a change in some annotations these controller copies are racing, as there are different versions of the controller running - an updated one in the operator and outdated in kube-apiserver sidecar.

This change ensures that controllers in
RefreshOnlyWhenExpired=true mode don't update metadata. The primary goal is to have certificate contents fresh enough to run the control plane - and the operator will take care of the secondary things like secret/configmap metadata.