### PR TITLE
NO-JIRA: Rename KMS UDS path

### DIFF
--- a/test/library/encryption/kms/assets/k8s_mock_kms_plugin_daemonset.yaml
+++ b/test/library/encryption/kms/assets/k8s_mock_kms_plugin_daemonset.yaml
@@ -63,7 +63,7 @@ spec:
           securityContext:
             privileged: true
           args:
-            - "-listen-addr=unix:///var/run/kmsplugin/socket.sock"
+            - "-listen-addr=unix:///var/run/kmsplugin/kms.sock"
             - "-config-file-path=/etc/softhsm-config.json"
           volumeMounts:
             - name: socket


### PR DESCRIPTION
As defined in the EP https://github.com/openshift/enhancements/blob/master/enhancements/kube-apiserver/kms-encryption-foundations.md#proposal, it needs to be `unix:///var/run/kmsplugin/kms.sock`