### PR TITLE
OCPBUGS-23746: Add availableInertia support to prevent transient APIServicesAvailable flapping

### DIFF
--- a/pkg/operator/apiserver/controllerset/apiservercontrollerset.go
+++ b/pkg/operator/apiserver/controllerset/apiservercontrollerset.go
@@ -170,6 +170,22 @@ func WithStatusControllerPdbCompatibleHighInertia(workloadConditionsPrefix strin
 	}
 }
 
+// WithStatusControllerAPIServicesAvailableInertia sets inertia for APIServicesAvailable
+// conditions to prevent brief transient errors from causing Available=False.
+// This is useful for handling temporary network issues or brief missing HTTP headers
+// that self-resolve within seconds.
+func WithStatusControllerAPIServicesAvailableInertia() func(s *status.StatusSyncer) *status.StatusSyncer {
+	return func(s *status.StatusSyncer) *status.StatusSyncer {
+		return s.WithAvailableInertia(status.MustNewInertia(
+			0, // default: no inertia for other conditions
+			status.InertiaCondition{
+				ConditionTypeMatcher: regexp.MustCompile("^APIServicesAvailable$"),
+				Duration:             5 * time.Second, // tolerate brief transient errors
+			}).Inertia,
+		)
+	}
+}
+
 func (cs *APIServerControllerSet) WithoutClusterOperatorStatusController() *APIServerControllerSet {
 	cs.clusterOperatorStatusController.controller = nil
 	cs.clusterOperatorStatusController.emptyAllowed = true


### PR DESCRIPTION
## Summary
- Add `availableInertia` field and `WithAvailableInertia()` method to StatusSyncer to support inertia for Available conditions
- Add `WithStatusControllerAPIServicesAvailableInertia()` helper that sets 5-second inertia for APIServicesAvailable conditions
- Apply availableInertia when setting OperatorAvailable condition in StatusSyncer.Sync()

This prevents brief transient errors (like temporary network issues or missing HTTP headers) from causing APIServicesAvailable conditions to flap between Available=True and Available=False. The 5-second inertia allows these transient issues to self-resolve before affecting the operator's Available status.

## Test plan
- [ ] Verify that temporary APIServicesAvailable errors (< 5 seconds) do not cause Available=False
- [ ] Verify that persistent APIServicesAvailable errors (> 5 seconds) correctly set Available=False
- [ ] Run existing unit and integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)