### PR TITLE
OCPSTRAT-485: Add ConfigMap revision pruner for API server operators

### DIFF
--- a/pkg/operator/revisionpruner/prune_controller.go
+++ b/pkg/operator/revisionpruner/prune_controller.go
@@ -1,0 +1,154 @@
+package revisionpruner
+
+import (
+	"context"
+	"maps"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	corev1informer "k8s.io/client-go/informers/core/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/klog/v2"
+)
+
+// ConfigMapRevisionPruneController is a controller that watches the operand pods and deletes old
+// revisioned configmaps that are not used anymore.
+type ConfigMapRevisionPruneController struct {
+	targetNamespace   string
+	configMapPrefixes []string
+	podSelector       labels.Selector
+
+	configMapGetter   corev1client.ConfigMapsGetter
+	podInformer       corev1informer.PodInformer
+	configMapInformer corev1informer.ConfigMapInformer
+}
+
+const (
+	numOldRevisionsToPreserve = 5
+)
+
+// NewConfigMapRevisionPruneController creates a new pruning controller
+func NewConfigMapRevisionPruneController(
+	targetNamespace string,
+	configMapPrefixes []string,
+	podLabelSelector labels.Selector,
+	configMapGetter corev1client.ConfigMapsGetter,
+	informers v1helpers.KubeInformersForNamespaces,
+	eventRecorder events.Recorder,
+) factory.Controller {
+	c := &ConfigMapRevisionPruneController{
+		targetNamespace:   targetNamespace,
+		configMapPrefixes: configMapPrefixes,
+		podSelector:       podLabelSelector,
+
+		configMapGetter:   configMapGetter,
+		podInformer:       informers.InformersFor(targetNamespace).Core().V1().Pods(),
+		configMapInformer: informers.InformersFor(targetNamespace).Core().V1().ConfigMaps(),
+	}
+
+	return factory.New().
+		WithInformers(
+			c.podInformer.Informer(),
+			c.configMapInformer.Informer(),
+		).
+		WithSync(c.sync).
+		ToController(
+			"ConfigMapRevisionPruneController",
+			eventRecorder.WithComponentSuffix("configmap-revision-prune-controller"),
+		)
+}
+
+func (c *ConfigMapRevisionPruneController) sync(ctx context.Context, syncContext factory.SyncContext) error {
+	klog.V(5).Infof("revision pruner sync for namespace: %s", c.targetNamespace)
+
+	pods, err := c.podInformer.Lister().Pods(c.targetNamespace).List(c.podSelector)
+	if err != nil {
+		return err
+	}
+
+	minRevision := minPodRevision(pods)
+	if minRevision == 0 {
+		return nil
+	}
+
+	configMaps, err := c.configMapInformer.Lister().ConfigMaps(c.targetNamespace).List(labels.Everything())
+	if err != nil {
+		return err
+	}
+
+	for _, cm := range configMapsToBePruned(minRevision, c.configMapPrefixes, configMaps) {
+		klog.V(4).Infof("pruning old revision ConfigMap %s/%s", cm.Namespace, cm.Name)
+
+		if err := c.configMapGetter.ConfigMaps(cm.Namespace).Delete(ctx, cm.Name, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func configMapsToBePruned(minRevision int, configMapPrefixes []string, configMaps []*corev1.ConfigMap) []*corev1.ConfigMap {
+	filtered := map[string]map[int][]*corev1.ConfigMap{}
+	for _, cm := range configMaps {
+		for _, pre := range configMapPrefixes {
+			r, found := strings.CutPrefix(cm.Name, pre)
+			if found {
+				rev, err := strconv.Atoi(r)
+				if err != nil || rev <= 0 {
+					klog.Warningf("revision configmap %s/%s with prefix %q has invalid suffix: %v", cm.Namespace, cm.Name, pre, err)
+					break
+				}
+
+				if rev < minRevision {
+					if filtered[pre] == nil {
+						filtered[pre] = map[int][]*corev1.ConfigMap{}
+					}
+					filtered[pre][rev] = append(filtered[pre][rev], cm)
+				}
+
+				break
+			}
+		}
+	}
+
+	prune := []*corev1.ConfigMap{}
+	for _, pre := range configMapPrefixes {
+		sorted := slices.Sorted(maps.Keys(filtered[pre]))
+		if len(sorted) <= numOldRevisionsToPreserve {
+			continue
+		}
+
+		for _, rev := range sorted[:len(sorted)-numOldRevisionsToPreserve] {
+			prune = append(prune, filtered[pre][rev]...)
+		}
+	}
+
+	return prune
+}
+
+func minPodRevision(pods []*corev1.Pod) int {
+	min := 0
+	for p := range pods {
+		l := pods[p].Labels["revision"]
+		if l == "" {
+			continue
+		}
+		r, err := strconv.Atoi(l)
+		if err != nil || r <= 0 {
+			klog.Warningf("invalid revision label on pod %s/%s: %q", pods[p].Namespace, pods[p].Name, l)
+			continue
+		}
+		if r < min || min == 0 {
+			min = r
+		}
+	}
+	return min
+}

--- a/pkg/operator/revisionpruner/prune_controller_test.go
+++ b/pkg/operator/revisionpruner/prune_controller_test.go
@@ -1,0 +1,571 @@
+package revisionpruner
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/clock"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+func TestConfigMapsToBePruned(t *testing.T) {
+	tests := []struct {
+		name           string
+		minRevision    int
+		prefixes       []string
+		configMaps     []*corev1.ConfigMap
+		expectedPruned []string
+	}{
+		{
+			name:           "no configmaps",
+			minRevision:    10,
+			prefixes:       []string{"revision-status-"},
+			configMaps:     []*corev1.ConfigMap{},
+			expectedPruned: nil,
+		},
+		{
+			name:        "not enough old revisions to prune",
+			minRevision: 10,
+			prefixes:    []string{"revision-status-"},
+			configMaps: []*corev1.ConfigMap{
+				newConfigMap("revision-status-", 5),
+				newConfigMap("revision-status-", 6),
+				newConfigMap("revision-status-", 7),
+				newConfigMap("revision-status-", 8),
+				newConfigMap("revision-status-", 9),
+				newConfigMap("revision-status-", 10),
+			},
+			expectedPruned: nil,
+		},
+		{
+			name:        "prune oldest revisions beyond buffer",
+			minRevision: 10,
+			prefixes:    []string{"revision-status-"},
+			configMaps: []*corev1.ConfigMap{
+				newConfigMap("revision-status-", 1),
+				newConfigMap("revision-status-", 2),
+				newConfigMap("revision-status-", 3),
+				newConfigMap("revision-status-", 4),
+				newConfigMap("revision-status-", 5),
+				newConfigMap("revision-status-", 6),
+				newConfigMap("revision-status-", 7),
+				newConfigMap("revision-status-", 8),
+				newConfigMap("revision-status-", 9),
+				newConfigMap("revision-status-", 10),
+			},
+			expectedPruned: []string{
+				"revision-status-1",
+				"revision-status-2",
+				"revision-status-3",
+				"revision-status-4",
+			},
+		},
+		{
+			name:        "skip non-matching configmaps",
+			minRevision: 8,
+			prefixes:    []string{"revision-status-"},
+			configMaps: []*corev1.ConfigMap{
+				newConfigMap("revision-status-", 1),
+				newConfigMap("revision-status-", 2),
+				newConfigMap("revision-status-", 3),
+				newConfigMap("revision-status-", 4),
+				newConfigMap("revision-status-", 5),
+				newConfigMap("revision-status-", 6),
+				{ObjectMeta: metav1.ObjectMeta{Name: "audit-1", Namespace: "test"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "some-other-config", Namespace: "test"}},
+				newConfigMap("revision-status-", 7),
+				newConfigMap("revision-status-", 8),
+			},
+			expectedPruned: []string{
+				"revision-status-1",
+				"revision-status-2",
+			},
+		},
+		{
+			name:        "skip revisions at or above minRevision",
+			minRevision: 5,
+			prefixes:    []string{"revision-status-"},
+			configMaps: []*corev1.ConfigMap{
+				newConfigMap("revision-status-", 1),
+				newConfigMap("revision-status-", 2),
+				newConfigMap("revision-status-", 3),
+				newConfigMap("revision-status-", 4),
+				newConfigMap("revision-status-", 5),
+				newConfigMap("revision-status-", 6),
+			},
+			expectedPruned: nil,
+		},
+		{
+			name:        "prune with gaps in revision numbers",
+			minRevision: 20,
+			prefixes:    []string{"revision-status-"},
+			configMaps: []*corev1.ConfigMap{
+				newConfigMap("revision-status-", 1),
+				newConfigMap("revision-status-", 3),
+				newConfigMap("revision-status-", 5),
+				newConfigMap("revision-status-", 7),
+				newConfigMap("revision-status-", 8),
+				newConfigMap("revision-status-", 12),
+				newConfigMap("revision-status-", 15),
+				newConfigMap("revision-status-", 18),
+				newConfigMap("revision-status-", 20),
+			},
+			expectedPruned: []string{
+				"revision-status-1",
+				"revision-status-3",
+				"revision-status-5",
+			},
+		},
+		{
+			name:        "skip configmaps with invalid suffix",
+			minRevision: 10,
+			prefixes:    []string{"revision-status-"},
+			configMaps: []*corev1.ConfigMap{
+				newConfigMap("revision-status-", 0), // invalid, should be skipped
+				newConfigMap("revision-status-", 1),
+				newConfigMap("revision-status-", 2),
+				newConfigMap("revision-status-", 3),
+				newConfigMap("revision-status-", 4),
+				newConfigMap("revision-status-", 5),
+				newConfigMap("revision-status-", 6),
+				{ObjectMeta: metav1.ObjectMeta{Name: "revision-status-abc", Namespace: "test"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "revision-status-1.5", Namespace: "test"}},
+				newConfigMap("revision-status-", 8),
+				newConfigMap("revision-status-", 9),
+				newConfigMap("revision-status-", 10),
+			},
+			expectedPruned: []string{
+				"revision-status-1",
+				"revision-status-2",
+				"revision-status-3",
+			},
+		},
+		{
+			name:        "multiple prefixes - same revision numbers",
+			minRevision: 10,
+			prefixes:    []string{"revision-status-", "installer-status-"},
+			configMaps: []*corev1.ConfigMap{
+				newConfigMap("revision-status-", 1),
+				newConfigMap("revision-status-", 2),
+				newConfigMap("revision-status-", 3),
+				newConfigMap("revision-status-", 4),
+				newConfigMap("revision-status-", 5),
+				newConfigMap("revision-status-", 6),
+				newConfigMap("installer-status-", 1),
+				newConfigMap("installer-status-", 2),
+				newConfigMap("installer-status-", 3),
+				newConfigMap("installer-status-", 4),
+				newConfigMap("installer-status-", 5),
+				newConfigMap("installer-status-", 6),
+			},
+			expectedPruned: []string{
+				"revision-status-1",
+				"installer-status-1",
+			},
+		},
+		{
+			name:        "multiple prefixes - interleaved revisions pruned independently per prefix",
+			minRevision: 15,
+			prefixes:    []string{"revision-status-", "installer-status-"},
+			configMaps: []*corev1.ConfigMap{
+				newConfigMap("revision-status-", 1),
+				newConfigMap("revision-status-", 3),
+				newConfigMap("revision-status-", 5),
+				newConfigMap("revision-status-", 8),
+				newConfigMap("revision-status-", 10),
+				newConfigMap("revision-status-", 12),
+				newConfigMap("revision-status-", 14),
+				newConfigMap("installer-status-", 2),
+				newConfigMap("installer-status-", 4),
+				newConfigMap("installer-status-", 6),
+				newConfigMap("installer-status-", 9),
+				newConfigMap("installer-status-", 11),
+				newConfigMap("installer-status-", 13),
+				newConfigMap("installer-status-", 15),
+			},
+			expectedPruned: []string{
+				"revision-status-1",
+				"revision-status-3",
+				"installer-status-2",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := configMapsToBePruned(tt.minRevision, tt.prefixes, tt.configMaps)
+
+			if len(result) != len(tt.expectedPruned) {
+				t.Errorf("expected %d configmaps to be pruned, got %d", len(tt.expectedPruned), len(result))
+				for _, cm := range result {
+					t.Logf("  got: %s", cm.Name)
+				}
+				return
+			}
+
+			resultNames := make(map[string]bool)
+			for _, cm := range result {
+				resultNames[cm.Name] = true
+			}
+
+			for _, expected := range tt.expectedPruned {
+				if !resultNames[expected] {
+					t.Errorf("expected configmap %s to be pruned, but it wasn't", expected)
+				}
+			}
+		})
+	}
+}
+
+func TestMinPodRevision(t *testing.T) {
+	tests := []struct {
+		name     string
+		pods     []*corev1.Pod
+		expected int
+	}{
+		{
+			name:     "no pods",
+			pods:     []*corev1.Pod{},
+			expected: 0,
+		},
+		{
+			name: "pods without revision label",
+			pods: []*corev1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Name: "pod-1", Labels: map[string]string{"app": "test"}}},
+			},
+			expected: 0,
+		},
+		{
+			name: "single pod with revision",
+			pods: []*corev1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Name: "pod-1", Labels: map[string]string{"revision": "5"}}},
+			},
+			expected: 5,
+		},
+		{
+			name: "multiple pods returns minimum",
+			pods: []*corev1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Name: "pod-1", Labels: map[string]string{"revision": "10"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "pod-2", Labels: map[string]string{"revision": "5"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "pod-3", Labels: map[string]string{"revision": "8"}}},
+			},
+			expected: 5,
+		},
+		{
+			name: "skip pods with invalid zero or negative revision",
+			pods: []*corev1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Name: "pod-1", Labels: map[string]string{"revision": "10"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "pod-2", Labels: map[string]string{"revision": "invalid"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "pod-3", Labels: map[string]string{"revision": "-1"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "pod-4", Labels: map[string]string{"revision": "8"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "pod-5", Labels: map[string]string{"revision": "2"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "pod-6", Labels: map[string]string{"revision": "0"}}},
+			},
+			expected: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := minPodRevision(tt.pods)
+			if result != tt.expected {
+				t.Errorf("expected minRevision %d, got %d", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestRevisionPruneControllerSync(t *testing.T) {
+	tests := []struct {
+		name                 string
+		prefixes             []string
+		pods                 []runtime.Object
+		configMaps           []runtime.Object
+		expectedDeletedCMs   []string
+		expectedRemainingCMs []string
+	}{
+		{
+			name:     "prune old configmaps",
+			prefixes: []string{"revision-status-"},
+			pods: []runtime.Object{
+				newPod("pod-1", "10"),
+			},
+			configMaps: []runtime.Object{
+				newConfigMap("revision-status-", 1),
+				newConfigMap("revision-status-", 2),
+				newConfigMap("revision-status-", 3),
+				newConfigMap("revision-status-", 4),
+				newConfigMap("revision-status-", 5),
+				newConfigMap("revision-status-", 6),
+				newConfigMap("revision-status-", 7),
+				newConfigMap("revision-status-", 8),
+				newConfigMap("revision-status-", 9),
+				newConfigMap("revision-status-", 10),
+			},
+			expectedDeletedCMs: []string{
+				"revision-status-1",
+				"revision-status-2",
+				"revision-status-3",
+				"revision-status-4",
+			},
+			expectedRemainingCMs: []string{
+				"revision-status-5",
+				"revision-status-6",
+				"revision-status-7",
+				"revision-status-8",
+				"revision-status-9",
+				"revision-status-10",
+			},
+		},
+		{
+			name:     "no pruning when not enough old revisions",
+			prefixes: []string{"revision-status-"},
+			pods: []runtime.Object{
+				newPod("pod-1", "10"),
+			},
+			configMaps: []runtime.Object{
+				newConfigMap("revision-status-", 1),
+				newConfigMap("revision-status-", 2),
+				newConfigMap("revision-status-", 3),
+				newConfigMap("revision-status-", 4),
+				newConfigMap("revision-status-", 5),
+				newConfigMap("revision-status-", 10),
+			},
+			expectedDeletedCMs: []string{},
+			expectedRemainingCMs: []string{
+				"revision-status-1",
+				"revision-status-2",
+				"revision-status-3",
+				"revision-status-4",
+				"revision-status-5",
+				"revision-status-10",
+			},
+		},
+		{
+			name:     "no pruning when no pods exist",
+			prefixes: []string{"revision-status-"},
+			pods:     []runtime.Object{},
+			configMaps: []runtime.Object{
+				newConfigMap("revision-status-", 1),
+				newConfigMap("revision-status-", 2),
+				newConfigMap("revision-status-", 3),
+				newConfigMap("revision-status-", 4),
+				newConfigMap("revision-status-", 5),
+				newConfigMap("revision-status-", 6),
+			},
+			expectedDeletedCMs: []string{},
+			expectedRemainingCMs: []string{
+				"revision-status-1",
+				"revision-status-2",
+				"revision-status-3",
+				"revision-status-4",
+				"revision-status-5",
+				"revision-status-6",
+			},
+		},
+		{
+			name:     "no pruning when no pods have revision labels",
+			prefixes: []string{"revision-status-"},
+			pods: []runtime.Object{
+				&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-1", Namespace: "test", Labels: map[string]string{"apiserver": "true"}}},
+			},
+			configMaps: []runtime.Object{
+				newConfigMap("revision-status-", 1),
+				newConfigMap("revision-status-", 2),
+				newConfigMap("revision-status-", 3),
+				newConfigMap("revision-status-", 4),
+				newConfigMap("revision-status-", 5),
+				newConfigMap("revision-status-", 6),
+			},
+			expectedDeletedCMs: []string{},
+			expectedRemainingCMs: []string{
+				"revision-status-1",
+				"revision-status-2",
+				"revision-status-3",
+				"revision-status-4",
+				"revision-status-5",
+				"revision-status-6",
+			},
+		},
+		{
+			name:     "prune based on minimum pod revision",
+			prefixes: []string{"revision-status-"},
+			pods: []runtime.Object{
+				newPod("pod-1", "15"),
+				newPod("pod-2", "10"), // minimum
+				newPod("pod-3", "12"),
+			},
+			configMaps: []runtime.Object{
+				newConfigMap("revision-status-", 1),
+				newConfigMap("revision-status-", 2),
+				newConfigMap("revision-status-", 3),
+				newConfigMap("revision-status-", 4),
+				newConfigMap("revision-status-", 5),
+				newConfigMap("revision-status-", 6),
+				newConfigMap("revision-status-", 7),
+				newConfigMap("revision-status-", 8),
+				newConfigMap("revision-status-", 9),
+				newConfigMap("revision-status-", 10),
+			},
+			expectedDeletedCMs: []string{
+				"revision-status-1",
+				"revision-status-2",
+				"revision-status-3",
+				"revision-status-4",
+			},
+			expectedRemainingCMs: []string{
+				"revision-status-5",
+				"revision-status-6",
+				"revision-status-7",
+				"revision-status-8",
+				"revision-status-9",
+				"revision-status-10",
+			},
+		},
+		{
+			name:     "multiple prefixes",
+			prefixes: []string{"revision-status-", "installer-status-"},
+			pods: []runtime.Object{
+				newPod("pod-1", "10"),
+			},
+			configMaps: []runtime.Object{
+				newConfigMap("revision-status-", 1),
+				newConfigMap("revision-status-", 2),
+				newConfigMap("revision-status-", 3),
+				newConfigMap("revision-status-", 4),
+				newConfigMap("revision-status-", 5),
+				newConfigMap("revision-status-", 6),
+				newConfigMap("installer-status-", 1),
+				newConfigMap("installer-status-", 2),
+				newConfigMap("installer-status-", 3),
+				newConfigMap("installer-status-", 4),
+				newConfigMap("installer-status-", 5),
+				newConfigMap("installer-status-", 6),
+			},
+			expectedDeletedCMs: []string{
+				"revision-status-1",
+				"installer-status-1",
+			},
+			expectedRemainingCMs: []string{
+				"revision-status-2",
+				"revision-status-3",
+				"revision-status-4",
+				"revision-status-5",
+				"revision-status-6",
+				"installer-status-2",
+				"installer-status-3",
+				"installer-status-4",
+				"installer-status-5",
+				"installer-status-6",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			allObjects := append(tt.pods, tt.configMaps...)
+			kubeClient := fake.NewSimpleClientset(allObjects...)
+
+			kubeInformers := informers.NewSharedInformerFactoryWithOptions(
+				kubeClient,
+				0,
+				informers.WithNamespace("test"),
+			)
+
+			for _, obj := range tt.pods {
+				if err := kubeInformers.Core().V1().Pods().Informer().GetStore().Add(obj); err != nil {
+					t.Fatalf("failed to add pod to store: %v", err)
+				}
+			}
+			for _, obj := range tt.configMaps {
+				if err := kubeInformers.Core().V1().ConfigMaps().Informer().GetStore().Add(obj); err != nil {
+					t.Fatalf("failed to add configmap to store: %v", err)
+				}
+			}
+
+			eventRecorder := events.NewInMemoryRecorder("test", clock.RealClock{})
+
+			c := &ConfigMapRevisionPruneController{
+				targetNamespace:   "test",
+				configMapPrefixes: tt.prefixes,
+				podSelector:       labels.SelectorFromSet(map[string]string{"apiserver": "true"}),
+				configMapGetter:   kubeClient.CoreV1(),
+				podInformer:       kubeInformers.Core().V1().Pods(),
+				configMapInformer: kubeInformers.Core().V1().ConfigMaps(),
+			}
+
+			syncCtx := factory.NewSyncContext("test", eventRecorder)
+			if err := c.sync(context.Background(), syncCtx); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			for _, cmName := range tt.expectedDeletedCMs {
+				_, err := kubeClient.CoreV1().ConfigMaps("test").Get(context.Background(), cmName, metav1.GetOptions{})
+				if err == nil {
+					t.Errorf("expected configmap %s to be deleted, but it still exists", cmName)
+				} else if !errors.IsNotFound(err) {
+					t.Errorf("expected NotFound error for configmap %s, got: %v", cmName, err)
+				}
+			}
+
+			for _, cmName := range tt.expectedRemainingCMs {
+				_, err := kubeClient.CoreV1().ConfigMaps("test").Get(context.Background(), cmName, metav1.GetOptions{})
+				if err != nil {
+					t.Errorf("expected configmap %s to remain, but got error: %v", cmName, err)
+				}
+			}
+		})
+	}
+}
+
+func TestNewConfigMapRevisionPruneController(t *testing.T) {
+	kubeClient := fake.NewSimpleClientset()
+	eventRecorder := events.NewInMemoryRecorder("test", clock.RealClock{})
+	kubeInformers := v1helpers.NewKubeInformersForNamespaces(kubeClient, "test")
+
+	controller := NewConfigMapRevisionPruneController(
+		"test",
+		[]string{"revision-status-", "installer-status-"},
+		labels.SelectorFromSet(map[string]string{"apiserver": "true"}),
+		kubeClient.CoreV1(),
+		kubeInformers,
+		eventRecorder,
+	)
+
+	if controller == nil {
+		t.Fatal("expected controller to be created, got nil")
+	}
+}
+
+func newConfigMap(prefix string, revision int) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s%d", prefix, revision),
+			Namespace: "test",
+		},
+	}
+}
+
+func newPod(name, revision string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "test",
+			Labels: map[string]string{
+				"apiserver": "true",
+				"revision":  revision,
+			},
+		},
+	}
+}


### PR DESCRIPTION
Add the new controller ConfigMapRevisionPruneController that prunes old revisioned ConfigMaps no longer in use by operand pods. This complements the existing SecretRevisionPruneController.

Key features:
- Prunes ConfigMaps by prefix (e.g., revision-status-, installer-status-)
- Preserves the 5 most recent revisions per prefix independently
- Only prunes revisions below the minimum pod revision in use

Also adds WithRevisionPruneController to APIServerControllerSet, allowing API server operators to configure ConfigMap revision pruning alongside the existing secret pruning capability.

With this, it will be possible to add revision pruning to the `openshift-apiserver` and `oauth-apiserver` in the future. As described in [RFE-3492](https://issues.redhat.com/browse/RFE-3492) and [RFE-4143](https://issues.redhat.com/browse/RFE-4143).