### PR TITLE
OCPBUGS-62173: Add TLSSecurityProfile controller

### DIFF
--- a/pkg/operator/apiserver/controller/tlssecurityprofile/tlssecurityprofile_controller.go
+++ b/pkg/operator/apiserver/controller/tlssecurityprofile/tlssecurityprofile_controller.go
@@ -1,0 +1,151 @@
+package tlssecurityprofile
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	operatorsv1 "github.com/openshift/api/operator/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	configinformers "github.com/openshift/client-go/config/informers/externalversions"
+	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
+	applyoperatorv1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/configobserver/apiserver"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type tlsSecurityProfileController struct {
+	controllerInstanceName string
+	apiserverConfigLister  configv1listers.APIServerLister
+	operatorClient         v1helpers.OperatorClient
+	eventRecorder          events.Recorder
+	callBack               func(config map[string]interface{})
+	minTLSVersionPath      []string
+	cipherSuitesPath       []string
+	profileTypePath        []string
+	lastObservedConfig     map[string]interface{}
+}
+
+// NewTLSSecurityProfileController creates a controller that watches the config.openshift.io/v1 APIServer object
+// It invokes a callback with data similar to the return value of apiserver.ObserveTLSSecuritySecurityProfile
+// It does not provide the profileType
+func NewTLSSecurityProfileController(
+	name string,
+	cb func(map[string]interface{}),
+	operatorClient v1helpers.OperatorClient,
+	configInformers configinformers.SharedInformerFactory,
+	eventRecorder events.Recorder,
+) factory.Controller {
+	return NewTLSSecurityProfileControllerWithPaths(name, cb, operatorClient, configInformers, eventRecorder,
+		[]string{"servingInfo", "minTLSVersion"},
+		[]string{"servingInfo", "cipherSuites"},
+		nil)
+}
+
+// NewTLSSecurityProfileControllerToArguments creates a controller that watches the config.openshift.io/v1 APIServer object
+// It invokes a callback with data similar to the return value of apiserver.ObserveTLSSecuritySecurityProfileToArguments
+// It does not provide the profileType
+func NewTLSSecurityProfileControllerToArguments(
+	name string,
+	cb func(map[string]interface{}),
+	operatorClient v1helpers.OperatorClient,
+	configInformers configinformers.SharedInformerFactory,
+	eventRecorder events.Recorder,
+) factory.Controller {
+	return NewTLSSecurityProfileControllerWithPaths(name, cb, operatorClient, configInformers, eventRecorder,
+		[]string{"apiServerArguments", "tls-min-version"},
+		[]string{"apiServerArguments", "tls-cipher-suites"},
+		nil)
+}
+
+// NewTLSSecurityProfileController creates a controller that watches the config.openshift.io/v1 APIServer object
+// It invokes a callback with data formatted according to the minTLSVersionPath, cipherSuitesPath and
+// profileTypePath arguments
+func NewTLSSecurityProfileControllerWithPaths(
+	name string,
+	cb func(map[string]interface{}),
+	operatorClient v1helpers.OperatorClient,
+	configInformers configinformers.SharedInformerFactory,
+	eventRecorder events.Recorder,
+	minTLSVersionPath []string,
+	cipherSuitesPath []string,
+	profileTypePath []string,
+) factory.Controller {
+	c := &tlsSecurityProfileController{
+		controllerInstanceName: factory.ControllerInstanceName(name, "TLSSecurityProfile"),
+		operatorClient:         operatorClient,
+		apiserverConfigLister:  configInformers.Config().V1().APIServers().Lister(),
+		callBack:               cb,
+		eventRecorder:          eventRecorder,
+		lastObservedConfig:     make(map[string]interface{}, 0),
+		minTLSVersionPath:      minTLSVersionPath,
+		cipherSuitesPath:       cipherSuitesPath,
+		profileTypePath:        profileTypePath,
+	}
+
+	return factory.New().WithSync(c.sync).WithControllerInstanceName(c.controllerInstanceName).ResyncEvery(1*time.Minute).WithInformers(
+		configInformers.Config().V1().APIServers().Informer(),
+		operatorClient.Informer(),
+	).ToController(
+		"TLSSecurityProfileController",
+		eventRecorder.WithComponentSuffix("tls-security-profile-controller"),
+	)
+}
+
+func (c *tlsSecurityProfileController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	operatorConfigSpec, _, _, err := c.operatorClient.GetOperatorState()
+	if err != nil {
+		return err
+	}
+
+	switch operatorConfigSpec.ManagementState {
+	case operatorsv1.Managed:
+	case operatorsv1.Unmanaged:
+		return nil
+	case operatorsv1.Removed:
+		return nil
+	default:
+		syncCtx.Recorder().Warningf("ManagementStateUnknown", "Unrecognized operator management state %q", operatorConfigSpec.ManagementState)
+		return nil
+	}
+
+	// Get the config from the TLSSecurityProfileObserver - such that the output is the same
+	observedConfig, errs := apiserver.GetTLSSecurityProfileObservations(c.apiserverConfigLister, c.eventRecorder, c.lastObservedConfig, c.minTLSVersionPath, c.cipherSuitesPath, c.profileTypePath)
+	err = errors.Join(errs...)
+
+	// Invoke callback
+	if err == nil {
+		c.lastObservedConfig = observedConfig
+		c.callBack(observedConfig)
+	}
+
+	// Update TLSSecurityProfileDegraded condition
+	condition := applyoperatorv1.OperatorCondition().
+		WithType("TLSSecurityProfileDegraded").
+		WithStatus(operatorv1.ConditionFalse).
+		WithReason("AsExpected").
+		WithMessage("Using default TLSSecurityProfile")
+	if len(c.profileTypePath) > 0 {
+		observedProfileType, _, _ := unstructured.NestedString(observedConfig, c.profileTypePath...)
+		if observedProfileType != "" {
+			condition = condition.WithMessage(fmt.Sprintf("Using TLSSecurityProfile %q", observedProfileType))
+		}
+	}
+	if err != nil {
+		condition = condition.
+			WithStatus(operatorv1.ConditionTrue).
+			WithReason("Error").
+			WithMessage(err.Error())
+	}
+	status := applyoperatorv1.OperatorStatus().WithConditions(condition)
+	updateError := c.operatorClient.ApplyOperatorStatus(ctx, c.controllerInstanceName, status)
+	if updateError != nil {
+		return updateError
+	}
+
+	return err
+}

