### PR TITLE
OCPBUGS-59526: certgraphanalysis: remove hash from primary cert bundle secret

### DIFF
--- a/pkg/certs/cert-inspection/certgraphanalysis/metadata_options.go
+++ b/pkg/certs/cert-inspection/certgraphanalysis/metadata_options.go
@@ -149,6 +149,15 @@ var (
 			return timestampReg.ReplaceAllString(path, "<timestamp>.pem")
 		},
 	}
+	RewritePrimaryCertBundleSecret = &metadataOptions{
+		rewriteSecretFn: func(secret *corev1.Secret) {
+			if secret.Namespace != "openshift-ingress" || !strings.HasSuffix(secret.Name, "-primary-cert-bundle-secret") {
+				return
+			}
+			hash := strings.TrimSuffix(secret.Name, "-primary-cert-bundle-secret")
+			secret.Name = strings.ReplaceAll(secret.Name, hash, "<hash>")
+		},
+	}
 )
 
 // skipRevisionedInOnDiskLocation returns true if location is for revisioned certificate and needs to be skipped


### PR DESCRIPTION
ROSA Hypershift tests create this secret with a certificate, but its name always starts with a random hash. This option would allow us to replace the variable part so that this certificate could be tracked in TLS registry.

See flaking test ` all registered tls artifacts must have no metadata violation regressions` in [this](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.20-e2e-rosa-sts-hypershift-ovn/1943821536276254720) ROSA test:
```
requirement/ownership: --namespace=openshift-ingress secret/2jvlkpa3d9m62op6t1789pd503rsl9g8-primary-cert-bundle-secret regressed and does not have value set
```

Tested in https://github.com/openshift/origin/pull/29995