### PR TITLE
OCPBUGS-60568: Use BoundServceAccountTokenVolume dy default

### DIFF
--- a/pkg/operator/staticpod/controller/installer/manifests/installer-pod.yaml
+++ b/pkg/operator/staticpod/controller/installer/manifests/installer-pod.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app: installer
 spec:
-  automountServiceAccountToken: false
   serviceAccountName: installer-sa
   nodeName: # Value set by operator
   containers:
@@ -31,9 +30,6 @@ spec:
       volumeMounts:
         - mountPath: /etc/kubernetes/
           name: kubelet-dir
-        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-          name: kube-api-access
-          readOnly: true
         - mountPath: /var/lock
           name: var-lock
       resources:
@@ -56,21 +52,3 @@ spec:
     - hostPath:
         path: /var/lock
       name: var-lock
-    - name: kube-api-access
-      projected:
-        defaultMode: 420
-        sources:
-        - serviceAccountToken:
-            expirationSeconds: 3600
-            path: token
-        - configMap:
-            items:
-            - key: ca.crt
-              path: ca.crt
-            name: kube-root-ca.crt
-        - downwardAPI:
-            items:
-            - fieldRef:
-                apiVersion: v1
-                fieldPath: metadata.namespace
-              path: namespace

--- a/pkg/operator/staticpod/controller/prune/manifests/pruner-pod.yaml
+++ b/pkg/operator/staticpod/controller/prune/manifests/pruner-pod.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app: pruner
 spec:
-  automountServiceAccountToken: false
   serviceAccountName: installer-sa
   nodeName: # Value set by operator
   containers:
@@ -29,9 +28,6 @@ spec:
     volumeMounts:
     - mountPath: /etc/kubernetes/
       name: kubelet-dir
-    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-      name: kube-api-access
-      readOnly: true
   restartPolicy: Never
   priorityClassName: system-node-critical
   tolerations:
@@ -42,21 +38,3 @@ spec:
   - hostPath:
       path: /etc/kubernetes/
     name: kubelet-dir
-  - name: kube-api-access
-    projected:
-      defaultMode: 420
-      sources:
-      - serviceAccountToken:
-          expirationSeconds: 3600
-          path: token
-      - configMap:
-          items:
-          - key: ca.crt
-            path: ca.crt
-          name: kube-root-ca.crt
-      - downwardAPI:
-          items:
-          - fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.namespace
-            path: namespace


### PR DESCRIPTION
kind of post-cleanup of https://github.com/openshift/library-go/pull/1100 and https://github.com/openshift/kubernetes/pull/714

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pod specifications and service account configurations for internal operator components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->