### PR TITLE
NO-JIRA: Do not delete kms plugin namespace after test exits

### DIFF
--- a/test/library/encryption/kms/k8s_mock_kms_plugin_deployer.go
+++ b/test/library/encryption/kms/k8s_mock_kms_plugin_deployer.go
@@ -4,15 +4,11 @@ import (
 	"bytes"
 	"context"
 	"embed"
-	"fmt"
-	"io"
-	"os"
 	"path/filepath"
 	"testing"
 	"text/template"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -59,10 +55,6 @@ type yamlTemplateData struct {
 func DeployUpstreamMockKMSPlugin(ctx context.Context, t testing.TB, kubeClient kubernetes.Interface, namespace, image string) func() {
 	t.Helper()
 
-	if err := destroyNamespaceIfNotExists(ctx, t, kubeClient, namespace); err != nil {
-		t.Fatalf("Failed to cleanup existing namespace %q: %v", namespace, err)
-	}
-
 	t.Logf("Deploying upstream mock KMS v2 plugin in namespace %q using image %s", namespace, image)
 	daemonSetName, err := applyUpstreamMockKMSPluginManifests(ctx, t, kubeClient, namespace, image)
 	if err != nil {
@@ -73,63 +65,7 @@ func DeployUpstreamMockKMSPlugin(ctx context.Context, t testing.TB, kubeClient k
 	}
 	t.Logf("Upstream mock KMS v2 plugin deployed successfully!")
 
-	return func() {
-		// Before destroying the namespace, collect the logs of the pods in namespace
-		collectPodLogs(ctx, t, kubeClient, namespace)
-
-		if err := destroyNamespaceIfNotExists(ctx, t, kubeClient, namespace); err != nil {
-			t.Errorf("Failed to cleanup namespace %q: %v", namespace, err)
-		}
-	}
-}
-
-// collectPodLogs collects logs from all pods in the namespace and writes them to ARTIFACT_DIR.
-func collectPodLogs(ctx context.Context, t testing.TB, kubeClient kubernetes.Interface, namespace string) {
-	t.Helper()
-
-	artifactDir := os.Getenv("ARTIFACT_DIR")
-	if artifactDir == "" {
-		t.Log("artifact directory not set. Skipping collection of pod logs...")
-		return
-	}
-
-	pods, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		t.Logf("Failed to list pods: %v", err)
-		return
-	}
-	if len(pods.Items) == 0 {
-		t.Logf("No pods found in %s", namespace)
-		return
-	}
-
-	for _, pod := range pods.Items {
-		for _, container := range pod.Spec.Containers {
-			func() {
-				logFileName := filepath.Join(artifactDir, fmt.Sprintf("%s_%s_%s_%s.log", namespace, t.Name(), pod.Name, container.Name))
-
-				logOpts := &corev1.PodLogOptions{Container: container.Name}
-				logs, err := kubeClient.CoreV1().Pods(namespace).GetLogs(pod.Name, logOpts).Stream(ctx)
-				if err != nil {
-					t.Logf("Pod %s logs can not be captured err: %v", pod.Name, err)
-					return
-				}
-				defer logs.Close()
-
-				logFile, err := os.Create(logFileName)
-				if err != nil {
-					t.Logf("creating log file %s failed: %v", logFileName, err)
-					return
-				}
-				defer logFile.Close()
-
-				_, err = io.Copy(logFile, logs)
-				if err != nil {
-					t.Logf("failed to copying logs: %v", err)
-				}
-			}()
-		}
-	}
+	return nil
 }
 
 // applyUpstreamMockKMSPluginManifests applies all the KMS plugin manifests.
@@ -193,29 +129,6 @@ func waitForDaemonSetReady(ctx context.Context, t testing.TB, kubeClient kuberne
 			return false, nil
 		}
 		return ds.Status.NumberReady == ds.Status.DesiredNumberScheduled, nil
-	})
-}
-
-// destroyNamespaceIfNotExists removes the namespace and waits for deletion.
-func destroyNamespaceIfNotExists(ctx context.Context, t testing.TB, kubeClient kubernetes.Interface, namespace string) error {
-	t.Helper()
-
-	t.Logf("Deleting namespace %q", namespace)
-	err := kubeClient.CoreV1().Namespaces().Delete(ctx, namespace, metav1.DeleteOptions{})
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil
-		}
-		return err
-	}
-
-	return wait.PollUntilContextTimeout(ctx, time.Second, defaultPollTimeout, true, func(ctx context.Context) (bool, error) {
-		_, err := kubeClient.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
-		if apierrors.IsNotFound(err) {
-			t.Logf("Namespace %q deleted", namespace)
-			return true, nil
-		}
-		return false, nil
 	})
 }
 


### PR DESCRIPTION
This PR removes the kms plugin namespace deletion. Because it appears that cluster requires the accessibility of kms plugin to complete. 

This PR also removes the daemonset logs collection. Because it appears that our CI can smartly collect kms namespace logs (e.g. https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/multi-pr-openshift-cluster-kube-apiserver-operator-2018-openshift-cluster-openshift-apiserver-operator-643-openshift-cluster-authentication-operator-832-e2e-gcp-operator-encryption-kms/2018674377842757632/artifacts/e2e-gcp-operator-encryption-kms/gather-extra/artifacts/pods/)