### PR TITLE
OCPBUGS-62517: Fix DeploymentController to comply with OpenShift Available API contract

### DIFF
--- a/pkg/operator/deploymentcontroller/deployment_controller_test.go
+++ b/pkg/operator/deploymentcontroller/deployment_controller_test.go
@@ -470,7 +470,8 @@ func TestSync(t *testing.T) {
 				operator: makeFakeOperatorInstance(
 					withGenerations(1),
 					withTrueConditions(conditionProgressing),
-					withFalseConditions(conditionAvailable),
+					// Per OpenShift API contract, Available remains True during normal upgrades/deployments
+					withTrueConditions(conditionAvailable),
 					withFinalizers(finalizerName),
 				),
 			},
@@ -526,7 +527,8 @@ func TestSync(t *testing.T) {
 					// withStatus(replica0),
 					withGenerations(1),
 					withTrueConditions(conditionProgressing),
-					withFalseConditions(conditionAvailable)), // Degraded is set later on
+					// Per OpenShift API contract, Available remains True during normal upgrades/deployments
+					withTrueConditions(conditionAvailable)),
 			},
 		},
 		{


### PR DESCRIPTION
The `DeploymentController` was violating the OpenShift API contract which states: '[A component must not report Available=False during the course of a normal upgrade'.](https://github.com/openshift/api/blob/master/config/v1/types_cluster_operator.go#L156)
This fix ensures Available remains True during normal rolling updates and only goes False for actual failures.
Assisted-by: Claude code