### PR TITLE
fix: ApplyDirectly add missing support for admissionregistrationv1 ValidatingAdmissionPolicy, ValidatingAdmissionPolicyBinding

### DIFF
--- a/pkg/operator/resource/resourceapply/generic.go
+++ b/pkg/operator/resource/resourceapply/generic.go
@@ -215,6 +215,18 @@ func ApplyDirectly(ctx context.Context, clients *ClientHolder, recorder events.R
 			} else {
 				result.Result, result.Changed, result.Error = ApplyValidatingAdmissionPolicyBindingV1beta1(ctx, clients.kubeClient.AdmissionregistrationV1beta1(), recorder, t, cache)
 			}
+		case *admissionregistrationv1.ValidatingAdmissionPolicy:
+			if clients.kubeClient == nil {
+				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				result.Result, result.Changed, result.Error = ApplyValidatingAdmissionPolicyV1(ctx, clients.kubeClient.AdmissionregistrationV1(), recorder, t, cache)
+			}
+		case *admissionregistrationv1.ValidatingAdmissionPolicyBinding:
+			if clients.kubeClient == nil {
+				result.Error = fmt.Errorf("missing kubeClient")
+			} else {
+				result.Result, result.Changed, result.Error = ApplyValidatingAdmissionPolicyBindingV1(ctx, clients.kubeClient.AdmissionregistrationV1(), recorder, t, cache)
+			}
 		case *storagev1.CSIDriver:
 			if clients.kubeClient == nil {
 				result.Error = fmt.Errorf("missing kubeClient")


### PR DESCRIPTION
The support for applying admissionregistrationv1 ValidatingAdmissionPolicy, ValidatingAdmissionPolicyBinding was added in https://github.com/openshift/library-go/pull/1748 but that wasn't explicitly added also to ApplyDirectly, which results in an error when ApplyDirectly tries to apply such manifests:

```
"admissionregistration.k8s.io/v1/ValidatingAdmissionPolicy " at position 9: unhandled type *v1.ValidatingAdmissionPolicy
```