### PR TITLE
HPCASE-208:Add TLSAdherencePolicy helper

### DIFF
--- a/pkg/crypto/tls_adherence.go
+++ b/pkg/crypto/tls_adherence.go
@@ -1,0 +1,23 @@
+package crypto
+
+import (
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+// ShouldHonorClusterTLSProfile returns true if the component should honor the
+// cluster-wide TLS security profile settings from apiserver.config.openshift.io/cluster.
+//
+// When this returns true (StrictAllComponents mode), components must honor the
+// cluster-wide TLS profile unless they have a component-specific TLS configuration
+// that overrides it.
+//
+// Unknown enum values are treated as StrictAllComponents for forward compatibility
+// and to default to the more secure behavior.
+func ShouldHonorClusterTLSProfile(tlsAdherence configv1.TLSAdherencePolicy) bool {
+	switch tlsAdherence {
+	case configv1.TLSAdherencePolicyNoOpinion, configv1.TLSAdherencePolicyLegacyAdheringComponentsOnly:
+		return false
+	default:
+		return true
+	}
+}

--- a/pkg/crypto/tls_adherence_test.go
+++ b/pkg/crypto/tls_adherence_test.go
@@ -1,0 +1,45 @@
+package crypto
+
+import (
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+func TestShouldHonorClusterTLSProfile(t *testing.T) {
+	tests := []struct {
+		name          string
+		tlsAdherence  configv1.TLSAdherencePolicy
+		expectedHonor bool
+	}{
+		{
+			name:          "empty string (no opinion) returns false",
+			tlsAdherence:  configv1.TLSAdherencePolicyNoOpinion,
+			expectedHonor: false,
+		},
+		{
+			name:          "LegacyAdheringComponentsOnly returns false",
+			tlsAdherence:  configv1.TLSAdherencePolicyLegacyAdheringComponentsOnly,
+			expectedHonor: false,
+		},
+		{
+			name:          "StrictAllComponents returns true",
+			tlsAdherence:  configv1.TLSAdherencePolicyStrictAllComponents,
+			expectedHonor: true,
+		},
+		{
+			name:          "unknown value defaults to true (strict behavior)",
+			tlsAdherence:  configv1.TLSAdherencePolicy("SomeUnknownFutureValue"),
+			expectedHonor: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ShouldHonorClusterTLSProfile(tt.tlsAdherence)
+			if got != tt.expectedHonor {
+				t.Errorf("ShouldHonorClusterTLSProfile(%q) = %v, want %v", tt.tlsAdherence, got, tt.expectedHonor)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add ShouldHonorClusterTLSProfile helper for TLS adherence policy

Adds a helper function that encapsulates the logic for determining
whether a component should honor the cluster-wide TLS security profile
from apiserver.config.openshift.io/cluster.

This function handles:
- Empty/unset values (treated as LegacyExternalAPIServerComponentsOnly)
- LegacyExternalAPIServerComponentsOnly (returns false)
- StrictAllComponents (returns true)
- Unknown enum values (returns true for forward compatibility)

Component implementors should use this helper rather than checking
tlsAdherence field values directly, allowing coordinated changes to
the default semantic across all implementations.

See: https://github.com/openshift/enhancements/pull/XXXX

Relevant APIServer changes: https://github.com/openshift/api/pull/2680