### PR TITLE
Updated OWNERS

### DIFF
--- a/pkg/operator/OWNERS
+++ b/pkg/operator/OWNERS
@@ -1,11 +1,10 @@
 reviewers:
-  - mfojtik
   - deads2k
-  - sttts
-  - soltysh
   - hexfusion
+  - p0lyn0mial
+  - bertinatto
   - jsafrane
 approvers:
-  - mfojtik
-  - soltysh
+  - p0lyn0mial
+  - bertinatto
   - jsafrane


### PR DESCRIPTION
In the current `OWNERS` list, some people have left RedHat and lack of `reviewers` and `approvers`.