### PR TITLE
OCPBUGS-38662: node controller: Don't degrade when node is upgrading

### DIFF
--- a/pkg/operator/staticpod/controller/node/node_controller.go
+++ b/pkg/operator/staticpod/controller/node/node_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	coreapiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -19,18 +20,34 @@ import (
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
 
+// DefaultRebootingNodeDegradedInertia is the default period during which a node rebooting for upgrade is not considered Degraded.
+// The value is pretty large because bare metal nodes can take a long time to reboot for upgrade.
+const DefaultRebootingNodeDegradedInertia = 2 * time.Hour
+
 const (
 	machineConfigDaemonPostConfigAction = "machineconfiguration.openshift.io/post-config-action"
-	machineConfigDaemonStateRebooting   = "Rebooting"
+
+	machineConfigDaemonStateRebooting = "Rebooting"
 )
+
+// NodeControllerOption can be passed to NewNodeController to configure the controller.
+type NodeControllerOption func(*NodeController)
+
+// SetRebootingNodeDegradedInertia sets the period during which a node rebooting for upgrade is not considered Degraded.
+func SetRebootingNodeDegradedInertia(inert time.Duration) NodeControllerOption {
+	return func(c *NodeController) {
+		c.rebootingNodeDegradedInertia = inert
+	}
+}
 
 // NodeController watches for new master nodes and adds them to the node status list in the operator config status.
 type NodeController struct {
-	controllerInstanceName string
-	operatorClient         v1helpers.StaticPodOperatorClient
-	nodeLister             corelisterv1.NodeLister
-	extraNodeSelector      labels.Selector
-	masterNodesSelector    labels.Selector
+	controllerInstanceName       string
+	operatorClient               v1helpers.StaticPodOperatorClient
+	nodeLister                   corelisterv1.NodeLister
+	extraNodeSelector            labels.Selector
+	masterNodesSelector          labels.Selector
+	rebootingNodeDegradedInertia time.Duration
 }
 
 // NewNodeController creates a new node controller.
@@ -40,12 +57,17 @@ func NewNodeController(
 	kubeInformersClusterScoped informers.SharedInformerFactory,
 	eventRecorder events.Recorder,
 	extraNodeSelector labels.Selector,
+	options ...NodeControllerOption,
 ) factory.Controller {
 	c := &NodeController{
-		controllerInstanceName: factory.ControllerInstanceName(instanceName, "Node"),
-		operatorClient:         operatorClient,
-		nodeLister:             kubeInformersClusterScoped.Core().V1().Nodes().Lister(),
-		extraNodeSelector:      extraNodeSelector,
+		controllerInstanceName:       factory.ControllerInstanceName(instanceName, "Node"),
+		operatorClient:               operatorClient,
+		nodeLister:                   kubeInformersClusterScoped.Core().V1().Nodes().Lister(),
+		extraNodeSelector:            extraNodeSelector,
+		rebootingNodeDegradedInertia: DefaultRebootingNodeDegradedInertia,
+	}
+	for _, opt := range options {
+		opt(c)
 	}
 
 	masterNodesSelector, err := labels.Parse("node-role.kubernetes.io/master=")
@@ -151,47 +173,54 @@ func (c *NodeController) sync(ctx context.Context, syncCtx factory.SyncContext) 
 	}
 
 	// Detect and report master nodes that are not ready.
-	// Nodes currently rebooting for upgrade do not cause Degraded condition to be set.
-	var notReadyNodes []string
-	var notReadyRebootingNodes []string
+	// Nodes currently rebooting for upgrade do not cause Degraded condition to be set within the inertia period.
+	var degradedNodes []string
+	var rebootingNodes []string
 	for _, node := range nodes {
 		nodeReadyCondition := nodeConditionFinder(&node.Status, coreapiv1.NodeReady)
 
-		// If a "Ready" condition is not found, that node should be deemed as not Ready by default.
-		var notReady bool
+		var degradedMsg string
 		switch {
 		case nodeReadyCondition == nil:
-			notReadyNodes = append(notReadyNodes, fmt.Sprintf("node %q not ready, no Ready condition found in status block", node.Name))
-			notReady = true
+			// If a "Ready" condition is not found, that node should be deemed as not Ready by default.
+			degradedMsg = fmt.Sprintf("node %q not ready, no Ready condition found in status block", node.Name)
 
 		case nodeReadyCondition.Status != coreapiv1.ConditionTrue:
-			notReadyNodes = append(notReadyNodes, fmt.Sprintf("node %q not ready since %s because %s (%s)", node.Name, nodeReadyCondition.LastTransitionTime, nodeReadyCondition.Reason, nodeReadyCondition.Message))
-			notReady = true
+			degradedMsg = fmt.Sprintf("node %q not ready since %s because %s (%s)", node.Name, nodeReadyCondition.LastTransitionTime, nodeReadyCondition.Reason, nodeReadyCondition.Message)
 		}
-		if notReady && nodeRebootingForUpgrade(node) {
-			notReadyRebootingNodes = append(notReadyRebootingNodes, node.Name)
+		if len(degradedMsg) > 0 {
+			if nodeRebootingForUpgrade(node) && !shouldDegradeRebootingNode(nodeReadyCondition, c.rebootingNodeDegradedInertia) {
+				rebootingNodes = append(rebootingNodes, fmt.Sprintf("node %q", node.Name))
+			} else {
+				degradedNodes = append(degradedNodes, degradedMsg)
+			}
 		}
 	}
 
-	switch {
-	case len(notReadyNodes) > len(notReadyRebootingNodes):
-		degradedCondition = degradedCondition.
-			WithStatus(operatorv1.ConditionTrue).
-			WithReason("MasterNodesReady").
-			WithMessage(fmt.Sprintf("The master nodes not ready: %s", strings.Join(notReadyNodes, ", ")))
+	degradedCondition = degradedCondition.WithReason("MasterNodesReady")
 
-	case len(notReadyRebootingNodes) > 0:
-		degradedCondition = degradedCondition.
-			WithStatus(operatorv1.ConditionFalse).
-			WithReason("MasterNodesReady").
-			WithMessage(fmt.Sprintf("The master nodes rebooting for upgrade: %s", strings.Join(notReadyRebootingNodes, ", ")))
-
-	default:
-		degradedCondition = degradedCondition.
-			WithStatus(operatorv1.ConditionFalse).
-			WithReason("MasterNodesReady").
-			WithMessage("All master nodes are ready")
+	if len(degradedNodes) > 0 {
+		degradedCondition = degradedCondition.WithStatus(operatorv1.ConditionTrue)
+	} else {
+		degradedCondition = degradedCondition.WithStatus(operatorv1.ConditionFalse)
 	}
+
+	var msg strings.Builder
+	if len(degradedNodes) > 0 {
+		msg.WriteString(fmt.Sprintf("The master nodes not ready: %s", strings.Join(degradedNodes, ", ")))
+	}
+	if len(rebootingNodes) > 0 {
+		if msg.Len() > 0 {
+			msg.WriteString(". ")
+		}
+		msg.WriteString(fmt.Sprintf("The master nodes rebooting for upgrade: %s", strings.Join(rebootingNodes, ", ")))
+	}
+	if msg.Len() > 0 {
+		degradedCondition = degradedCondition.WithMessage(msg.String())
+	} else {
+		degradedCondition = degradedCondition.WithMessage("All master nodes are ready")
+	}
+
 	status := applyoperatorv1.StaticPodOperatorStatus().
 		WithConditions(degradedCondition).
 		WithNodeStatuses(newTargetNodeStates...)
@@ -219,4 +248,8 @@ func nodeConditionFinder(status *coreapiv1.NodeStatus, condType coreapiv1.NodeCo
 
 func nodeRebootingForUpgrade(node *coreapiv1.Node) bool {
 	return node.Annotations[machineConfigDaemonPostConfigAction] == machineConfigDaemonStateRebooting
+}
+
+func shouldDegradeRebootingNode(nodeReadyCondition *coreapiv1.NodeCondition, inert time.Duration) bool {
+	return nodeReadyCondition == nil || time.Since(nodeReadyCondition.LastTransitionTime.Time) > inert
 }

--- a/pkg/operator/staticpod/controller/node/node_controller.go
+++ b/pkg/operator/staticpod/controller/node/node_controller.go
@@ -20,14 +20,14 @@ import (
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
 
-// DefaultUpgradingNodeDegradedInertia is the default period during which a node rebooting for upgrade is not considered Degraded.
+// DefaultUpgradingNodeDegradedInertia is the default period during which a node upgrading is not considered Degraded.
 // The value is pretty large because bare metal nodes can take a long time to reboot for upgrade.
 const DefaultUpgradingNodeDegradedInertia = 2 * time.Hour
 
 // NodeControllerOption can be passed to NewNodeController to configure the controller.
 type NodeControllerOption func(*NodeController)
 
-// SetUpgradingNodeDegradedInertia sets the period during which a node rebooting for upgrade is not considered Degraded.
+// SetUpgradingNodeDegradedInertia sets the period during which a node upgrading is not considered Degraded.
 func SetUpgradingNodeDegradedInertia(inert time.Duration) NodeControllerOption {
 	return func(c *NodeController) {
 		c.rebootingNodeDegradedInertia = inert
@@ -167,9 +167,9 @@ func (c *NodeController) sync(ctx context.Context, syncCtx factory.SyncContext) 
 	}
 
 	// Detect and report master nodes that are not ready.
-	// Nodes currently rebooting for upgrade do not cause Degraded condition to be set within the inertia period.
+	// Nodes currently upgrading do not cause Degraded condition to be set within the inertia period.
 	var degradedNodes []string
-	var rebootingNodes []string
+	var upgradingNodes []string
 	for _, node := range nodes {
 		nodeReadyCondition := nodeConditionFinder(&node.Status, coreapiv1.NodeReady)
 
@@ -184,7 +184,7 @@ func (c *NodeController) sync(ctx context.Context, syncCtx factory.SyncContext) 
 		}
 		if len(degradedMsg) > 0 {
 			if nodeUpgrading(node) && !shouldDegradeUpgradingNode(nodeReadyCondition, c.rebootingNodeDegradedInertia) {
-				rebootingNodes = append(rebootingNodes, fmt.Sprintf("node %q", node.Name))
+				upgradingNodes = append(upgradingNodes, fmt.Sprintf("node %q", node.Name))
 			} else {
 				degradedNodes = append(degradedNodes, degradedMsg)
 			}
@@ -203,11 +203,11 @@ func (c *NodeController) sync(ctx context.Context, syncCtx factory.SyncContext) 
 	if len(degradedNodes) > 0 {
 		msg.WriteString(fmt.Sprintf("The master nodes not ready: %s", strings.Join(degradedNodes, ", ")))
 	}
-	if len(rebootingNodes) > 0 {
+	if len(upgradingNodes) > 0 {
 		if msg.Len() > 0 {
 			msg.WriteString(". ")
 		}
-		msg.WriteString(fmt.Sprintf("The master nodes rebooting for upgrade: %s", strings.Join(rebootingNodes, ", ")))
+		msg.WriteString(fmt.Sprintf("The master nodes upgrading: %s", strings.Join(upgradingNodes, ", ")))
 	}
 	if msg.Len() > 0 {
 		degradedCondition = degradedCondition.WithMessage(msg.String())

--- a/pkg/operator/staticpod/controller/node/node_controller.go
+++ b/pkg/operator/staticpod/controller/node/node_controller.go
@@ -20,21 +20,15 @@ import (
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
 
-// DefaultRebootingNodeDegradedInertia is the default period during which a node rebooting for upgrade is not considered Degraded.
+// DefaultUpgradingNodeDegradedInertia is the default period during which a node rebooting for upgrade is not considered Degraded.
 // The value is pretty large because bare metal nodes can take a long time to reboot for upgrade.
-const DefaultRebootingNodeDegradedInertia = 2 * time.Hour
-
-const (
-	machineConfigDaemonPostConfigAction = "machineconfiguration.openshift.io/post-config-action"
-
-	machineConfigDaemonStateRebooting = "Rebooting"
-)
+const DefaultUpgradingNodeDegradedInertia = 2 * time.Hour
 
 // NodeControllerOption can be passed to NewNodeController to configure the controller.
 type NodeControllerOption func(*NodeController)
 
-// SetRebootingNodeDegradedInertia sets the period during which a node rebooting for upgrade is not considered Degraded.
-func SetRebootingNodeDegradedInertia(inert time.Duration) NodeControllerOption {
+// SetUpgradingNodeDegradedInertia sets the period during which a node rebooting for upgrade is not considered Degraded.
+func SetUpgradingNodeDegradedInertia(inert time.Duration) NodeControllerOption {
 	return func(c *NodeController) {
 		c.rebootingNodeDegradedInertia = inert
 	}
@@ -64,7 +58,7 @@ func NewNodeController(
 		operatorClient:               operatorClient,
 		nodeLister:                   kubeInformersClusterScoped.Core().V1().Nodes().Lister(),
 		extraNodeSelector:            extraNodeSelector,
-		rebootingNodeDegradedInertia: DefaultRebootingNodeDegradedInertia,
+		rebootingNodeDegradedInertia: DefaultUpgradingNodeDegradedInertia,
 	}
 	for _, opt := range options {
 		opt(c)
@@ -189,7 +183,7 @@ func (c *NodeController) sync(ctx context.Context, syncCtx factory.SyncContext) 
 			degradedMsg = fmt.Sprintf("node %q not ready since %s because %s (%s)", node.Name, nodeReadyCondition.LastTransitionTime, nodeReadyCondition.Reason, nodeReadyCondition.Message)
 		}
 		if len(degradedMsg) > 0 {
-			if nodeRebootingForUpgrade(node) && !shouldDegradeRebootingNode(nodeReadyCondition, c.rebootingNodeDegradedInertia) {
+			if nodeUpgrading(node) && !shouldDegradeUpgradingNode(nodeReadyCondition, c.rebootingNodeDegradedInertia) {
 				rebootingNodes = append(rebootingNodes, fmt.Sprintf("node %q", node.Name))
 			} else {
 				degradedNodes = append(degradedNodes, degradedMsg)
@@ -246,10 +240,14 @@ func nodeConditionFinder(status *coreapiv1.NodeStatus, condType coreapiv1.NodeCo
 	return nil
 }
 
-func nodeRebootingForUpgrade(node *coreapiv1.Node) bool {
-	return node.Annotations[machineConfigDaemonPostConfigAction] == machineConfigDaemonStateRebooting
+func nodeUpgrading(node *coreapiv1.Node) bool {
+	stat := GetNodeUpgradeState(node)
+	// The most narrow and robust time window we can use is
+	//   - Rebooting when available.
+	//   - Working otherwise. This explicitly does not include Draining.
+	return stat == NodeUpgradeStateRebooting || stat == NodeUpgradeStateWorking
 }
 
-func shouldDegradeRebootingNode(nodeReadyCondition *coreapiv1.NodeCondition, inert time.Duration) bool {
+func shouldDegradeUpgradingNode(nodeReadyCondition *coreapiv1.NodeCondition, inert time.Duration) bool {
 	return nodeReadyCondition == nil || time.Since(nodeReadyCondition.LastTransitionTime.Time) > inert
 }

--- a/pkg/operator/staticpod/controller/node/node_controller_test.go
+++ b/pkg/operator/staticpod/controller/node/node_controller_test.go
@@ -51,7 +51,11 @@ func masterNodesSelector(t *testing.T) labels.Selector {
 }
 
 func makeNodeNotReady(node *corev1.Node) *corev1.Node {
-	return addNodeReadyCondition(node, corev1.ConditionFalse)
+	return makeNodeNotReadyAt(node, time.Date(2018, 01, 12, 22, 51, 48, 324359102, time.UTC))
+}
+
+func makeNodeNotReadyAt(node *corev1.Node, transitionTimestamp time.Time) *corev1.Node {
+	return addNodeReadyCondition(node, corev1.ConditionFalse, transitionTimestamp)
 }
 
 func makeNodeRebooting(node *corev1.Node) *corev1.Node {
@@ -63,16 +67,20 @@ func makeNodeRebooting(node *corev1.Node) *corev1.Node {
 }
 
 func makeNodeReady(node *corev1.Node) *corev1.Node {
-	return addNodeReadyCondition(node, corev1.ConditionTrue)
+	return makeNodeReadyAt(node, time.Date(2018, 01, 12, 22, 51, 48, 324359102, time.UTC))
 }
 
-func addNodeReadyCondition(node *corev1.Node, status corev1.ConditionStatus) *corev1.Node {
+func makeNodeReadyAt(node *corev1.Node, transitionTimestamp time.Time) *corev1.Node {
+	return addNodeReadyCondition(node, corev1.ConditionTrue, transitionTimestamp)
+}
+
+func addNodeReadyCondition(node *corev1.Node, status corev1.ConditionStatus, lastTransitionTime time.Time) *corev1.Node {
 	con := corev1.NodeCondition{}
 	con.Type = corev1.NodeReady
 	con.Status = status
 	con.Reason = "TestReason"
 	con.Message = "test message"
-	con.LastTransitionTime = metav1.Time{Time: time.Date(2018, 01, 12, 22, 51, 48, 324359102, time.UTC)}
+	con.LastTransitionTime = metav1.Time{Time: lastTransitionTime}
 	node.Status.Conditions = append(node.Status.Conditions, con)
 	return node
 }
@@ -501,7 +509,23 @@ func TestNodeControllerDegradedConditionType(t *testing.T) {
 			},
 		},
 		{
-			name: "scenario 13: one unhealthy but rebooting master node is reported",
+			name: "scenario 13: one unhealthy but rebooting master node is reported (within inertia)",
+			masterNodes: []runtime.Object{
+				makeNodeRebooting(makeNodeNotReadyAt(fakeMasterNode("test-node-1"), time.Now().Add(-DefaultRebootingNodeDegradedInertia+1*time.Minute))),
+				makeNodeReady(fakeMasterNode("test-node-2")),
+			},
+			verifyNodeStatus: func(conditions []operatorv1.OperatorCondition) error {
+				var expectedCondition operatorv1.OperatorCondition
+				expectedCondition.Type = condition.NodeControllerDegradedConditionType
+				expectedCondition.Reason = "MasterNodesReady"
+				expectedCondition.Status = operatorv1.ConditionFalse
+				expectedCondition.Message = `The master nodes rebooting for upgrade: node "test-node-1"`
+
+				return validateNodeControllerDegradedCondition(conditions, expectedCondition)
+			},
+		},
+		{
+			name: "scenario 14: one unhealthy but rebooting master node is reported (inertia expired)",
 			masterNodes: []runtime.Object{
 				makeNodeRebooting(makeNodeNotReady(fakeMasterNode("test-node-1"))),
 				makeNodeReady(fakeMasterNode("test-node-2")),
@@ -510,14 +534,14 @@ func TestNodeControllerDegradedConditionType(t *testing.T) {
 				var expectedCondition operatorv1.OperatorCondition
 				expectedCondition.Type = condition.NodeControllerDegradedConditionType
 				expectedCondition.Reason = "MasterNodesReady"
-				expectedCondition.Status = operatorv1.ConditionFalse
-				expectedCondition.Message = `The master nodes rebooting for upgrade: test-node-1`
+				expectedCondition.Status = operatorv1.ConditionTrue
+				expectedCondition.Message = `The master nodes not ready: node "test-node-1" not ready since 2018-01-12 22:51:48.324359102 +0000 UTC because TestReason (test message)`
 
 				return validateNodeControllerDegradedCondition(conditions, expectedCondition)
 			},
 		},
 		{
-			name: "scenario 14: one healthy but rebooting master node is reported",
+			name: "scenario 15: one healthy but rebooting master node is reported",
 			masterNodes: []runtime.Object{
 				makeNodeRebooting(makeNodeReady(fakeMasterNode("test-node-1"))),
 				makeNodeReady(fakeMasterNode("test-node-2")),
@@ -528,6 +552,45 @@ func TestNodeControllerDegradedConditionType(t *testing.T) {
 				expectedCondition.Reason = "MasterNodesReady"
 				expectedCondition.Status = operatorv1.ConditionFalse
 				expectedCondition.Message = `All master nodes are ready`
+
+				return validateNodeControllerDegradedCondition(conditions, expectedCondition)
+			},
+		},
+		{
+			name: "scenario 16: mixed state nodes cause Degraded to be reported",
+			masterNodes: []runtime.Object{
+				// 2 ready
+				makeNodeReady(fakeMasterNode("test-node-1")),
+				makeNodeReady(fakeMasterNode("test-node-2")),
+				// 1 not ready
+				makeNodeNotReady(fakeMasterNode("test-node-3")),
+				// 1 rebooting with Degraded inertia expired
+				makeNodeRebooting(makeNodeNotReady(fakeMasterNode("test-node-4"))),
+				// 1 rebooting within inertia
+				makeNodeRebooting(makeNodeNotReadyAt(fakeMasterNode("test-node-5"), time.Now().Add(-DefaultRebootingNodeDegradedInertia+1*time.Minute))),
+			},
+			verifyNodeStatus: func(conditions []operatorv1.OperatorCondition) error {
+				var expectedCondition operatorv1.OperatorCondition
+				expectedCondition.Type = condition.NodeControllerDegradedConditionType
+				expectedCondition.Reason = "MasterNodesReady"
+				expectedCondition.Status = operatorv1.ConditionTrue
+				expectedCondition.Message = `The master nodes not ready: node "test-node-3" not ready since 2018-01-12 22:51:48.324359102 +0000 UTC because TestReason (test message), node "test-node-4" not ready since 2018-01-12 22:51:48.324359102 +0000 UTC because TestReason (test message). The master nodes rebooting for upgrade: node "test-node-5"`
+
+				return validateNodeControllerDegradedCondition(conditions, expectedCondition)
+			},
+		},
+		{
+			name: "scenario 17: one rebooting master node missing the condition reported",
+			masterNodes: []runtime.Object{
+				makeNodeReady(fakeMasterNode("test-node-1")),
+				makeNodeRebooting(fakeMasterNode("test-node-2")),
+			},
+			verifyNodeStatus: func(conditions []operatorv1.OperatorCondition) error {
+				var expectedCondition operatorv1.OperatorCondition
+				expectedCondition.Type = condition.NodeControllerDegradedConditionType
+				expectedCondition.Reason = "MasterNodesReady"
+				expectedCondition.Status = operatorv1.ConditionTrue
+				expectedCondition.Message = `The master nodes not ready: node "test-node-2" not ready, no Ready condition found in status block`
 
 				return validateNodeControllerDegradedCondition(conditions, expectedCondition)
 			},
@@ -562,9 +625,10 @@ func TestNodeControllerDegradedConditionType(t *testing.T) {
 			eventRecorder := events.NewRecorder(kubeClient.CoreV1().Events("test"), "test-operator", &corev1.ObjectReference{}, clocktesting.NewFakePassiveClock(time.Now()))
 
 			c := &NodeController{
-				operatorClient:      fakeStaticPodOperatorClient,
-				nodeLister:          fakeLister,
-				masterNodesSelector: masterNodesSelector(t),
+				operatorClient:               fakeStaticPodOperatorClient,
+				nodeLister:                   fakeLister,
+				masterNodesSelector:          masterNodesSelector(t),
+				rebootingNodeDegradedInertia: DefaultRebootingNodeDegradedInertia,
 			}
 
 			if scenario.withArbiter {

--- a/pkg/operator/staticpod/controller/node/node_controller_test.go
+++ b/pkg/operator/staticpod/controller/node/node_controller_test.go
@@ -62,7 +62,8 @@ func makeNodeRebooting(node *corev1.Node) *corev1.Node {
 	if node.Annotations == nil {
 		node.Annotations = map[string]string{}
 	}
-	node.Annotations[machineConfigDaemonPostConfigAction] = machineConfigDaemonStateRebooting
+	node.Annotations[machineConfigState] = machineConfigStateWorking
+	node.Annotations[machineConfigPostConfigAction] = machineConfigPostConfigAction
 	return node
 }
 
@@ -511,7 +512,7 @@ func TestNodeControllerDegradedConditionType(t *testing.T) {
 		{
 			name: "scenario 13: one unhealthy but rebooting master node is reported (within inertia)",
 			masterNodes: []runtime.Object{
-				makeNodeRebooting(makeNodeNotReadyAt(fakeMasterNode("test-node-1"), time.Now().Add(-DefaultRebootingNodeDegradedInertia+1*time.Minute))),
+				makeNodeRebooting(makeNodeNotReadyAt(fakeMasterNode("test-node-1"), time.Now().Add(-DefaultUpgradingNodeDegradedInertia+1*time.Minute))),
 				makeNodeReady(fakeMasterNode("test-node-2")),
 			},
 			verifyNodeStatus: func(conditions []operatorv1.OperatorCondition) error {
@@ -567,7 +568,7 @@ func TestNodeControllerDegradedConditionType(t *testing.T) {
 				// 1 rebooting with Degraded inertia expired
 				makeNodeRebooting(makeNodeNotReady(fakeMasterNode("test-node-4"))),
 				// 1 rebooting within inertia
-				makeNodeRebooting(makeNodeNotReadyAt(fakeMasterNode("test-node-5"), time.Now().Add(-DefaultRebootingNodeDegradedInertia+1*time.Minute))),
+				makeNodeRebooting(makeNodeNotReadyAt(fakeMasterNode("test-node-5"), time.Now().Add(-DefaultUpgradingNodeDegradedInertia+1*time.Minute))),
 			},
 			verifyNodeStatus: func(conditions []operatorv1.OperatorCondition) error {
 				var expectedCondition operatorv1.OperatorCondition
@@ -628,7 +629,7 @@ func TestNodeControllerDegradedConditionType(t *testing.T) {
 				operatorClient:               fakeStaticPodOperatorClient,
 				nodeLister:                   fakeLister,
 				masterNodesSelector:          masterNodesSelector(t),
-				rebootingNodeDegradedInertia: DefaultRebootingNodeDegradedInertia,
+				rebootingNodeDegradedInertia: DefaultUpgradingNodeDegradedInertia,
 			}
 
 			if scenario.withArbiter {

--- a/pkg/operator/staticpod/controller/node/node_controller_test.go
+++ b/pkg/operator/staticpod/controller/node/node_controller_test.go
@@ -77,6 +77,15 @@ func makeNodeDraining(node *corev1.Node) *corev1.Node {
 	return node
 }
 
+func makeNodeWorking(node *corev1.Node) *corev1.Node {
+	if node.Annotations == nil {
+		node.Annotations = map[string]string{}
+	}
+	node.Annotations[machineConfigState] = machineConfigStateWorking
+	// No post-config-action and no drain annotations = plain Working state
+	return node
+}
+
 func makeNodeReady(node *corev1.Node) *corev1.Node {
 	return makeNodeReadyAt(node, time.Date(2018, 01, 12, 22, 51, 48, 324359102, time.UTC))
 }
@@ -655,7 +664,71 @@ func TestNodeControllerDegradedConditionType(t *testing.T) {
 			},
 		},
 		{
-			name: "scenario 21: mixed draining and rebooting nodes",
+			name: "scenario 21: one unhealthy but working master node is reported (within inertia)",
+			masterNodes: []runtime.Object{
+				makeNodeWorking(makeNodeNotReadyAt(fakeMasterNode("test-node-1"), time.Now().Add(-DefaultUpgradingNodeDegradedInertia+1*time.Minute))),
+				makeNodeReady(fakeMasterNode("test-node-2")),
+			},
+			verifyNodeStatus: func(conditions []operatorv1.OperatorCondition) error {
+				var expectedCondition operatorv1.OperatorCondition
+				expectedCondition.Type = condition.NodeControllerDegradedConditionType
+				expectedCondition.Reason = "MasterNodesReady"
+				expectedCondition.Status = operatorv1.ConditionFalse
+				expectedCondition.Message = `The master nodes upgrading: node "test-node-1"`
+
+				return validateNodeControllerDegradedCondition(conditions, expectedCondition)
+			},
+		},
+		{
+			name: "scenario 22: one unhealthy but working master node is reported (inertia expired)",
+			masterNodes: []runtime.Object{
+				makeNodeWorking(makeNodeNotReady(fakeMasterNode("test-node-1"))),
+				makeNodeReady(fakeMasterNode("test-node-2")),
+			},
+			verifyNodeStatus: func(conditions []operatorv1.OperatorCondition) error {
+				var expectedCondition operatorv1.OperatorCondition
+				expectedCondition.Type = condition.NodeControllerDegradedConditionType
+				expectedCondition.Reason = "MasterNodesReady"
+				expectedCondition.Status = operatorv1.ConditionTrue
+				expectedCondition.Message = `The master nodes not ready: node "test-node-1" not ready since 2018-01-12 22:51:48.324359102 +0000 UTC because TestReason (test message)`
+
+				return validateNodeControllerDegradedCondition(conditions, expectedCondition)
+			},
+		},
+		{
+			name: "scenario 23: one healthy but working master node is reported",
+			masterNodes: []runtime.Object{
+				makeNodeWorking(makeNodeReady(fakeMasterNode("test-node-1"))),
+				makeNodeReady(fakeMasterNode("test-node-2")),
+			},
+			verifyNodeStatus: func(conditions []operatorv1.OperatorCondition) error {
+				var expectedCondition operatorv1.OperatorCondition
+				expectedCondition.Type = condition.NodeControllerDegradedConditionType
+				expectedCondition.Reason = "MasterNodesReady"
+				expectedCondition.Status = operatorv1.ConditionFalse
+				expectedCondition.Message = `All master nodes are ready`
+
+				return validateNodeControllerDegradedCondition(conditions, expectedCondition)
+			},
+		},
+		{
+			name: "scenario 24: one working master node missing the condition reported",
+			masterNodes: []runtime.Object{
+				makeNodeReady(fakeMasterNode("test-node-1")),
+				makeNodeWorking(fakeMasterNode("test-node-2")),
+			},
+			verifyNodeStatus: func(conditions []operatorv1.OperatorCondition) error {
+				var expectedCondition operatorv1.OperatorCondition
+				expectedCondition.Type = condition.NodeControllerDegradedConditionType
+				expectedCondition.Reason = "MasterNodesReady"
+				expectedCondition.Status = operatorv1.ConditionTrue
+				expectedCondition.Message = `The master nodes not ready: node "test-node-2" not ready, no Ready condition found in status block`
+
+				return validateNodeControllerDegradedCondition(conditions, expectedCondition)
+			},
+		},
+		{
+			name: "scenario 25: mixed working, draining and rebooting nodes",
 			masterNodes: []runtime.Object{
 				makeNodeReady(fakeMasterNode("test-node-1")),
 				// plain unhealthy node
@@ -668,13 +741,17 @@ func TestNodeControllerDegradedConditionType(t *testing.T) {
 				makeNodeRebooting(makeNodeNotReadyAt(fakeMasterNode("test-node-5"), time.Now().Add(-DefaultUpgradingNodeDegradedInertia+1*time.Minute))),
 				// rebooting + inertia expired = degraded
 				makeNodeRebooting(makeNodeNotReady(fakeMasterNode("test-node-6"))),
+				// working + within inertia = protected from degradation
+				makeNodeWorking(makeNodeNotReadyAt(fakeMasterNode("test-node-7"), time.Now().Add(-DefaultUpgradingNodeDegradedInertia+1*time.Minute))),
+				// working + healthy = not degraded
+				makeNodeWorking(makeNodeReady(fakeMasterNode("test-node-8"))),
 			},
 			verifyNodeStatus: func(conditions []operatorv1.OperatorCondition) error {
 				var expectedCondition operatorv1.OperatorCondition
 				expectedCondition.Type = condition.NodeControllerDegradedConditionType
 				expectedCondition.Reason = "MasterNodesReady"
 				expectedCondition.Status = operatorv1.ConditionTrue
-				expectedCondition.Message = `The master nodes not ready: node "test-node-2" not ready since 2018-01-12 22:51:48.324359102 +0000 UTC because TestReason (test message), node "test-node-3" not ready since 2018-01-12 22:51:48.324359102 +0000 UTC because TestReason (test message), node "test-node-6" not ready since 2018-01-12 22:51:48.324359102 +0000 UTC because TestReason (test message). The master nodes upgrading: node "test-node-5"`
+				expectedCondition.Message = `The master nodes not ready: node "test-node-2" not ready since 2018-01-12 22:51:48.324359102 +0000 UTC because TestReason (test message), node "test-node-3" not ready since 2018-01-12 22:51:48.324359102 +0000 UTC because TestReason (test message), node "test-node-6" not ready since 2018-01-12 22:51:48.324359102 +0000 UTC because TestReason (test message). The master nodes upgrading: node "test-node-5", node "test-node-7"`
 
 				return validateNodeControllerDegradedCondition(conditions, expectedCondition)
 			},

--- a/pkg/operator/staticpod/controller/node/node_controller_test.go
+++ b/pkg/operator/staticpod/controller/node/node_controller_test.go
@@ -63,7 +63,17 @@ func makeNodeRebooting(node *corev1.Node) *corev1.Node {
 		node.Annotations = map[string]string{}
 	}
 	node.Annotations[machineConfigState] = machineConfigStateWorking
-	node.Annotations[machineConfigPostConfigAction] = machineConfigPostConfigAction
+	node.Annotations[machineConfigPostConfigAction] = machineConfigPostConfigActionRebooting
+	return node
+}
+
+func makeNodeDraining(node *corev1.Node) *corev1.Node {
+	if node.Annotations == nil {
+		node.Annotations = map[string]string{}
+	}
+	node.Annotations[machineConfigState] = machineConfigStateWorking
+	node.Annotations[machineConfigDesiredDrain] = "drain-rendered-worker-xyz789"
+	node.Annotations[machineConfigLastAppliedDrain] = "drain-rendered-worker-abc123"
 	return node
 }
 
@@ -520,7 +530,7 @@ func TestNodeControllerDegradedConditionType(t *testing.T) {
 				expectedCondition.Type = condition.NodeControllerDegradedConditionType
 				expectedCondition.Reason = "MasterNodesReady"
 				expectedCondition.Status = operatorv1.ConditionFalse
-				expectedCondition.Message = `The master nodes rebooting for upgrade: node "test-node-1"`
+				expectedCondition.Message = `The master nodes upgrading: node "test-node-1"`
 
 				return validateNodeControllerDegradedCondition(conditions, expectedCondition)
 			},
@@ -575,7 +585,7 @@ func TestNodeControllerDegradedConditionType(t *testing.T) {
 				expectedCondition.Type = condition.NodeControllerDegradedConditionType
 				expectedCondition.Reason = "MasterNodesReady"
 				expectedCondition.Status = operatorv1.ConditionTrue
-				expectedCondition.Message = `The master nodes not ready: node "test-node-3" not ready since 2018-01-12 22:51:48.324359102 +0000 UTC because TestReason (test message), node "test-node-4" not ready since 2018-01-12 22:51:48.324359102 +0000 UTC because TestReason (test message). The master nodes rebooting for upgrade: node "test-node-5"`
+				expectedCondition.Message = `The master nodes not ready: node "test-node-3" not ready since 2018-01-12 22:51:48.324359102 +0000 UTC because TestReason (test message), node "test-node-4" not ready since 2018-01-12 22:51:48.324359102 +0000 UTC because TestReason (test message). The master nodes upgrading: node "test-node-5"`
 
 				return validateNodeControllerDegradedCondition(conditions, expectedCondition)
 			},
@@ -592,6 +602,79 @@ func TestNodeControllerDegradedConditionType(t *testing.T) {
 				expectedCondition.Reason = "MasterNodesReady"
 				expectedCondition.Status = operatorv1.ConditionTrue
 				expectedCondition.Message = `The master nodes not ready: node "test-node-2" not ready, no Ready condition found in status block`
+
+				return validateNodeControllerDegradedCondition(conditions, expectedCondition)
+			},
+		},
+		{
+			name: "scenario 18: draining node is degraded (no inertia protection)",
+			masterNodes: []runtime.Object{
+				makeNodeDraining(makeNodeNotReady(fakeMasterNode("test-node-1"))),
+				makeNodeReady(fakeMasterNode("test-node-2")),
+			},
+			verifyNodeStatus: func(conditions []operatorv1.OperatorCondition) error {
+				var expectedCondition operatorv1.OperatorCondition
+				expectedCondition.Type = condition.NodeControllerDegradedConditionType
+				expectedCondition.Reason = "MasterNodesReady"
+				expectedCondition.Status = operatorv1.ConditionTrue
+				expectedCondition.Message = `The master nodes not ready: node "test-node-1" not ready since 2018-01-12 22:51:48.324359102 +0000 UTC because TestReason (test message)`
+
+				return validateNodeControllerDegradedCondition(conditions, expectedCondition)
+			},
+		},
+		{
+			name: "scenario 19: healthy draining node does not degrade",
+			masterNodes: []runtime.Object{
+				makeNodeDraining(makeNodeReady(fakeMasterNode("test-node-1"))),
+				makeNodeReady(fakeMasterNode("test-node-2")),
+			},
+			verifyNodeStatus: func(conditions []operatorv1.OperatorCondition) error {
+				var expectedCondition operatorv1.OperatorCondition
+				expectedCondition.Type = condition.NodeControllerDegradedConditionType
+				expectedCondition.Reason = "MasterNodesReady"
+				expectedCondition.Status = operatorv1.ConditionFalse
+				expectedCondition.Message = `All master nodes are ready`
+
+				return validateNodeControllerDegradedCondition(conditions, expectedCondition)
+			},
+		},
+		{
+			name: "scenario 20: draining node with missing Ready condition is degraded",
+			masterNodes: []runtime.Object{
+				makeNodeReady(fakeMasterNode("test-node-1")),
+				makeNodeDraining(fakeMasterNode("test-node-2")),
+			},
+			verifyNodeStatus: func(conditions []operatorv1.OperatorCondition) error {
+				var expectedCondition operatorv1.OperatorCondition
+				expectedCondition.Type = condition.NodeControllerDegradedConditionType
+				expectedCondition.Reason = "MasterNodesReady"
+				expectedCondition.Status = operatorv1.ConditionTrue
+				expectedCondition.Message = `The master nodes not ready: node "test-node-2" not ready, no Ready condition found in status block`
+
+				return validateNodeControllerDegradedCondition(conditions, expectedCondition)
+			},
+		},
+		{
+			name: "scenario 21: mixed draining and rebooting nodes",
+			masterNodes: []runtime.Object{
+				makeNodeReady(fakeMasterNode("test-node-1")),
+				// plain unhealthy node
+				makeNodeNotReady(fakeMasterNode("test-node-2")),
+				// draining + unhealthy = degraded (no inertia protection)
+				makeNodeDraining(makeNodeNotReady(fakeMasterNode("test-node-3"))),
+				// draining + healthy = not degraded
+				makeNodeDraining(makeNodeReady(fakeMasterNode("test-node-4"))),
+				// rebooting + within inertia = protected from degradation
+				makeNodeRebooting(makeNodeNotReadyAt(fakeMasterNode("test-node-5"), time.Now().Add(-DefaultUpgradingNodeDegradedInertia+1*time.Minute))),
+				// rebooting + inertia expired = degraded
+				makeNodeRebooting(makeNodeNotReady(fakeMasterNode("test-node-6"))),
+			},
+			verifyNodeStatus: func(conditions []operatorv1.OperatorCondition) error {
+				var expectedCondition operatorv1.OperatorCondition
+				expectedCondition.Type = condition.NodeControllerDegradedConditionType
+				expectedCondition.Reason = "MasterNodesReady"
+				expectedCondition.Status = operatorv1.ConditionTrue
+				expectedCondition.Message = `The master nodes not ready: node "test-node-2" not ready since 2018-01-12 22:51:48.324359102 +0000 UTC because TestReason (test message), node "test-node-3" not ready since 2018-01-12 22:51:48.324359102 +0000 UTC because TestReason (test message), node "test-node-6" not ready since 2018-01-12 22:51:48.324359102 +0000 UTC because TestReason (test message). The master nodes upgrading: node "test-node-5"`
 
 				return validateNodeControllerDegradedCondition(conditions, expectedCondition)
 			},

--- a/pkg/operator/staticpod/controller/node/node_state.go
+++ b/pkg/operator/staticpod/controller/node/node_state.go
@@ -1,0 +1,116 @@
+package node
+
+import corev1 "k8s.io/api/core/v1"
+
+// NodeUpgradeState represents the current state of a node's Machine Config Operator upgrade.
+type NodeUpgradeState string
+
+const (
+	// NodeUpgradeStateWorking indicates the node is actively applying configuration changes.
+	// This state is set when the Machine Config Daemon is updating files, applying OS changes,
+	// or performing other non-disruptive update operations.
+	NodeUpgradeStateWorking NodeUpgradeState = "Working"
+
+	// NodeUpgradeStateUnreconcilable indicates the desired MachineConfig contains changes
+	// that cannot be applied in-place to a running node (e.g., FIPS mode changes, incompatible
+	// storage configurations). Manual intervention or reinstallation is required.
+	NodeUpgradeStateUnreconcilable NodeUpgradeState = "Unreconcilable"
+
+	// NodeUpgradeStateDraining indicates the node is being cordoned and drained of workloads
+	// in preparation for disruptive changes (typically a reboot).
+	NodeUpgradeStateDraining NodeUpgradeState = "Draining"
+
+	// NodeUpgradeStateRebooting indicates the node is rebooting or queued for reboot to
+	// complete the configuration update.
+	NodeUpgradeStateRebooting NodeUpgradeState = "Rebooting"
+
+	// NodeUpgradeStateDegraded indicates an operational error occurred during the update
+	// (e.g., service restart failures, validation failures, timeouts). The MachineConfig
+	// itself is valid, but environmental or operational issues prevent applying it.
+	NodeUpgradeStateDegraded NodeUpgradeState = "Degraded"
+
+	// NodeUpgradeStateDone indicates the node has successfully completed the update and
+	// the current configuration matches the desired configuration.
+	NodeUpgradeStateDone NodeUpgradeState = "Done"
+
+	// NodeUpgradeStateUnknown indicates the node's upgrade status cannot be determined,
+	// either because annotations are missing or the state has an unexpected value.
+	NodeUpgradeStateUnknown NodeUpgradeState = "Unknown"
+)
+
+// Machine Config Operator node annotation keys and values.
+const (
+	// machineConfigState is the annotation key for the current state of the Machine Config Daemon.
+	machineConfigState = "machineconfiguration.openshift.io/state"
+
+	// machineConfigDesiredDrain is the annotation key set by the daemon to request node drain.
+	machineConfigDesiredDrain = "machineconfiguration.openshift.io/desiredDrain"
+
+	// machineConfigLastAppliedDrain is the annotation key set by the drain controller to indicate
+	// the last drain request that was successfully applied.
+	machineConfigLastAppliedDrain = "machineconfiguration.openshift.io/lastAppliedDrain"
+
+	// machineConfigPostConfigAction is the annotation key for post-configuration actions,
+	// such as indicating a reboot is queued or in progress.
+	machineConfigPostConfigAction = "machineconfiguration.openshift.io/post-config-action"
+
+	// machineConfigStateDone indicates the daemon has successfully completed an update.
+	machineConfigStateDone = "Done"
+
+	// machineConfigStateWorking indicates the daemon is actively applying an update.
+	machineConfigStateWorking = "Working"
+
+	// machineConfigStateDegraded indicates an operational error occurred during the update.
+	machineConfigStateDegraded = "Degraded"
+
+	// machineConfigStateUnreconcilable indicates the MachineConfig contains incompatible changes.
+	machineConfigStateUnreconcilable = "Unreconcilable"
+
+	// machineConfigPostConfigActionRebooting indicates a reboot is queued or in progress.
+	machineConfigPostConfigActionRebooting = "Rebooting"
+)
+
+// GetNodeUpgradeState returns the current upgrade status of a node based on
+// Machine Config Operator annotations.
+//
+// The function examines the node's MCO annotations to determine the upgrade state.
+// When the state annotation is "Working", it further distinguishes between different
+// phases of the update process:
+//   - Rebooting: node is rebooting or queued for reboot (post-config-action == "Rebooting")
+//   - Draining: node is being cordoned and drained (desiredDrain != lastAppliedDrain)
+//   - Working: node is applying configuration changes (default "Working" state)
+//
+// Returns NodeUpgradeStateUnknown if the node has no annotations or the state
+// annotation has an unexpected value.
+func GetNodeUpgradeState(node *corev1.Node) NodeUpgradeState {
+	if node.Annotations == nil {
+		return NodeUpgradeStateUnknown
+	}
+
+	switch node.Annotations[machineConfigState] {
+	case machineConfigStateDone:
+		return NodeUpgradeStateDone
+
+	case machineConfigStateWorking:
+		if node.Annotations[machineConfigPostConfigAction] == machineConfigPostConfigActionRebooting {
+			return NodeUpgradeStateRebooting
+		}
+
+		desiredDrain := node.Annotations[machineConfigDesiredDrain]
+		lastAppliedDrain := node.Annotations[machineConfigLastAppliedDrain]
+		if desiredDrain != "" && lastAppliedDrain != desiredDrain {
+			return NodeUpgradeStateDraining
+		}
+
+		return NodeUpgradeStateWorking
+
+	case machineConfigStateDegraded:
+		return NodeUpgradeStateDegraded
+
+	case machineConfigStateUnreconcilable:
+		return NodeUpgradeStateUnreconcilable
+
+	default:
+		return NodeUpgradeStateUnknown
+	}
+}

--- a/pkg/operator/staticpod/controller/node/node_state.go
+++ b/pkg/operator/staticpod/controller/node/node_state.go
@@ -1,6 +1,10 @@
 package node
 
-import corev1 "k8s.io/api/core/v1"
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
 
 // NodeUpgradeState represents the current state of a node's Machine Config Operator upgrade.
 type NodeUpgradeState string
@@ -98,7 +102,8 @@ func GetNodeUpgradeState(node *corev1.Node) NodeUpgradeState {
 
 		desiredDrain := node.Annotations[machineConfigDesiredDrain]
 		lastAppliedDrain := node.Annotations[machineConfigLastAppliedDrain]
-		if desiredDrain != "" && lastAppliedDrain != desiredDrain {
+		// The desired action is not always "drain". We need to check the action prefix.
+		if strings.HasPrefix(desiredDrain, "drain-") && lastAppliedDrain != desiredDrain {
 			return NodeUpgradeStateDraining
 		}
 

--- a/pkg/operator/staticpod/controller/node/node_state_test.go
+++ b/pkg/operator/staticpod/controller/node/node_state_test.go
@@ -198,12 +198,72 @@ func TestGetNodeUpgradeState(t *testing.T) {
 						machineConfigState:            machineConfigStateWorking,
 						machineConfigPostConfigAction: machineConfigPostConfigActionRebooting,
 						machineConfigDesiredDrain:     "drain-rendered-worker-xyz789",
-						machineConfigLastAppliedDrain: "drain-rendered-worker-xyz789",
+						machineConfigLastAppliedDrain: "drain-rendered-worker-xyz666",
 					},
 				},
 			},
 			wantStatus:  NodeUpgradeStateRebooting,
 			description: "Rebooting is checked before draining status",
+		},
+		{
+			name: "uncordon requested - not draining",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+					Annotations: map[string]string{
+						machineConfigState:            machineConfigStateWorking,
+						machineConfigDesiredDrain:     "uncordon-rendered-worker-xyz789",
+						machineConfigLastAppliedDrain: "drain-rendered-worker-xyz789",
+					},
+				},
+			},
+			wantStatus:  NodeUpgradeStateWorking,
+			description: "Uncordon request is not treated as draining",
+		},
+		{
+			name: "uncordon requested but not applied - still not draining",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+					Annotations: map[string]string{
+						machineConfigState:            machineConfigStateWorking,
+						machineConfigDesiredDrain:     "uncordon-rendered-worker-xyz789",
+						machineConfigLastAppliedDrain: "uncordon-rendered-worker-abc123",
+					},
+				},
+			},
+			wantStatus:  NodeUpgradeStateWorking,
+			description: "Uncordon mismatch is not treated as draining",
+		},
+		{
+			name: "uncordon with no previous drain - not draining",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+					Annotations: map[string]string{
+						machineConfigState:        machineConfigStateWorking,
+						machineConfigDesiredDrain: "uncordon-rendered-worker-xyz789",
+						// no lastAppliedDrain
+					},
+				},
+			},
+			wantStatus:  NodeUpgradeStateWorking,
+			description: "Uncordon without previous drain is not treated as draining",
+		},
+		{
+			name: "invalid drain prefix - not draining",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+					Annotations: map[string]string{
+						machineConfigState:            machineConfigStateWorking,
+						machineConfigDesiredDrain:     "something-rendered-worker-xyz789",
+						machineConfigLastAppliedDrain: "drain-rendered-worker-abc123",
+					},
+				},
+			},
+			wantStatus:  NodeUpgradeStateWorking,
+			description: "Invalid drain prefix is not treated as draining",
 		},
 	}
 

--- a/pkg/operator/staticpod/controller/node/node_state_test.go
+++ b/pkg/operator/staticpod/controller/node/node_state_test.go
@@ -1,0 +1,218 @@
+package node
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetNodeUpgradeState(t *testing.T) {
+	tests := []struct {
+		name        string
+		node        *corev1.Node
+		wantStatus  NodeUpgradeState
+		description string
+	}{
+		{
+			name: "node with Done state",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+					Annotations: map[string]string{
+						machineConfigState: machineConfigStateDone,
+					},
+				},
+			},
+			wantStatus:  NodeUpgradeStateDone,
+			description: "Node has successfully completed update",
+		},
+		{
+			name: "node with Working state - basic",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+					Annotations: map[string]string{
+						machineConfigState: machineConfigStateWorking,
+					},
+				},
+			},
+			wantStatus:  NodeUpgradeStateWorking,
+			description: "Node is applying configuration changes",
+		},
+		{
+			name: "node with Working state - rebooting",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+					Annotations: map[string]string{
+						machineConfigState:            machineConfigStateWorking,
+						machineConfigPostConfigAction: machineConfigPostConfigActionRebooting,
+					},
+				},
+			},
+			wantStatus:  NodeUpgradeStateRebooting,
+			description: "Node is rebooting or queued for reboot",
+		},
+		{
+			name: "node with Working state - draining in progress",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+					Annotations: map[string]string{
+						machineConfigState:            machineConfigStateWorking,
+						machineConfigDesiredDrain:     "drain-rendered-worker-xyz789",
+						machineConfigLastAppliedDrain: "drain-rendered-worker-abc123",
+					},
+				},
+			},
+			wantStatus:  NodeUpgradeStateDraining,
+			description: "Node is being drained (desiredDrain != lastAppliedDrain)",
+		},
+		{
+			name: "node with Working state - draining requested but not started",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+					Annotations: map[string]string{
+						machineConfigState:        machineConfigStateWorking,
+						machineConfigDesiredDrain: "drain-rendered-worker-xyz789",
+						// lastAppliedDrain is empty/missing
+					},
+				},
+			},
+			wantStatus:  NodeUpgradeStateDraining,
+			description: "Node drain requested but controller hasn't started yet",
+		},
+		{
+			name: "node with Working state - drain completed",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+					Annotations: map[string]string{
+						machineConfigState:            machineConfigStateWorking,
+						machineConfigDesiredDrain:     "drain-rendered-worker-xyz789",
+						machineConfigLastAppliedDrain: "drain-rendered-worker-xyz789",
+					},
+				},
+			},
+			wantStatus:  NodeUpgradeStateWorking,
+			description: "Drain completed (desiredDrain == lastAppliedDrain), node is applying changes",
+		},
+		{
+			name: "node with Working state - no drain needed",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+					Annotations: map[string]string{
+						machineConfigState: machineConfigStateWorking,
+						// desiredDrain is empty - no drain needed
+					},
+				},
+			},
+			wantStatus:  NodeUpgradeStateWorking,
+			description: "No drain required for this update",
+		},
+		{
+			name: "node with Degraded state",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+					Annotations: map[string]string{
+						machineConfigState: machineConfigStateDegraded,
+					},
+				},
+			},
+			wantStatus:  NodeUpgradeStateDegraded,
+			description: "Node encountered operational errors during update",
+		},
+		{
+			name: "node with Unreconcilable state",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+					Annotations: map[string]string{
+						machineConfigState: machineConfigStateUnreconcilable,
+					},
+				},
+			},
+			wantStatus:  NodeUpgradeStateUnreconcilable,
+			description: "MachineConfig contains incompatible changes",
+		},
+		{
+			name: "node with nil annotations",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-node",
+					Annotations: nil,
+				},
+			},
+			wantStatus:  NodeUpgradeStateUnknown,
+			description: "Node has no annotations",
+		},
+		{
+			name: "node with empty annotations",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-node",
+					Annotations: map[string]string{},
+				},
+			},
+			wantStatus:  NodeUpgradeStateUnknown,
+			description: "Node has annotations but state is missing",
+		},
+		{
+			name: "node with unexpected state value",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+					Annotations: map[string]string{
+						machineConfigState: "UnexpectedState",
+					},
+				},
+			},
+			wantStatus:  NodeUpgradeStateUnknown,
+			description: "State annotation has unexpected value",
+		},
+		{
+			name: "edge case - empty desiredDrain but old lastAppliedDrain exists",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+					Annotations: map[string]string{
+						machineConfigState:            machineConfigStateWorking,
+						machineConfigDesiredDrain:     "", // No drain needed now
+						machineConfigLastAppliedDrain: "drain-rendered-worker-old",
+					},
+				},
+			},
+			wantStatus:  NodeUpgradeStateWorking,
+			description: "Previous drain completed, current update doesn't need drain",
+		},
+		{
+			name: "rebooting takes precedence over drain annotations",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+					Annotations: map[string]string{
+						machineConfigState:            machineConfigStateWorking,
+						machineConfigPostConfigAction: machineConfigPostConfigActionRebooting,
+						machineConfigDesiredDrain:     "drain-rendered-worker-xyz789",
+						machineConfigLastAppliedDrain: "drain-rendered-worker-xyz789",
+					},
+				},
+			},
+			wantStatus:  NodeUpgradeStateRebooting,
+			description: "Rebooting is checked before draining status",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotStatus := GetNodeUpgradeState(tt.node)
+			if gotStatus != tt.wantStatus {
+				t.Errorf("GetNodeUpgradeState() = %v, want %v\nDescription: %s", gotStatus, tt.wantStatus, tt.description)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Treat nodes as `Degraded` only when they are not upgrading.
This prevents `Degraded=True` in operators from blipping during upgrade.

There is a helper function that returns a node upgrade state enum value called `GetNodeUpgradeState`. The upgrade state is decided based on relevant MCO annotations on the Node object. This can be used by other controllers in library-go as well.

The idea is then to not mark nodes as Degraded when they are Rebooting or Working, which explicitly excludes draining, because that is unrelated to the node Ready status anyway. This seems the best we can do.

---

### Obsolete Description to Keep Context

Treat nodes as `Degraded` only when they are not rebooting for upgrade.
This prevents `Degraded=True` in operators from blipping during upgrade.

Based on https://github.com/openshift/machine-config-operator/blob/b4ea81d6885c61c91e1503d5f9f5ebed696092b1/pkg/daemon/update.go#L2812

Now the issue is that the annotation can be removed when the reboot is finished before the node becomes `Ready`. But this should be like seconds before it's `Ready`. On top of that, there is a 2-minute inertia for `Degraded` on the operator status, so this should be plenty to cover the gap. Another potential issue is that failing to update the annotations is only logged, it does not prevent the reboot. So we may have rebooting nodes missing the annotation.

An alternative would be ignore nodes with `machineconfiguration.openshift.io/state == Working`, but that seems to be too broad a condition as it covers basically the whole upgrade process, so that can show too positive view of the system. But it is a possibility.

There may be other ways to implement this for sure, but that would require pulling in other objects like `machineconfignode` for the nodes, where you can check the timestamp of the last reboot, for example. This doesn't seem particularly necessary as the inertia should cover vast majority of our use cases. So I focused on what we already have, which are the `Node` objects.

As discussed, I also ended up adding a `Degraded` inertia here, which means that the rebooting node is only ignored for certain period of time, which is by default 10 minutes. In case something goes very wrong during the upgrade...