### PR TITLE
OCPBUGS-33013: atomicdir: Split testing utils into a helper package

### DIFF
--- a/pkg/operator/staticpod/internal/atomicdir/swap_linux_test.go
+++ b/pkg/operator/staticpod/internal/atomicdir/swap_linux_test.go
@@ -7,11 +7,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
+	adtesting "github.com/openshift/library-go/pkg/operator/staticpod/internal/atomicdir/testing"
 )
 
 func TestSwap(t *testing.T) {
-	stateFirst := directoryState{
+	stateFirst := adtesting.DirectoryState{
 		"1.txt": {
 			Content: []byte("hello 1 world"),
 			Perm:    0600,
@@ -21,13 +21,13 @@ func TestSwap(t *testing.T) {
 			Perm:    0400,
 		},
 	}
-	stateSecond := directoryState{
+	stateSecond := adtesting.DirectoryState{
 		"a.txt": {
 			Content: []byte("hello a world"),
 			Perm:    0600,
 		},
 	}
-	stateEmpty := directoryState{}
+	stateEmpty := adtesting.DirectoryState{}
 
 	expectNoError := func(t *testing.T, err error) {
 		t.Helper()
@@ -36,7 +36,7 @@ func TestSwap(t *testing.T) {
 		}
 	}
 
-	checkSuccess := func(t *testing.T, pathFirst string, stateFirst directoryState, pathSecond string, stateSecond directoryState, err error) {
+	checkSuccess := func(t *testing.T, pathFirst string, stateFirst adtesting.DirectoryState, pathSecond string, stateSecond adtesting.DirectoryState, err error) {
 		t.Helper()
 		expectNoError(t, err)
 
@@ -47,12 +47,12 @@ func TestSwap(t *testing.T) {
 
 	testCases := []struct {
 		name        string
-		setup       func(t *testing.T, tmpDir string) (pathFirst string, stateFirst directoryState, pathSecond string, stateSecond directoryState)
-		checkResult func(t *testing.T, pathFirst string, stateFirst directoryState, pathSecond string, stateSecond directoryState, err error)
+		setup       func(t *testing.T, tmpDir string) (pathFirst string, stateFirst adtesting.DirectoryState, pathSecond string, stateSecond adtesting.DirectoryState)
+		checkResult func(t *testing.T, pathFirst string, stateFirst adtesting.DirectoryState, pathSecond string, stateSecond adtesting.DirectoryState, err error)
 	}{
 		{
 			name: "success with absolute paths",
-			setup: func(t *testing.T, tmpDir string) (string, directoryState, string, directoryState) {
+			setup: func(t *testing.T, tmpDir string) (string, adtesting.DirectoryState, string, adtesting.DirectoryState) {
 				pathFirst := filepath.Join(tmpDir, "first")
 				pathSecond := filepath.Join(tmpDir, "second")
 
@@ -65,7 +65,7 @@ func TestSwap(t *testing.T) {
 		},
 		{
 			name: "success with the first path relative",
-			setup: func(t *testing.T, tmpDir string) (string, directoryState, string, directoryState) {
+			setup: func(t *testing.T, tmpDir string) (string, adtesting.DirectoryState, string, adtesting.DirectoryState) {
 				pathFirst := filepath.Join(tmpDir, "first")
 				pathSecond := filepath.Join(tmpDir, "second")
 
@@ -84,7 +84,7 @@ func TestSwap(t *testing.T) {
 		},
 		{
 			name: "success with the second path relative",
-			setup: func(t *testing.T, tmpDir string) (string, directoryState, string, directoryState) {
+			setup: func(t *testing.T, tmpDir string) (string, adtesting.DirectoryState, string, adtesting.DirectoryState) {
 				pathFirst := filepath.Join(tmpDir, "first")
 				pathSecond := filepath.Join(tmpDir, "second")
 
@@ -103,7 +103,7 @@ func TestSwap(t *testing.T) {
 		},
 		{
 			name: "success with an empty directory",
-			setup: func(t *testing.T, tmpDir string) (string, directoryState, string, directoryState) {
+			setup: func(t *testing.T, tmpDir string) (string, adtesting.DirectoryState, string, adtesting.DirectoryState) {
 				pathFirst := filepath.Join(tmpDir, "first")
 				pathSecond := filepath.Join(tmpDir, "second")
 
@@ -116,7 +116,7 @@ func TestSwap(t *testing.T) {
 		},
 		{
 			name: "success with both directories empty",
-			setup: func(t *testing.T, tmpDir string) (string, directoryState, string, directoryState) {
+			setup: func(t *testing.T, tmpDir string) (string, adtesting.DirectoryState, string, adtesting.DirectoryState) {
 				pathFirst := filepath.Join(tmpDir, "first")
 				pathSecond := filepath.Join(tmpDir, "second")
 
@@ -129,7 +129,7 @@ func TestSwap(t *testing.T) {
 		},
 		{
 			name: "error with the first directory not existing",
-			setup: func(t *testing.T, tmpDir string) (string, directoryState, string, directoryState) {
+			setup: func(t *testing.T, tmpDir string) (string, adtesting.DirectoryState, string, adtesting.DirectoryState) {
 				pathFirst := filepath.Join(tmpDir, "first")
 				pathSecond := filepath.Join(tmpDir, "second")
 
@@ -137,7 +137,7 @@ func TestSwap(t *testing.T) {
 
 				return pathFirst, stateEmpty, pathSecond, stateEmpty
 			},
-			checkResult: func(t *testing.T, pathFirst string, stateFirst directoryState, pathSecond string, stateSecond directoryState, err error) {
+			checkResult: func(t *testing.T, pathFirst string, stateFirst adtesting.DirectoryState, pathSecond string, stateSecond adtesting.DirectoryState, err error) {
 				if !os.IsNotExist(err) {
 					t.Errorf("Expected a directory not exists error, got %v", err)
 				}
@@ -145,7 +145,7 @@ func TestSwap(t *testing.T) {
 		},
 		{
 			name: "error with the second directory not existing",
-			setup: func(t *testing.T, tmpDir string) (string, directoryState, string, directoryState) {
+			setup: func(t *testing.T, tmpDir string) (string, adtesting.DirectoryState, string, adtesting.DirectoryState) {
 				pathFirst := filepath.Join(tmpDir, "first")
 				pathSecond := filepath.Join(tmpDir, "second")
 
@@ -153,7 +153,7 @@ func TestSwap(t *testing.T) {
 
 				return pathFirst, stateEmpty, pathSecond, stateEmpty
 			},
-			checkResult: func(t *testing.T, pathFirst string, stateFirst directoryState, pathSecond string, stateSecond directoryState, err error) {
+			checkResult: func(t *testing.T, pathFirst string, stateFirst adtesting.DirectoryState, pathSecond string, stateSecond adtesting.DirectoryState, err error) {
 				if !os.IsNotExist(err) {
 					t.Errorf("Expected a directory not exists error, got %v", err)
 				}
@@ -161,13 +161,13 @@ func TestSwap(t *testing.T) {
 		},
 		{
 			name: "error with no directory existing",
-			setup: func(t *testing.T, tmpDir string) (string, directoryState, string, directoryState) {
+			setup: func(t *testing.T, tmpDir string) (string, adtesting.DirectoryState, string, adtesting.DirectoryState) {
 				pathFirst := filepath.Join(tmpDir, "first")
 				pathSecond := filepath.Join(tmpDir, "second")
 
 				return pathFirst, stateEmpty, pathSecond, stateEmpty
 			},
-			checkResult: func(t *testing.T, pathFirst string, stateFirst directoryState, pathSecond string, stateSecond directoryState, err error) {
+			checkResult: func(t *testing.T, pathFirst string, stateFirst adtesting.DirectoryState, pathSecond string, stateSecond adtesting.DirectoryState, err error) {
 				if !os.IsNotExist(err) {
 					t.Errorf("Expected a directory not exists error, got %v", err)
 				}
@@ -177,68 +177,9 @@ func TestSwap(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			pathFirst, stateFirst, pathSecond, stateSecond := tc.setup(t, t.TempDir())
 			tc.checkResult(t, pathFirst, stateFirst, pathSecond, stateSecond, swap(pathFirst, pathSecond))
 		})
-	}
-}
-
-type directoryState map[string]File
-
-func (dir directoryState) Write(tb testing.TB, dirPath string, dirPerm os.FileMode) {
-	if err := os.MkdirAll(dirPath, dirPerm); err != nil {
-		tb.Fatalf("Failed to create directory %q: %v", dirPath, err)
-	}
-
-	for filename, state := range dir {
-		fullFilename := filepath.Join(dirPath, filename)
-		if err := os.WriteFile(fullFilename, state.Content, state.Perm); err != nil {
-			tb.Fatalf("Failed to write file %q: %v", fullFilename, err)
-		}
-	}
-}
-
-func (dir directoryState) CheckDirectoryMatches(tb testing.TB, dirPath string, dirPerm os.FileMode) {
-	// Ensure the directory permissions match.
-	stat, err := os.Stat(dirPath)
-	if err != nil {
-		tb.Fatalf("Failed to stat %q: %v", dirPath, err)
-	}
-	if perm := stat.Mode().Perm(); perm != dirPerm {
-		tb.Errorf("Permissions mismatch detected for %q: expected %v, got %v", dirPath, dirPerm, perm)
-	}
-
-	// Ensure all files are in sync.
-	entries, err := os.ReadDir(dirPath)
-	if err != nil {
-		tb.Fatalf("Failed to read directory %q: %v", dirPath, err)
-	}
-
-	actualState := make(directoryState, len(entries))
-	for _, entry := range entries {
-		filePath := filepath.Join(dirPath, entry.Name())
-
-		info, err := entry.Info()
-		if err != nil {
-			tb.Fatalf("Failed to stat %q: %v", filePath, err)
-		}
-
-		if info.IsDir() {
-			tb.Errorf("Unexpected directory detected: %q", filePath)
-			continue
-		}
-
-		content, err := os.ReadFile(filePath)
-		if err != nil {
-			tb.Fatalf("Failed to read %q: %v", filePath, err)
-		}
-
-		actualState[entry.Name()] = File{
-			Content: content,
-			Perm:    info.Mode(),
-		}
-	}
-	if !cmp.Equal(dir, actualState) {
-		tb.Errorf("Unexpected directory content for %q:\n%s\n", dirPath, cmp.Diff(dir, actualState))
 	}
 }

--- a/pkg/operator/staticpod/internal/atomicdir/sync.go
+++ b/pkg/operator/staticpod/internal/atomicdir/sync.go
@@ -6,13 +6,9 @@ import (
 	"path/filepath"
 
 	"k8s.io/klog/v2"
-)
 
-// File represents file content together with the associated permissions.
-type File struct {
-	Content []byte
-	Perm    os.FileMode
-}
+	"github.com/openshift/library-go/pkg/operator/staticpod/internal/atomicdir/types"
+)
 
 // Sync can be used to atomically synchronize target directory with the given file content map.
 // This is done by populating a staging directory, then atomically swapping it with the target directory.
@@ -21,7 +17,7 @@ type File struct {
 // The staging directory needs to be explicitly specified. It is initially created using os.MkdirAll with targetDirPerm.
 // It is then populated using files with filePerm. Once the atomic swap is performed, the staging directory
 // (which is now the original target directory) is removed.
-func Sync(targetDir string, targetDirPerm os.FileMode, stagingDir string, files map[string]File) error {
+func Sync(targetDir string, targetDirPerm os.FileMode, stagingDir string, files map[string]types.File) error {
 	return sync(&realFS, targetDir, targetDirPerm, stagingDir, files)
 }
 
@@ -49,7 +45,7 @@ var realFS = fileSystem{
 // In other words, it's for compatibility reasons. And if we were to migrate to the symlink approach,
 // we would anyway need to atomically turn the current data directory into a symlink.
 // This would all just increase complexity and require atomic swap on the OS level anyway.
-func sync(fs *fileSystem, targetDir string, targetDirPerm os.FileMode, stagingDir string, files map[string]File) (retErr error) {
+func sync(fs *fileSystem, targetDir string, targetDirPerm os.FileMode, stagingDir string, files map[string]types.File) (retErr error) {
 	klog.Infof("Ensuring target directory %q exists ...", targetDir)
 	if err := fs.MkdirAll(targetDir, targetDirPerm); err != nil {
 		return fmt.Errorf("failed creating target directory: %w", err)

--- a/pkg/operator/staticpod/internal/atomicdir/testing/directory_state.go
+++ b/pkg/operator/staticpod/internal/atomicdir/testing/directory_state.go
@@ -1,0 +1,74 @@
+package testing
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/openshift/library-go/pkg/operator/staticpod/internal/atomicdir/types"
+)
+
+// DirectoryState can be used both bootstrap and check a directory state.
+type DirectoryState map[string]types.File
+
+// Write writes the given state into the given directory.
+func (dir DirectoryState) Write(tb testing.TB, dirPath string, dirPerm os.FileMode) {
+	if err := os.MkdirAll(dirPath, dirPerm); err != nil {
+		tb.Fatalf("Failed to create directory %q: %v", dirPath, err)
+	}
+
+	for filename, state := range dir {
+		fullFilename := filepath.Join(dirPath, filename)
+		if err := os.WriteFile(fullFilename, state.Content, state.Perm); err != nil {
+			tb.Fatalf("Failed to write file %q: %v", fullFilename, err)
+		}
+	}
+}
+
+// CheckDirectoryMatches checks the given directory against the given state.
+func (dir DirectoryState) CheckDirectoryMatches(tb testing.TB, dirPath string, dirPerm os.FileMode) {
+	// Ensure the directory permissions match.
+	stat, err := os.Stat(dirPath)
+	if err != nil {
+		tb.Fatalf("Failed to stat %q: %v", dirPath, err)
+	}
+	if perm := stat.Mode().Perm(); perm != dirPerm {
+		tb.Errorf("Permissions mismatch detected for %q: expected %v, got %v", dirPath, dirPerm, perm)
+	}
+
+	// Ensure all files are in sync.
+	entries, err := os.ReadDir(dirPath)
+	if err != nil {
+		tb.Fatalf("Failed to read directory %q: %v", dirPath, err)
+	}
+
+	actualState := make(DirectoryState, len(entries))
+	for _, entry := range entries {
+		filePath := filepath.Join(dirPath, entry.Name())
+
+		info, err := entry.Info()
+		if err != nil {
+			tb.Fatalf("Failed to stat %q: %v", filePath, err)
+		}
+
+		if info.IsDir() {
+			tb.Errorf("Unexpected directory detected: %q", filePath)
+			continue
+		}
+
+		content, err := os.ReadFile(filePath)
+		if err != nil {
+			tb.Fatalf("Failed to read %q: %v", filePath, err)
+		}
+
+		actualState[entry.Name()] = types.File{
+			Content: content,
+			Perm:    info.Mode(),
+		}
+	}
+	if !cmp.Equal(dir, actualState) {
+		tb.Errorf("Unexpected directory content for %q:\n%s\n", dirPath, cmp.Diff(dir, actualState))
+	}
+}

--- a/pkg/operator/staticpod/internal/atomicdir/types/file.go
+++ b/pkg/operator/staticpod/internal/atomicdir/types/file.go
@@ -1,0 +1,10 @@
+// Package types exists to avoid import cycles as it's imported by both atomicdir and atomicdir/testing.
+package types
+
+import "os"
+
+// File represents file content together with the associated permissions.
+type File struct {
+	Content []byte
+	Perm    os.FileMode
+}


### PR DESCRIPTION
There is also a separate package now to hold the File type.