### PR TITLE
OCPBUGS-65626: add service account to guard pod

### DIFF
--- a/pkg/operator/staticpod/controller/guard/guard_controller.go
+++ b/pkg/operator/staticpod/controller/guard/guard_controller.go
@@ -12,7 +12,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/policy/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -48,6 +47,8 @@ type GuardController struct {
 	podGetter  corev1client.PodsGetter
 	pdbGetter  policyclientv1.PodDisruptionBudgetsGetter
 	pdbLister  policylisterv1.PodDisruptionBudgetLister
+	saLister   corelisterv1.ServiceAccountLister
+	saGetter   corev1client.ServiceAccountsGetter
 
 	// installerPodImageFn returns the image name for the installer pod
 	installerPodImageFn   func() string
@@ -70,6 +71,7 @@ func NewGuardController(
 	operatorClient operatorv1helpers.StaticPodOperatorClient,
 	podGetter corev1client.PodsGetter,
 	pdbGetter policyclientv1.PodDisruptionBudgetsGetter,
+	saGetter corev1client.ServiceAccountsGetter,
 	eventRecorder events.Recorder,
 	createConditionalFunc func() (bool, bool, error),
 	extraNodeSelector labels.Selector,
@@ -102,6 +104,8 @@ func NewGuardController(
 		podGetter:                     podGetter,
 		pdbGetter:                     pdbGetter,
 		pdbLister:                     kubeInformersForTargetNamespace.Policy().V1().PodDisruptionBudgets().Lister(),
+		saGetter:                      saGetter,
+		saLister:                      kubeInformersForTargetNamespace.Core().V1().ServiceAccounts().Lister(),
 		installerPodImageFn:           getInstallerPodImageFromEnv,
 		createConditionalFunc:         createConditionalFunc,
 		extraNodeSelector:             extraNodeSelector,
@@ -116,6 +120,7 @@ func NewGuardController(
 		WithInformers(
 			kubeInformersForTargetNamespace.Core().V1().Pods().Informer(),
 			kubeInformersClusterScoped.Core().V1().Nodes().Informer(),
+			kubeInformersForTargetNamespace.Core().V1().ServiceAccounts().Informer(),
 		).
 		WithSync(c.sync).
 		WithSyncDegradedOnError(operatorClient).
@@ -178,6 +183,9 @@ var pdbTemplate []byte
 //go:embed manifests/guard-pod.yaml
 var podTemplate []byte
 
+//go:embed manifests/guard-pod-sa.yaml
+var serviceAccountTemplate []byte
+
 func (c *GuardController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
 	klog.V(5).Info("Syncing guards")
 
@@ -227,10 +235,25 @@ func (c *GuardController) sync(ctx context.Context, syncCtx factory.SyncContext)
 			for _, pod := range pods {
 				_, _, err = resourceapply.DeletePod(ctx, c.podGetter, syncCtx.Recorder(), pod)
 				if err != nil {
-					klog.Errorf("Unable to delete Pod: %v", err)
+					klog.Errorf("unable to delete Pod: %v", err)
 					errs = append(errs, err)
 				}
 			}
+		}
+
+		// delete the guard service account
+		serviceAccount := resourceread.ReadServiceAccountV1OrDie(serviceAccountTemplate)
+		serviceAccount.Namespace = c.targetNamespace
+
+		// Check if the service account exists using the lister to avoid unnecessary API calls
+		_, err = c.saLister.ServiceAccounts(serviceAccount.Namespace).Get(serviceAccount.Name)
+		if err == nil {
+			_, _, err = resourceapply.DeleteServiceAccount(ctx, c.saGetter, syncCtx.Recorder(), serviceAccount)
+			if err != nil {
+				errs = append(errs, err)
+			}
+		} else if !apierrors.IsNotFound(err) {
+			errs = append(errs, err)
 		}
 	} else {
 		nodes, err := c.nodeLister.List(c.masterNodesSelector)
@@ -275,7 +298,7 @@ func (c *GuardController) sync(ctx context.Context, syncCtx factory.SyncContext)
 					return fmt.Errorf("Unable to apply PodDisruptionBudget changes: %v", err)
 				}
 			}
-		} else if errors.IsNotFound(err) {
+		} else if apierrors.IsNotFound(err) {
 			_, _, err = resourceapply.ApplyPodDisruptionBudget(ctx, c.pdbGetter, syncCtx.Recorder(), pdb)
 			if err != nil {
 				klog.Errorf("Unable to create PodDisruptionBudget: %v", err)
@@ -289,6 +312,24 @@ func (c *GuardController) sync(ctx context.Context, syncCtx factory.SyncContext)
 		operands := map[string]*corev1.Pod{}
 		for _, pod := range pods {
 			operands[pod.Spec.NodeName] = pod
+		}
+
+		// Create the guard service account once for all guard pods
+		serviceAccount := resourceread.ReadServiceAccountV1OrDie(serviceAccountTemplate)
+		serviceAccount.Namespace = c.targetNamespace
+
+		// Check if the service account exists using the lister to avoid unnecessary API calls
+		// There are no secrets, no image pull secrets, no annotations.
+		// The guard pod uses automountServiceAccountToken: false.
+		// There's nothing meaningful to update. So update logic isn't needed right now.
+		_, err = c.saLister.ServiceAccounts(serviceAccount.Namespace).Get(serviceAccount.Name)
+		if apierrors.IsNotFound(err) {
+			_, _, err = resourceapply.ApplyServiceAccount(ctx, c.saGetter, syncCtx.Recorder(), serviceAccount)
+			if err != nil {
+				return fmt.Errorf("unable to create service account %v for Guard Pods: %w", serviceAccount.Name, err)
+			}
+		} else if err != nil {
+			return err
 		}
 
 		for _, node := range nodes {
@@ -328,6 +369,7 @@ func (c *GuardController) sync(ctx context.Context, syncCtx factory.SyncContext)
 			pod.Spec.NodeName = node.Name
 			pod.Spec.Containers[0].Image = c.installerPodImageFn()
 			pod.Spec.Containers[0].ReadinessProbe.HTTPGet.Host = operands[node.Name].Status.PodIP
+			pod.Spec.ServiceAccountName = serviceAccount.Name
 			// The readyz port as string type is expected to be convertible into int!!!
 			readyzPort, err := strconv.Atoi(c.readyzPort)
 			if err != nil {
@@ -362,6 +404,10 @@ func (c *GuardController) sync(ctx context.Context, syncCtx factory.SyncContext)
 				}
 				if actual.Status.Phase != "" && actual.Status.Phase != corev1.PodPending && actual.Status.Phase != corev1.PodRunning {
 					klog.V(5).Infof("Pod phase is neither pending nor running, deleting %v so the guard can be re-created", pod.Name)
+					delete = true
+				}
+				if actual.Spec.ServiceAccountName != pod.Spec.ServiceAccountName {
+					klog.V(5).Infof("Service Account changed, deleting %v so the guard can be re-created", pod.Name)
 					delete = true
 				}
 				if delete {

--- a/pkg/operator/staticpod/controller/guard/guard_controller_test.go
+++ b/pkg/operator/staticpod/controller/guard/guard_controller_test.go
@@ -9,6 +9,7 @@ import (
 	clocktesting "k8s.io/utils/clock/testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -270,8 +271,10 @@ func TestRenderGuardPod(t *testing.T) {
 		node                  *corev1.Node
 		guardExists           bool
 		guardPod              *corev1.Pod
+		guardServiceAccount   *corev1.ServiceAccount
 		createConditionalFunc func() (bool, bool, error)
 		withArbiter           bool
+		expectSADeleted       bool
 	}{
 		{
 			name: "Operand pod missing",
@@ -400,6 +403,7 @@ func TestRenderGuardPod(t *testing.T) {
 					ControlPlaneTopology: configv1.HighlyAvailableTopologyMode,
 				},
 			},
+			expectSADeleted: true,
 			operandPod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "operand1",
@@ -427,6 +431,13 @@ func TestRenderGuardPod(t *testing.T) {
 					PodIP: "1.1.1.1",
 				},
 			},
+			guardServiceAccount: &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "guard-sa",
+					Namespace: "test",
+					Labels:    map[string]string{"app": "guard"},
+				},
+			},
 			node: fakeMasterNode("master1"),
 		},
 		{
@@ -439,6 +450,7 @@ func TestRenderGuardPod(t *testing.T) {
 					ControlPlaneTopology: configv1.TopologyMode("HighlyAvailableArbiter"),
 				},
 			},
+			expectSADeleted: true,
 			operandPod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "operand1",
@@ -464,6 +476,13 @@ func TestRenderGuardPod(t *testing.T) {
 				},
 				Status: corev1.PodStatus{
 					PodIP: "1.1.1.1",
+				},
+			},
+			guardServiceAccount: &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "guard-sa",
+					Namespace: "test",
+					Labels:    map[string]string{"app": "guard"},
 				},
 			},
 			//createConditionalFunc: func() (bool, bool, error) { return true, true, nil },
