### PR TITLE
crypto: add DefaultTLSProfileType const

### DIFF
--- a/pkg/crypto/crypto.go
+++ b/pkg/crypto/crypto.go
@@ -30,6 +30,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/client-go/util/cert"
+
+	configv1 "github.com/openshift/api/config/v1"
 )
 
 // TLS versions that are known to golang. Go 1.13 adds support for
@@ -242,6 +244,9 @@ func ValidCipherSuites() []string {
 	sort.Strings(validCipherSuites)
 	return validCipherSuites
 }
+
+// DefaultTLSProfileType is the intermediate profile type.
+const DefaultTLSProfileType = configv1.TLSProfileIntermediateType
 
 // DefaultCiphers returns the default cipher suites for TLS connections.
 //

--- a/pkg/operator/configobserver/apiserver/observe_tlssecurityprofile.go
+++ b/pkg/operator/configobserver/apiserver/observe_tlssecurityprofile.go
@@ -85,7 +85,7 @@ func innerTLSSecurityProfileObservations(genericListers configobserver.Listers, 
 func getSecurityProfileCiphers(profile *configv1.TLSSecurityProfile) (string, []string) {
 	var profileType configv1.TLSProfileType
 	if profile == nil {
-		profileType = configv1.TLSProfileIntermediateType
+		profileType = crypto.DefaultTLSProfileType
 	} else {
 		profileType = profile.Type
 	}
@@ -101,7 +101,7 @@ func getSecurityProfileCiphers(profile *configv1.TLSSecurityProfile) (string, []
 
 	// nothing found / custom type set but no actual custom spec
 	if profileSpec == nil {
-		profileSpec = configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+		profileSpec = configv1.TLSProfiles[crypto.DefaultTLSProfileType]
 	}
 
 	// need to remap all Ciphers to their respective IANA names used by Go


### PR DESCRIPTION
Rather than relying on implicit knowledge that the configv1.TLSProfileIntermediateType is the default, we set a const that defines this, and that can be referenced also from consumers of this package (e.g. tls config oberver, openshift/controller-runtime-commons)

Context: it was originally discussed here: https://github.com/openshift/controller-runtime-common/pull/2#discussion_r2749500761