--- a/pkg/operator/apiserver/controller/tlssecurityprofile/tlssecurityprofile_controller_test.go
+++ b/pkg/operator/apiserver/controller/tlssecurityprofile/tlssecurityprofile_controller_test.go
@@ -1,0 +1,262 @@
+package tlssecurityprofile
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	clocktesting "k8s.io/utils/clock/testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+	applyoperatorv1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
+
+	"github.com/openshift/library-go/pkg/apiserver/jsonpatch"
+	"github.com/openshift/library-go/pkg/operator/events"
+)
+
+const (
+	cipherSuitesPath = "cipher-suites"
+	minVersionPath   = "minimum-tls-version"
+	profileTypePath  = "profile-type"
+)
+
+func TestObserveTLSSecurityProfile(t *testing.T) {
+	tests := []struct {
+		name            string
+		managementState operatorv1.ManagementState
+		config          *configv1.TLSSecurityProfile
+		expectedConfig  map[string]interface{}
+	}{
+		{
+			name:            "NoAPIServerConfig",
+			managementState: operatorv1.Managed,
+			config:          nil,
+			expectedConfig: map[string]interface{}{
+				minVersionPath:  string(configv1.VersionTLS12),
+				profileTypePath: "",
+				cipherSuitesPath: []interface{}{
+					"TLS_AES_128_GCM_SHA256",
+					"TLS_AES_256_GCM_SHA384",
+					"TLS_CHACHA20_POLY1305_SHA256",
+					"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+					"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+					"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+					"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+					"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+					"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+				},
+			},
+		},
+		{
+			name:            "ModernCrypto",
+			managementState: operatorv1.Managed,
+			config: &configv1.TLSSecurityProfile{
+				Type:   configv1.TLSProfileModernType,
+				Modern: &configv1.ModernTLSProfile{},
+			},
+			expectedConfig: map[string]interface{}{
+				minVersionPath:  string(configv1.VersionTLS13),
+				profileTypePath: string(configv1.TLSProfileModernType),
+				cipherSuitesPath: []interface{}{
+					"TLS_AES_128_GCM_SHA256",
+					"TLS_AES_256_GCM_SHA384",
+					"TLS_CHACHA20_POLY1305_SHA256",
+				},
+			},
+		},
+		{
+			name:            "IntermediateConfig",
+			managementState: operatorv1.Managed,
+			config: &configv1.TLSSecurityProfile{
+				Type:         configv1.TLSProfileIntermediateType,
+				Intermediate: &configv1.IntermediateTLSProfile{},
+			},
+			expectedConfig: map[string]interface{}{
+				minVersionPath:  string(configv1.VersionTLS12),
+				profileTypePath: string(configv1.TLSProfileIntermediateType),
+				cipherSuitesPath: []interface{}{
+					"TLS_AES_128_GCM_SHA256",
+					"TLS_AES_256_GCM_SHA384",
+					"TLS_CHACHA20_POLY1305_SHA256",
+					"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+					"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+					"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+					"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+					"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+					"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+				},
+			},
+		},
+		{
+			name:            "OldCrypto",
+			managementState: operatorv1.Managed,
+			config: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileOldType,
+				Old:  &configv1.OldTLSProfile{},
+			},
+			expectedConfig: map[string]interface{}{
+				minVersionPath:  string(configv1.VersionTLS10),
+				profileTypePath: string(configv1.TLSProfileOldType),
+				cipherSuitesPath: []interface{}{
+					"TLS_AES_128_GCM_SHA256",
+					"TLS_AES_256_GCM_SHA384",
+					"TLS_CHACHA20_POLY1305_SHA256",
+					"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+					"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+					"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+					"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+					"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+					"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+					"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
+					"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+					"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
+					"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+					"TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
+					"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+					"TLS_RSA_WITH_AES_128_GCM_SHA256",
+					"TLS_RSA_WITH_AES_256_GCM_SHA384",
+					"TLS_RSA_WITH_AES_128_CBC_SHA256",
+					"TLS_RSA_WITH_AES_128_CBC_SHA",
+					"TLS_RSA_WITH_AES_256_CBC_SHA",
+					"TLS_RSA_WITH_3DES_EDE_CBC_SHA",
+				},
+			},
+		},
+		{
+			name:            "CustomCrypto",
+			managementState: operatorv1.Managed,
+			config: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						Ciphers: []string{
+							"TLS_AES_128_GCM_SHA256",
+							"TLS_AES_256_GCM_SHA384",
+							"TLS_CHACHA20_POLY1305_SHA256",
+							// Inputs expect OpenSSL names and are mapped to IANA names that golang uses
+							// via github.com/openshift/library-go/pkg/crypto.OpenSSLToIANACipherSuites()
+							"ECDHE-ECDSA-AES128-GCM-SHA256",
+							"ECDHE-RSA-AES128-GCM-SHA256",
+						},
+						MinTLSVersion: configv1.VersionTLS11,
+					},
+				},
+			},
+			expectedConfig: map[string]interface{}{
+				minVersionPath:  string(configv1.VersionTLS11),
+				profileTypePath: string(configv1.TLSProfileCustomType),
+				cipherSuitesPath: []interface{}{
+					"TLS_AES_128_GCM_SHA256",
+					"TLS_AES_256_GCM_SHA384",
+					"TLS_CHACHA20_POLY1305_SHA256",
+					"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+					"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			if tt.config != nil {
+				if err := indexer.Add(&configv1.APIServer{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster",
+					},
+					Spec: configv1.APIServerSpec{
+						TLSSecurityProfile: tt.config,
+					},
+				}); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			var result map[string]interface{}
+			// Enough to make sync() happy
+			controller := &tlsSecurityProfileController{
+				controllerInstanceName: t.Name(),
+				operatorClient:         mockOperatorClient{managementState: tt.managementState},
+				apiserverConfigLister:  configlistersv1.NewAPIServerLister(indexer),
+				callBack: func(config map[string]interface{}) {
+					result = config
+				},
+				eventRecorder:      events.NewInMemoryRecorder(t.Name(), clocktesting.NewFakePassiveClock(time.Now())),
+				lastObservedConfig: make(map[string]interface{}, 0),
+				minTLSVersionPath:  []string{minVersionPath},
+				cipherSuitesPath:   []string{cipherSuitesPath},
+				profileTypePath:    []string{profileTypePath},
+			}
+
+			if err := controller.sync(context.Background(), mockSyncContext{}); err != nil {
+				t.Fatal(err)
+			}
+
+			if !reflect.DeepEqual(result, tt.expectedConfig) {
+				t.Errorf("\ngot      = %v,\nexpected = %v", result, tt.expectedConfig)
+			}
+		})
+	}
+}
+
+type mockSyncContext struct {
+}
+
+func (mockSyncContext) Queue() workqueue.RateLimitingInterface {
+	panic("mockSyncContext.Queue() called")
+}
+
+func (mockSyncContext) QueueKey() string {
+	panic("mockSyncContext.QueueKey() called")
+}
+
+func (mockSyncContext) Recorder() events.Recorder {
+	panic("mockSyncContext.Recorder() called")
+}
+
+type mockOperatorClient struct {
+	managementState operatorv1.ManagementState
+}
+
+func (m mockOperatorClient) GetOperatorState() (spec *operatorv1.OperatorSpec, status *operatorv1.OperatorStatus, resourceVersion string, err error) {
+	return &operatorv1.OperatorSpec{
+		ManagementState: m.managementState,
+	}, nil, "", nil
+}
+
+func (mockOperatorClient) Informer() cache.SharedIndexInformer {
+	panic("mockOperatorClient.Informer() called")
+}
+
+func (mockOperatorClient) GetObjectMeta() (meta *metav1.ObjectMeta, err error) {
+	panic("mockOperatorClient.GetObjectMeta() called")
+}
+
+func (mockOperatorClient) GetOperatorStateWithQuorum(ctx context.Context) (spec *operatorv1.OperatorSpec, status *operatorv1.OperatorStatus, resourceVersion string, err error) {
+	panic("mockOperatorClient.GetOperatorStateWithQuorum() called")
+}
+
+func (mockOperatorClient) UpdateOperatorSpec(ctx context.Context, oldResourceVersion string, in *operatorv1.OperatorSpec) (out *operatorv1.OperatorSpec, newResourceVersion string, err error) {
+	panic("mockOperatorClient.UpdateOperatorSpec() called")
+}
+
+func (mockOperatorClient) UpdateOperatorStatus(ctx context.Context, oldResourceVersion string, in *operatorv1.OperatorStatus) (out *operatorv1.OperatorStatus, err error) {
+	panic("mockOperatorClient.UpdateOperatorStatus() called")
+}
+
+func (mockOperatorClient) ApplyOperatorSpec(ctx context.Context, fieldManager string, applyConfiguration *applyoperatorv1.OperatorSpecApplyConfiguration) (err error) {
+	panic("mockOperatorClient.ApplyOperatorSpec() called")
+}
+func (mockOperatorClient) ApplyOperatorStatus(ctx context.Context, fieldManager string, applyConfiguration *applyoperatorv1.OperatorStatusApplyConfiguration) (err error) {
+	return nil
+}
+
+func (mockOperatorClient) PatchOperatorStatus(ctx context.Context, jsonPatch *jsonpatch.PatchSet) (err error) {
+	panic("mockOperatorClient.PatcheOperatorStatus() called")
+}

