### PR TITLE
OCPBUGS-51357: Only check deployment time when remaining in Progressing state

### DIFF
--- a/pkg/operator/deploymentcontroller/deployment_controller.go
+++ b/pkg/operator/deploymentcontroller/deployment_controller.go
@@ -299,12 +299,14 @@ func (c *DeploymentController) syncManaged(ctx context.Context, opSpec *opv1.Ope
 				WithStatus(opv1.ConditionTrue).
 				WithMessage(msg).
 				WithReason("Deploying")
+
+			// Degrade when operator is progressing too long.
+			// Only do this if we would continue to be in the Progressing state, otherwise, we'll never get out
+			if v1helpers.IsUpdatingTooLong(opStatus, c.instanceName+opv1.OperatorStatusTypeProgressing) {
+				return fmt.Errorf("Deployment was progressing too long")
+			}
 		}
 
-		// Degrade when operator is progressing too long.
-		if v1helpers.IsUpdatingTooLong(opStatus, c.instanceName+opv1.OperatorStatusTypeProgressing) {
-			return fmt.Errorf("Deployment was progressing too long")
-		}
 		status = status.WithConditions(progressingCondition)
 	}
 


### PR DESCRIPTION
Once a deployment takes more than 15 minutes to come up, the owner operator can never get out of the progressing state.

This check was introduced in #1914

However, it is positioned in a way that will never allow a cluster operator to get out of the progressing state, it will always return an error if the deployment has taken too long.

Move the check to occur only when the operator remains in the progressing state. If the operator is exiting the progressing state, then don't do the check.