### PR TITLE
CNTRLPLANE-894: Add JobController implementation and related resources

### DIFF
--- a/pkg/operator/jobcontroller/job_controller.go
+++ b/pkg/operator/jobcontroller/job_controller.go
@@ -1,0 +1,356 @@
+package jobcontroller
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	opv1 "github.com/openshift/api/operator/v1"
+	applyoperatorv1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/management"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+	batchinformersv1 "k8s.io/client-go/informers/batch/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
+)
+
+// JobHookFunc is a hook function to modify the Job.
+type JobHookFunc func(*opv1.OperatorSpec, *batchv1.Job) error
+
+// JobController is a generic controller that manages a job.
+//
+// This controller optionally produces the following conditions:
+// <name>Available: indicates that the Job was successfully deployed and completed.
+// <name>Progressing: indicates that the Job is active.
+// <name>Degraded: produced when the Job failed.
+type JobController struct {
+	// instanceName is the name to identify what instance this belongs too: FooDriver for instance
+	instanceName string
+	// controllerInstanceName is the name to identify this instance of this particular control loop: FooDriver-CSIDriverNodeService for instance.
+	controllerInstanceName string
+
+	manifest          []byte
+	operatorClient    v1helpers.OperatorClient
+	kubeClient        kubernetes.Interface
+	jobInformer       batchinformersv1.JobInformer
+	optionalInformers []factory.Informer
+	recorder          events.Recorder
+	conditions        []string
+	// Optional hook functions to modify the Job.
+	// If one of these functions returns an error, the sync
+	// fails indicating the ordinal position of the failed function.
+	// Also, in that scenario the Degraded status is set to True.
+	optionalJobHooks []JobHookFunc
+	// errors contains any errors that occur during the configuration
+	// and setup of the JobController.
+	errors []error
+}
+
+// NewJobController creates a new instance of JobController,
+// returning it as a factory.Controller interface. Under the hood it uses
+// the NewJobControllerBuilder to construct the controller.
+func NewJobController(
+	name string,
+	manifest []byte,
+	recorder events.Recorder,
+	operatorClient v1helpers.OperatorClient,
+	kubeClient kubernetes.Interface,
+	jobInformer batchinformersv1.JobInformer,
+	optionalInformers []factory.Informer,
+	optionalJobHooks ...JobHookFunc,
+) factory.Controller {
+	c := NewJobControllerBuilder(
+		name,
+		manifest,
+		recorder,
+		operatorClient,
+		kubeClient,
+		jobInformer,
+	).WithConditions(
+		opv1.OperatorStatusTypeAvailable,
+		opv1.OperatorStatusTypeProgressing,
+		opv1.OperatorStatusTypeDegraded,
+	).WithExtraInformers(
+		optionalInformers...,
+	).WithJobHooks(
+		optionalJobHooks...,
+	)
+
+	controller, err := c.ToController()
+	if err != nil {
+		panic(err)
+	}
+	return controller
+}
+
+// NewJobControllerBuilder initializes and returns a pointer to a
+// minimal JobController.
+func NewJobControllerBuilder(
+	instanceName string,
+	manifest []byte,
+	recorder events.Recorder,
+	operatorClient v1helpers.OperatorClient,
+	kubeClient kubernetes.Interface,
+	jobInformer batchinformersv1.JobInformer,
+) *JobController {
+	return &JobController{
+		instanceName:           instanceName,
+		controllerInstanceName: factory.ControllerInstanceName(instanceName, "Job"),
+		manifest:               manifest,
+		operatorClient:         operatorClient,
+		kubeClient:             kubeClient,
+		jobInformer:            jobInformer,
+		recorder:               recorder,
+	}
+}
+
+// WithExtraInformers appends additional informers to the JobController.
+// These informers are used to watch for additional resources that might affect the Jobs's state.
+func (c *JobController) WithExtraInformers(informers ...factory.Informer) *JobController {
+	c.optionalInformers = informers
+	return c
+}
+
+// WithJobHooks adds custom hook functions that are called during the sync.
+// These hooks can perform operations or modifications at specific points in the Job.
+func (c *JobController) WithJobHooks(hooks ...JobHookFunc) *JobController {
+	c.optionalJobHooks = hooks
+	return c
+}
+
+// WithConditions sets the operational conditions under which the JobController will operate.
+// Only 'Available', 'Progressing' and 'Degraded' are valid conditions; other values are ignored.
+func (c *JobController) WithConditions(conditions ...string) *JobController {
+	validConditions := sets.New[string]()
+	validConditions.Insert(
+		opv1.OperatorStatusTypeAvailable,
+		opv1.OperatorStatusTypeProgressing,
+		opv1.OperatorStatusTypeDegraded,
+	)
+	for _, condition := range conditions {
+		if validConditions.Has(condition) {
+			if !slices.Contains(c.conditions, condition) {
+				c.conditions = append(c.conditions, condition)
+			}
+		} else {
+			err := fmt.Errorf("invalid condition %q. Valid conditions include %v", condition, validConditions.UnsortedList())
+			c.errors = append(c.errors, err)
+		}
+	}
+	return c
+}
+
+// ToController converts the JobController into a factory.Controller.
+// It aggregates and returns all errors reported during the builder phase.
+func (c *JobController) ToController() (factory.Controller, error) {
+	informers := append(
+		c.optionalInformers,
+		c.operatorClient.Informer(),
+		c.jobInformer.Informer(),
+	)
+	controller := factory.New().WithControllerInstanceName(c.controllerInstanceName).WithInformers(
+		informers...,
+	).WithSync(
+		c.sync,
+	).ResyncEvery(
+		time.Minute,
+	)
+	if slices.Contains(c.conditions, opv1.OperatorStatusTypeDegraded) {
+		controller = controller.WithSyncDegradedOnError(c.operatorClient)
+	}
+	return controller.ToController(
+		c.instanceName, // don't change what is passed here unless you also remove the old FooDegraded condition
+		c.recorder.WithComponentSuffix(strings.ToLower(c.instanceName)+"-job-controller-"),
+	), errors.NewAggregate(c.errors)
+}
+
+// Name returns the name of the JobController.
+func (c *JobController) Name() string {
+	return c.instanceName
+}
+
+func (c *JobController) sync(ctx context.Context, syncContext factory.SyncContext) error {
+	opSpec, opStatus, _, err := c.operatorClient.GetOperatorState()
+	if apierrors.IsNotFound(err) && management.IsOperatorRemovable() {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	if opSpec.ManagementState == opv1.Removed && management.IsOperatorRemovable() {
+		return c.syncDeleting(ctx, opSpec, opStatus, syncContext)
+	}
+
+	if opSpec.ManagementState != opv1.Managed {
+		return nil
+	}
+
+	meta, err := c.operatorClient.GetObjectMeta()
+	if err != nil {
+		return err
+	}
+	if management.IsOperatorRemovable() && meta.DeletionTimestamp != nil {
+		return c.syncDeleting(ctx, opSpec, opStatus, syncContext)
+	}
+	return c.syncManaged(ctx, opSpec, opStatus, syncContext)
+}
+
+func (c *JobController) syncManaged(ctx context.Context, opSpec *opv1.OperatorSpec, opStatus *opv1.OperatorStatus, syncContext factory.SyncContext) error {
+	klog.V(4).Infof("syncManaged")
+
+	required, err := c.getJob(opSpec)
+	if err != nil {
+		return err
+	}
+
+	job, _, err := resourceapply.ApplyJob(
+		ctx,
+		c.kubeClient.BatchV1(),
+		syncContext.Recorder(),
+		required,
+		resourcemerge.ExpectedJobGeneration(required, opStatus.Generations),
+	)
+	if err != nil {
+		return err
+	}
+
+	// Create an OperatorStatusApplyConfiguration with generations
+	status := applyoperatorv1.OperatorStatus().
+		WithGenerations(&applyoperatorv1.GenerationStatusApplyConfiguration{
+			Group:          ptr.To("batch"),
+			Resource:       ptr.To("jobs"),
+			Namespace:      ptr.To(job.Namespace),
+			Name:           ptr.To(job.Name),
+			LastGeneration: ptr.To(job.Generation),
+		})
+
+	// Set Available condition
+	if slices.Contains(c.conditions, opv1.OperatorStatusTypeAvailable) {
+		availableCondition := applyoperatorv1.
+			OperatorCondition().WithType(c.instanceName + opv1.OperatorStatusTypeAvailable)
+
+		if isComplete(job) {
+			availableCondition = availableCondition.
+				WithStatus(opv1.ConditionTrue).
+				WithReason("JobComplete").
+				WithMessage("Job completed")
+		} else if isFailed(job) {
+			availableCondition = availableCondition.
+				WithStatus(opv1.ConditionFalse).
+				WithReason("JobFailed").
+				WithMessage("Job failed")
+		} else {
+			availableCondition = availableCondition.
+				WithStatus(opv1.ConditionFalse).
+				WithReason("JobRunning").
+				WithMessage("Job is running")
+		}
+
+		status = status.WithConditions(availableCondition)
+	}
+
+	// Set Progressing condition
+	if slices.Contains(c.conditions, opv1.OperatorStatusTypeProgressing) {
+		progressingCondition := applyoperatorv1.OperatorCondition().
+			WithType(c.instanceName + opv1.OperatorStatusTypeProgressing)
+
+		if isComplete(job) {
+			progressingCondition = progressingCondition.
+				WithStatus(opv1.ConditionFalse).
+				WithReason("JobComplete").
+				WithMessage("Job completed")
+		} else if isFailed(job) {
+			progressingCondition = progressingCondition.
+				WithStatus(opv1.ConditionFalse).
+				WithReason("JobFailed").
+				WithMessage("Job failed")
+		} else {
+			progressingCondition = progressingCondition.
+				WithStatus(opv1.ConditionTrue).
+				WithReason("JobRunning").
+				WithMessage("Job is running")
+		}
+
+		status = status.WithConditions(progressingCondition)
+	}
+
+	err = c.operatorClient.ApplyOperatorStatus(
+		ctx,
+		c.controllerInstanceName,
+		status,
+	)
+	if err != nil {
+		return err
+	}
+
+	// return an error for reporting degraded status!
+	// setting a condition manually, similar to available and progressing, doesn't work
+	if isFailed(job) {
+		return fmt.Errorf("job failed")
+	}
+	return nil
+}
+
+func (c *JobController) syncDeleting(ctx context.Context, opSpec *opv1.OperatorSpec, opStatus *opv1.OperatorStatus, syncContext factory.SyncContext) error {
+	klog.V(4).Infof("syncDeleting")
+	required, err := c.getJob(opSpec)
+	if err != nil {
+		return err
+	}
+
+	err = c.kubeClient.BatchV1().Jobs(required.Namespace).Delete(ctx, required.Name, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	} else {
+		klog.V(2).Infof("Deleted Job %s/%s", required.Namespace, required.Name)
+	}
+	return nil
+}
+
+func (c *JobController) getJob(opSpec *opv1.OperatorSpec) (*batchv1.Job, error) {
+	manifest := c.manifest
+	required := resourceread.ReadJobV1OrDie(manifest)
+	for i := range c.optionalJobHooks {
+		err := c.optionalJobHooks[i](opSpec, required)
+		if err != nil {
+			return nil, fmt.Errorf("error running hook function (index=%d): %w", i, err)
+		}
+	}
+	return required, nil
+}
+
+func isComplete(job *batchv1.Job) bool {
+	return isConditionTrue(job.Status.Conditions, batchv1.JobComplete)
+}
+
+func isFailed(job *batchv1.Job) bool {
+	return isConditionTrue(job.Status.Conditions, batchv1.JobFailed)
+}
+
+func isConditionTrue(conditions []batchv1.JobCondition, conditionType batchv1.JobConditionType) bool {
+	return isConditionPresentAndEqual(conditions, conditionType, corev1.ConditionTrue)
+}
+
+func isConditionPresentAndEqual(conditions []batchv1.JobCondition, conditionType batchv1.JobConditionType, status corev1.ConditionStatus) bool {
+	for _, condition := range conditions {
+		if condition.Type == conditionType {
+			return condition.Status == status
+		}
+	}
+	return false
+}

--- a/pkg/operator/jobcontroller/job_controller_test.go
+++ b/pkg/operator/jobcontroller/job_controller_test.go
@@ -1,0 +1,650 @@
+package jobcontroller
+
+import (
+	"context"
+	"os"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	configv1 "github.com/openshift/api/config/v1"
+	opv1 "github.com/openshift/api/operator/v1"
+	fakeconfig "github.com/openshift/client-go/config/clientset/versioned/fake"
+	configinformers "github.com/openshift/client-go/config/informers/externalversions"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/management"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	coreinformers "k8s.io/client-go/informers"
+	fakecore "k8s.io/client-go/kubernetes/fake"
+	core "k8s.io/client-go/testing"
+	clocktesting "k8s.io/utils/clock/testing"
+)
+
+const (
+	infraConfigName  = "cluster"
+	jobName          = "testjob"
+	defaultClusterID = "ID1234"
+	controllerName   = "TestJobController"
+	operandName      = "dummy-controller"
+	operandNamespace = "openshift-test"
+	// From github.com/openshift/library-go/pkg/operator/resource/resourceapply/batch.go
+	specHashAnnotation = "operator.openshift.io/spec-hash"
+	finalizerName      = "test.operator.openshift.io/" + controllerName
+)
+
+var (
+	conditionAvailable   = controllerName + opv1.OperatorStatusTypeAvailable
+	conditionProgressing = controllerName + opv1.OperatorStatusTypeProgressing
+)
+
+func TestJobCreation(t *testing.T) {
+	// Initialize
+	coreClient := fakecore.NewSimpleClientset()
+	coreInformerFactory := coreinformers.NewSharedInformerFactory(coreClient, 0 /*no resync */)
+	initialInfras := []runtime.Object{makeInfra()}
+	configClient := fakeconfig.NewSimpleClientset(initialInfras...)
+	configInformerFactory := configinformers.NewSharedInformerFactory(configClient, 0)
+	configInformer := configInformerFactory.Config().V1().Infrastructures().Informer()
+	configInformer.GetIndexer().Add(initialInfras[0])
+	driverInstance := makeFakeOperatorInstance()
+	fakeOperatorClient := v1helpers.NewFakeOperatorClientWithObjectMeta(&driverInstance.ObjectMeta, &driverInstance.Spec, &driverInstance.Status, nil /*triggerErr func*/)
+	var optionalInformers []factory.Informer
+	optionalInformers = append(optionalInformers, configInformer)
+	var optionalJobHooks []JobHookFunc
+	controller := NewJobController(
+		controllerName,
+		makeFakeManifest(),
+		events.NewInMemoryRecorder(operandName, clocktesting.NewFakePassiveClock(time.Now())),
+		fakeOperatorClient,
+		coreClient,
+		coreInformerFactory.Batch().V1().Jobs(),
+		optionalInformers,
+		optionalJobHooks...,
+	)
+
+	// Act
+	err := controller.Sync(context.TODO(), factory.NewSyncContext(controllerName, events.NewInMemoryRecorder("dummy-controller", clocktesting.NewFakePassiveClock(time.Now()))))
+	if err != nil {
+		t.Fatalf("sync() returned unexpected error: %v", err)
+	}
+
+	// Assert
+	_, err = coreClient.BatchV1().Jobs(operandNamespace).Get(context.TODO(), jobName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get Job %s: %v", jobName, err)
+	}
+}
+
+func TestSync(t *testing.T) {
+	testCases := []testCase{
+		{
+			// Only CR exists, everything else is created
+			name: "initial sync",
+			initialObjects: testObjects{
+				operator: makeFakeOperatorInstance(),
+			},
+			expectedObjects: testObjects{
+				job: makeJob(
+					withJobGeneration(1)),
+				operator: makeFakeOperatorInstance(
+					withGenerations(1),
+					withTrueConditions(conditionProgressing),
+					withFalseConditions(conditionAvailable)),
+			},
+		},
+		{
+			// Job is completed and its status is synced to CR
+			name: "job completed",
+			initialObjects: testObjects{
+				job: makeJob(
+					withJobGeneration(1),
+					withJobStatus(0, 1, 0),
+					withJobComplete()),
+				operator: makeFakeOperatorInstance(withGenerations(1)),
+			},
+			expectedObjects: testObjects{
+				job: makeJob(
+					withJobGeneration(1),
+					withJobStatus(0, 1, 0),
+					withJobComplete()),
+				operator: makeFakeOperatorInstance(
+					withGenerations(1),
+					withTrueConditions(conditionAvailable),
+					withFalseConditions(conditionProgressing)),
+			},
+		},
+		{
+			// Job is running
+			name: "job running",
+			initialObjects: testObjects{
+				job: makeJob(
+					withJobGeneration(1),
+					withJobStatus(1, 0, 0)), // the Job has 1 active pod
+				operator: makeFakeOperatorInstance(withGenerations(1)),
+			},
+			expectedObjects: testObjects{
+				job: makeJob(
+					withJobGeneration(1),
+					withJobStatus(1, 0, 0)), // no change to the Job
+				operator: makeFakeOperatorInstance(
+					withGenerations(1),
+					withTrueConditions(conditionProgressing),
+					withFalseConditions(conditionAvailable)),
+			},
+		},
+		{
+			// Job failed - this should trigger degraded condition
+			name: "job failed",
+			initialObjects: testObjects{
+				job: makeJob(
+					withJobGeneration(1),
+					withJobStatus(0, 0, 1),
+					withJobFailed()),
+				operator: makeFakeOperatorInstance(withGenerations(1)),
+			},
+			expectedObjects: testObjects{
+				job: makeJob(
+					withJobGeneration(1),
+					withJobStatus(0, 0, 1),
+					withJobFailed()),
+				operator: makeFakeOperatorInstance(
+					withGenerations(1),
+					withFalseConditions(conditionAvailable, conditionProgressing)),
+			},
+			expectErr: true, // Job failure should return an error
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			// Initialize
+			os.Setenv("OPERATOR_NAME", "test")
+			management.SetOperatorNotRemovable()
+			ctx := newTestContext(test, t)
+
+			// Act
+			err := ctx.controller.Sync(context.TODO(), factory.NewSyncContext(controllerName, events.NewInMemoryRecorder("test-job-controller", clocktesting.NewFakePassiveClock(time.Now()))))
+
+			// Assert
+			// Check error
+			if err != nil && !test.expectErr {
+				t.Errorf("sync() returned unexpected error: %v", err)
+			}
+			if err == nil && test.expectErr {
+				t.Error("sync() unexpectedly succeeded when error was expected")
+			}
+
+			// Check expectedObjects.job
+			if test.expectedObjects.job != nil {
+				actualJob, err := ctx.coreClient.BatchV1().Jobs(operandNamespace).Get(context.TODO(), jobName, metav1.GetOptions{})
+				if err != nil {
+					t.Errorf("Failed to get Job %s: %v", jobName, err)
+				}
+				sanitizeJob(actualJob)
+				sanitizeJob(test.expectedObjects.job)
+				if !equality.Semantic.DeepEqual(test.expectedObjects.job, actualJob) {
+					t.Errorf("Unexpected Job %+v content:\n%s", operandName, cmp.Diff(test.expectedObjects.job, actualJob))
+				}
+			}
+			if test.expectedObjects.job == nil && test.initialObjects.job != nil {
+				actualJob, err := ctx.coreClient.BatchV1().Jobs(operandNamespace).Get(context.TODO(), jobName, metav1.GetOptions{})
+				if err == nil {
+					t.Errorf("Expected Job to be deleted, found generation %d", actualJob.Generation)
+				}
+				if !errors.IsNotFound(err) {
+					t.Errorf("Expected error to be NotFound, got %s", err)
+				}
+			}
+
+			// Check expectedObjects.operator.Status
+			if test.expectedObjects.operator != nil {
+				_, actualStatus, _, err := ctx.operatorClient.GetOperatorState()
+				if err != nil {
+					t.Errorf("Failed to get operator: %v", err)
+				}
+				sanitizeInstanceStatus(actualStatus)
+				sanitizeInstanceStatus(&test.expectedObjects.operator.Status)
+				if !equality.Semantic.DeepEqual(test.expectedObjects.operator.Status, *actualStatus) {
+					t.Errorf("Unexpected operator %+v content:\n%s", operandName, cmp.Diff(test.expectedObjects.operator.Status, *actualStatus))
+				}
+			}
+
+			// Check expected ObjectMeta - only check what's relevant for non-finalizer operations
+			actualMeta, err := ctx.operatorClient.GetObjectMeta()
+			if err != nil {
+				t.Errorf("Failed to get operator: %v", err)
+			}
+			sanitizeObjectMeta(actualMeta)
+			expectedMeta := &test.expectedObjects.operator.ObjectMeta
+			sanitizeObjectMeta(expectedMeta)
+			// For job controller, we only care about basic ObjectMeta fields, not finalizers
+			if actualMeta.Name != expectedMeta.Name || actualMeta.Generation != expectedMeta.Generation {
+				t.Errorf("Unexpected operator ObjectMeta basic fields: name=%s vs %s, generation=%d vs %d",
+					actualMeta.Name, expectedMeta.Name, actualMeta.Generation, expectedMeta.Generation)
+			}
+		})
+	}
+}
+
+type testCase struct {
+	name            string
+	initialObjects  testObjects
+	expectedObjects testObjects
+	expectErr       bool
+}
+
+type testObjects struct {
+	job      *batchv1.Job
+	operator *fakeOperatorInstance
+}
+
+type testContext struct {
+	controller     factory.Controller
+	operatorClient v1helpers.OperatorClient
+	coreClient     *fakecore.Clientset
+	coreInformers  coreinformers.SharedInformerFactory
+}
+
+// fakeOperatorInstance is a fake Operator instance that  fullfils the OperatorClient interface.
+type fakeOperatorInstance struct {
+	metav1.ObjectMeta
+	Spec   opv1.OperatorSpec
+	Status opv1.OperatorStatus
+}
+
+type jobModifier func(*batchv1.Job) *batchv1.Job
+
+// Infrastructure
+func makeInfra() *configv1.Infrastructure {
+	return &configv1.Infrastructure{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      infraConfigName,
+			Namespace: v1.NamespaceAll,
+		},
+		Status: configv1.InfrastructureStatus{
+			InfrastructureName: defaultClusterID,
+		},
+	}
+}
+
+func makeJob(modifiers ...jobModifier) *batchv1.Job {
+	manifest := makeFakeManifest()
+	job := resourceread.ReadJobV1OrDie(manifest)
+
+	for _, modifier := range modifiers {
+		job = modifier(job)
+	}
+
+	return job
+}
+
+func withJobGeneration(generation int64) jobModifier {
+	return func(instance *batchv1.Job) *batchv1.Job {
+		instance.Generation = generation
+		return instance
+	}
+}
+
+func withJobStatus(active, succeeded, failed int32) jobModifier {
+	return func(instance *batchv1.Job) *batchv1.Job {
+		instance.Status.Active = active
+		instance.Status.Succeeded = succeeded
+		instance.Status.Failed = failed
+		return instance
+	}
+}
+
+func withJobComplete() jobModifier {
+	return func(instance *batchv1.Job) *batchv1.Job {
+		instance.Status.Conditions = append(instance.Status.Conditions, batchv1.JobCondition{
+			Type:   batchv1.JobComplete,
+			Status: v1.ConditionTrue,
+		})
+		return instance
+	}
+}
+
+func withJobFailed() jobModifier {
+	return func(instance *batchv1.Job) *batchv1.Job {
+		instance.Status.Conditions = append(instance.Status.Conditions, batchv1.JobCondition{
+			Type:   batchv1.JobFailed,
+			Status: v1.ConditionTrue,
+		})
+		return instance
+	}
+}
+
+func makeFakeManifest() []byte {
+	return []byte(`
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    app.kubernetes.io/name: testjob
+  namespace: openshift-test
+  name: testjob
+spec:
+  template:
+    metadata:
+      annotations:
+        openshift.io/required-scc: "privileged"
+    spec:
+      containers:
+        - name: testjob
+          image: testimage
+          imagePullPolicy: IfNotPresent
+          command: [ "test", "arg" ]
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          securityContext:
+            privileged: true
+            allowPrivilegeEscalation: true
+      hostIPC: false
+      hostNetwork: false
+      hostPID: true
+      priorityClassName: system-node-critical
+      serviceAccountName: test-manager
+      terminationGracePeriodSeconds: 10
+      restartPolicy: Never
+    backoffLimit: 3`)
+}
+
+type operatorModifier func(instance *fakeOperatorInstance) *fakeOperatorInstance
+
+func makeFakeOperatorInstance(modifiers ...operatorModifier) *fakeOperatorInstance {
+	instance := &fakeOperatorInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "cluster",
+			Generation: 0,
+		},
+		Spec: opv1.OperatorSpec{
+			ManagementState: opv1.Managed,
+		},
+		Status: opv1.OperatorStatus{},
+	}
+	for _, modifier := range modifiers {
+		instance = modifier(instance)
+	}
+	return instance
+}
+
+func withGenerations(job int64) operatorModifier {
+	return func(i *fakeOperatorInstance) *fakeOperatorInstance {
+		i.Status.Generations = []opv1.GenerationStatus{
+			{
+				Group:          batchv1.GroupName,
+				LastGeneration: job,
+				Name:           jobName,
+				Namespace:      operandNamespace,
+				Resource:       "jobs",
+			},
+		}
+		return i
+	}
+}
+
+func withTrueConditions(conditions ...string) operatorModifier {
+	return func(i *fakeOperatorInstance) *fakeOperatorInstance {
+		if i.Status.Conditions == nil {
+			i.Status.Conditions = []opv1.OperatorCondition{}
+		}
+		for _, cond := range conditions {
+			i.Status.Conditions = append(i.Status.Conditions, opv1.OperatorCondition{
+				Type:   cond,
+				Status: opv1.ConditionTrue,
+			})
+		}
+		return i
+	}
+}
+
+func withFalseConditions(conditions ...string) operatorModifier {
+	return func(i *fakeOperatorInstance) *fakeOperatorInstance {
+		if i.Status.Conditions == nil {
+			i.Status.Conditions = []opv1.OperatorCondition{}
+		}
+		for _, c := range conditions {
+			i.Status.Conditions = append(i.Status.Conditions, opv1.OperatorCondition{
+				Type:   c,
+				Status: opv1.ConditionFalse,
+			})
+		}
+		return i
+	}
+}
+
+func newTestContext(test testCase, t *testing.T) *testContext {
+	// Add job to informer
+	var initialObjects []runtime.Object
+	if test.initialObjects.job != nil {
+		resourceapply.SetSpecHashAnnotation(&test.initialObjects.job.ObjectMeta, test.initialObjects.job.Spec)
+		initialObjects = append(initialObjects, test.initialObjects.job)
+	}
+
+	coreClient := fakecore.NewSimpleClientset(initialObjects...)
+	coreInformerFactory := coreinformers.NewSharedInformerFactory(coreClient, 0 /*no resync */)
+
+	// Fill the informer
+	if test.initialObjects.job != nil {
+		coreInformerFactory.Batch().V1().Jobs().Informer().GetIndexer().Add(test.initialObjects.job)
+	}
+
+	// Add global reactors
+	addGenerationReactor(coreClient)
+
+	// Add a fake Infrastructure object to informer. This is not
+	// optional because it is always present in the cluster.
+	initialInfras := []runtime.Object{makeInfra()}
+	configClient := fakeconfig.NewSimpleClientset(initialInfras...)
+	configInformerFactory := configinformers.NewSharedInformerFactory(configClient, 0)
+	configInformer := configInformerFactory.Config().V1().Infrastructures().Informer()
+	configInformer.GetIndexer().Add(initialInfras[0])
+
+	// fakeOperatorInstance also fulfils the OperatorClient interface
+	fakeOperatorClient := v1helpers.NewFakeOperatorClientWithObjectMeta(
+		&test.initialObjects.operator.ObjectMeta,
+		&test.initialObjects.operator.Spec,
+		&test.initialObjects.operator.Status,
+		nil, /*triggerErr func*/
+	)
+	optionalInformers := []factory.Informer{configInformer}
+	var optionalJobHooks []JobHookFunc
+	controller := NewJobController(
+		controllerName,
+		makeFakeManifest(),
+		events.NewInMemoryRecorder(operandName, clocktesting.NewFakePassiveClock(time.Now())),
+		fakeOperatorClient,
+		coreClient,
+		coreInformerFactory.Batch().V1().Jobs(),
+		optionalInformers,
+		optionalJobHooks...,
+	)
+
+	return &testContext{
+		controller:     controller,
+		operatorClient: fakeOperatorClient,
+		coreClient:     coreClient,
+		coreInformers:  coreInformerFactory,
+	}
+}
+
+// This reactor is always enabled and bumps Job generation when it gets updated.
+func addGenerationReactor(client *fakecore.Clientset) {
+	client.PrependReactor("*", "jobs", func(action core.Action) (handled bool, ret runtime.Object, err error) {
+		switch a := action.(type) {
+		case core.CreateActionImpl:
+			object := a.GetObject()
+			job := object.(*batchv1.Job)
+			job.Generation++
+			return false, job, nil
+		case core.UpdateActionImpl:
+			object := a.GetObject()
+			job := object.(*batchv1.Job)
+			job.Generation++
+			return false, job, nil
+		}
+		return false, nil, nil
+	})
+}
+
+func sanitizeJob(job *batchv1.Job) {
+	// nil and empty array are the same
+	if len(job.Labels) == 0 {
+		job.Labels = nil
+	}
+	if len(job.Annotations) == 0 {
+		job.Annotations = nil
+	}
+	// Remove random annotations set by ApplyJob
+	delete(job.Annotations, specHashAnnotation)
+}
+
+func sanitizeInstanceStatus(status *opv1.OperatorStatus) {
+	// Remove condition texts
+	for i := range status.Conditions {
+		status.Conditions[i].LastTransitionTime = metav1.Time{}
+		status.Conditions[i].Message = ""
+		status.Conditions[i].Reason = ""
+	}
+	// Sort the conditions by name to have consistent position in the array
+	sort.Slice(status.Conditions, func(i, j int) bool {
+		return status.Conditions[i].Type < status.Conditions[j].Type
+	})
+}
+
+func sanitizeObjectMeta(meta *metav1.ObjectMeta) {
+	// Treat empty array as nil for easier comparison.
+	if len(meta.Finalizers) == 0 {
+		meta.Finalizers = nil
+	}
+}
+
+// withModifiedJob creates a job that differs from the expected manifest
+func withModifiedJob() jobModifier {
+	return func(instance *batchv1.Job) *batchv1.Job {
+		// Modify the job to be different from the expected manifest
+		// Change the command to make it different
+		if len(instance.Spec.Template.Spec.Containers) > 0 {
+			instance.Spec.Template.Spec.Containers[0].Command = []string{"modified", "command"}
+		}
+		// Add a label that shouldn't be there
+		if instance.Labels == nil {
+			instance.Labels = make(map[string]string)
+		}
+		instance.Labels["modified"] = "true"
+		return instance
+	}
+}
+
+func TestJobModificationRecreation(t *testing.T) {
+	// Initialize
+	os.Setenv("OPERATOR_NAME", "test")
+	management.SetOperatorNotRemovable()
+
+	coreClient := fakecore.NewSimpleClientset()
+	coreInformerFactory := coreinformers.NewSharedInformerFactory(coreClient, 0)
+
+	// Create a modified job that differs from the expected manifest
+	modifiedJob := makeJob(
+		withJobGeneration(1),
+		withModifiedJob(), // This makes it different from expected manifest
+	)
+
+	// Add the modified job to the fake client and informer
+	coreClient.BatchV1().Jobs(operandNamespace).Create(context.TODO(), modifiedJob, metav1.CreateOptions{})
+	coreInformerFactory.Batch().V1().Jobs().Informer().GetIndexer().Add(modifiedJob)
+
+	// Add global reactors
+	addGenerationReactor(coreClient)
+
+	// Add infrastructure config
+	initialInfras := []runtime.Object{makeInfra()}
+	configClient := fakeconfig.NewSimpleClientset(initialInfras...)
+	configInformerFactory := configinformers.NewSharedInformerFactory(configClient, 0)
+	configInformer := configInformerFactory.Config().V1().Infrastructures().Informer()
+	configInformer.GetIndexer().Add(initialInfras[0])
+
+	// Create fake operator instance
+	operatorInstance := makeFakeOperatorInstance(withGenerations(1))
+	fakeOperatorClient := v1helpers.NewFakeOperatorClientWithObjectMeta(
+		&operatorInstance.ObjectMeta,
+		&operatorInstance.Spec,
+		&operatorInstance.Status,
+		nil,
+	)
+
+	// Create controller
+	optionalInformers := []factory.Informer{configInformer}
+	var optionalJobHooks []JobHookFunc
+	controller := NewJobController(
+		controllerName,
+		makeFakeManifest(),
+		events.NewInMemoryRecorder(operandName, clocktesting.NewFakePassiveClock(time.Now())),
+		fakeOperatorClient,
+		coreClient,
+		coreInformerFactory.Batch().V1().Jobs(),
+		optionalInformers,
+		optionalJobHooks...,
+	)
+
+	// FIRST SYNC: Should detect the modified job and delete it
+	err := controller.Sync(context.TODO(), factory.NewSyncContext(controllerName, events.NewInMemoryRecorder("test-job-controller", clocktesting.NewFakePassiveClock(time.Now()))))
+	if err == nil {
+		t.Fatalf("First sync should have returned an error when detecting modified job")
+	}
+
+	// Verify the error message indicates the job was modified and deleted
+	expectedErrorMsg := "job spec was modified, old job is deleted"
+	if err.Error() != expectedErrorMsg {
+		t.Errorf("First sync returned unexpected error message: got %q, want %q", err.Error(), expectedErrorMsg)
+	}
+
+	// Verify the job was deleted
+	_, err = coreClient.BatchV1().Jobs(operandNamespace).Get(context.TODO(), jobName, metav1.GetOptions{})
+	if err == nil {
+		t.Errorf("Job should have been deleted after first sync")
+	}
+	if !errors.IsNotFound(err) {
+		t.Errorf("Expected NotFound error, got: %v", err)
+	}
+
+	// SECOND SYNC: Should succeed and ensure proper job is in place
+	err = controller.Sync(context.TODO(), factory.NewSyncContext(controllerName, events.NewInMemoryRecorder("test-job-controller", clocktesting.NewFakePassiveClock(time.Now()))))
+	if err != nil {
+		t.Fatalf("Second sync returned unexpected error: %v", err)
+	}
+
+	// Verify the job now exists and matches expected manifest
+	finalJob, err := coreClient.BatchV1().Jobs(operandNamespace).Get(context.TODO(), jobName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Job should exist after second sync: %v", err)
+	}
+
+	// Verify the job has the expected values (not the modified ones)
+	if finalJob.Labels != nil && finalJob.Labels["modified"] == "true" {
+		t.Errorf("Second sync job still has modified label")
+	}
+
+	// Verify the command is correct (should be from the manifest)
+	if len(finalJob.Spec.Template.Spec.Containers) > 0 {
+		actualCommand := finalJob.Spec.Template.Spec.Containers[0].Command
+		expectedCommand := []string{"test", "arg"} // From makeFakeManifest
+		if !equality.Semantic.DeepEqual(actualCommand, expectedCommand) {
+			t.Errorf("Second sync job has unexpected command: got %v, want %v", actualCommand, expectedCommand)
+		}
+	}
+
+	t.Logf("Test completed successfully: job was modified, detected, and recreated properly")
+}

