### PR TITLE
NO-JIRA: Fix static pod pruning logic for non-contiguous set of revisions

### DIFF
--- a/pkg/operator/staticpod/controller/prune/prune_controller.go
+++ b/pkg/operator/staticpod/controller/prune/prune_controller.go
@@ -135,7 +135,7 @@ func (c *PruneController) revisionsToKeep(status *operatorv1.StaticPodOperatorSt
 		}
 	}
 
-	if keep.Len() > 0 && sets.List(keep)[0] == 1 && sets.List(keep)[keep.Len()-1] == status.LatestAvailableRevision {
+	if keep.Len() > 0 && int32(keep.Len()) == status.LatestAvailableRevision && sets.List(keep)[0] == 1 && sets.List(keep)[keep.Len()-1] == status.LatestAvailableRevision {
 		return true, nil
 	}
 

--- a/pkg/operator/staticpod/controller/prune/prune_controller_test.go
+++ b/pkg/operator/staticpod/controller/prune/prune_controller_test.go
@@ -3,11 +3,12 @@ package prune
 import (
 	"context"
 	"fmt"
-	clocktesting "k8s.io/utils/clock/testing"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	clocktesting "k8s.io/utils/clock/testing"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -218,6 +219,33 @@ func TestSync(t *testing.T) {
 			objects:          []int32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20},
 			expectedObjects:  []int32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20},
 			expectedPrunePod: false,
+		},
+		{
+			name:            "prunes non-contiguous set (keeps 1-10 and 96-100, prunes 11-95)",
+			targetNamespace: "prune-api",
+			status: operatorv1.StaticPodOperatorStatus{
+				OperatorStatus: operatorv1.OperatorStatus{
+					LatestAvailableRevision: 100,
+				},
+				NodeStatuses: []operatorv1.NodeStatus{
+					{
+						NodeName:           "test-node-1",
+						CurrentRevision:    100,
+						LastFailedRevision: 5,
+					},
+					{
+						NodeName:           "test-node-2",
+						CurrentRevision:    100,
+						LastFailedRevision: 10,
+					},
+				},
+			},
+			failedLimit:       5,
+			succeededLimit:    5,
+			objects:           int32Range(1, 100),
+			expectedObjects:   append(int32Range(1, 10), int32Range(96, 100)...),
+			expectedPrunePod:  true,
+			expectedPruneArgs: "-v=4 --max-eligible-revision=100 --protected-revisions=1,2,3,4,5,6,7,8,9,10,96,97,98,99,100 --resource-dir=/etc/kubernetes/static-pod-resources --cert-dir= --static-pod-name=test-pod",
 		},
 		{
 			name:            "protects all with unlimited revisions",


### PR DESCRIPTION
### Fix static pod pruning logic for non-contiguous set of revisions

#### Problem
The `PruneController` contains a logic bug in `revisionsToKeep()` that prevents pruning when the protected revision set is non-contiguous but spans from revision `1` to `LatestAvailableRevision`.

**Scenario that triggers the bug:**
Node has very old `LastFailedRevision: 5`
Cluster is now at `LatestAvailableRevision: 100`
Limits are `failedRevisionLimit: 5`, `succeededRevisionLimit: 5`
Protected set becomes {1,2,3,4,5,96,97,98,99,100} (10 revisions)

**The buggy logic sees:**
First element: `1`
Last element: `100`
Returns `keepAll = true` -> No pruning happens.
This causes **a lot** of `revision-status-* ConfigMaps` (and their owned `ConfigMaps`) to accumulate until a later failed revision eventually removes the first revision from the set.

#### Solution
Check if the set has exactly LatestAvailableRevision elements before triggering the keepAll optimization. This ensures that the set has no gaps and is in-fact contiguous.

#### Testing
Added test case: "prunes non-contiguous set (keeps 1-10 and 96-100, prunes 11-95)" that verifies:

Two nodes with `LastFailedRevision: 5` and `LastFailedRevision: 10`
`CurrentRevision: 100` on both nodes
`LatestAvailableRevision: 100`

Protected set: `{1,2,3,4,5,6,7,8,9,10,96,97,98,99,100}` (15 revisions)
Revisions `11 - 95` are pruned.
`keepAll` optimization does not trigger.