### PR TITLE
OCPBUGS-26008: installer pods: consider `Pod`s with phase `Failed` and no container statuses as terminated

### DIFF
--- a/pkg/operator/staticpod/installerpod/cmd.go
+++ b/pkg/operator/staticpod/installerpod/cmd.go
@@ -426,7 +426,7 @@ func (o *InstallOptions) Run(ctx context.Context) error {
 	}
 
 	klog.Infof("Waiting for installer revisions to settle for node %s", o.NodeName)
-	if err := o.waitForOtherInstallerRevisionsToSettle(ctx); err != nil {
+	if err := o.waitForOtherInstallerRevisionsToSettle(ctx, 30*time.Second); err != nil {
 		return err
 	}
 
@@ -456,7 +456,7 @@ func (o *InstallOptions) Run(ctx context.Context) error {
 	return nil
 }
 
-func (o *InstallOptions) waitForOtherInstallerRevisionsToSettle(ctx context.Context) error {
+func (o *InstallOptions) waitForOtherInstallerRevisionsToSettle(ctx context.Context, settledGracePeriod time.Duration) error {
 	currRevision64, err := strconv.ParseInt(o.Revision, 10, 32)
 	if err != nil {
 		return fmt.Errorf("bad local revision %v: %w", o.Revision, err)
@@ -514,7 +514,7 @@ func (o *InstallOptions) waitForOtherInstallerRevisionsToSettle(ctx context.Cont
 	// once there are no other running revisions, wait Xs.
 	// In an extreme case, this can be grace period seconds+1.  Trying 30s to start. Etcd has been the worst off since
 	// it requires 2 out 3 to be functioning.
-	time.Sleep(30 * time.Second)
+	time.Sleep(settledGracePeriod)
 
 	klog.Infof("Getting installer pods for node %s", o.NodeName)
 	installerPods, err := o.getInstallerPodsOnThisNode(ctx)

--- a/pkg/operator/staticpod/installerpod/cmd_test.go
+++ b/pkg/operator/staticpod/installerpod/cmd_test.go
@@ -504,9 +504,9 @@ func TestWaitForOtherInstallerRevisionsToSettle(t *testing.T) {
 				NodeName: "foo",
 			}
 
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 			defer cancel()
-			err := installOptions.waitForOtherInstallerRevisionsToSettle(ctx)
+			err := installOptions.waitForOtherInstallerRevisionsToSettle(ctx, time.Second)
 			if err != tc.expected {
 				t.Errorf("error returned by waitForOtherInstallerRevisionsToSettle did not match expected - actual: %v | expected: %v", err, tc.expected)
 			}


### PR DESCRIPTION
OCPBUGS-26008 identified an edge case where installer pods could get stuck and continuously time out while waiting for an installer pod that entered a state where it had a `.status.phase = Failed` with `.status.reason = NodeShutdown`.

Because the installer pods have a `restartPolicy = Never`, the installer pod in this case never ran and future installer pods were stuck waiting for the previous installer pod to get populated with container statuses. Because it failed due to a `NodeShutdown`, the containers never ran and thus no container statuses were populated.

This PR updates the logic installer pods use to check that all other installer pods are terminated to include installer pods with phase `Failed` and no container statuses populated as "terminated".