--- a/pkg/operator/resource/resourceapply/batch.go
+++ b/pkg/operator/resource/resourceapply/batch.go
@@ -1,0 +1,55 @@
+package resourceapply
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourcehelper"
+	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
+	batchv1 "k8s.io/api/batch/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	batchclientv1 "k8s.io/client-go/kubernetes/typed/batch/v1"
+)
+
+// ApplyJob ensures the form of the specified job is present in the API. If it
+// does not exist, it will be created. If it does exist, the existing job will be deleted,
+// and a new Job will be created.
+func ApplyJob(ctx context.Context, client batchclientv1.JobsGetter, recorder events.Recorder,
+	requiredOriginal *batchv1.Job, expectedGeneration int64) (*batchv1.Job, bool, error) {
+
+	required := requiredOriginal.DeepCopy()
+	err := SetSpecHashAnnotation(&required.ObjectMeta, required.Spec)
+	if err != nil {
+		return nil, false, err
+	}
+
+	existing, err := client.Jobs(required.Namespace).Get(ctx, required.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		actual, err := client.Jobs(required.Namespace).Create(ctx, required, metav1.CreateOptions{})
+		resourcehelper.ReportCreateEvent(recorder, required, err)
+		return actual, true, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+
+	modified := false
+	existingCopy := existing.DeepCopy()
+	resourcemerge.EnsureObjectMeta(&modified, &existingCopy.ObjectMeta, required.ObjectMeta)
+
+	// there was no change to metadata, and the generation was right
+	if !modified && existingCopy.ObjectMeta.Generation == expectedGeneration {
+		return existingCopy, false, nil
+	}
+
+	// We do not update jobs, we always recreate them, since significant parts are immutable.
+	// Delete here, recreate on next sync.
+	err = client.Jobs(required.Namespace).Delete(ctx, required.Name, metav1.DeleteOptions{})
+	if err != nil {
+		return nil, false, err
+	}
+	resourcehelper.ReportDeleteEvent(recorder, required, nil)
+	return nil, false, fmt.Errorf("job spec was modified, old job is deleted")
+}

--- a/pkg/operator/resource/resourcemerge/batch.go
+++ b/pkg/operator/resource/resourcemerge/batch.go
@@ -1,0 +1,15 @@
+package resourcemerge
+
+import (
+	operatorsv1 "github.com/openshift/api/operator/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func ExpectedJobGeneration(required *batchv1.Job, previousGenerations []operatorsv1.GenerationStatus) int64 {
+	generation := GenerationFor(previousGenerations, schema.GroupResource{Group: "batch", Resource: "jobs"}, required.Namespace, required.Name)
+	if generation != nil {
+		return generation.LastGeneration
+	}
+	return -1
+}

--- a/pkg/operator/resource/resourceread/batch.go
+++ b/pkg/operator/resource/resourceread/batch.go
@@ -1,0 +1,26 @@
+package resourceread
+
+import (
+	batchv1 "k8s.io/api/batch/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+)
+
+var (
+	batchScheme = runtime.NewScheme()
+	batchCodecs = serializer.NewCodecFactory(batchScheme)
+)
+
+func init() {
+	if err := batchv1.AddToScheme(batchScheme); err != nil {
+		panic(err)
+	}
+}
+
+func ReadJobV1OrDie(objBytes []byte) *batchv1.Job {
+	requiredObj, err := runtime.Decode(batchCodecs.UniversalDecoder(batchv1.SchemeGroupVersion), objBytes)
+	if err != nil {
+		panic(err)
+	}
+	return requiredObj.(*batchv1.Job)
+}


### PR DESCRIPTION
This PR introduces a new JobController that manages Kubernetes jobs, including functionality for job creation, deletion, and status reporting. It also includes the necessary resource application and merging logic for jobs, along with test cases to validate the controller's behavior.

The controller was implemented and is used in CEO for setting up two node fencing: https://github.com/openshift/cluster-etcd-operator/tree/main/pkg/tnf/pkg/jobs
