### PR TITLE
NO-JIRA: Enable test-e2e-encryption

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ verify-podnetworkconnectivitychecks:
 	$(MAKE) -C pkg/operator/connectivitycheckcontroller verify
 
 test-e2e-encryption: GO_TEST_PACKAGES :=./test/e2e-encryption/...
+test-e2e-encryption: GO_TEST_FLAGS += -v
+test-e2e-encryption: test-unit
 .PHONY: test-e2e-encryption
 
 test-e2e-monitoring: GO_TEST_PACKAGES :=./test/e2e-monitoring/...


### PR DESCRIPTION
It appears that [integration tests for encryption controllers](https://github.com/openshift/library-go/blob/master/test/e2e-encryption/encryption_test.go) are never being executed ([example job](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_library-go/2086/pull-ci-openshift-library-go-master-e2e-aws-encryption/2014621776604041216/artifacts/e2e-aws-encryption/test/build-log.txt)). This PR updates the Makefile target to enable them.