### PR TITLE
Add KeyGenerator interface to CSR controller for testability

### DIFF
--- a/pkg/operator/csr/cert_controller_test.go
+++ b/pkg/operator/csr/cert_controller_test.go
@@ -235,6 +235,7 @@ func newTestController(client *fake.Clientset) *clientCertificateController {
 		"test-controller",
 		"",
 		[]byte{},
+		NewDefaultKeyGenerator(),
 	}
 }
 

--- a/pkg/operator/csr/fakes.go
+++ b/pkg/operator/csr/fakes.go
@@ -1,0 +1,11 @@
+package csr
+
+type fakeKeyGenerator struct{}
+
+func (k *fakeKeyGenerator) GenerateKeyData() ([]byte, error) {
+	return []byte("fake"), nil
+}
+
+func NewFakeKeyGenerator() KeyGenerator {
+	return &fakeKeyGenerator{}
+}

--- a/pkg/operator/csr/simple_clientcert_controller.go
+++ b/pkg/operator/csr/simple_clientcert_controller.go
@@ -46,5 +46,6 @@ func NewSimpleClientCertificateController(
 		kubeClient.CoreV1(),
 		recorder,
 		controllerName,
+		nil, // defaultKeyGenerator
 	)
 }


### PR DESCRIPTION
This will make it possible to run the controller with OM and get the same results every time, which is useful for testing.