@@ -522,6 +541,13 @@ func TestRenderGuardPod(t *testing.T) {
 					Phase: corev1.PodSucceeded,
 				},
 			},
+			guardServiceAccount: &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "guard-sa",
+					Namespace: "test",
+					Labels:    map[string]string{"app": "guard"},
+				},
+			},
 			node:        fakeMasterNode("master1"),
 			guardExists: true,
 		},
@@ -574,6 +600,13 @@ func TestRenderGuardPod(t *testing.T) {
 					Phase: corev1.PodSucceeded,
 				},
 			},
+			guardServiceAccount: &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "guard-sa",
+					Namespace: "test",
+					Labels:    map[string]string{"app": "guard"},
+				},
+			},
 			createConditionalFunc: func() (bool, bool, error) { return true, true, nil },
 			node:                  fakeArbiterNode("arbiter"),
 			guardExists:           true,
@@ -622,6 +655,9 @@ func TestRenderGuardPod(t *testing.T) {
 			if test.guardPod != nil {
 				kubeClient.Tracker().Add(test.guardPod)
 			}
+			if test.guardServiceAccount != nil {
+				kubeClient.Tracker().Add(test.guardServiceAccount)
+			}
 			kubeInformers := informers.NewSharedInformerFactoryWithOptions(kubeClient, 1*time.Minute)
 			eventRecorder := events.NewRecorder(kubeClient.CoreV1().Events("test"), "test-operator", &corev1.ObjectReference{}, clocktesting.NewFakePassiveClock(time.Now()))
 
@@ -651,6 +687,8 @@ func TestRenderGuardPod(t *testing.T) {
 				podGetter:               kubeClient.CoreV1(),
 				pdbGetter:               kubeClient.PolicyV1(),
 				pdbLister:               kubeInformers.Policy().V1().PodDisruptionBudgets().Lister(),
+				saGetter:                kubeClient.CoreV1(),
+				saLister:                kubeInformers.Core().V1().ServiceAccounts().Lister(),
 				installerPodImageFn:     getInstallerPodImageFromEnv,
 				createConditionalFunc:   createConditionalFunc,
 			}
@@ -696,11 +734,27 @@ func TestRenderGuardPod(t *testing.T) {
 						if p.Status.Phase != "" {
 							t.Errorf("%s: unexpected pod status: %v, expected no status set", test.name, p.Status.Phase)
 						}
+						// check to ensure service account is created for pod.
+						expectedSAName := "guard-sa"
+						if p.Spec.ServiceAccountName != expectedSAName {
+							t.Errorf("%s: expected ServiceAccountName %q, got %q", test.name, expectedSAName, p.Spec.ServiceAccountName)
+						}
+						_, saErr := kubeClient.CoreV1().ServiceAccounts("test").Get(ctx, expectedSAName, metav1.GetOptions{})
+						if saErr != nil {
+							t.Errorf("%s: expected ServiceAccount %q to exist, got error instead: %q", test.name, expectedSAName, saErr)
+						}
 					}
 				} else {
 					_, err := kubeClient.CoreV1().Pods("test").Get(ctx, getGuardPodName("operand", "master1"), metav1.GetOptions{})
 					if !apierrors.IsNotFound(err) {
 						t.Errorf("%s: expected 'pods \"%v\" not found' error, got %q instead", test.name, getGuardPodName("operand", "master1"), err)
+					}
+					// verify service account deletion based on expectSADeleted flag
+					if test.expectSADeleted {
+						_, err = kubeClient.CoreV1().ServiceAccounts("test").Get(ctx, "guard-sa", metav1.GetOptions{})
+						if !apierrors.IsNotFound(err) {
+							t.Errorf("%s: expected 'service account \"guard-sa\" not found' error, but got %q instead", test.name, err)
+						}
 					}
 				}
 			}
