### PR TITLE
API-1835: manifestclient/mutation_tracke: improve some methods of AllActionsTracker to not panic when no data

### DIFF
--- a/pkg/manifestclient/mutation_tracker.go
+++ b/pkg/manifestclient/mutation_tracker.go
@@ -92,7 +92,11 @@ func (a *AllActionsTracker[T]) ListActions() []Action {
 
 func (a *AllActionsTracker[T]) RequestsForAction(action Action) []SerializedRequestish {
 	ret := []SerializedRequestish{}
-	mutations := a.actionToTracker[action].Mutations()
+	tracker, ok := a.actionToTracker[action]
+	if !ok {
+		return nil
+	}
+	mutations := tracker.Mutations()
 	for _, mutation := range mutations {
 		ret = append(ret, mutation)
 	}
@@ -101,7 +105,11 @@ func (a *AllActionsTracker[T]) RequestsForAction(action Action) []SerializedRequ
 
 func (a *AllActionsTracker[T]) RequestsForResource(metadata ActionMetadata) []SerializedRequestish {
 	ret := []SerializedRequestish{}
-	mutations := a.actionToTracker[metadata.Action].Mutations()
+	tracker, ok := a.actionToTracker[metadata.Action]
+	if !ok {
+		return nil
+	}
+	mutations := tracker.Mutations()
 	for _, mutation := range mutations {
 		if mutation.GetSerializedRequest().GetLookupMetadata() == metadata {
 			ret = append(ret, mutation)

--- a/pkg/manifestclient/mutation_tracker_test.go
+++ b/pkg/manifestclient/mutation_tracker_test.go
@@ -1,0 +1,35 @@
+package manifestclient_test
+
+import (
+	"testing"
+
+	"github.com/openshift/library-go/pkg/manifestclient"
+)
+
+// TestNoPanicFromAllActionTracker
+// is a simple test to ensure that the read methods
+// of NewAllActionsTracker do not panic on an empty instance.
+func TestNoPanicFromAllActionTracker(t *testing.T) {
+	target := manifestclient.NewAllActionsTracker[manifestclient.FileOriginatedSerializedRequest]()
+
+	if actions := target.ListActions(); len(actions) != 0 {
+		t.Errorf("ListActions() returned non empty response: %v", actions)
+	}
+
+	if reqs := target.AllRequests(); len(reqs) != 0 {
+		t.Errorf("AllRequests() returned non empty response: %v", reqs)
+	}
+
+	ret := target.RequestsForAction(manifestclient.ActionUpdate)
+	if ret != nil {
+		t.Errorf("RequestsForAction() returned non nil response: %v", ret)
+	}
+
+	ret = target.RequestsForResource(manifestclient.ActionMetadata{Action: manifestclient.ActionApply})
+	if ret != nil {
+		t.Errorf("RequestsForResource() returned non nil response: %v", ret)
+	}
+
+	// just make sure it doens panic
+	_ = target.DeepCopy()
+}


### PR DESCRIPTION
before this PR `RequestsForAction` and `RequestsForAction` were panicking when no data/requests were recorder for a given action.