### PR TITLE
CNTRLPLANE-2247: add a script to build Kube mock KMS plugin image from k8s source code

### DIFF
--- a/test/library/encryption/kms/k8s-mock-plugin/README.md
+++ b/test/library/encryption/kms/k8s-mock-plugin/README.md
@@ -1,0 +1,29 @@
+# k8s-mock-kms-plugin
+
+Builds the Kubernetes mock KMS plugin image from upstream source.
+
+## Building
+
+```bash
+./build-from-k8s.sh
+```
+
+Builds and tags as `k8s-mock-kms-plugin`.
+
+Optionally specify a different Kubernetes branch:
+
+```bash
+K8S_BRANCH=release-1.34 ./build-from-k8s.sh
+```
+
+## Pushing to registry
+
+```bash
+docker tag k8s-mock-kms-plugin quay.io/polynomial/k8s-mock-kms-plugin:latest
+docker push quay.io/polynomial/k8s-mock-kms-plugin:latest
+```
+
+## TODO
+
+- Automate image builds (CI in openshift/origin?)
+- Publish to quay.io/openshifttest

--- a/test/library/encryption/kms/k8s-mock-plugin/build-from-k8s.sh
+++ b/test/library/encryption/kms/k8s-mock-plugin/build-from-k8s.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly K8S_REPO_URL="https://github.com/kubernetes/kubernetes.git"
+readonly IMAGE_TAG="k8s-mock-kms-plugin"
+K8S_BRANCH="${K8S_BRANCH:-master}"
+
+TMP_DIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+echo "Cloning Kubernetes (${K8S_BRANCH})..."
+git clone --depth 1 --branch "${K8S_BRANCH}" "${K8S_REPO_URL}" "${TMP_DIR}/kubernetes"
+
+CONTEXT_DIR="${TMP_DIR}/kubernetes/staging/src/k8s.io"
+DOCKERFILE_PATH="${CONTEXT_DIR}/kms/internal/plugins/_mock/Dockerfile"
+
+echo "Building image ${IMAGE_TAG}..."
+docker build \
+  --platform linux/amd64 \
+  -t "${IMAGE_TAG}" \
+  -f "${DOCKERFILE_PATH}" \
+  "${CONTEXT_DIR}"
+
+echo "Done. Image built: ${IMAGE_TAG}"


### PR DESCRIPTION
Adds a simple script to build the Kube mock KMS plugin from upstream source code.

The image needs to be pushed manually to a remote registry.

This is a fist simple step which allows us for testing/validating v1 iteration.

In the future:

```
TODO
- Automate image builds (CI in openshift/origin?)
- Publish to quay.io/openshifttest
```

NOTE:

@bertinatto checked and upstream doesn't push the mock kms plugin image to a well-known registry ([xref](https://redhat-internal.slack.com/archives/C0A0DMK3N7K/p1769175895469009))