### PR TITLE
NO-JIRA: Introduce KMS encryption mode into encryption controllers

### DIFF
--- a/pkg/operator/encryption/controllers/key_controller_test.go
+++ b/pkg/operator/encryption/controllers/key_controller_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/openshift/library-go/pkg/operator/encryption/state"
 	clocktesting "k8s.io/utils/clock/testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -53,6 +54,8 @@ func TestKeyController(t *testing.T) {
 		validateFunc               func(ts *testing.T, actions []clientgotesting.Action, targetNamespace string, targetGRs []schema.GroupResource)
 		validateOperatorClientFunc func(ts *testing.T, operatorClient v1helpers.OperatorClient)
 		expectedError              error
+		kmsConfigHash              string
+		kmsKeyIDHash               string
 	}{
 		{
 			name: "no apiservers config",
@@ -324,6 +327,211 @@ func TestKeyController(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "KMS: creates first encryption key when none exists",
+			targetGRs: []schema.GroupResource{
+				{Group: "", Resource: "secrets"},
+			},
+			kmsConfigHash: "config-hash-12345678",
+			kmsKeyIDHash:  "key-id-hash-abcdefgh",
+			initialObjects: []runtime.Object{
+				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
+			},
+			apiServerObjects: []runtime.Object{
+				func() *configv1.APIServer {
+					apiServer := &configv1.APIServer{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}}
+					apiServer.Spec.Encryption = configv1.APIServerEncryption{
+						Type: configv1.EncryptionTypeKMS,
+						KMS: &configv1.KMSConfig{
+							Type: configv1.AWSKMSProvider,
+							AWS: &configv1.AWSKMSConfig{
+								KeyARN: "arn:aws:kms:us-east-1:123456789012:key/test-key",
+								Region: "us-east-1",
+							},
+						},
+					}
+					return apiServer
+				}(),
+			},
+			targetNamespace: "kms",
+			expectedActions: []string{
+				"list:pods:kms",
+				"get:secrets:kms",
+				"list:secrets:openshift-config-managed",
+				"create:secrets:openshift-config-managed",
+				"create:events:kms",
+			},
+			validateFunc: func(ts *testing.T, actions []clientgotesting.Action, targetNamespace string, targetGRs []schema.GroupResource) {
+				wasSecretValidated := false
+				for _, action := range actions {
+					if action.Matches("create", "secrets") {
+						createAction := action.(clientgotesting.CreateAction)
+						actualSecret := createAction.GetObject().(*corev1.Secret)
+
+						// Verify KMS annotations are set
+						if actualSecret.Annotations["encryption.apiserver.operator.openshift.io/kms-config-hash"] == "" {
+							ts.Error("expected KMS config hash annotation to be set")
+						}
+						if actualSecret.Annotations["encryption.apiserver.operator.openshift.io/mode"] != string(state.KMS) {
+							ts.Errorf("expected mode to be 'kms', got '%s'", actualSecret.Annotations["encryption.apiserver.operator.openshift.io/mode"])
+						}
+
+						wasSecretValidated = true
+						break
+					}
+				}
+				if !wasSecretValidated {
+					ts.Errorf("the secret wasn't created and validated")
+				}
+			},
+		},
+
+		{
+			name: "KMS: no-op when only KMS config hash changes but key ID hash is the same",
+			targetGRs: []schema.GroupResource{
+				{Group: "", Resource: "secrets"},
+			},
+			kmsConfigHash: "new-config-hash-xyz",
+			kmsKeyIDHash:  "key-id-hash-abcd1234",
+			initialObjects: []runtime.Object{
+				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
+				func() *corev1.Secret {
+					// Secret with the same key ID hash (stored in Data)
+					s := encryptiontesting.CreateEncryptionKeySecretWithRawKeyWithMode("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 1, []byte("key-id-hash-abcd1234"), string(state.KMS))
+					s.Annotations["encryption.apiserver.operator.openshift.io/kms-config-hash"] = "old-config-hash-1234"
+					return s
+				}(),
+			},
+			apiServerObjects: []runtime.Object{
+				func() *configv1.APIServer {
+					apiServer := &configv1.APIServer{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}}
+					apiServer.Spec.Encryption = configv1.APIServerEncryption{
+						Type: configv1.EncryptionTypeKMS,
+						KMS: &configv1.KMSConfig{
+							Type: configv1.AWSKMSProvider,
+							AWS: &configv1.AWSKMSConfig{
+								KeyARN: "arn:aws:kms:us-east-1:123456789012:key/new-key", // Different key ARN
+								Region: "us-east-1",
+							},
+						},
+					}
+					return apiServer
+				}(),
+			},
+			targetNamespace: "kms",
+			expectedActions: []string{
+				"list:pods:kms",
+				"get:secrets:kms",
+				"list:secrets:openshift-config-managed",
+			},
+		},
+
+		{
+			name: "KMS: creates new key when KMS key ID hash changes (key rotation)",
+			targetGRs: []schema.GroupResource{
+				{Group: "", Resource: "secrets"},
+			},
+			kmsConfigHash: "config-hash-12345678",
+			kmsKeyIDHash:  "new-key-id-hash-xyz",
+			initialObjects: []runtime.Object{
+				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
+				func() *corev1.Secret {
+					// Secret with old key ID hash stored in Data
+					s := encryptiontesting.CreateEncryptionKeySecretWithRawKeyWithMode("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 1, []byte("old-key-id-hash-abc"), string(state.KMS))
+					s.Annotations["encryption.apiserver.operator.openshift.io/kms-config-hash"] = "config-hash-12345678"
+					return s
+				}(),
+			},
+			apiServerObjects: []runtime.Object{
+				func() *configv1.APIServer {
+					apiServer := &configv1.APIServer{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}}
+					apiServer.Spec.Encryption = configv1.APIServerEncryption{
+						Type: configv1.EncryptionTypeKMS,
+						KMS: &configv1.KMSConfig{
+							Type: configv1.AWSKMSProvider,
+							AWS: &configv1.AWSKMSConfig{
+								KeyARN: "arn:aws:kms:us-east-1:123456789012:key/test-key",
+								Region: "us-east-1",
+							},
+						},
+					}
+					return apiServer
+				}(),
+			},
+			targetNamespace: "kms",
+			expectedActions: []string{
+				"list:pods:kms",
+				"get:secrets:kms",
+				"list:secrets:openshift-config-managed",
+				"create:secrets:openshift-config-managed",
+				"create:events:kms",
+			},
+			validateFunc: func(ts *testing.T, actions []clientgotesting.Action, targetNamespace string, targetGRs []schema.GroupResource) {
+				wasSecretValidated := false
+				for _, action := range actions {
+					if action.Matches("create", "secrets") {
+						createAction := action.(clientgotesting.CreateAction)
+						actualSecret := createAction.GetObject().(*corev1.Secret)
+
+						// Verify config hash stays the same
+						configHash := actualSecret.Annotations["encryption.apiserver.operator.openshift.io/kms-config-hash"]
+						if configHash != "config-hash-12345678" {
+							ts.Errorf("expected config hash to remain 'config-hash-12345678', got '%s'", configHash)
+						}
+
+						// Verify internal reason mentions KMS key change
+						internalReason := actualSecret.Annotations["encryption.apiserver.operator.openshift.io/internal-reason"]
+						if internalReason != "secrets-kms-key-changed" {
+							ts.Errorf("expected internal reason 'secrets-kms-key-changed', got '%s'", internalReason)
+						}
+
+						wasSecretValidated = true
+						break
+					}
+				}
+				if !wasSecretValidated {
+					ts.Errorf("the secret wasn't created and validated")
+				}
+			},
+		},
+		{
+			name: "KMS: no-op when hashes match and key is migrated",
+			targetGRs: []schema.GroupResource{
+				{Group: "", Resource: "secrets"},
+			},
+			kmsConfigHash: "config-hash-12345678",
+			kmsKeyIDHash:  "key-id-hash-abcdefgh",
+			initialObjects: []runtime.Object{
+				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
+				func() *corev1.Secret {
+					s := encryptiontesting.CreateEncryptionKeySecretWithRawKeyWithMode("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 1, []byte("key-id-hash-abcdefgh"), string(state.KMS))
+					s.Annotations["encryption.apiserver.operator.openshift.io/kms-config-hash"] = "config-hash-12345678"
+					return s
+				}(),
+			},
+			apiServerObjects: []runtime.Object{
+				func() *configv1.APIServer {
+					apiServer := &configv1.APIServer{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}}
+					apiServer.Spec.Encryption = configv1.APIServerEncryption{
+						Type: configv1.EncryptionTypeKMS,
+						KMS: &configv1.KMSConfig{
+							Type: configv1.AWSKMSProvider,
+							AWS: &configv1.AWSKMSConfig{
+								KeyARN: "arn:aws:kms:us-east-1:123456789012:key/test-key",
+								Region: "us-east-1",
+							},
+						},
+					}
+					return apiServer
+				}(),
+			},
+			targetNamespace: "kms",
+			expectedActions: []string{
+				"list:pods:kms",
+				"get:secrets:kms",
+				"list:secrets:openshift-config-managed",
+			},
+		},
 	}
 
 	for _, scenario := range scenarios {
@@ -374,6 +582,12 @@ func TestKeyController(t *testing.T) {
 			provider := newTestProvider(scenario.targetGRs)
 
 			target := NewKeyController(scenario.targetNamespace, nil, provider, deployer, alwaysFulfilledPreconditions, fakeOperatorClient, fakeApiServerClient, fakeApiServerInformer, kubeInformers, fakeSecretClient, scenario.encryptionSecretSelector, eventRecorder)
+
+			if scenario.kmsConfigHash != "" || scenario.kmsKeyIDHash != "" {
+				kmsHashesGetterFunc = func(ctx context.Context, kmsConfig *configv1.KMSConfig) (string, []byte, error) {
+					return scenario.kmsConfigHash, []byte(scenario.kmsKeyIDHash), nil
+				}
+			}
 
 			// act
 			err = target.Sync(context.TODO(), factory.NewSyncContext("test", eventRecorder))
@@ -495,7 +709,7 @@ func TestGetCurrentModeAndExternalReason(t *testing.T) {
 
 			// act
 			target := keyController{unsupportedConfigPrefix: scenario.prefix, operatorClient: fakeOperatorClient, apiServerClient: fakeApiServerClient}
-			_, externalReason, err := target.getCurrentModeAndExternalReason(context.TODO())
+			_, externalReason, _, err := target.getCurrentModeAndExternalReason(context.TODO())
 
 			// validate
 			if err != nil {

--- a/pkg/operator/encryption/crypto/keys.go
+++ b/pkg/operator/encryption/crypto/keys.go
@@ -7,15 +7,16 @@ import (
 )
 
 var (
-	ModeToNewKeyFunc = map[state.Mode]func() []byte{
+	ModeToNewKeyFunc = map[state.Mode]func(externalKey []byte) []byte{
 		state.AESCBC:    NewAES256Key,
 		state.AESGCM:    NewAES256Key,
 		state.SecretBox: NewAES256Key, // secretbox requires a 32 byte key so we can reuse the same function here
 		state.Identity:  NewIdentityKey,
+		state.KMS:       NewKMSKey,
 	}
 )
 
-func NewAES256Key() []byte {
+func NewAES256Key(_ []byte) []byte {
 	b := make([]byte, 32) // AES-256 == 32 byte key
 	if _, err := rand.Read(b); err != nil {
 		panic(err) // rand should never fail
@@ -23,6 +24,12 @@ func NewAES256Key() []byte {
 	return b
 }
 
-func NewIdentityKey() []byte {
+func NewIdentityKey(_ []byte) []byte {
 	return make([]byte, 16) // the key is not used to perform encryption but must be a valid AES key
+}
+
+// NewKMSKey just stores the hashsum of configurations to track the any changes.
+// It does not store any confidential value.
+func NewKMSKey(externalKey []byte) []byte {
+	return externalKey
 }

--- a/pkg/operator/encryption/kms/kms.go
+++ b/pkg/operator/encryption/kms/kms.go
@@ -1,0 +1,141 @@
+package kms
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"regexp"
+	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/library-go/pkg/operator/encryption/state"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
+)
+
+const (
+	// unixSocketBaseDir is the base directory for KMS unix sockets
+	unixSocketBaseDir = "unix:///var/run/kms"
+)
+
+// GenerateUnixSocketPath generates a unique unix socket path from KMS configuration
+// by hashing the provider-specific configuration.
+// Returns the socket path and the hash value.
+func GenerateUnixSocketPath(kmsConfig *configv1.KMSConfig) (string, string, error) {
+	if kmsConfig == nil {
+		return "", "", fmt.Errorf("kmsConfig cannot be nil")
+	}
+
+	switch kmsConfig.Type {
+	case configv1.AWSKMSProvider:
+		if kmsConfig.AWS == nil {
+			return "", "", fmt.Errorf("AWS KMS config cannot be nil for AWS provider type")
+		}
+		return generateAWSUnixSocketPath(kmsConfig.AWS)
+	default:
+		return "", "", fmt.Errorf("unsupported KMS provider type: %s", kmsConfig.Type)
+	}
+}
+
+// generateAWSUnixSocketPath generates a unique unix socket path from AWS KMS configuration
+// by hashing the ARN and region. Returns the socket path and the hash.
+func generateAWSUnixSocketPath(awsConfig *configv1.AWSKMSConfig) (string, string, error) {
+	if awsConfig.KeyARN == "" {
+		return "", "", fmt.Errorf("AWS KMS KeyARN cannot be empty")
+	}
+
+	if awsConfig.Region == "" {
+		return "", "", fmt.Errorf("AWS region cannot be empty")
+	}
+
+	combined := awsConfig.KeyARN + ":" + awsConfig.Region
+
+	hash := sha256.Sum256([]byte(combined))
+	hashStr := hex.EncodeToString(hash[:])
+
+	// Take first 16 characters of hash for shorter path to not exceed any naming limits.
+	// Theoretically this should satisfy the uniqueness.
+	shortHash := hashStr[:16]
+
+	socketPath := fmt.Sprintf("%s/kms-%s.sock", unixSocketBaseDir, shortHash)
+
+	return socketPath, shortHash, nil
+}
+
+// ComputeKMSKeyHash computes a hash of the KMS key ID returned from the Status endpoint.
+// Returns the first 32 characters of the SHA256 hash.
+func ComputeKMSKeyHash(configHash, keyID string) []byte {
+	if keyID == "" {
+		return nil
+	}
+
+	combined := configHash + ":" + keyID
+	hash := sha256.Sum256([]byte(combined))
+	hashStr := hex.EncodeToString(hash[:])
+
+	return []byte(hashStr[:32])
+}
+
+var (
+	// endpointHashRegex matches the config hash in endpoint path: unix://var/run/kms/kms-{configHash16}.sock
+	endpointHashRegex = regexp.MustCompile(`kms-([a-f0-9]{16})\.sock$`)
+	// providerNameRegex matches the key ID hash, key ID, and resource in provider name: kms-provider-{keyIDHash32}-{keyID}-{resource}
+	// Example: kms-provider-abcdef1234567890abcdef1234567890-1-secrets
+	providerNameRegex = regexp.MustCompile(`^kms-provider-([a-f0-9]{32})-([^-]+)-(.+)$`)
+)
+
+// ExtractKMSHashAndKeyName extracts the KMSConfigHash, KMSKeyIDHash, and key.Name embedded into provider
+// name and socket path. Returns (configHash, keyIDHash, keyName, error)
+func ExtractKMSHashAndKeyName(provider v1.ProviderConfiguration) (string, string, string, error) {
+	// Extract the config hash from the endpoint path: unix://var/run/kms/kms-{configHash}.sock
+	endpoint := provider.KMS.Endpoint
+	var configHash string
+	if matches := endpointHashRegex.FindStringSubmatch(endpoint); len(matches) == 2 {
+		configHash = matches[1]
+	} else {
+		return "", "", "", fmt.Errorf("invalid KMS endpoint format: %s", endpoint)
+	}
+
+	// Extract the key ID hash, key ID, and resource from the provider name: kms-provider-{keyIDHash32}-{keyID}-{resource}
+	// Example: kms-provider-abcdef1234567890abcdef1234567890-1-secrets
+	var keyHash, keyName string
+	providerName := provider.KMS.Name
+	if matches := providerNameRegex.FindStringSubmatch(providerName); len(matches) == 4 {
+		keyHash = matches[1]
+		keyName = matches[2]
+		// matches[3] is the resource, but we don't need to return it
+	} else {
+		return "", "", "", fmt.Errorf("invalid KMS provider name format: %s", providerName)
+	}
+
+	return configHash, base64.StdEncoding.EncodeToString([]byte(keyHash)), keyName, nil
+}
+
+// GenerateKMSProviderConfigurationFromKey generates the compatible ProviderConfiguration with
+// opinionated and extractable fields. We embed:
+// - KMSConfigHash in the socket path (endpoint)
+// - KMSKeyIDHash, key.Name, and resource in the provider name
+// This allows us to extract all three values and detect both config changes and key rotations.
+// The resource parameter ensures uniqueness when the same KMS config is used for multiple resources.
+func GenerateKMSProviderConfigurationFromKey(resource string, key state.KeyState) v1.ProviderConfiguration {
+	// Embed KMSConfigHash in the endpoint so we can extract it
+	// This must generate the same format as GenerateUnixSocketPath
+	socketPath := fmt.Sprintf("%s/kms-%s.sock", unixSocketBaseDir, key.KMSConfigHash)
+	// Embed KMSKeyIDHash, key ID, and resource in the provider name so we can extract them when reading back
+	// Format: kms-provider-{keyIDHash32}-{keyID}-{resource}
+	// This must match the providerNameRegex
+	decoded, _ := base64.StdEncoding.DecodeString(key.Key.Secret)
+	providerName := fmt.Sprintf("kms-provider-%s-%s-%s", decoded, key.Key.Name, resource)
+
+	return v1.ProviderConfiguration{
+		KMS: &v1.KMSConfiguration{
+			APIVersion: "v2",
+			Name:       providerName,
+			Endpoint:   socketPath,
+			Timeout: &metav1.Duration{
+				Duration: 10 * time.Second,
+			},
+		},
+	}
+}

--- a/pkg/operator/encryption/kms/kms_test.go
+++ b/pkg/operator/encryption/kms/kms_test.go
@@ -1,0 +1,128 @@
+package kms
+
+import (
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+func TestGenerateUnixSocketPath(t *testing.T) {
+	tests := []struct {
+		name      string
+		kmsConfig *configv1.KMSConfig
+		wantPath  string
+		wantHash  string
+		wantErr   bool
+	}{
+		{
+			name: "valid AWS KMS config generates socket path",
+			kmsConfig: &configv1.KMSConfig{
+				Type: configv1.AWSKMSProvider,
+				AWS: &configv1.AWSKMSConfig{
+					KeyARN: "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012",
+					Region: "us-east-1",
+				},
+			},
+			wantPath: "unix:///var/run/kms/kms-2e55e11c0b187f2d.sock",
+			wantHash: "2e55e11c0b187f2d",
+			wantErr:  false,
+		},
+		{
+			name: "missing ARN returns error",
+			kmsConfig: &configv1.KMSConfig{
+				Type: configv1.AWSKMSProvider,
+				AWS: &configv1.AWSKMSConfig{
+					KeyARN: "",
+					Region: "us-east-1",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing region returns error",
+			kmsConfig: &configv1.KMSConfig{
+				Type: configv1.AWSKMSProvider,
+				AWS: &configv1.AWSKMSConfig{
+					KeyARN: "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012",
+					Region: "",
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotPath, gotHash, err := GenerateUnixSocketPath(tt.kmsConfig)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GenerateUnixSocketPath() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+
+			if gotPath != tt.wantPath {
+				t.Fatalf("GenerateUnixSocketPath() gotPath = %v, want %v", gotPath, tt.wantPath)
+			}
+			if gotHash != tt.wantHash {
+				t.Fatalf("GenerateUnixSocketPath() gotHash = %v, want %v", gotHash, tt.wantHash)
+			}
+		})
+	}
+
+	// Test determinism - same config should always generate same path
+	t.Run("deterministic generation", func(t *testing.T) {
+		kmsConfig := &configv1.KMSConfig{
+			Type: configv1.AWSKMSProvider,
+			AWS: &configv1.AWSKMSConfig{
+				KeyARN: "arn:aws:kms:us-east-1:123456789012:key/test-key",
+				Region: "us-east-1",
+			},
+		}
+
+		path1, hash1, err := GenerateUnixSocketPath(kmsConfig)
+		if err != nil {
+			t.Fatalf("first call failed: %v", err)
+		}
+
+		path2, hash2, err := GenerateUnixSocketPath(kmsConfig)
+		if err != nil {
+			t.Fatalf("second call failed: %v", err)
+		}
+
+		if path1 != path2 {
+			t.Errorf("paths not deterministic: %v != %v", path1, path2)
+		}
+
+		if hash1 != hash2 {
+			t.Errorf("hashes not deterministic: %v != %v", hash1, hash2)
+		}
+	})
+}
+
+func TestComputeKMSKeyHash(t *testing.T) {
+	tests := []struct {
+		name       string
+		configHash string
+		keyID      string
+		wantHash   string
+	}{
+		{
+			name:       "valid config hash and key ID",
+			configHash: "2e55e11c0b187f2d",
+			keyID:      "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012",
+			wantHash:   "26f87255a78a26fb93d8da5f7b1ada0c",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotHash := ComputeKMSKeyHash(tt.configHash, tt.keyID)
+
+			if string(gotHash) != tt.wantHash {
+				t.Fatalf("ComputeKMSKeyHash() gotHash = %v, want %v", string(gotHash), tt.wantHash)
+			}
+		})
+	}
+}

--- a/pkg/operator/encryption/secrets/secrets_test.go
+++ b/pkg/operator/encryption/secrets/secrets_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	v1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
 	"k8s.io/utils/diff"
@@ -127,4 +129,278 @@ func TestRoundtrip(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestToKeyState_KMS(t *testing.T) {
+	tests := []struct {
+		name          string
+		secretName    string
+		secretData    []byte
+		annotations   map[string]string
+		wantKeyState  state.KeyState
+		wantErr       bool
+		errorContains string
+	}{
+		{
+			name:       "valid KMS secret with keyIDHash data",
+			secretName: "encryption-key-apiserver-1",
+			secretData: []byte("abcd1234ef567890abcd1234ef567890"), // 32-char hex keyIDHash
+			annotations: map[string]string{
+				encryptionSecretMode:           string(state.KMS),
+				EncryptionSecretKMSConfigHash:  "2e55e11c0b187f2d",
+				encryptionSecretInternalReason: "kms-config-changed",
+				encryptionSecretExternalReason: "kms-key-rotated",
+			},
+			wantKeyState: state.KeyState{
+				Key: v1.Key{
+					Name:   "1",
+					Secret: base64.StdEncoding.EncodeToString([]byte("abcd1234ef567890abcd1234ef567890")),
+				},
+				Backed:         true,
+				Mode:           state.KMS,
+				KMSConfigHash:  "2e55e11c0b187f2d",
+				InternalReason: "kms-config-changed",
+				ExternalReason: "kms-key-rotated",
+			},
+			wantErr: false,
+		},
+		{
+			name:       "KMS secret with valid keyIDHash",
+			secretName: "encryption-key-apiserver-2",
+			secretData: []byte("1234567890abcdef1234567890abcdef"), // 32-char hex keyIDHash
+			annotations: map[string]string{
+				encryptionSecretMode:          string(state.KMS),
+				EncryptionSecretKMSConfigHash: "3f66f22d1c298e3e",
+			},
+			wantKeyState: state.KeyState{
+				Key: v1.Key{
+					Name:   "2",
+					Secret: base64.StdEncoding.EncodeToString([]byte("1234567890abcdef1234567890abcdef")),
+				},
+				Backed:        true,
+				Mode:          state.KMS,
+				KMSConfigHash: "3f66f22d1c298e3e",
+			},
+			wantErr: false,
+		},
+		{
+			name:       "KMS secret with empty data should fail",
+			secretName: "encryption-key-apiserver-3",
+			secretData: []byte{},
+			annotations: map[string]string{
+				encryptionSecretMode: string(state.KMS),
+			},
+			wantErr:       true,
+			errorContains: "must have non-empty key",
+		},
+		{
+			name:       "invalid mode should fail",
+			secretName: "encryption-key-apiserver-4",
+			secretData: []byte("some-key"),
+			annotations: map[string]string{
+				encryptionSecretMode: "invalid-mode",
+			},
+			wantErr:       true,
+			errorContains: "has invalid mode",
+		},
+		{
+			name:       "aescbc with empty data should fail",
+			secretName: "encryption-key-apiserver-5",
+			secretData: []byte{},
+			annotations: map[string]string{
+				encryptionSecretMode: "aescbc",
+			},
+			wantErr:       true,
+			errorContains: "must have non-empty key",
+		},
+		{
+			name:       "aesgcm with empty data should fail",
+			secretName: "encryption-key-apiserver-6",
+			secretData: []byte{},
+			annotations: map[string]string{
+				encryptionSecretMode: "aesgcm",
+			},
+			wantErr:       true,
+			errorContains: "must have non-empty key",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        tt.secretName,
+					Namespace:   "openshift-config-managed",
+					Annotations: tt.annotations,
+				},
+				Data: map[string][]byte{
+					EncryptionSecretKeyDataKey: tt.secretData,
+				},
+			}
+
+			got, err := ToKeyState(secret)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ToKeyState() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				if tt.errorContains != "" && err != nil {
+					if !contains(err.Error(), tt.errorContains) {
+						t.Errorf("ToKeyState() error = %v, should contain %q", err, tt.errorContains)
+					}
+				}
+				return
+			}
+			if !reflect.DeepEqual(got, tt.wantKeyState) {
+				t.Errorf("ToKeyState() mismatch:\n%s", diff.ObjectDiff(tt.wantKeyState, got))
+			}
+		})
+	}
+}
+
+func TestFromKeyState_KMS(t *testing.T) {
+	tests := []struct {
+		name            string
+		component       string
+		keyState        state.KeyState
+		wantSecretName  string
+		wantDataEmpty   bool
+		wantAnnotations map[string]string
+		wantErr         bool
+	}{
+		{
+			name:      "KMS key state creates secret with annotations",
+			component: "apiserver",
+			keyState: state.KeyState{
+				Key: v1.Key{
+					Name:   "1",
+					Secret: "",
+				},
+				Mode:          state.KMS,
+				KMSConfigHash: "2e55e11c0b187f2d",
+			},
+			wantSecretName: "encryption-key-apiserver-1",
+			wantDataEmpty:  true,
+			wantAnnotations: map[string]string{
+				encryptionSecretMode:          string(state.KMS),
+				EncryptionSecretKMSConfigHash: "2e55e11c0b187f2d",
+			},
+			wantErr: false,
+		},
+		{
+			name:      "KMS key state with only config hash",
+			component: "apiserver",
+			keyState: state.KeyState{
+				Key: v1.Key{
+					Name:   "2",
+					Secret: "",
+				},
+				Mode:          state.KMS,
+				KMSConfigHash: "3f66f22d1c298e3e",
+			},
+			wantSecretName: "encryption-key-apiserver-2",
+			wantDataEmpty:  true,
+			wantAnnotations: map[string]string{
+				encryptionSecretMode:          string(state.KMS),
+				EncryptionSecretKMSConfigHash: "3f66f22d1c298e3e",
+			},
+			wantErr: false,
+		},
+		{
+			name:      "KMS key state without any hashes",
+			component: "apiserver",
+			keyState: state.KeyState{
+				Key: v1.Key{
+					Name:   "3",
+					Secret: "",
+				},
+				Mode: state.KMS,
+			},
+			wantSecretName: "encryption-key-apiserver-3",
+			wantDataEmpty:  true,
+			wantAnnotations: map[string]string{
+				encryptionSecretMode: string(state.KMS),
+			},
+			wantErr: false,
+		},
+		{
+			name:      "KMS with reasons",
+			component: "apiserver",
+			keyState: state.KeyState{
+				Key: v1.Key{
+					Name:   "4",
+					Secret: "",
+				},
+				Mode:           state.KMS,
+				KMSConfigHash:  "1a2b3c4d5e6f7890",
+				InternalReason: "kms-provider-changed",
+				ExternalReason: "user-rotation",
+			},
+			wantSecretName: "encryption-key-apiserver-4",
+			wantDataEmpty:  true,
+			wantAnnotations: map[string]string{
+				encryptionSecretMode:           string(state.KMS),
+				EncryptionSecretKMSConfigHash:  "1a2b3c4d5e6f7890",
+				encryptionSecretInternalReason: "kms-provider-changed",
+				encryptionSecretExternalReason: "user-rotation",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := FromKeyState(tt.component, tt.keyState)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("FromKeyState() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+
+			// Verify secret name
+			if got.Name != tt.wantSecretName {
+				t.Errorf("FromKeyState() secret name = %v, want %v", got.Name, tt.wantSecretName)
+			}
+
+			// Verify namespace
+			if got.Namespace != "openshift-config-managed" {
+				t.Errorf("FromKeyState() namespace = %v, want openshift-config-managed", got.Namespace)
+			}
+
+			// Verify data is empty for KMS
+			dataLen := len(got.Data[EncryptionSecretKeyDataKey])
+			if tt.wantDataEmpty && dataLen != 0 {
+				t.Errorf("FromKeyState() expected empty data for KMS, got %d bytes", dataLen)
+			}
+
+			// Verify annotations
+			for k, v := range tt.wantAnnotations {
+				if gotV, ok := got.Annotations[k]; !ok {
+					t.Errorf("FromKeyState() missing annotation %q", k)
+				} else if gotV != v {
+					t.Errorf("FromKeyState() annotation %q = %v, want %v", k, gotV, v)
+				}
+			}
+
+			// Verify mode annotation specifically
+			if got.Annotations[encryptionSecretMode] != string(state.KMS) {
+				t.Errorf("FromKeyState() mode annotation = %v, want %v", got.Annotations[encryptionSecretMode], state.KMS)
+			}
+		})
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > len(substr) && containsAt(s, substr))
+}
+
+func containsAt(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/operator/encryption/secrets/types.go
+++ b/pkg/operator/encryption/secrets/types.go
@@ -49,6 +49,10 @@ const (
 	// by the encryption controllers.  Its sole purpose is to prevent the accidental
 	// deletion of secrets by enforcing a two phase delete.
 	EncryptionSecretFinalizer = "encryption.apiserver.operator.openshift.io/deletion-protection"
+
+	// EncryptionSecretKMSConfigHash is the annotation that stores the hash of the KMS configuration.
+	// This is used to detect changes in the KMS configuration that would require a new key.
+	EncryptionSecretKMSConfigHash = "encryption.apiserver.operator.openshift.io/kms-config-hash"
 )
 
 // MigratedGroupResources is the data structured stored in the

--- a/pkg/operator/encryption/state/types.go
+++ b/pkg/operator/encryption/state/types.go
@@ -40,6 +40,8 @@ type KeyState struct {
 	InternalReason string
 	// the user via unsupportConfigOverrides.encryption.reason triggered this key.
 	ExternalReason string
+	// hash of the KMS configuration to detect changes
+	KMSConfigHash string
 }
 
 type MigrationState struct {
@@ -60,6 +62,7 @@ const (
 	AESGCM    Mode = "aesgcm"
 	SecretBox Mode = "secretbox" // available from the first release, see defaultMode below
 	Identity  Mode = "identity"  // available from the first release, see defaultMode below
+	KMS       Mode = "KMS"
 
 	// Changing this value requires caution to not break downgrades.
 	// Specifically, if some new Mode is released in version X, that new Mode cannot


### PR DESCRIPTION
This PR adds KMS as a new mode in encryption controllers to be functioning along side with the other modes. Functionality has been proved to be working https://github.com/openshift/library-go/pull/2041. 

This PR takes the minimal bits from https://github.com/openshift/library-go/pull/2041 (because PoC PR also contains kms plugin communication to obtain the key_id. However, we decided that initially we don't need to track key_id).

Basically, idea is to track the hash of kmsconfig to detect any configuration changes. So that key_controller can create new secret to initiate migration. KMS key secret will not contain any confidential data. It will simply store the hash value of key_id. But for now, we don't access KMS plugin in operator controllers. That means key_id hash value will stay static.
