### PR TITLE
OCPBUGS-62634,	OCPBUGS-62624: Fix DeploymentController Progressing

### DIFF
--- a/pkg/operator/deploymentcontroller/deployment_controller.go
+++ b/pkg/operator/deploymentcontroller/deployment_controller.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/errors"
@@ -256,7 +257,6 @@ func (c *DeploymentController) syncManaged(ctx context.Context, opSpec *opv1.Ope
 	if err != nil {
 		return err
 	}
-
 	// Create an OperatorStatusApplyConfiguration with generations
 	status := applyoperatorv1.OperatorStatus().
 		WithGenerations(&applyoperatorv1.GenerationStatusApplyConfiguration{
@@ -357,6 +357,7 @@ func (c *DeploymentController) getDeployment(opSpec *opv1.OperatorSpec) (*appsv1
 }
 
 func isProgressing(deployment *appsv1.Deployment) (bool, string) {
+
 	var deploymentExpectedReplicas int32
 	if deployment.Spec.Replicas != nil {
 		deploymentExpectedReplicas = *deployment.Spec.Replicas
@@ -365,6 +366,8 @@ func isProgressing(deployment *appsv1.Deployment) (bool, string) {
 	switch {
 	case deployment.Generation != deployment.Status.ObservedGeneration:
 		return true, "Waiting for Deployment to act on changes"
+	case hasFinishedProgressing(deployment):
+		return false, ""
 	case deployment.Status.UnavailableReplicas > 0:
 		return true, "Waiting for Deployment to deploy pods"
 	case deployment.Status.UpdatedReplicas < deploymentExpectedReplicas:
@@ -373,4 +376,16 @@ func isProgressing(deployment *appsv1.Deployment) (bool, string) {
 		return true, "Waiting for Deployment to deploy pods"
 	}
 	return false, ""
+}
+
+func hasFinishedProgressing(deployment *appsv1.Deployment) bool {
+	// Deployment whose rollout is complete gets Progressing condition with Reason NewReplicaSetAvailable condition.
+	// https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#complete-deployment
+	// Any subsequent missing replicas (e.g. caused by a node reboot) must not not change the Progressing condition.
+	for _, cond := range deployment.Status.Conditions {
+		if cond.Type == appsv1.DeploymentProgressing {
+			return cond.Status == corev1.ConditionTrue && cond.Reason == "NewReplicaSetAvailable"
+		}
+	}
+	return false
 }

--- a/pkg/operator/deploymentcontroller/helpers_test.go
+++ b/pkg/operator/deploymentcontroller/helpers_test.go
@@ -66,6 +66,17 @@ func withDeploymentGeneration(generations ...int64) deploymentModifier {
 	}
 }
 
+func withDeploymentConditions(conditionType appsv1.DeploymentConditionType, reason string, status v1.ConditionStatus) deploymentModifier {
+	return func(instance *appsv1.Deployment) *appsv1.Deployment {
+		instance.Status.Conditions = append(instance.Status.Conditions, appsv1.DeploymentCondition{
+			Type:   conditionType,
+			Status: status,
+			Reason: reason,
+		})
+		return instance
+	}
+}
+
 func TestWithReplicasHook(t *testing.T) {
 	var (
 		masterNodeLabels = map[string]string{"node-role.kubernetes.io/master": ""}


### PR DESCRIPTION
The Progression condition should be set only when the Deployment has a new content and is actively rolling out its update. After all replicas are updated, the Progressing condition should be false, even when some pods are missing. E.g. because a node is drained, something evicted them or so on.

Use Deployment condition `Progressing` with reason `NewReplicaSetAvailable` to detect that Deployment has been fully rolled out in the past.