### PR TITLE
CM-758: (resourceapply) fix NetworkPolicy spec not reconciling on update and potential infinite loops

### DIFF
--- a/pkg/operator/resource/resourceapply/generic.go
+++ b/pkg/operator/resource/resourceapply/generic.go
@@ -147,7 +147,7 @@ func ApplyDirectly(ctx context.Context, clients *ClientHolder, recorder events.R
 			if clients.kubeClient == nil {
 				result.Error = fmt.Errorf("missing kubeClient")
 			} else {
-				result.Result, result.Changed, result.Error = ApplyNetworkPolicy(ctx, clients.kubeClient.NetworkingV1(), recorder, t)
+				result.Result, result.Changed, result.Error = ApplyNetworkPolicy(ctx, clients.kubeClient.NetworkingV1(), recorder, t, cache)
 			}
 		case *rbacv1.ClusterRole:
 			if clients.kubeClient == nil {

--- a/pkg/operator/resource/resourceapply/networking.go
+++ b/pkg/operator/resource/resourceapply/networking.go
@@ -15,27 +15,36 @@ import (
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
 )
 
-// ApplyClusterRole merges objectmeta, does not worry about anything else
-func ApplyNetworkPolicy(ctx context.Context, client networkingclientv1.NetworkPoliciesGetter, recorder events.Recorder, required *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, bool, error) {
+// ApplyNetworkPolicy merges objectmeta and requires spec
+func ApplyNetworkPolicy(ctx context.Context, client networkingclientv1.NetworkPoliciesGetter, recorder events.Recorder, required *networkingv1.NetworkPolicy, cache ResourceCache) (*networkingv1.NetworkPolicy, bool, error) {
 	existing, err := client.NetworkPolicies(required.Namespace).Get(ctx, required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		requiredCopy := required.DeepCopy()
 		actual, err := client.NetworkPolicies(required.Namespace).Create(
 			ctx, resourcemerge.WithCleanLabelsAndAnnotations(requiredCopy).(*networkingv1.NetworkPolicy), metav1.CreateOptions{})
 		resourcehelper.ReportCreateEvent(recorder, required, err)
+		cache.UpdateCachedResourceMetadata(required, actual)
 		return actual, true, err
 	}
 	if err != nil {
 		return nil, false, err
 	}
 
+	if cache.SafeToSkipApply(required, existing) {
+		return existing, false, nil
+	}
+
 	modified := false
 	existingCopy := existing.DeepCopy()
 
 	resourcemerge.EnsureObjectMeta(&modified, &existingCopy.ObjectMeta, required.ObjectMeta)
-	if equality.Semantic.DeepEqual(existingCopy.Spec, required.Spec) && !modified {
+	specContentSame := equality.Semantic.DeepEqual(existingCopy.Spec, required.Spec)
+	if specContentSame && !modified {
+		cache.UpdateCachedResourceMetadata(required, existingCopy)
 		return existingCopy, false, nil
 	}
+
+	existingCopy.Spec = required.Spec
 
 	if klog.V(2).Enabled() {
 		klog.Infof("NetworkPolicy %q changes: %v", required.Name, JSONPatchNoError(existing, existingCopy))
@@ -43,6 +52,7 @@ func ApplyNetworkPolicy(ctx context.Context, client networkingclientv1.NetworkPo
 
 	actual, err := client.NetworkPolicies(existingCopy.Namespace).Update(ctx, existingCopy, metav1.UpdateOptions{})
 	resourcehelper.ReportUpdateEvent(recorder, required, err)
+	cache.UpdateCachedResourceMetadata(required, actual)
 	return actual, true, err
 }
 


### PR DESCRIPTION
### Motivation

Follow-up: https://github.com/openshift/library-go/pull/1961#discussion_r2465268109

The `ApplyNetworkPolicy` function was introduced earlier to support NetworkPolicy resources in the StaticResourceController.

The first problem is when `ApplyNetworkPolicy` attempted to update an existing NetworkPolicy with a modified spec, it never assigned the new spec to the object being updated so the `Update` call sent the old spec instead of the new one. This meant NetworkPolicy spec changes were never reconciled, even though the function returned true (indicating a change was made).

Another critical issue is that the `ApplyNetworkPolicy` was vulnerable to infinite reconciliation loops if the API server applies server-side defaults. For instance, operator sends NetworkPolicy with minimal spec (port without [`protocol`](https://github.com/kubernetes/api/blob/v0.34.1/networking/v1/types.go#L154-L158)), API server applies defaults (`protocol: TCP`), then in the next reconciliation `DeepEqual` detects difference between manifest and cluster state would cause busy loop between defaults and Update.

### Change

Fix above issues in NetworkPolicy spec reconciliation:
1. Assign required spec before Update: This ensures the updated object contains the new spec.
2. Apply ResourceCache pattern: This aims to prevent busy-loops caused by server-side defaults and helps eliminate unnecessary API calls.

### E2E Validation

Problem 1: No reconciliation after NetworkPolicy spec tampered (e.g. port being modified by the user)
- w/ the fix: the operator managed NetworkPolicy resource would be immediately reconciled back.

Problem 2: Potential busy-loop for fields that have default values (e.g. a port without an explicit protocol field set by by the operator author. API server adds `protocol: TCP` but manifest managed by operator doesn't have it)

- without the fix: concerning loop repeats every `$controller_resync_interval` (60 seconds in our case)

  <details>
  <summary>process flow</summary>

  1. Operator sends: `spec.egress[0].ports[0].port` = `6443` (no protocol)
  2. API server defaults: `spec.egress[0].ports[0].protocol` = `"TCP"`
  3. Operator reads back: sees `protocol` = `"TCP"`
  4. DeepEqual: manifest != existing -> Update again
  5. Loop forever

  </details>

  <details>
  <summary>controller logs</summary>

  ```
  I1028 02:09:04.098493       1 event.go:377] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"cert-manager-operator", Name:"cert-manager-operator-controller-manager", UID:"9be055ac-4e2e-4149-8b95-8958c5a32a5f", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'NetworkPolicyCreated' Created NetworkPolicy.networking.k8s.io/cert-manager-allow-egress-to-api-server -n cert-manager because it was missing
  I1028 02:09:05.485846       1 networking.go:44] NetworkPolicy "cert-manager-allow-egress-to-api-server" changes: {"spec":{"egress":[{"ports":[{"port":6443}]}]}}
  I1028 02:09:05.489748       1 event.go:377] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"cert-manager-operator", Name:"cert-manager-operator-controller-manager", UID:"9be055ac-4e2e-4149-8b95-8958c5a32a5f", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'NetworkPolicyUpdated' Updated NetworkPolicy.networking.k8s.io/cert-manager-allow-egress-to-api-server -n cert-manager because it changed
  I1028 02:09:37.839260       1 networking.go:44] NetworkPolicy "cert-manager-allow-egress-to-api-server" changes: {"spec":{"egress":[{"ports":[{"port":6443}]}]}}
  I1028 02:09:37.846546       1 event.go:377] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"cert-manager-operator", Name:"cert-manager-operator-controller-manager", UID:"9be055ac-4e2e-4149-8b95-8958c5a32a5f", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'NetworkPolicyUpdated' Updated NetworkPolicy.networking.k8s.io/cert-manager-allow-egress-to-api-server -n cert-manager because it changed
  I1028 02:10:37.843744       1 networking.go:44] NetworkPolicy "cert-manager-allow-egress-to-api-server" changes: {"spec":{"egress":[{"ports":[{"port":6443}]}]}}
  I1028 02:10:37.847746       1 event.go:377] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"cert-manager-operator", Name:"cert-manager-operator-controller-manager", UID:"9be055ac-4e2e-4149-8b95-8958c5a32a5f", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'NetworkPolicyUpdated' Updated NetworkPolicy.networking.k8s.io/cert-manager-allow-egress-to-api-server -n cert-manager because it changed
  I1028 02:11:37.844829       1 networking.go:44] NetworkPolicy "cert-manager-allow-egress-to-api-server" changes: {"spec":{"egress":[{"ports":[{"port":6443}]}]}}
  I1028 02:11:37.851518       1 event.go:377] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"cert-manager-operator", Name:"cert-manager-operator-controller-manager", UID:"9be055ac-4e2e-4149-8b95-8958c5a32a5f", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'NetworkPolicyUpdated' Updated NetworkPolicy.networking.k8s.io/cert-manager-allow-egress-to-api-server -n cert-manager because it changed
  I1028 02:12:37.845783       1 networking.go:44] NetworkPolicy "cert-manager-allow-egress-to-api-server" changes: {"spec":{"egress":[{"ports":[{"port":6443}]}]}}
  I1028 02:12:37.850593       1 event.go:377] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"cert-manager-operator", Name:"cert-manager-operator-controller-manager", UID:"9be055ac-4e2e-4149-8b95-8958c5a32a5f", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'NetworkPolicyUpdated' Updated NetworkPolicy.networking.k8s.io/cert-manager-allow-egress-to-api-server -n cert-manager because it changed
  ...
  ```

  </details>

- w/ the fix: none after creation

  <details>
  <summary>process flow</summary>

  1. Operator sends NetworkPolicy
  2. API defaults protocol to `TCP`
  3. ResourceCache stores: hash(required) + resourceVersion
  4. Next reconciliation:
     - `cache.SafeToSkipApply()` checks:
       - Same required (hash matches)
       - Unchanged existing (resourceVersion matches)
     - Returns early without update
  5. No busy loop

  </details>

  <details>
  <summary>controller logs</summary>

  ```
  I1028 02:09:05.768413       1 event.go:377] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"cert-manager-operator", Name:"cert-manager-operator-controller-manager", UID:"670b8fb9-7d8f-422f-90bb-1c73220a8620", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'NetworkPolicyCreated' Created NetworkPolicy.networking.k8s.io/cert-manager-allow-egress-to-api-server -n cert-manager because it was missing
  ...
  ```

  </details>