### PR TITLE
Add optional hook for operator specific status modifications

### DIFF
--- a/pkg/operator/status/status_controller.go
+++ b/pkg/operator/status/status_controller.go
@@ -38,7 +38,7 @@ type VersionGetter interface {
 
 type RelatedObjectsFunc func() (isset bool, objs []configv1.ObjectReference)
 
-type ClusterOperatorStatusHook func(original *configv1.ClusterOperatorStatus, modified *configv1.ClusterOperatorStatus) error
+type ClusterOperatorStatusHook func(original *configv1.ClusterOperator, mutated *configv1.ClusterOperator) error
 
 type StatusSyncer struct {
 	clusterOperatorName string
@@ -234,7 +234,7 @@ func (c StatusSyncer) Sync(ctx context.Context, syncCtx factory.SyncContext) err
 	c.syncStatusVersions(clusterOperatorObj, syncCtx)
 
 	if hook := c.beforeStatusUpdateHook; hook != nil {
-		if err := hook(&originalClusterOperatorObj.Status, &clusterOperatorObj.Status); err != nil {
+		if err := hook(originalClusterOperatorObj, clusterOperatorObj); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Description
  

This PR adds an optional hook mechanism to StatusSyncer that allows operators to modify their ClusterOperator status before the update request is send to API server. The hook receives both the original status (reconcile start) and the mutated status (done by the reconcile logic), enabling operators informed decisions about additional tweaks, i.e. version that is going to send to API server.

  Changes:
  - Add `ClusterOperatorStatusHook` function type
  - Add `WithBeforeStatusUpdateHook()` builder method
  - Hook is invoked in `Sync()` after standard status logic completes, before the API update

  ## Motivation
Operators sometimes need custom status logic such as detecting version changes during cluster upgrades. This usually  requires comparing the target version (from environment) against the current version (in ClusterOperator status). Without access to the original status from etcd, operators cannot reliably detect these transitions. This hook provides a generic mechanism for operators to implement such custom logic.

  Co-authored-by: Predrag Knezevic <pknezevi@redhat.com>