### PR TITLE
NO-JIRA: needNewTargetCertKeyPair: handle RefreshOnlyWhenExpired

### DIFF
--- a/pkg/operator/certrotation/target.go
+++ b/pkg/operator/certrotation/target.go
@@ -164,6 +164,11 @@ func needNewTargetCertKeyPair(secret *corev1.Secret, signer *crypto.CA, caBundle
 		return reason
 	}
 
+	// Exit early if we're only refreshing when expired and the certificate does not need an update
+	if refreshOnlyWhenExpired {
+		return ""
+	}
+
 	// check the signer common name against all the common names in our ca bundle so we don't refresh early
 	signerCommonName := annotations[CertificateIssuer]
 	if len(signerCommonName) == 0 {


### PR DESCRIPTION
Ensure that we exit early when no refresh is necessary in RefreshOnlyWhenExpired=true mode. This prevents from unnecessary check of CA bundle contents.

Tested in https://github.com/openshift/cluster-kube-apiserver-operator/pull/1905