--- a/pkg/operator/configobserver/apiserver/observe_tlssecurityprofile.go
+++ b/pkg/operator/configobserver/apiserver/observe_tlssecurityprofile.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/klog/v2"
 
 	configv1 "github.com/openshift/api/config/v1"
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
 	"github.com/openshift/library-go/pkg/crypto"
 	"github.com/openshift/library-go/pkg/operator/configobserver"
 	"github.com/openshift/library-go/pkg/operator/events"
@@ -37,22 +38,38 @@ func innerTLSSecurityProfileObservations(genericListers configobserver.Listers, 
 		ret = configobserver.Pruned(ret, minTLSVersionPath, cipherSuitesPath)
 	}()
 
-	listers := genericListers.(APIServerLister)
+	listers := genericListers.(APIServerLister).APIServerLister()
+
+	return GetTLSSecurityProfileObservations(listers, recorder, existingConfig, minTLSVersionPath, cipherSuitesPath, nil)
+}
+
+func GetTLSSecurityProfileObservations(listers configlistersv1.APIServerLister, recorder events.Recorder, existingConfig map[string]interface{}, minTLSVersionPath, cipherSuitesPath, profileTypePath []string) (ret map[string]interface{}, _ []error) {
 	errs := []error{}
 
 	currentMinTLSVersion, _, versionErr := unstructured.NestedString(existingConfig, minTLSVersionPath...)
 	if versionErr != nil {
-		errs = append(errs, fmt.Errorf("failed to retrieve spec.servingInfo.minTLSVersion: %v", versionErr))
+		errs = append(errs, fmt.Errorf("failed to retrieve %v: %v", minTLSVersionPath, versionErr))
 		// keep going on read error from existing config
 	}
 
 	currentCipherSuites, _, suitesErr := unstructured.NestedStringSlice(existingConfig, cipherSuitesPath...)
 	if suitesErr != nil {
-		errs = append(errs, fmt.Errorf("failed to retrieve spec.servingInfo.cipherSuites: %v", suitesErr))
+		errs = append(errs, fmt.Errorf("failed to retrieve %v: %v", cipherSuitesPath, suitesErr))
 		// keep going on read error from existing config
 	}
 
-	apiServer, err := listers.APIServerLister().Get("cluster")
+	// Only get the profileType if the profileTypePath is set
+	var currentProfileType string
+	if len(profileTypePath) > 0 {
+		var profileErr error
+		currentProfileType, _, profileErr = unstructured.NestedString(existingConfig, profileTypePath...)
+		if profileErr != nil {
+			errs = append(errs, fmt.Errorf("failed to retrieve %v: %v", profileTypePath, profileErr))
+			// keep going on read error from existing config
+		}
+	}
+
+	apiServer, err := listers.Get("cluster")
 	if errors.IsNotFound(err) {
 		klog.Warningf("apiserver.config.openshift.io/cluster: not found")
 		apiServer = &configv1.APIServer{}
@@ -61,12 +78,18 @@ func innerTLSSecurityProfileObservations(genericListers configobserver.Listers, 
 	}
 
 	observedConfig := map[string]interface{}{}
-	observedMinTLSVersion, observedCipherSuites := getSecurityProfileCiphers(apiServer.Spec.TLSSecurityProfile)
+	observedMinTLSVersion, observedCipherSuites, observedProfileType := getSecurityProfileCiphers(apiServer.Spec.TLSSecurityProfile)
 	if err = unstructured.SetNestedField(observedConfig, observedMinTLSVersion, minTLSVersionPath...); err != nil {
 		return existingConfig, append(errs, err)
 	}
 	if err = unstructured.SetNestedStringSlice(observedConfig, observedCipherSuites, cipherSuitesPath...); err != nil {
 		return existingConfig, append(errs, err)
+	}
+	// Only set the profileType if the profileTypePath is set
+	if len(profileTypePath) > 0 {
+		if err = unstructured.SetNestedField(observedConfig, observedProfileType, profileTypePath...); err != nil {
+			return existingConfig, append(errs, err)
+		}
 	}
 
 	if observedMinTLSVersion != currentMinTLSVersion {
@@ -75,19 +98,25 @@ func innerTLSSecurityProfileObservations(genericListers configobserver.Listers, 
 	if !reflect.DeepEqual(observedCipherSuites, currentCipherSuites) {
 		recorder.Eventf("ObserveTLSSecurityProfile", "cipherSuites changed to %q", observedCipherSuites)
 	}
+	// Only generate an event on profileType if the profileTypePath is set
+	if len(profileTypePath) > 0 && observedProfileType != currentProfileType {
+		recorder.Eventf("ObserveTLSSecurityProfile", "profileType changed to %q", observedProfileType)
+	}
 
 	return observedConfig, errs
 }
 
-// Extracts the minimum TLS version and cipher suites from TLSSecurityProfile object,
+// Extracts the minimum TLS version, cipher suites and profile name from TLSSecurityProfile object,
 // Converts the ciphers to IANA names as supported by Kube ServingInfo config.
 // If profile is nil, returns config defined by the Intermediate TLS Profile
-func getSecurityProfileCiphers(profile *configv1.TLSSecurityProfile) (string, []string) {
+func getSecurityProfileCiphers(profile *configv1.TLSSecurityProfile) (string, []string, string) {
 	var profileType configv1.TLSProfileType
+	var returnedProfileType configv1.TLSProfileType
 	if profile == nil {
 		profileType = configv1.TLSProfileIntermediateType
 	} else {
 		profileType = profile.Type
+		returnedProfileType = profile.Type
 	}
 
 	var profileSpec *configv1.TLSProfileSpec
@@ -105,5 +134,5 @@ func getSecurityProfileCiphers(profile *configv1.TLSSecurityProfile) (string, []
 	}
 
 	// need to remap all Ciphers to their respective IANA names used by Go
-	return string(profileSpec.MinTLSVersion), crypto.OpenSSLToIANACipherSuites(profileSpec.Ciphers)
+	return string(profileSpec.MinTLSVersion), crypto.OpenSSLToIANACipherSuites(profileSpec.Ciphers), string(returnedProfileType)
 }


### PR DESCRIPTION
Watches the apiservers.config.openshift.io resource for updates to the tlsSecurityProfile and invokes a callback when.

Adds support for ProfileType (in addition to ciphers and minimum version), so the callback knows if it's "old", "modern", "intermediate", or "custom".

Uses the TLSSecurityProfileObserver for output generation.

Proof PR:
* https://github.com/openshift/cluster-olm-operator/pull/143