### PR TITLE
OCPBUGS-52466: Exclude machineconfig and controllerconfig objects from audit logs

### DIFF
--- a/pkg/operator/apiserver/audit/manifests/allrequestbodies-rules.yaml
+++ b/pkg/operator/apiserver/audit/manifests/allrequestbodies-rules.yaml
@@ -8,5 +8,7 @@
     resources: ["tokenreviews", "tokenrequests"]
   - group: "oauth.openshift.io"
     resources: ["oauthclients", "tokenreviews"]
+  - group: "machineconfiguration.openshift.io"
+    resource: ["machineconfig", "controllerconfig"]
 # catch-all rule to log all other requests with request and response payloads
 - level: RequestResponse

--- a/pkg/operator/apiserver/audit/manifests/writerequestbodies-rules.yaml
+++ b/pkg/operator/apiserver/audit/manifests/writerequestbodies-rules.yaml
@@ -8,6 +8,8 @@
     resources: ["tokenreviews", "tokenrequests"]
   - group: "oauth.openshift.io"
     resources: ["oauthclients", "tokenreviews"]
+  - group: "machineconfiguration.openshift.io"
+    resource: ["machineconfig", "controllerconfig"]
 # log request and response payloads for all write requests
 - level: RequestResponse
   verbs:

--- a/pkg/operator/apiserver/audit/testdata/allrequestbodies.yaml
+++ b/pkg/operator/apiserver/audit/testdata/allrequestbodies.yaml
@@ -34,5 +34,7 @@ rules:
     resources: ["tokenreviews", "tokenrequests"]
   - group: "oauth.openshift.io"
     resources: ["oauthclients", "tokenreviews"]
+  - group: "machineconfiguration.openshift.io"
+    resource: ["machineconfig", "controllerconfig"]
 # catch-all rule to log all other requests with request and response payloads
 - level: RequestResponse

--- a/pkg/operator/apiserver/audit/testdata/multipleCr.yaml
+++ b/pkg/operator/apiserver/audit/testdata/multipleCr.yaml
@@ -34,6 +34,8 @@ rules:
     resources: ["tokenreviews", "tokenrequests"]
   - group: "oauth.openshift.io"
     resources: ["oauthclients", "tokenreviews"]
+  - group: "machineconfiguration.openshift.io"
+    resource: ["machineconfig", "controllerconfig"]
   userGroups:
   - system:authenticated:oauth
 # log request and response payloads for all write requests
@@ -64,6 +66,8 @@ rules:
       resources: ["tokenreviews", "tokenrequests"]
     - group: "oauth.openshift.io"
       resources: ["oauthclients", "tokenreviews"]
+    - group: "machineconfiguration.openshift.io"
+      resource: ["machineconfig", "controllerconfig"]
   userGroups:
     - system:authenticated
 - level: RequestResponse

--- a/pkg/operator/apiserver/audit/testdata/oauth.yaml
+++ b/pkg/operator/apiserver/audit/testdata/oauth.yaml
@@ -34,6 +34,8 @@ rules:
     resources: ["tokenreviews", "tokenrequests"]
   - group: "oauth.openshift.io"
     resources: ["oauthclients", "tokenreviews"]
+  - group: "machineconfiguration.openshift.io"
+    resource: ["machineconfig", "controllerconfig"]
   userGroups:
   - system:authenticated:oauth
 # log request and response payloads for all write requests

--- a/pkg/operator/apiserver/audit/testdata/writerequestbodies.yaml
+++ b/pkg/operator/apiserver/audit/testdata/writerequestbodies.yaml
@@ -34,6 +34,8 @@ rules:
     resources: ["tokenreviews", "tokenrequests"]
   - group: "oauth.openshift.io"
     resources: ["oauthclients", "tokenreviews"]
+  - group: "machineconfiguration.openshift.io"
+    resource: ["machineconfig", "controllerconfig"]
 # log request and response payloads for all write requests
 - level: RequestResponse
   verbs:


### PR DESCRIPTION
`MachineConfig` and `ControllerConfig` APIs from the `machineconfiguration.openshift.io` group can contain sensitive data such as pull secrets (in general they contain everything that needs to be written to disk).

This PR excludes these objects from being logged into the audit logs for the `WriteRequestBodies` and `AllRequestBodies` policies.