### PR TITLE
OCPBUGS-74225: Fix update of stable-generation annotation

### DIFF
--- a/pkg/operator/csi/csidrivernodeservicecontroller/csi_driver_node_service_controller_test.go
+++ b/pkg/operator/csi/csidrivernodeservicecontroller/csi_driver_node_service_controller_test.go
@@ -576,7 +576,8 @@ func TestSync(t *testing.T) {
 					argsLevel2,
 					defaultImages(),
 					withDaemonSetGeneration(1, 1),
-					withDaemonSetStatus(replica1, replica1, replica1, replica0)),
+					withDaemonSetStatus(replica1, replica1, replica1, replica0),
+					withDaemonSetAnnotation(stableGenerationAnnotationName, "1")), // the DaemonSet is fully deployed
 				driver: makeFakeDriverInstance(
 					withGenerations(1),
 					withLogLevel(opv1.Trace)), // User changed the log level...
@@ -586,7 +587,8 @@ func TestSync(t *testing.T) {
 					argsLevel6,      // New log level
 					defaultImages(), // And the same goes for the DaemonSet
 					withDaemonSetGeneration(2, 1),
-					withDaemonSetStatus(replica1, replica1, replica1, replica0)),
+					withDaemonSetStatus(replica1, replica1, replica1, replica0),
+					withDaemonSetAnnotation(stableGenerationAnnotationName, "1")),
 				driver: makeFakeDriverInstance(
 					// withStatus(replica1),
 					withLogLevel(opv1.Trace),
@@ -604,7 +606,8 @@ func TestSync(t *testing.T) {
 					argsLevel2,
 					oldImages(),
 					withDaemonSetGeneration(1, 1),
-					withDaemonSetStatus(replica1, replica1, replica1, replica0)),
+					withDaemonSetStatus(replica1, replica1, replica1, replica0),
+					withDaemonSetAnnotation(stableGenerationAnnotationName, "1")), // the DaemonSet is fully deployed
 				driver: makeFakeDriverInstance(
 					// withStatus(replica1),k
 					withGenerations(1),
@@ -616,7 +619,8 @@ func TestSync(t *testing.T) {
 					argsLevel2,
 					defaultImages(),
 					withDaemonSetGeneration(2, 1),
-					withDaemonSetStatus(replica1, replica1, replica1, replica0)),
+					withDaemonSetStatus(replica1, replica1, replica1, replica0),
+					withDaemonSetAnnotation(stableGenerationAnnotationName, "1")),
 				driver: makeFakeDriverInstance(
 					// withStatus(replica1),
 					withGenerations(2),
@@ -657,7 +661,8 @@ func TestSync(t *testing.T) {
 					argsLevel2,
 					defaultImages(),
 					withDaemonSetGeneration(1, 1),
-					withDaemonSetStatus(replica1, replica1, replica1, replica0)),
+					withDaemonSetStatus(replica1, replica1, replica1, replica0),
+					withDaemonSetAnnotation(stableGenerationAnnotationName, "1")), // the DaemonSet is fully deployed
 				driver: makeFakeDriverInstance(
 					withGenerations(1),
 					withFinalizers(finalizerName),


### PR DESCRIPTION
When a CSI driver DaemonSet reaches a stable state, it updates the annotation `storage.openshift.io/stable-generation`. Such update accidentally changed annotation `operator.openshift.io/spec-hash`, which led to another DaemonSet updates fixing the hash.

Rework the code that updates stable-generation to do it before the main `ApplyDaemonSet()` that computes the right hash. Since the controller does not have the DaemonSet status at that point, read it from its informer cache.

The controller now updates the stable-generation annotation earlier than before, but it still correctly. See the updated unit tests. `Sync()` gets a DaemonSet that has reached a stable state (usually with generation "1"), so the controller records it in the annotation. At the same time the controller makes a change that bumps the generation to "2". The previous code waited for "2" to get stable before updating the annotation.

The progressing condition is not affected by this change, as the unit tests show.