### PR TITLE
OCPBUGS-38662: guard controller: Handle conflict gracefully

### DIFF
--- a/pkg/operator/staticpod/controller/guard/guard_controller.go
+++ b/pkg/operator/staticpod/controller/guard/guard_controller.go
@@ -380,7 +380,9 @@ func (c *GuardController) sync(ctx context.Context, syncCtx factory.SyncContext)
 			_, _, err = resourceapply.ApplyPod(ctx, c.podGetter, syncCtx.Recorder(), pod)
 			if err != nil {
 				klog.Errorf("Unable to apply pod %v changes: %v", pod.Name, err)
-				errs = append(errs, fmt.Errorf("Unable to apply pod %v changes: %v", pod.Name, err))
+				if !apierrors.IsConflict(err) {
+					errs = append(errs, fmt.Errorf("Unable to apply pod %v changes: %v", pod.Name, err))
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Currently the controller degrades on any error, including an apply conflict. This can happen during upgrades and should not be the case.

The cause is probably the fact that we delete and create the guard pod in the very same sync call. But instead of handling this specifically, the apply call now simply ignores conflict errors and sync is automatically invoked again as the changes propagate.

This is to remove degrading like
```
GuardControllerDegraded: Unable to apply pod openshift-kube-scheduler-guard-ip-10-0-106-117.us-east-2.compute.internal changes: Operation cannot be fulfilled on pods \"openshift-kube-scheduler-guard-ip-10-0-106-117.us-east-2.compute.internal\": the object has been modified; please apply your changes to the latest version and try again
```