### PR TITLE
OCPBUGS-35102: certrotation: ignore optimistic lock errors

### DIFF
--- a/pkg/operator/certrotation/cabundle.go
+++ b/pkg/operator/certrotation/cabundle.go
@@ -98,6 +98,10 @@ func (c CABundleConfigMap) EnsureConfigMapCABundle(ctx context.Context, signingC
 		caBundleConfigMap = actualCABundleConfigMap
 	} else if updateRequired {
 		actualCABundleConfigMap, err := c.Client.ConfigMaps(c.Namespace).Update(ctx, caBundleConfigMap, metav1.UpdateOptions{})
+		if apierrors.IsConflict(err) {
+			// ignore error if its attempting to update outdated version of the configmap
+			return nil, nil
+		}
 		resourcehelper.ReportUpdateEvent(c.EventRecorder, actualCABundleConfigMap, err)
 		if err != nil {
 			return nil, err

--- a/pkg/operator/certrotation/client_cert_rotation_controller.go
+++ b/pkg/operator/certrotation/client_cert_rotation_controller.go
@@ -130,7 +130,7 @@ func (c CertRotationController) getSigningCertKeyPairLocation() string {
 
 func (c CertRotationController) SyncWorker(ctx context.Context) error {
 	signingCertKeyPair, _, err := c.RotatedSigningCASecret.EnsureSigningCertKeyPair(ctx)
-	if err != nil {
+	if err != nil || signingCertKeyPair == nil {
 		return err
 	}
 

--- a/pkg/operator/certrotation/signer.go
+++ b/pkg/operator/certrotation/signer.go
@@ -110,6 +110,10 @@ func (c RotatedSigningCASecret) EnsureSigningCertKeyPair(ctx context.Context) (*
 		signingCertKeyPairSecret = actualSigningCertKeyPairSecret
 	} else if updateRequired {
 		actualSigningCertKeyPairSecret, err := c.Client.Secrets(c.Namespace).Update(ctx, signingCertKeyPairSecret, metav1.UpdateOptions{})
+		if apierrors.IsConflict(err) {
+			// ignore error if its attempting to update outdated version of the secret
+			return nil, false, nil
+		}
 		resourcehelper.ReportUpdateEvent(c.EventRecorder, actualSigningCertKeyPairSecret, err)
 		if err != nil {
 			return nil, false, err

--- a/pkg/operator/certrotation/target.go
+++ b/pkg/operator/certrotation/target.go
@@ -136,6 +136,10 @@ func (c RotatedSelfSignedCertKeySecret) EnsureTargetCertKeyPair(ctx context.Cont
 		targetCertKeyPairSecret = actualTargetCertKeyPairSecret
 	} else if updateRequired {
 		actualTargetCertKeyPairSecret, err := c.Client.Secrets(c.Namespace).Update(ctx, targetCertKeyPairSecret, metav1.UpdateOptions{})
+		if apierrors.IsConflict(err) {
+			// ignore error if its attempting to update outdated version of the secret
+			return nil, nil
+		}
 		resourcehelper.ReportUpdateEvent(c.EventRecorder, actualTargetCertKeyPairSecret, err)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Signer/CABundle/Target certcontrollers use informers to fetch updates and may work on outdated versions of the secret/configmap. If update has returned "please apply your changes to the latest version and try again" error the controller should silently skip it, otherwise it will produce multiple duplicate events and operator status updates.