### PR TITLE
OCPBUGS-57049: Update cert annotations

### DIFF
--- a/pkg/operator/certrotation/annotations.go
+++ b/pkg/operator/certrotation/annotations.go
@@ -16,9 +16,13 @@ const (
 	CertificateIssuer = "auth.openshift.io/certificate-issuer"
 	// CertificateHostnames contains the hostnames used by a signer.
 	CertificateHostnames = "auth.openshift.io/certificate-hostnames"
-	// AutoRegenerateAfterOfflineExpiryAnnotation contains a link to PR and an e2e test name which verifies
+	// CertificateTestNameAnnotation is an e2e test name which verifies that TLS artifact is created and used correctly
+	CertificateTestNameAnnotation string = "certificates.openshift.io/test-name"
+	// CertificateAutoRegenerateAfterOfflineExpiryAnnotation contains a link to PR adding this annotation which verifies
 	// that TLS artifact is correctly regenerated after it has expired
-	AutoRegenerateAfterOfflineExpiryAnnotation string = "certificates.openshift.io/auto-regenerate-after-offline-expiry"
+	CertificateAutoRegenerateAfterOfflineExpiryAnnotation string = "certificates.openshift.io/auto-regenerate-after-offline-expiry"
+	// CertificateRefreshPeriodAnnotation is the interval at which the certificate should be refreshed.
+	CertificateRefreshPeriodAnnotation string = "certificates.openshift.io/refresh-period"
 )
 
 type AdditionalAnnotations struct {
@@ -26,13 +30,16 @@ type AdditionalAnnotations struct {
 	JiraComponent string
 	// Description is a human-readable one sentence description of certificate purpose
 	Description string
-	// AutoRegenerateAfterOfflineExpiry contains a link to PR and an e2e test name which verifies
-	// that TLS artifact is correctly regenerated after it has expired
+	// TestName is an e2e test name which verifies that TLS artifact is created and used correctly
+	TestName string
+	// AutoRegenerateAfterOfflineExpiry contains a link to PR which adds this annotation on the TLS artifact
 	AutoRegenerateAfterOfflineExpiry string
 	// NotBefore contains certificate the certificate creation date in RFC3339 format.
 	NotBefore string
 	// NotAfter contains certificate the certificate validity date in RFC3339 format.
 	NotAfter string
+	// RefreshPeriod contains the interval at which the certificate should be refreshed.
+	RefreshPeriod string
 }
 
 func (a AdditionalAnnotations) EnsureTLSMetadataUpdate(meta *metav1.ObjectMeta) bool {
@@ -52,18 +59,34 @@ func (a AdditionalAnnotations) EnsureTLSMetadataUpdate(meta *metav1.ObjectMeta) 
 		meta.Annotations[annotations.OpenShiftDescription] = a.Description
 		modified = true
 	}
-	if len(a.AutoRegenerateAfterOfflineExpiry) > 0 && meta.Annotations[AutoRegenerateAfterOfflineExpiryAnnotation] != a.AutoRegenerateAfterOfflineExpiry {
-		diff := cmp.Diff(meta.Annotations[AutoRegenerateAfterOfflineExpiryAnnotation], a.AutoRegenerateAfterOfflineExpiry)
-		klog.V(2).Infof("Updating %q annotation for %s/%s, diff: %s", AutoRegenerateAfterOfflineExpiryAnnotation, meta.Namespace, meta.Name, diff)
-		meta.Annotations[AutoRegenerateAfterOfflineExpiryAnnotation] = a.AutoRegenerateAfterOfflineExpiry
+	if len(a.TestName) > 0 && meta.Annotations[CertificateTestNameAnnotation] != a.TestName {
+		diff := cmp.Diff(meta.Annotations[CertificateTestNameAnnotation], a.TestName)
+		klog.V(2).Infof("Updating %q annotation for %s/%s, diff: %s", CertificateTestNameAnnotation, meta.Name, meta.Namespace, diff)
+		meta.Annotations[CertificateTestNameAnnotation] = a.TestName
+		modified = true
+	}
+	if len(a.AutoRegenerateAfterOfflineExpiry) > 0 && meta.Annotations[CertificateAutoRegenerateAfterOfflineExpiryAnnotation] != a.AutoRegenerateAfterOfflineExpiry {
+		diff := cmp.Diff(meta.Annotations[CertificateAutoRegenerateAfterOfflineExpiryAnnotation], a.AutoRegenerateAfterOfflineExpiry)
+		klog.V(2).Infof("Updating %q annotation for %s/%s, diff: %s", CertificateAutoRegenerateAfterOfflineExpiryAnnotation, meta.Namespace, meta.Name, diff)
+		meta.Annotations[CertificateAutoRegenerateAfterOfflineExpiryAnnotation] = a.AutoRegenerateAfterOfflineExpiry
 		modified = true
 	}
 	if len(a.NotBefore) > 0 && meta.Annotations[CertificateNotBeforeAnnotation] != a.NotBefore {
+		diff := cmp.Diff(meta.Annotations[CertificateNotBeforeAnnotation], a.NotBefore)
+		klog.V(2).Infof("Updating %q annotation for %s/%s, diff: %s", CertificateNotBeforeAnnotation, meta.Name, meta.Namespace, diff)
 		meta.Annotations[CertificateNotBeforeAnnotation] = a.NotBefore
 		modified = true
 	}
 	if len(a.NotAfter) > 0 && meta.Annotations[CertificateNotAfterAnnotation] != a.NotAfter {
+		diff := cmp.Diff(meta.Annotations[CertificateNotAfterAnnotation], a.NotAfter)
+		klog.V(2).Infof("Updating %q annotation for %s/%s, diff: %s", CertificateNotAfterAnnotation, meta.Name, meta.Namespace, diff)
 		meta.Annotations[CertificateNotAfterAnnotation] = a.NotAfter
+		modified = true
+	}
+	if len(a.RefreshPeriod) > 0 && meta.Annotations[CertificateRefreshPeriodAnnotation] != a.RefreshPeriod {
+		diff := cmp.Diff(meta.Annotations[CertificateRefreshPeriodAnnotation], a.RefreshPeriod)
+		klog.V(2).Infof("Updating %q annotation for %s/%s, diff: %s", CertificateRefreshPeriodAnnotation, meta.Name, meta.Namespace, diff)
+		meta.Annotations[CertificateRefreshPeriodAnnotation] = a.RefreshPeriod
 		modified = true
 	}
 	return modified

--- a/pkg/operator/certrotation/target.go
+++ b/pkg/operator/certrotation/target.go
@@ -121,7 +121,7 @@ func (c RotatedSelfSignedCertKeySecret) EnsureTargetCertKeyPair(ctx context.Cont
 
 	if reason := c.CertCreator.NeedNewTargetCertKeyPair(targetCertKeyPairSecret, signingCertKeyPair, caBundleCerts, c.Refresh, c.RefreshOnlyWhenExpired, creationRequired); len(reason) > 0 {
 		c.EventRecorder.Eventf("TargetUpdateRequired", "%q in %q requires a new target cert/key pair: %v", c.Name, c.Namespace, reason)
-		if err = setTargetCertKeyPairSecretAndTLSAnnotations(targetCertKeyPairSecret, c.Validity, signingCertKeyPair, c.CertCreator, c.AdditionalAnnotations); err != nil {
+		if err = setTargetCertKeyPairSecretAndTLSAnnotations(targetCertKeyPairSecret, c.Validity, c.Refresh, signingCertKeyPair, c.CertCreator, c.AdditionalAnnotations); err != nil {
 			return nil, err
 		}
 
@@ -234,13 +234,13 @@ func needNewTargetCertKeyPairForTime(annotations map[string]string, signer *cryp
 
 // setTargetCertKeyPairSecretAndTLSAnnotations generates a new cert/key pair,
 // stores them in the specified secret, and adds predefined TLS annotations to that secret.
-func setTargetCertKeyPairSecretAndTLSAnnotations(targetCertKeyPairSecret *corev1.Secret, validity time.Duration, signer *crypto.CA, certCreator TargetCertCreator, tlsAnnotations AdditionalAnnotations) error {
+func setTargetCertKeyPairSecretAndTLSAnnotations(targetCertKeyPairSecret *corev1.Secret, validity, refresh time.Duration, signer *crypto.CA, certCreator TargetCertCreator, tlsAnnotations AdditionalAnnotations) error {
 	certKeyPair, err := setTargetCertKeyPairSecret(targetCertKeyPairSecret, validity, signer, certCreator)
 	if err != nil {
 		return err
 	}
 
-	setTLSAnnotationsOnTargetCertKeyPairSecret(targetCertKeyPairSecret, certKeyPair, certCreator, tlsAnnotations)
+	setTLSAnnotationsOnTargetCertKeyPairSecret(targetCertKeyPairSecret, certKeyPair, certCreator, refresh, tlsAnnotations)
 	return nil
 }
 
@@ -277,11 +277,12 @@ func setTargetCertKeyPairSecret(targetCertKeyPairSecret *corev1.Secret, validity
 //
 // These assumptions are safe because this function is only called after the secret
 // has been initialized in setTargetCertKeyPairSecret.
-func setTLSAnnotationsOnTargetCertKeyPairSecret(targetCertKeyPairSecret *corev1.Secret, certKeyPair *crypto.TLSCertificateConfig, certCreator TargetCertCreator, tlsAnnotations AdditionalAnnotations) {
+func setTLSAnnotationsOnTargetCertKeyPairSecret(targetCertKeyPairSecret *corev1.Secret, certKeyPair *crypto.TLSCertificateConfig, certCreator TargetCertCreator, refresh time.Duration, tlsAnnotations AdditionalAnnotations) {
 	targetCertKeyPairSecret.Annotations[CertificateIssuer] = certKeyPair.Certs[0].Issuer.CommonName
 
 	tlsAnnotations.NotBefore = certKeyPair.Certs[0].NotBefore.Format(time.RFC3339)
 	tlsAnnotations.NotAfter = certKeyPair.Certs[0].NotAfter.Format(time.RFC3339)
+	tlsAnnotations.RefreshPeriod = refresh.String()
 	_ = tlsAnnotations.EnsureTLSMetadataUpdate(&targetCertKeyPairSecret.ObjectMeta)
 
 	certCreator.SetAnnotations(certKeyPair, targetCertKeyPairSecret.Annotations)


### PR DESCRIPTION
Move testcase name out of auto-regenerate-after-offline-expiry, add
refresh-period.

Follow-up for https://github.com/openshift/origin/pull/29327
Tested in https://github.com/openshift/cluster-kube-apiserver-operator/pull/1768 and https://github.com/openshift/cluster-authentication-operator/pull/742