### PR TITLE
OCPBUGS-62243: pruner regression test for cert names with tmp in it

### DIFF
--- a/pkg/operator/staticpod/prune/cmd_test.go
+++ b/pkg/operator/staticpod/prune/cmd_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/fvbommel/sortorder"
 )
@@ -81,6 +82,60 @@ func TestRun(t *testing.T) {
 			checkPruned(t, o.ResourceDir, test.expected)
 		})
 	}
+}
+
+func TestTmpClusterNameInCertificate(t *testing.T) {
+	testDir, err := os.MkdirTemp("", "prune-tmpclustername-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_ = os.RemoveAll(testDir)
+	})
+
+	resourceDir := path.Join(testDir, "resources")
+	err = os.Mkdir(resourceDir, os.ModePerm)
+	if err != nil {
+		t.Error(err)
+	}
+
+	certDirRel := path.Join("etcd-secrets", "secrets", "etcd-all-certs")
+	certDirAbs := path.Join(resourceDir, certDirRel)
+	err = os.MkdirAll(certDirAbs, os.ModePerm)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// this is a file we should not delete, but it has .tmp in its name which used to be a problem
+	peerCert, err := os.Create(path.Join(certDirAbs, "etcd-peer-master-2.tmp-1337.gg.mf.crt"))
+	if err != nil {
+		t.Error(err)
+	}
+	_ = peerCert.Close()
+
+	// set the file back by an hour to trigger the actual deletion logic
+	err = os.Chtimes(peerCert.Name(), time.Now().Add(-time.Hour), time.Now().Add(-time.Hour))
+	if err != nil {
+		t.Error(err)
+	}
+
+	// do NOT expect this file to be deleted, this is not a temporary left-over file
+	expected := []string{"etcd-peer-master-2.tmp-1337.gg.mf.crt"}
+	o := PruneOptions{
+		MaxEligibleRevision: 5,
+		ProtectedRevisions:  []int{},
+		ResourceDir:         resourceDir,
+		CertDir:             certDirRel,
+		StaticPodName:       "master-2.tmp-1337.gg.mf",
+	}
+
+	err = o.Run()
+	if err != nil {
+		t.Error(err)
+	}
+
+	checkPruned(t, certDirAbs, expected)
 }
 
 func checkPruned(t *testing.T, resourceDir string, expected []string) {


### PR DESCRIPTION
This is a regression test that creates a cert structure similar to a customer case that had their cluster name with ".tmp" in their domain name.