### PR TITLE
resourceread: fix codec in ReadNetworkPolicyV1OrDie

### DIFF
--- a/pkg/operator/resource/resourceread/networking.go
+++ b/pkg/operator/resource/resourceread/networking.go
@@ -18,7 +18,7 @@ func init() {
 }
 
 func ReadNetworkPolicyV1OrDie(objBytes []byte) *networkingv1.NetworkPolicy {
-	requiredObj, err := runtime.Decode(coreCodecs.UniversalDecoder(networkingv1.SchemeGroupVersion), objBytes)
+	requiredObj, err := runtime.Decode(netCodecs.UniversalDecoder(networkingv1.SchemeGroupVersion), objBytes)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
ReadNetworkPolicyV1OrDie should use netCodecs instead of coreCodecs,
otherwise it panics because NetworkPolicy is not in the core scheme.

Example panic where I called this function from a new controller in openshift/local-storage-operator:
```
I0813 10:46:03.944908 2644555 reconcile.go:41] "Reconciling NetworkPolicies" namespace="openshift-local-storage" name=""
2025-08-13T10:46:03.945-0600    ERROR   runtime/runtime.go:142  Observed a panic        {"controller": "networkpolicy", "controllerGroup": "networking.k8s.io", "controllerKind": "NetworkPolicy", "NetworkPolicy": {"name":"","namespace":"openshift-local-storage"}, "namespace": "openshift-local-storage", "name": "", "reconcileID": "93797f73-f3ff-48e8-a860-34b0dbbec9f0", "panic": "no kind \"NetworkPolicy\" is registered for version \"networking.k8s.io/v1\" in scheme \"github.com/openshift/library-go/pkg/operator/resource/resourceread/core.go:10\"", "panicGoValue": "&runtime.notRegisteredErr{schemeName:\"github.com/openshift/library-go/pkg/operator/resource/resourceread/core.go:10\", gvk:schema.GroupVersionKind{Group:\"networking.k8s.io\", Version:\"v1\", Kind:\"NetworkPolicy\"}, target:runtime.GroupVersioner(nil), t:reflect.Type(nil)}", "stacktrace": "goroutine 427 [running]:\nk8s.io/apimachinery/pkg/util/runtime.logPanic({0x2a92c48, 0xc0009fb560}, {0x2262320, 0xc000c8ef00})\n\t/home/jon/workspace/local-storage-operator/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:132 +0xbc\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile.func1()\n\t/home/jon/workspace/local-storage-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:108 +0x112\npanic({0x2262320?, 0xc000c8ef00?})\n\t/home/jon/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.4.linux-amd64/src/runtime/panic.go:792 +0x132\ngithub.com/openshift/library-go/pkg/operator/resource/resourceread.ReadNetworkPolicyV1OrDie({0xc000470f00, 0x263, 0x280})\n\t/home/jon/workspace/local-storage-operator/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceread/networking.go:23 +0x11e\ngithub.com/openshift/local-storage-operator/pkg/controllers/networkpolicy.(*NetworkPolicyReconciler).Reconcile(0xc000464a50, {0x2a92c48, 0xc0009fb560}, {{{0xc00085e078?, 0x268a7cb?}, {0x0?, 0x100?}}})\n\t/home/jon/workspace/local-storage-operator/pkg/controllers/networkpolicy/reconcile.go:59 +0x295\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile(0xc0009fb4d0?, {0x2a92c48?, 0xc0009fb560?}, {{{0xc00085e078?, 0x0?}, {0x0?, 0x0?}}})\n\t/home/jon/workspace/local-storage-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:119 +0xbf\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler(0x2abfec0, {0x2a92c80, 0xc0003b5860}, {{{0xc00085e078, 0x17}, {0x0, 0x0}}}, 0x0)\n\t/home/jon/workspace/local-storage-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:340 +0x3ad\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem(0x2abfec0, {0x2a92c80, 0xc0003b5860})\n\t/home/jon/workspace/local-storage-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:300 +0x21b\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.1()\n\t/home/jon/workspace/local-storage-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:202 +0x85\ncreated by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2 in goroutine 111\n\t/home/jon/workspace/local-storage-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:198 +0x28f\n"}
k8s.io/apimachinery/pkg/util/runtime.logPanic
        /home/jon/workspace/local-storage-operator/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:142
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile.func1
        /home/jon/workspace/local-storage-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:108
runtime.gopanic
        /home/jon/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.4.linux-amd64/src/runtime/panic.go:792
github.com/openshift/library-go/pkg/operator/resource/resourceread.ReadNetworkPolicyV1OrDie
        /home/jon/workspace/local-storage-operator/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceread/networking.go:23
github.com/openshift/local-storage-operator/pkg/controllers/networkpolicy.(*NetworkPolicyReconciler).Reconcile
        /home/jon/workspace/local-storage-operator/pkg/controllers/networkpolicy/reconcile.go:59
```

The panic message is the important bit:
`"no kind \"NetworkPolicy\" is registered for version \"networking.k8s.io/v1\" in scheme \"github.com/openshift/library-go/pkg/operator/resource/resourceread/core.go:10\""`

Using `netCodecs` instead of `coreCodecs` fixes this issue and allows ReadNetworkPolicyV1OrDie to return successfully.

/cc @tmshort @jsafrane
