### PR TITLE
Don't fail on CipherSuites lookup for TLSv1.3 ciphers

### DIFF
--- a/pkg/crypto/crypto.go
+++ b/pkg/crypto/crypto.go
@@ -223,8 +223,8 @@ func CipherSuite(cipherName string) (uint16, error) {
 		return cipher, nil
 	}
 
-	if _, ok := ciphersTLS13[cipherName]; ok {
-		return 0, fmt.Errorf("all golang TLSv1.3 ciphers are always used for TLSv1.3 flows")
+	if cipherTLS13, ok := ciphersTLS13[cipherName]; ok {
+		return cipherTLS13, nil
 	}
 
 	return 0, fmt.Errorf("unknown cipher name %q", cipherName)


### PR DESCRIPTION
https://github.com/openshift/library-go/pull/1850
enabled TLS 1.3 ciphers.
But CipherSuite lookup functions are
still explicitly failing for TLSv1.3 ciphers.
Let's fix it to avoid the need to filter out
the list on caller side before calling
CipherSuitesOrDie