### PR TITLE
NO-JIRA: Update `pkg/crypto` OWNERS

### DIFF
--- a/pkg/crypto/OWNERS
+++ b/pkg/crypto/OWNERS
@@ -1,4 +1,4 @@
 reviewers:
-  - stlaz
+  - ibihim
 approvers:
-  - stlaz
+  - ibihim


### PR DESCRIPTION
This PR replaces `stlaz` with `ibihim` as reviewer and approver.