### PR TITLE
[release-4.16] Updated OWNERS

### DIFF
--- a/pkg/operator/OWNERS
+++ b/pkg/operator/OWNERS
@@ -1,9 +1,10 @@
 reviewers:
-  - mfojtik
   - deads2k
-  - sttts
-  - soltysh
   - hexfusion
+  - p0lyn0mial
+  - bertinatto
+  - jsafrane
 approvers:
-  - mfojtik
-  - soltysh
+  - p0lyn0mial
+  - bertinatto
+  - jsafrane


### PR DESCRIPTION
Backport PR https://github.com/openshift/library-go/pull/2015 to release-4.16