@@ -759,13 +813,20 @@ func TestRenderGuardPodPortChanged(t *testing.T) {
 			PodIP: "1.1.1.1",
 		},
 	}
+	guardServiceAccount := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "guard-sa",
+			Namespace: "test",
+			Labels:    map[string]string{"app": "guard"},
+		},
+	}
 
 	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
 	if err := indexer.Add(infraObject); err != nil {
 		t.Fatal(err.Error())
 	}
 
-	kubeClient := fake.NewSimpleClientset(fakeMasterNode("master1"), operandPod, guardPod)
+	kubeClient := fake.NewSimpleClientset(fakeMasterNode("master1"), operandPod, guardPod, guardServiceAccount)
 	kubeInformers := informers.NewSharedInformerFactoryWithOptions(kubeClient, 1*time.Minute)
 	eventRecorder := events.NewRecorder(kubeClient.CoreV1().Events("test"), "test-operator", &corev1.ObjectReference{}, clocktesting.NewFakePassiveClock(time.Now()))
 
@@ -791,6 +852,8 @@ func TestRenderGuardPodPortChanged(t *testing.T) {
 		podGetter:               kubeClient.CoreV1(),
 		pdbGetter:               kubeClient.PolicyV1(),
 		pdbLister:               kubeInformers.Policy().V1().PodDisruptionBudgets().Lister(),
+		saGetter:                kubeClient.CoreV1(),
+		saLister:                kubeInformers.Core().V1().ServiceAccounts().Lister(),
 		installerPodImageFn:     getInstallerPodImageFromEnv,
 		createConditionalFunc:   staticcontrollercommon.NewIsSingleNodePlatformFn(informer),
 	}
