### PR TITLE
CNTRLPLANE-1544: staticpod: guard: Use user namespace

### DIFF
--- a/pkg/operator/staticpod/controller/guard/manifests/guard-pod.yaml
+++ b/pkg/operator/staticpod/controller/guard/manifests/guard-pod.yaml
@@ -14,6 +14,7 @@ spec:
   terminationGracePeriodSeconds: 3
   tolerations:
     - operator: Exists
+  hostUsers: false
   containers:
     - name: guard
       image: # Value set by operator


### PR DESCRIPTION
#### Test for Downstream Components

- [x] kube-controller-manager: https://github.com/openshift/cluster-kube-controller-manager-operator/pull/887
- [x] kube-apiserver: https://github.com/openshift/cluster-kube-apiserver-operator/pull/1936
- [x] etcd: https://github.com/openshift/cluster-etcd-operator/pull/1498
- [x] kube-scheduler: https://github.com/openshift/cluster-kube-scheduler-operator/pull/582