@@ -872,6 +935,27 @@ func TestGuardPodTemplate(t *testing.T) {
 				t.Error(err)
 			}
 		})
+	}
+}
+
+func TestGuardServiceAccountManifestStability(t *testing.T) {
+	sa := resourceread.ReadServiceAccountV1OrDie(serviceAccountTemplate)
+
+	expected := &corev1.ServiceAccount{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ServiceAccount",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "guard-sa",
+			Labels: map[string]string{"app": "guard"},
+		},
+	}
+
+	if !equality.Semantic.DeepEqual(sa, expected) {
+		t.Fatalf("guard-pod-sa.yaml manifest has changed. " +
+			"The controller only creates the SA, it does not update existing ones. " +
+			"If the manifest changed, add update logic and update the expected value in this test.")
 	}
 }
 

--- a/pkg/operator/staticpod/controller/guard/manifests/guard-pod-sa.yaml
+++ b/pkg/operator/staticpod/controller/guard/manifests/guard-pod-sa.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: # Value set by operator
+  name: guard-sa
+  labels:
+    app: guard

--- a/pkg/operator/staticpod/controller/guard/manifests/guard-pod.yaml
+++ b/pkg/operator/staticpod/controller/guard/manifests/guard-pod.yaml
@@ -9,6 +9,8 @@ metadata:
     app: guard
   ownerReferences: # Value set by operator
 spec:
+  serviceAccountName: # Value set by operator
+  automountServiceAccountToken: false
   affinity: # Value set by operator
   priorityClassName: "system-cluster-critical"
   terminationGracePeriodSeconds: 3

--- a/pkg/operator/staticpod/controllers.go
+++ b/pkg/operator/staticpod/controllers.go
@@ -242,6 +242,7 @@ func (b *staticPodOperatorControllerBuilder) ToControllers() (manager.Controller
 	podClient := b.kubeClient.CoreV1()
 	eventsClient := b.kubeClient.CoreV1()
 	pdbClient := b.kubeClient.PolicyV1()
+	saClient := b.kubeClient.CoreV1()
 	operandInformers := b.kubeNamespaceInformers.InformersFor(b.operandNamespace)
 	clusterInformers := b.kubeClusterInformers
 	infraInformers := b.configInformers.Config().V1().Infrastructures()
@@ -398,6 +399,7 @@ func (b *staticPodOperatorControllerBuilder) ToControllers() (manager.Controller
 			b.staticPodOperatorClient,
 			podClient,
 			pdbClient,
+			saClient,
 			eventRecorder,
 			b.guardCreateConditionalFunc,
 			b.extraNodeSelector,


### PR DESCRIPTION
This change adds a bespoke service account to the guard pod. It also handles service account cleanup, and includes additional fields in tests and basic service account testing.

The reason for the change is that we should opt to use a bespoke service account rather than default. 