### PR TITLE
OCPBUGS-65896: controller/workload: Rework Degraded/Progressing conditions

### DIFF
--- a/pkg/operator/apiserver/controller/workload/workload.go
+++ b/pkg/operator/apiserver/controller/workload/workload.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -16,6 +17,7 @@ import (
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/ptr"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	applyoperatorv1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
@@ -217,10 +219,7 @@ func (c *Controller) updateOperatorStatus(ctx context.Context, previousStatus *o
 	}()
 
 	if !preconditionsReady {
-		var message string
-		for _, err := range errs {
-			message = message + err.Error() + "\n"
-		}
+		message := errMessage(errs)
 		if len(message) == 0 {
 			message = "the operator didn't specify what preconditions are missing"
 		}
@@ -248,24 +247,14 @@ func (c *Controller) updateOperatorStatus(ctx context.Context, previousStatus *o
 		return kerrors.NewAggregate(errs)
 	}
 
-	if len(errs) > 0 {
-		message := ""
-		for _, err := range errs {
-			message = message + err.Error() + "\n"
+	defer func() {
+		if len(errs) > 0 {
+			workloadDegradedCondition = workloadDegradedCondition.
+				WithStatus(operatorv1.ConditionTrue).
+				WithReason("SyncError").
+				WithMessage(errMessage(errs))
 		}
-		workloadDegradedCondition = workloadDegradedCondition.
-			WithStatus(operatorv1.ConditionTrue).
-			WithReason("SyncError").
-			WithMessage(message)
-	} else if workload == nil {
-		workloadDegradedCondition = workloadDegradedCondition.
-			WithStatus(operatorv1.ConditionTrue).
-			WithReason("NoDeployment").
-			WithMessage(fmt.Sprintf("deployment/%s: could not be retrieved", c.targetNamespace))
-	} else {
-		workloadDegradedCondition = workloadDegradedCondition.
-			WithStatus(operatorv1.ConditionFalse)
-	}
+	}()
 
 	if workload == nil {
 		message := fmt.Sprintf("deployment/%s: could not be retrieved", c.targetNamespace)
@@ -284,42 +273,53 @@ func (c *Controller) updateOperatorStatus(ctx context.Context, previousStatus *o
 			WithReason("NoDeployment").
 			WithMessage(message)
 
+		workloadDegradedCondition = workloadDegradedCondition.
+			WithStatus(operatorv1.ConditionTrue).
+			WithReason("NoDeployment").
+			WithMessage(message)
+
 		return kerrors.NewAggregate(errs)
 	}
+
+	workloadDegradedCondition = workloadDegradedCondition.WithStatus(operatorv1.ConditionFalse)
 
 	if workload.Status.AvailableReplicas == 0 {
 		deploymentAvailableCondition = deploymentAvailableCondition.
 			WithStatus(operatorv1.ConditionFalse).
 			WithReason("NoPod").
-			WithMessage(fmt.Sprintf("no %s.%s pods available on any node.", workload.Name, c.targetNamespace))
+			WithMessage(fmt.Sprintf("no %s.%s pods available on any node", workload.Name, c.targetNamespace))
 	} else {
 		deploymentAvailableCondition = deploymentAvailableCondition.
 			WithStatus(operatorv1.ConditionTrue).
 			WithReason("AsExpected")
 	}
 
-	desiredReplicas := int32(1)
-	if workload.Spec.Replicas != nil {
-		desiredReplicas = *(workload.Spec.Replicas)
+	desiredReplicas := ptr.Deref(workload.Spec.Replicas, 1)
+
+	// Update is done when the deployment controller has reported NewReplicaSetAvailable.
+	// Checking the current vs. observed generation here is not possible since we don't want to be Progressing on scaling.
+	progressTimedOutMessage, workloadIsBeingUpdatedTooLong := hasDeploymentTimedOutProgressing(workload.Status)
+	workloadIsBeingUpdated := !hasDeploymentProgressed(workload.Status) && !workloadIsBeingUpdatedTooLong
+
+	var progressDeadlineExceededMessage string
+	if workloadIsBeingUpdatedTooLong {
+		progressDeadlineExceededMessage = fmt.Sprintf("deployment/%s.%s has timed out progressing: %s", workload.Name, c.targetNamespace, progressTimedOutMessage)
 	}
 
-	// If the workload is up to date, then we are no longer progressing
-	workloadAtHighestGeneration := workload.ObjectMeta.Generation == workload.Status.ObservedGeneration
-	// Update is done when all pods have been updated to the latest revision
-	// and the deployment controller has reported NewReplicaSetAvailable
-	workloadIsBeingUpdated := !workloadAtHighestGeneration || !hasDeploymentProgressed(workload.Status)
-	workloadIsBeingUpdatedTooLong := v1helpers.IsUpdatingTooLong(previousStatus, *deploymentProgressingCondition.Type)
-	if !workloadAtHighestGeneration {
-		deploymentProgressingCondition = deploymentProgressingCondition.
-			WithStatus(operatorv1.ConditionTrue).
-			WithReason("NewGeneration").
-			WithMessage(fmt.Sprintf("deployment/%s.%s: observed generation is %d, desired generation is %d.", workload.Name, c.targetNamespace, workload.Status.ObservedGeneration, workload.ObjectMeta.Generation))
-	} else if workloadIsBeingUpdated {
+	switch {
+	case workloadIsBeingUpdated:
 		deploymentProgressingCondition = deploymentProgressingCondition.
 			WithStatus(operatorv1.ConditionTrue).
 			WithReason("PodsUpdating").
-			WithMessage(fmt.Sprintf("deployment/%s.%s: %d/%d pods have been updated to the latest generation and %d/%d pods are available", workload.Name, c.targetNamespace, workload.Status.UpdatedReplicas, desiredReplicas, workload.Status.AvailableReplicas, desiredReplicas))
-	} else {
+			WithMessage(fmt.Sprintf("deployment/%s.%s: %d/%d pods have been updated to the latest revision and %d/%d pods are available", workload.Name, c.targetNamespace, workload.Status.UpdatedReplicas, desiredReplicas, workload.Status.AvailableReplicas, desiredReplicas))
+
+	case workloadIsBeingUpdatedTooLong:
+		deploymentProgressingCondition = deploymentProgressingCondition.
+			WithStatus(operatorv1.ConditionFalse).
+			WithReason("ProgressDeadlineExceeded").
+			WithMessage(progressDeadlineExceededMessage)
+
+	default:
 		// Terminating pods don't account for any of the other status fields but
 		// still can exist in a state when they are accepting connections and would
 		// contribute to unexpected behavior when we report Progressing=False.
@@ -332,22 +332,42 @@ func (c *Controller) updateOperatorStatus(ctx context.Context, previousStatus *o
 			WithReason("AsExpected")
 	}
 
-	// During a rollout the default maxSurge (25%) will allow the available
-	// replicas to temporarily exceed the desired replica count. If this were
-	// to occur, the operator should not report degraded.
-	workloadHasAllPodsAvailable := workload.Status.AvailableReplicas >= desiredReplicas
-	if !workloadHasAllPodsAvailable && (!workloadIsBeingUpdated || workloadIsBeingUpdatedTooLong) {
-		numNonAvailablePods := desiredReplicas - workload.Status.AvailableReplicas
+	switch {
+	case workloadIsBeingUpdatedTooLong:
 		deploymentDegradedCondition = deploymentDegradedCondition.
 			WithStatus(operatorv1.ConditionTrue).
-			WithReason("UnavailablePod")
-		podContainersStatus, err := deployment.PodContainersStatus(workload, c.podsLister)
+			WithReason("ProgressDeadlineExceeded").
+			WithMessage(progressDeadlineExceededMessage)
+
+	// The following case handles Degraded when not progressing, particularly on scaling.
+	case !workloadIsBeingUpdated && workload.Status.AvailableReplicas < desiredReplicas:
+		hasFailing, err := hasFailingPods(workload, c.podsLister, time.Now())
 		if err != nil {
-			podContainersStatus = []string{fmt.Sprintf("failed to get pod containers details: %v", err)}
+			errs = append(errs, err)
 		}
-		deploymentDegradedCondition = deploymentDegradedCondition.
-			WithMessage(fmt.Sprintf("%v of %v requested instances are unavailable for %s.%s (%s)", numNonAvailablePods, desiredReplicas, workload.Name, c.targetNamespace, strings.Join(podContainersStatus, ", ")))
-	} else {
+		if hasFailing || workload.Status.AvailableReplicas == 0 {
+			containerMessages, err := deployment.PodContainersStatus(workload, c.podsLister)
+			if err != nil {
+				errs = append(errs, err)
+			}
+			var failureDescription string
+			if len(containerMessages) > 0 {
+				failureDescription = ` (` + strings.Join(containerMessages, ", ") + `)`
+			}
+
+			numUnavailable := desiredReplicas - workload.Status.AvailableReplicas
+			message := fmt.Sprintf("%d of %d requested instances are unavailable for %s.%s%s", numUnavailable, desiredReplicas, workload.Name, c.targetNamespace, failureDescription)
+			deploymentDegradedCondition = deploymentDegradedCondition.
+				WithStatus(operatorv1.ConditionTrue).
+				WithReason("UnavailablePod").
+				WithMessage(message)
+		} else {
+			deploymentDegradedCondition = deploymentDegradedCondition.
+				WithStatus(operatorv1.ConditionFalse).
+				WithReason("AsExpected")
+		}
+
+	default:
 		deploymentDegradedCondition = deploymentDegradedCondition.
 			WithStatus(operatorv1.ConditionFalse).
 			WithReason("AsExpected")
@@ -356,8 +376,11 @@ func (c *Controller) updateOperatorStatus(ctx context.Context, previousStatus *o
 	// if the deployment is all available and at the expected generation, then update the version to the latest
 	// when we update, the image pull spec should immediately be different, which should immediately cause a deployment rollout
 	// which should immediately result in a deployment generation diff, which should cause this block to be skipped until it is ready.
-	workloadHasAllPodsUpdated := workload.Status.UpdatedReplicas == desiredReplicas
-	if workloadAtHighestGeneration && workloadHasAllPodsAvailable && workloadHasAllPodsUpdated && operatorConfigAtHighestGeneration {
+	if operatorConfigAtHighestGeneration &&
+		workload.ObjectMeta.Generation == workload.Status.ObservedGeneration &&
+		workload.Status.AvailableReplicas == desiredReplicas &&
+		workload.Status.UpdatedReplicas == desiredReplicas {
+
 		c.versionRecorder.SetVersion(c.constructOperandNameFor(workload.Name), c.targetOperandVersion)
 	}
 
@@ -384,6 +407,77 @@ func hasDeploymentProgressed(status appsv1.DeploymentStatus) bool {
 		}
 	}
 	return false
+}
+
+// hasDeploymentTimedOutProgressing returns true if the deployment reports ProgressDeadlineExceeded.
+// The function returns the Progressing condition message as the first return value.
+func hasDeploymentTimedOutProgressing(status appsv1.DeploymentStatus) (string, bool) {
+	for _, cond := range status.Conditions {
+		if cond.Type == appsv1.DeploymentProgressing {
+			return cond.Message, cond.Status == corev1.ConditionFalse && cond.Reason == "ProgressDeadlineExceeded"
+		}
+	}
+	return "", false
+}
+
+func hasFailingPods(workload *appsv1.Deployment, podsLister corev1listers.PodLister, now time.Time) (bool, error) {
+	selector, err := metav1.LabelSelectorAsSelector(workload.Spec.Selector)
+	if err != nil {
+		return false, err
+	}
+	pods, err := podsLister.Pods(workload.Namespace).List(selector)
+	if err != nil {
+		return false, err
+	}
+
+	progressDeadline := time.Duration(ptr.Deref(workload.Spec.ProgressDeadlineSeconds, 600)) * time.Second
+	minReady := time.Duration(workload.Spec.MinReadySeconds) * time.Second
+
+	for _, pod := range pods {
+		if pod.DeletionTimestamp != nil {
+			continue
+		}
+
+		readyCond := findPodReadyCondition(pod)
+		deadline := pod.CreationTimestamp.Time.Add(progressDeadline)
+
+		if (readyCond == nil || readyCond.Status != corev1.ConditionTrue) && now.After(deadline) {
+			return true, nil
+		}
+
+		// Detect flapping Ready condition: the pod is currently Ready but its
+		// Ready condition transitioned too recently to count as available
+		// (hasn't stayed continuously ready for MinReadySeconds).
+		//
+		// Make the check only relevant after ProgressDeadlineSeconds + minReadySeconds.
+		if minReady > 0 && readyCond != nil && readyCond.Status == corev1.ConditionTrue {
+			isRelevant := now.After(pod.CreationTimestamp.Time.Add(progressDeadline + minReady))
+			if isRelevant && now.Sub(readyCond.LastTransitionTime.Time) < minReady {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+func findPodReadyCondition(pod *corev1.Pod) *corev1.PodCondition {
+	for i := range pod.Status.Conditions {
+		if pod.Status.Conditions[i].Type == corev1.PodReady {
+			return &pod.Status.Conditions[i]
+		}
+	}
+	return nil
+}
+
+func errMessage(errs []error) string {
+	var b strings.Builder
+	for i, err := range errs {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		b.WriteString(err.Error())
+	}
+	return b.String()
 }
 
 // EnsureAtMostOnePodPerNode updates the deployment spec to prevent more than

--- a/pkg/operator/apiserver/controller/workload/workload.go
+++ b/pkg/operator/apiserver/controller/workload/workload.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -218,10 +219,7 @@ func (c *Controller) updateOperatorStatus(ctx context.Context, previousStatus *o
 	}()
 
 	if !preconditionsReady {
-		var message string
-		if err := errors.Join(errs...); err != nil {
-			message = err.Error()
-		}
+		message := errMessage(errs)
 		if len(message) == 0 {
 			message = "the operator didn't specify what preconditions are missing"
 		}
@@ -249,24 +247,14 @@ func (c *Controller) updateOperatorStatus(ctx context.Context, previousStatus *o
 		return kerrors.NewAggregate(errs)
 	}
 
-	if len(errs) > 0 {
-		var message string
-		if err := errors.Join(errs...); err != nil {
-			message = err.Error()
+	defer func() {
+		if len(errs) > 0 {
+			workloadDegradedCondition = workloadDegradedCondition.
+				WithStatus(operatorv1.ConditionTrue).
+				WithReason("SyncError").
+				WithMessage(errMessage(errs))
 		}
-		workloadDegradedCondition = workloadDegradedCondition.
-			WithStatus(operatorv1.ConditionTrue).
-			WithReason("SyncError").
-			WithMessage(message)
-	} else if workload == nil {
-		workloadDegradedCondition = workloadDegradedCondition.
-			WithStatus(operatorv1.ConditionTrue).
-			WithReason("NoDeployment").
-			WithMessage(fmt.Sprintf("deployment/%s: could not be retrieved", c.targetNamespace))
-	} else {
-		workloadDegradedCondition = workloadDegradedCondition.
-			WithStatus(operatorv1.ConditionFalse)
-	}
+	}()
 
 	if workload == nil {
 		message := fmt.Sprintf("deployment/%s: could not be retrieved", c.targetNamespace)
@@ -285,14 +273,21 @@ func (c *Controller) updateOperatorStatus(ctx context.Context, previousStatus *o
 			WithReason("NoDeployment").
 			WithMessage(message)
 
+		workloadDegradedCondition = workloadDegradedCondition.
+			WithStatus(operatorv1.ConditionTrue).
+			WithReason("NoDeployment").
+			WithMessage(message)
+
 		return kerrors.NewAggregate(errs)
 	}
+
+	workloadDegradedCondition = workloadDegradedCondition.WithStatus(operatorv1.ConditionFalse)
 
 	if workload.Status.AvailableReplicas == 0 {
 		deploymentAvailableCondition = deploymentAvailableCondition.
 			WithStatus(operatorv1.ConditionFalse).
 			WithReason("NoPod").
-			WithMessage(fmt.Sprintf("no %s.%s pods available on any node.", workload.Name, c.targetNamespace))
+			WithMessage(fmt.Sprintf("no %s.%s pods available on any node", workload.Name, c.targetNamespace))
 	} else {
 		deploymentAvailableCondition = deploymentAvailableCondition.
 			WithStatus(operatorv1.ConditionTrue).
@@ -301,23 +296,30 @@ func (c *Controller) updateOperatorStatus(ctx context.Context, previousStatus *o
 
 	desiredReplicas := ptr.Deref(workload.Spec.Replicas, 1)
 
-	// If the workload is up to date, then we are no longer progressing
-	workloadAtHighestGeneration := workload.ObjectMeta.Generation == workload.Status.ObservedGeneration
-	// Update is done when all pods have been updated to the latest revision
-	// and the deployment controller has reported NewReplicaSetAvailable
-	workloadIsBeingUpdated := !workloadAtHighestGeneration || !hasDeploymentProgressed(workload.Status)
-	workloadIsBeingUpdatedTooLong := v1helpers.IsUpdatingTooLong(previousStatus, *deploymentProgressingCondition.Type)
-	if !workloadAtHighestGeneration {
-		deploymentProgressingCondition = deploymentProgressingCondition.
-			WithStatus(operatorv1.ConditionTrue).
-			WithReason("NewGeneration").
-			WithMessage(fmt.Sprintf("deployment/%s.%s: observed generation is %d, desired generation is %d.", workload.Name, c.targetNamespace, workload.Status.ObservedGeneration, workload.ObjectMeta.Generation))
-	} else if workloadIsBeingUpdated {
+	// Update is done when the deployment controller has reported NewReplicaSetAvailable.
+	// Checking the current vs. observed generation here is not possible since we don't want to be Progressing on scaling.
+	progressTimedOutMessage, workloadIsBeingUpdatedTooLong := hasDeploymentTimedOutProgressing(workload.Status)
+	workloadIsBeingUpdated := !hasDeploymentProgressed(workload.Status) && !workloadIsBeingUpdatedTooLong
+
+	var progressDeadlineExceededMessage string
+	if workloadIsBeingUpdatedTooLong {
+		progressDeadlineExceededMessage = fmt.Sprintf("deployment/%s.%s has timed out progressing: %s", workload.Name, c.targetNamespace, progressTimedOutMessage)
+	}
+
+	switch {
+	case workloadIsBeingUpdated:
 		deploymentProgressingCondition = deploymentProgressingCondition.
 			WithStatus(operatorv1.ConditionTrue).
 			WithReason("PodsUpdating").
-			WithMessage(fmt.Sprintf("deployment/%s.%s: %d/%d pods have been updated to the latest generation and %d/%d pods are available", workload.Name, c.targetNamespace, workload.Status.UpdatedReplicas, desiredReplicas, workload.Status.AvailableReplicas, desiredReplicas))
-	} else {
+			WithMessage(fmt.Sprintf("deployment/%s.%s: %d/%d pods have been updated to the latest revision and %d/%d pods are available", workload.Name, c.targetNamespace, workload.Status.UpdatedReplicas, desiredReplicas, workload.Status.AvailableReplicas, desiredReplicas))
+
+	case workloadIsBeingUpdatedTooLong:
+		deploymentProgressingCondition = deploymentProgressingCondition.
+			WithStatus(operatorv1.ConditionFalse).
+			WithReason("ProgressDeadlineExceeded").
+			WithMessage(progressDeadlineExceededMessage)
+
+	default:
 		// Terminating pods don't account for any of the other status fields but
 		// still can exist in a state when they are accepting connections and would
 		// contribute to unexpected behavior when we report Progressing=False.
@@ -330,22 +332,42 @@ func (c *Controller) updateOperatorStatus(ctx context.Context, previousStatus *o
 			WithReason("AsExpected")
 	}
 
-	// During a rollout the default maxSurge (25%) will allow the available
-	// replicas to temporarily exceed the desired replica count. If this were
-	// to occur, the operator should not report degraded.
-	workloadHasAllPodsAvailable := workload.Status.AvailableReplicas >= desiredReplicas
-	if !workloadHasAllPodsAvailable && (!workloadIsBeingUpdated || workloadIsBeingUpdatedTooLong) {
-		numNonAvailablePods := desiredReplicas - workload.Status.AvailableReplicas
+	switch {
+	case workloadIsBeingUpdatedTooLong:
 		deploymentDegradedCondition = deploymentDegradedCondition.
 			WithStatus(operatorv1.ConditionTrue).
-			WithReason("UnavailablePod")
-		podContainersStatus, err := deployment.PodContainersStatus(workload, c.podsLister)
+			WithReason("ProgressDeadlineExceeded").
+			WithMessage(progressDeadlineExceededMessage)
+
+	// The following case handles Degraded when not progressing, particularly on scaling.
+	case !workloadIsBeingUpdated && workload.Status.AvailableReplicas < desiredReplicas:
+		hasFailing, err := hasFailingPods(workload, c.podsLister, time.Now())
 		if err != nil {
-			podContainersStatus = []string{fmt.Sprintf("failed to get pod containers details: %v", err)}
+			errs = append(errs, err)
 		}
-		deploymentDegradedCondition = deploymentDegradedCondition.
-			WithMessage(fmt.Sprintf("%v of %v requested instances are unavailable for %s.%s (%s)", numNonAvailablePods, desiredReplicas, workload.Name, c.targetNamespace, strings.Join(podContainersStatus, ", ")))
-	} else {
+		if hasFailing || workload.Status.AvailableReplicas == 0 {
+			containerMessages, err := deployment.PodContainersStatus(workload, c.podsLister)
+			if err != nil {
+				errs = append(errs, err)
+			}
+			var failureDescription string
+			if len(containerMessages) > 0 {
+				failureDescription = ` (` + strings.Join(containerMessages, ", ") + `)`
+			}
+
+			numUnavailable := desiredReplicas - workload.Status.AvailableReplicas
+			message := fmt.Sprintf("%d of %d requested instances are unavailable for %s.%s%s", numUnavailable, desiredReplicas, workload.Name, c.targetNamespace, failureDescription)
+			deploymentDegradedCondition = deploymentDegradedCondition.
+				WithStatus(operatorv1.ConditionTrue).
+				WithReason("UnavailablePod").
+				WithMessage(message)
+		} else {
+			deploymentDegradedCondition = deploymentDegradedCondition.
+				WithStatus(operatorv1.ConditionFalse).
+				WithReason("AsExpected")
+		}
+
+	default:
 		deploymentDegradedCondition = deploymentDegradedCondition.
 			WithStatus(operatorv1.ConditionFalse).
 			WithReason("AsExpected")
@@ -354,8 +376,11 @@ func (c *Controller) updateOperatorStatus(ctx context.Context, previousStatus *o
 	// if the deployment is all available and at the expected generation, then update the version to the latest
 	// when we update, the image pull spec should immediately be different, which should immediately cause a deployment rollout
 	// which should immediately result in a deployment generation diff, which should cause this block to be skipped until it is ready.
-	workloadHasAllPodsUpdated := workload.Status.UpdatedReplicas == desiredReplicas
-	if workloadAtHighestGeneration && workloadHasAllPodsAvailable && workloadHasAllPodsUpdated && operatorConfigAtHighestGeneration {
+	if operatorConfigAtHighestGeneration &&
+		workload.ObjectMeta.Generation == workload.Status.ObservedGeneration &&
+		workload.Status.AvailableReplicas == desiredReplicas &&
+		workload.Status.UpdatedReplicas == desiredReplicas {
+
 		c.versionRecorder.SetVersion(c.constructOperandNameFor(workload.Name), c.targetOperandVersion)
 	}
 
@@ -382,6 +407,77 @@ func hasDeploymentProgressed(status appsv1.DeploymentStatus) bool {
 		}
 	}
 	return false
+}
+
+// hasDeploymentTimedOutProgressing returns true if the deployment reports ProgressDeadlineExceeded.
+// The function returns the Progressing condition message as the first return value.
+func hasDeploymentTimedOutProgressing(status appsv1.DeploymentStatus) (string, bool) {
+	for _, cond := range status.Conditions {
+		if cond.Type == appsv1.DeploymentProgressing {
+			return cond.Message, cond.Status == corev1.ConditionFalse && cond.Reason == "ProgressDeadlineExceeded"
+		}
+	}
+	return "", false
+}
+
+func hasFailingPods(workload *appsv1.Deployment, podsLister corev1listers.PodLister, now time.Time) (bool, error) {
+	selector, err := metav1.LabelSelectorAsSelector(workload.Spec.Selector)
+	if err != nil {
+		return false, err
+	}
+	pods, err := podsLister.Pods(workload.Namespace).List(selector)
+	if err != nil {
+		return false, err
+	}
+
+	progressDeadline := time.Duration(ptr.Deref(workload.Spec.ProgressDeadlineSeconds, 600)) * time.Second
+	minReady := time.Duration(workload.Spec.MinReadySeconds) * time.Second
+
+	for _, pod := range pods {
+		if pod.DeletionTimestamp != nil {
+			continue
+		}
+
+		readyCond := findPodReadyCondition(pod)
+		deadline := pod.CreationTimestamp.Time.Add(progressDeadline)
+
+		if (readyCond == nil || readyCond.Status != corev1.ConditionTrue) && now.After(deadline) {
+			return true, nil
+		}
+
+		// Detect flapping Ready condition: the pod is currently Ready but its
+		// Ready condition transitioned too recently to count as available
+		// (hasn't stayed continuously ready for MinReadySeconds).
+		//
+		// Make the check only relevant after ProgressDeadlineSeconds + minReadySeconds.
+		if minReady > 0 && readyCond != nil && readyCond.Status == corev1.ConditionTrue {
+			isRelevant := now.After(pod.CreationTimestamp.Time.Add(progressDeadline + minReady))
+			if isRelevant && now.Sub(readyCond.LastTransitionTime.Time) < minReady {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+func findPodReadyCondition(pod *corev1.Pod) *corev1.PodCondition {
+	for i := range pod.Status.Conditions {
+		if pod.Status.Conditions[i].Type == corev1.PodReady {
+			return &pod.Status.Conditions[i]
+		}
+	}
+	return nil
+}
+
+func errMessage(errs []error) string {
+	var b strings.Builder
+	for i, err := range errs {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		b.WriteString(err.Error())
+	}
+	return b.String()
 }
 
 // EnsureAtMostOnePodPerNode updates the deployment spec to prevent more than

--- a/pkg/operator/apiserver/controller/workload/workload_test.go
+++ b/pkg/operator/apiserver/controller/workload/workload_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	corev1listers "k8s.io/client-go/listers/core/v1"
@@ -57,13 +59,15 @@ func TestUpdateOperatorStatus(t *testing.T) {
 
 		workload                        *appsv1.Deployment
 		pods                            []*corev1.Pod
+		podListErr                      error
 		operatorConfigAtHighestRevision bool
 		operatorPreconditionsNotReady   bool
 		preconditionError               error
 		errors                          []error
 		previousConditions              []operatorv1.OperatorCondition
 
-		validateOperatorStatus func(*operatorv1.OperatorStatus) error
+		validateOperatorStatus  func(*operatorv1.OperatorStatus) error
+		validateVersionRecorder func(*fakeVersionRecorder) error
 	}{
 		{
 			name: "scenario: no workload, no errors thus we are degraded and we are progressing",
@@ -112,7 +116,7 @@ func TestUpdateOperatorStatus(t *testing.T) {
 					{
 						Type:    fmt.Sprintf("%sWorkloadDegraded", defaultControllerName),
 						Status:  operatorv1.ConditionTrue,
-						Message: "nasty error\n",
+						Message: "nasty error",
 						Reason:  "SyncError",
 					},
 					{
@@ -133,14 +137,13 @@ func TestUpdateOperatorStatus(t *testing.T) {
 			},
 		},
 		{
-			name: "scenario: we have an unavailable workload being updated for too long and no errors thus we are degraded",
+			name: "scenario: unavailable workload with progress deadline exceeded",
 			workload: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "apiserver",
 					Namespace: "openshift-apiserver",
 				},
 				Spec: appsv1.DeploymentSpec{
-					Template: corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"foo": "bar"}}},
 					Replicas: ptr.To[int32](3),
 				},
 				Status: appsv1.DeploymentStatus{
@@ -152,7 +155,7 @@ func TestUpdateOperatorStatus(t *testing.T) {
 			},
 			pods: []*corev1.Pod{
 				{
-					ObjectMeta: metav1.ObjectMeta{Name: "apiserver", Namespace: "openshift-apiserver", Labels: map[string]string{"foo": "bar"}},
+					ObjectMeta: metav1.ObjectMeta{Name: "apiserver", Namespace: "openshift-apiserver"},
 					Status: corev1.PodStatus{
 						Phase: corev1.PodPending,
 						ContainerStatuses: []corev1.ContainerStatus{
@@ -184,7 +187,7 @@ func TestUpdateOperatorStatus(t *testing.T) {
 						Type:    fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeAvailable),
 						Status:  operatorv1.ConditionFalse,
 						Reason:  "NoPod",
-						Message: "no apiserver.openshift-apiserver pods available on any node.",
+						Message: "no apiserver.openshift-apiserver pods available on any node",
 					},
 					{
 						Type:   fmt.Sprintf("%sWorkloadDegraded", defaultControllerName),
@@ -193,28 +196,27 @@ func TestUpdateOperatorStatus(t *testing.T) {
 					{
 						Type:    fmt.Sprintf("%sDeploymentDegraded", defaultControllerName),
 						Status:  operatorv1.ConditionTrue,
-						Reason:  "UnavailablePod",
-						Message: "3 of 3 requested instances are unavailable for apiserver.openshift-apiserver (container is waiting in pending apiserver pod)",
+						Reason:  "ProgressDeadlineExceeded",
+						Message: "deployment/apiserver.openshift-apiserver has timed out progressing: timed out",
 					},
 					{
 						Type:    fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
-						Status:  operatorv1.ConditionTrue,
-						Reason:  "PodsUpdating",
-						Message: "deployment/apiserver.openshift-apiserver: 0/3 pods have been updated to the latest generation and 0/3 pods are available",
+						Status:  operatorv1.ConditionFalse,
+						Reason:  "ProgressDeadlineExceeded",
+						Message: "deployment/apiserver.openshift-apiserver has timed out progressing: timed out",
 					},
 				}
 				return areCondidtionsEqual(expectedConditions, actualStatus.Conditions)
 			},
 		},
 		{
-			name: "scenario: we have an unavailable workload being updated for a short time and no errors so we are progressing",
+			name: "scenario: unavailable workload progressing normally",
 			workload: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "apiserver",
 					Namespace: "openshift-apiserver",
 				},
 				Spec: appsv1.DeploymentSpec{
-					Template: corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"foo": "bar"}}},
 					Replicas: ptr.To[int32](3),
 				},
 				Status: appsv1.DeploymentStatus{
@@ -226,7 +228,7 @@ func TestUpdateOperatorStatus(t *testing.T) {
 			},
 			pods: []*corev1.Pod{
 				{
-					ObjectMeta: metav1.ObjectMeta{Name: "apiserver", Namespace: "openshift-apiserver", Labels: map[string]string{"foo": "bar"}},
+					ObjectMeta: metav1.ObjectMeta{Name: "apiserver", Namespace: "openshift-apiserver"},
 					Status: corev1.PodStatus{
 						Phase: corev1.PodPending,
 						ContainerStatuses: []corev1.ContainerStatus{
@@ -235,8 +237,7 @@ func TestUpdateOperatorStatus(t *testing.T) {
 								Ready: false,
 								State: corev1.ContainerState{
 									Waiting: &corev1.ContainerStateWaiting{
-										Reason:  "ImagePull",
-										Message: "slow registry",
+										Reason: "ContainerCreating",
 									},
 								},
 							},
@@ -258,7 +259,7 @@ func TestUpdateOperatorStatus(t *testing.T) {
 						Type:    fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeAvailable),
 						Status:  operatorv1.ConditionFalse,
 						Reason:  "NoPod",
-						Message: "no apiserver.openshift-apiserver pods available on any node.",
+						Message: "no apiserver.openshift-apiserver pods available on any node",
 					},
 					{
 						Type:   fmt.Sprintf("%sWorkloadDegraded", defaultControllerName),
@@ -273,21 +274,81 @@ func TestUpdateOperatorStatus(t *testing.T) {
 						Type:    fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
 						Status:  operatorv1.ConditionTrue,
 						Reason:  "PodsUpdating",
-						Message: "deployment/apiserver.openshift-apiserver: 0/3 pods have been updated to the latest generation and 0/3 pods are available",
+						Message: "deployment/apiserver.openshift-apiserver: 0/3 pods have been updated to the latest revision and 0/3 pods are available",
 					},
 				}
 				return areCondidtionsEqual(expectedConditions, actualStatus.Conditions)
 			},
 		},
 		{
-			name: "scenario: we have an incomplete workload and no errors thus we are available and degraded (missing 1 replica)",
+			name: "scenario: unavailable workload that previously progressed successfully",
+			workload: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "apiserver",
+					Namespace:  "openshift-apiserver",
+					Generation: 5,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: ptr.To[int32](3),
+				},
+				Status: appsv1.DeploymentStatus{
+					AvailableReplicas:  0,
+					UpdatedReplicas:    3,
+					ObservedGeneration: 5,
+					Conditions: []appsv1.DeploymentCondition{
+						{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, LastUpdateTime: metav1.Now(), LastTransitionTime: metav1.Now(), Reason: "NewReplicaSetAvailable", Message: "has successfully progressed"},
+					},
+				},
+			},
+			pods: []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "apiserver-1", Namespace: "openshift-apiserver", CreationTimestamp: metav1.NewTime(time.Now().Add(-20 * time.Minute))},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodReady, Status: corev1.ConditionFalse},
+						},
+						ContainerStatuses: []corev1.ContainerStatus{
+							{Name: "apiserver", Ready: false, RestartCount: 8},
+						},
+					},
+				},
+			},
+			validateOperatorStatus: func(actualStatus *operatorv1.OperatorStatus) error {
+				expectedConditions := []operatorv1.OperatorCondition{
+					{
+						Type:    fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeAvailable),
+						Status:  operatorv1.ConditionFalse,
+						Reason:  "NoPod",
+						Message: "no apiserver.openshift-apiserver pods available on any node",
+					},
+					{
+						Type:   fmt.Sprintf("%sWorkloadDegraded", defaultControllerName),
+						Status: operatorv1.ConditionFalse,
+					},
+					{
+						Type:    fmt.Sprintf("%sDeploymentDegraded", defaultControllerName),
+						Status:  operatorv1.ConditionTrue,
+						Reason:  "UnavailablePod",
+						Message: "3 of 3 requested instances are unavailable for apiserver.openshift-apiserver (container is crashlooping in apiserver-1 pod)",
+					},
+					{
+						Type:   fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
+						Status: operatorv1.ConditionFalse,
+						Reason: "AsExpected",
+					},
+				}
+				return areCondidtionsEqual(expectedConditions, actualStatus.Conditions)
+			},
+		},
+		{
+			name: "scenario: partially available workload with failing pod",
 			workload: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "apiserver",
 					Namespace: "openshift-apiserver",
 				},
 				Spec: appsv1.DeploymentSpec{
-					Template: corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"foo": "bar"}}},
 					Replicas: ptr.To[int32](3),
 				},
 				Status: appsv1.DeploymentStatus{
@@ -300,20 +361,26 @@ func TestUpdateOperatorStatus(t *testing.T) {
 			},
 			pods: []*corev1.Pod{
 				{
-					ObjectMeta: metav1.ObjectMeta{Name: "apiserver", Namespace: "openshift-apiserver"},
+					ObjectMeta: metav1.ObjectMeta{Name: "apiserver-ready", Namespace: "openshift-apiserver", CreationTimestamp: metav1.NewTime(time.Now().Add(-20 * time.Minute))},
 					Status: corev1.PodStatus{
-						Phase: corev1.PodSucceeded,
+						Phase: corev1.PodRunning,
+						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+						},
 						ContainerStatuses: []corev1.ContainerStatus{
-							{
-								Name:  "test",
-								Ready: true,
-								State: corev1.ContainerState{
-									Terminated: &corev1.ContainerStateTerminated{
-										Reason:  "PodKilled",
-										Message: "john wick was here",
-									},
-								},
-							},
+							{Name: "test", Ready: true},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "apiserver-crash", Namespace: "openshift-apiserver", CreationTimestamp: metav1.NewTime(time.Now().Add(-20 * time.Minute))},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodReady, Status: corev1.ConditionFalse},
+						},
+						ContainerStatuses: []corev1.ContainerStatus{
+							{Name: "test", Ready: false, RestartCount: 5},
 						},
 					},
 				},
@@ -334,7 +401,7 @@ func TestUpdateOperatorStatus(t *testing.T) {
 						Type:    fmt.Sprintf("%sDeploymentDegraded", defaultControllerName),
 						Status:  operatorv1.ConditionTrue,
 						Reason:  "UnavailablePod",
-						Message: "1 of 3 requested instances are unavailable for apiserver.openshift-apiserver ()",
+						Message: "1 of 3 requested instances are unavailable for apiserver.openshift-apiserver (container is crashlooping in apiserver-crash pod)",
 					},
 					{
 						Type:    fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
@@ -393,7 +460,7 @@ func TestUpdateOperatorStatus(t *testing.T) {
 			},
 		},
 		{
-			name: "scenario: we have an outdated (generation) workload and no errors thus we are available and we are progressing",
+			name: "scenario: workload scaling with generation mismatch",
 			workload: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "apiserver",
@@ -401,7 +468,7 @@ func TestUpdateOperatorStatus(t *testing.T) {
 					Generation: 100,
 				},
 				Spec: appsv1.DeploymentSpec{
-					Replicas: ptr.To[int32](3),
+					Replicas: ptr.To[int32](5),
 				},
 				Status: appsv1.DeploymentStatus{
 					Replicas:           3,
@@ -434,17 +501,16 @@ func TestUpdateOperatorStatus(t *testing.T) {
 					},
 					{
 						Type:    fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
-						Status:  operatorv1.ConditionTrue,
-						Reason:  "NewGeneration",
-						Message: "deployment/apiserver.openshift-apiserver: observed generation is 99, desired generation is 100.",
+						Status:  operatorv1.ConditionFalse,
+						Reason:  "AsExpected",
+						Message: "",
 					},
 				}
 				return areCondidtionsEqual(expectedConditions, actualStatus.Conditions)
 			},
 		},
-
 		{
-			name: "scenario: rare case when we have an outdated (generation) workload and one old replica failing is but it will be picked up soon by the new rollout thus we are available and we are progressing",
+			name: "scenario: partially available during scale-up, pods starting",
 			workload: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "apiserver",
@@ -455,13 +521,96 @@ func TestUpdateOperatorStatus(t *testing.T) {
 					Replicas: ptr.To[int32](3),
 				},
 				Status: appsv1.DeploymentStatus{
-					Replicas:           3,
-					ReadyReplicas:      2,
-					AvailableReplicas:  2,
+					AvailableReplicas:  1,
+					UpdatedReplicas:    1,
+					ObservedGeneration: 99,
+					Conditions: []appsv1.DeploymentCondition{
+						{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, Reason: "NewReplicaSetAvailable"},
+					},
+				},
+			},
+			pods: []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "apiserver-new-1", Namespace: "openshift-apiserver", CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Minute))},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodPending,
+						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodReady, Status: corev1.ConditionFalse},
+						},
+						ContainerStatuses: []corev1.ContainerStatus{
+							{Name: "test", Ready: false, RestartCount: 0, State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "ContainerCreating"}}},
+						},
+					},
+				},
+			},
+			validateOperatorStatus: func(actualStatus *operatorv1.OperatorStatus) error {
+				expectedConditions := []operatorv1.OperatorCondition{
+					{
+						Type:   fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeAvailable),
+						Status: operatorv1.ConditionTrue,
+						Reason: "AsExpected",
+					},
+					{
+						Type:   fmt.Sprintf("%sWorkloadDegraded", defaultControllerName),
+						Status: operatorv1.ConditionFalse,
+					},
+					{
+						Type:   fmt.Sprintf("%sDeploymentDegraded", defaultControllerName),
+						Status: operatorv1.ConditionFalse,
+						Reason: "AsExpected",
+					},
+					{
+						Type:   fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
+						Status: operatorv1.ConditionFalse,
+						Reason: "AsExpected",
+					},
+				}
+				return areCondidtionsEqual(expectedConditions, actualStatus.Conditions)
+			},
+		},
+		{
+			name: "scenario: partially available during scale-up, new pods failing",
+			workload: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "apiserver",
+					Namespace:  "openshift-apiserver",
+					Generation: 100,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: ptr.To[int32](5),
+				},
+				Status: appsv1.DeploymentStatus{
+					AvailableReplicas:  3,
 					UpdatedReplicas:    3,
 					ObservedGeneration: 99,
 					Conditions: []appsv1.DeploymentCondition{
-						{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, LastUpdateTime: metav1.Now(), LastTransitionTime: metav1.Now(), Reason: "NewReplicaSetAvailable", Message: "has successfully progressed"},
+						{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, Reason: "NewReplicaSetAvailable"},
+					},
+				},
+			},
+			pods: []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "apiserver-fail-1", Namespace: "openshift-apiserver", CreationTimestamp: metav1.NewTime(time.Now().Add(-20 * time.Minute))},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodReady, Status: corev1.ConditionFalse},
+						},
+						ContainerStatuses: []corev1.ContainerStatus{
+							{Name: "test", Ready: false, RestartCount: 3},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "apiserver-fail-2", Namespace: "openshift-apiserver", CreationTimestamp: metav1.NewTime(time.Now().Add(-20 * time.Minute))},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodReady, Status: corev1.ConditionFalse},
+						},
+						ContainerStatuses: []corev1.ContainerStatus{
+							{Name: "test", Ready: false, RestartCount: 3},
+						},
 					},
 				},
 			},
@@ -479,15 +628,432 @@ func TestUpdateOperatorStatus(t *testing.T) {
 					},
 					{
 						Type:    fmt.Sprintf("%sDeploymentDegraded", defaultControllerName),
+						Status:  operatorv1.ConditionTrue,
+						Reason:  "UnavailablePod",
+						Message: "2 of 5 requested instances are unavailable for apiserver.openshift-apiserver (container is crashlooping in apiserver-fail-1 pod, container is crashlooping in apiserver-fail-2 pod)",
+					},
+					{
+						Type:    fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
 						Status:  operatorv1.ConditionFalse,
 						Reason:  "AsExpected",
 						Message: "",
 					},
+				}
+				return areCondidtionsEqual(expectedConditions, actualStatus.Conditions)
+			},
+		},
+		{
+			name: "scenario: partially available during active rollout, pods starting",
+			workload: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "apiserver",
+					Namespace: "openshift-apiserver",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: ptr.To[int32](3),
+				},
+				Status: appsv1.DeploymentStatus{
+					AvailableReplicas: 2,
+					UpdatedReplicas:   1,
+					Conditions: []appsv1.DeploymentCondition{
+						{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, Reason: "ReplicaSetUpdated", Message: "progressing"},
+					},
+				},
+			},
+			pods: []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "apiserver-new", Namespace: "openshift-apiserver"},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodPending,
+						ContainerStatuses: []corev1.ContainerStatus{
+							{Name: "test", Ready: false, RestartCount: 0, State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "ContainerCreating"}}},
+						},
+					},
+				},
+			},
+			validateOperatorStatus: func(actualStatus *operatorv1.OperatorStatus) error {
+				expectedConditions := []operatorv1.OperatorCondition{
+					{
+						Type:   fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeAvailable),
+						Status: operatorv1.ConditionTrue,
+						Reason: "AsExpected",
+					},
+					{
+						Type:   fmt.Sprintf("%sWorkloadDegraded", defaultControllerName),
+						Status: operatorv1.ConditionFalse,
+					},
+					{
+						Type:   fmt.Sprintf("%sDeploymentDegraded", defaultControllerName),
+						Status: operatorv1.ConditionFalse,
+						Reason: "AsExpected",
+					},
 					{
 						Type:    fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
 						Status:  operatorv1.ConditionTrue,
-						Reason:  "NewGeneration",
-						Message: "deployment/apiserver.openshift-apiserver: observed generation is 99, desired generation is 100.",
+						Reason:  "PodsUpdating",
+						Message: "deployment/apiserver.openshift-apiserver: 1/3 pods have been updated to the latest revision and 2/3 pods are available",
+					},
+				}
+				return areCondidtionsEqual(expectedConditions, actualStatus.Conditions)
+			},
+		},
+		{
+			name: "scenario: zero available replicas, no pods exist",
+			workload: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "apiserver",
+					Namespace:  "openshift-apiserver",
+					Generation: 5,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: ptr.To[int32](3),
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{"app": "apiserver"},
+						},
+					},
+				},
+				Status: appsv1.DeploymentStatus{
+					AvailableReplicas:  0,
+					UpdatedReplicas:    0,
+					ObservedGeneration: 5,
+					Conditions: []appsv1.DeploymentCondition{
+						{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, Reason: "NewReplicaSetAvailable"},
+					},
+				},
+			},
+			pods: []*corev1.Pod{},
+			validateOperatorStatus: func(actualStatus *operatorv1.OperatorStatus) error {
+				expectedConditions := []operatorv1.OperatorCondition{
+					{
+						Type:    fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeAvailable),
+						Status:  operatorv1.ConditionFalse,
+						Reason:  "NoPod",
+						Message: "no apiserver.openshift-apiserver pods available on any node",
+					},
+					{
+						Type:   fmt.Sprintf("%sWorkloadDegraded", defaultControllerName),
+						Status: operatorv1.ConditionFalse,
+					},
+					{
+						Type:    fmt.Sprintf("%sDeploymentDegraded", defaultControllerName),
+						Status:  operatorv1.ConditionTrue,
+						Reason:  "UnavailablePod",
+						Message: `3 of 3 requested instances are unavailable for apiserver.openshift-apiserver (no pods found with labels "app=apiserver")`,
+					},
+					{
+						Type:   fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
+						Status: operatorv1.ConditionFalse,
+						Reason: "AsExpected",
+					},
+				}
+				return areCondidtionsEqual(expectedConditions, actualStatus.Conditions)
+			},
+		},
+		{
+			name: "scenario: pod list error",
+			workload: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "apiserver",
+					Namespace: "openshift-apiserver",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: ptr.To[int32](3),
+				},
+				Status: appsv1.DeploymentStatus{
+					AvailableReplicas: 2,
+					UpdatedReplicas:   3,
+					Conditions: []appsv1.DeploymentCondition{
+						{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, Reason: "NewReplicaSetAvailable", Message: "has successfully progressed"},
+					},
+				},
+			},
+			podListErr: fmt.Errorf("fake list error"),
+			validateOperatorStatus: func(actualStatus *operatorv1.OperatorStatus) error {
+				expectedConditions := []operatorv1.OperatorCondition{
+					{
+						Type:   fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeAvailable),
+						Status: operatorv1.ConditionTrue,
+						Reason: "AsExpected",
+					},
+					{
+						Type:    fmt.Sprintf("%sWorkloadDegraded", defaultControllerName),
+						Status:  operatorv1.ConditionTrue,
+						Reason:  "SyncError",
+						Message: "fake list error",
+					},
+					{
+						Type:   fmt.Sprintf("%sDeploymentDegraded", defaultControllerName),
+						Status: operatorv1.ConditionFalse,
+						Reason: "AsExpected",
+					},
+					{
+						Type:   fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
+						Status: operatorv1.ConditionFalse,
+						Reason: "AsExpected",
+					},
+				}
+				return areCondidtionsEqual(expectedConditions, actualStatus.Conditions)
+			},
+		},
+		{
+			name: "scenario: terminating pod past deadline is not reported as failing",
+			workload: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "apiserver",
+					Namespace:  "openshift-apiserver",
+					Generation: 5,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: ptr.To[int32](3),
+				},
+				Status: appsv1.DeploymentStatus{
+					AvailableReplicas:  2,
+					UpdatedReplicas:    3,
+					ObservedGeneration: 5,
+					Conditions: []appsv1.DeploymentCondition{
+						{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, Reason: "NewReplicaSetAvailable"},
+					},
+				},
+			},
+			pods: []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:                       "apiserver-old",
+						Namespace:                  "openshift-apiserver",
+						CreationTimestamp:          metav1.NewTime(time.Now().Add(-20 * time.Minute)),
+						DeletionTimestamp:          ptr.To(metav1.NewTime(time.Now().Add(-1 * time.Minute))),
+						DeletionGracePeriodSeconds: ptr.To[int64](30),
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodReady, Status: corev1.ConditionFalse},
+						},
+						ContainerStatuses: []corev1.ContainerStatus{
+							{Name: "test", Ready: false, RestartCount: 10},
+						},
+					},
+				},
+			},
+			validateOperatorStatus: func(actualStatus *operatorv1.OperatorStatus) error {
+				expectedConditions := []operatorv1.OperatorCondition{
+					{
+						Type:   fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeAvailable),
+						Status: operatorv1.ConditionTrue,
+						Reason: "AsExpected",
+					},
+					{
+						Type:   fmt.Sprintf("%sWorkloadDegraded", defaultControllerName),
+						Status: operatorv1.ConditionFalse,
+					},
+					{
+						Type:   fmt.Sprintf("%sDeploymentDegraded", defaultControllerName),
+						Status: operatorv1.ConditionFalse,
+						Reason: "AsExpected",
+					},
+					{
+						Type:   fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
+						Status: operatorv1.ConditionFalse,
+						Reason: "AsExpected",
+					},
+				}
+				return areCondidtionsEqual(expectedConditions, actualStatus.Conditions)
+			},
+		},
+		{
+			// MinReadySeconds=60, ProgressDeadlineSeconds defaults to 600.
+			// Combined deadline: 600+60 = 660s (11m).
+			// Pod created 15m ago → past combined deadline → check is relevant.
+			// LastTransitionTime 10s ago < MinReadySeconds (60s) → flapping → degraded.
+			name: "scenario: pod with flapping Ready condition after successful rollout detected as failing",
+			workload: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "apiserver",
+					Namespace:  "openshift-apiserver",
+					Generation: 5,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas:        ptr.To[int32](3),
+					MinReadySeconds: 60,
+				},
+				Status: appsv1.DeploymentStatus{
+					AvailableReplicas:  2,
+					UpdatedReplicas:    3,
+					ObservedGeneration: 5,
+					Conditions: []appsv1.DeploymentCondition{
+						{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, Reason: "NewReplicaSetAvailable"},
+					},
+				},
+			},
+			pods: []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "apiserver-flap", Namespace: "openshift-apiserver", CreationTimestamp: metav1.NewTime(time.Now().Add(-15 * time.Minute))},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodReady, Status: corev1.ConditionTrue, LastTransitionTime: metav1.NewTime(time.Now().Add(-10 * time.Second))},
+						},
+						ContainerStatuses: []corev1.ContainerStatus{
+							{Name: "apiserver", Ready: true, RestartCount: 12},
+						},
+					},
+				},
+			},
+			validateOperatorStatus: func(actualStatus *operatorv1.OperatorStatus) error {
+				expectedConditions := []operatorv1.OperatorCondition{
+					{
+						Type:   fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeAvailable),
+						Status: operatorv1.ConditionTrue,
+						Reason: "AsExpected",
+					},
+					{
+						Type:   fmt.Sprintf("%sWorkloadDegraded", defaultControllerName),
+						Status: operatorv1.ConditionFalse,
+					},
+					{
+						Type:    fmt.Sprintf("%sDeploymentDegraded", defaultControllerName),
+						Status:  operatorv1.ConditionTrue,
+						Reason:  "UnavailablePod",
+						Message: "1 of 3 requested instances are unavailable for apiserver.openshift-apiserver",
+					},
+					{
+						Type:   fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
+						Status: operatorv1.ConditionFalse,
+						Reason: "AsExpected",
+					},
+				}
+				return areCondidtionsEqual(expectedConditions, actualStatus.Conditions)
+			},
+		},
+		{
+			// MinReadySeconds=300, ProgressDeadlineSeconds defaults to 600.
+			// Combined deadline: 600+300 = 900s (15m).
+			// Pod created 8m ago → still within combined deadline → check not relevant → not degraded.
+			name: "scenario: pod with flapping Ready condition after successful rollout within combined deadline not flagged",
+			workload: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "apiserver",
+					Namespace:  "openshift-apiserver",
+					Generation: 5,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas:        ptr.To[int32](3),
+					MinReadySeconds: 300,
+				},
+				Status: appsv1.DeploymentStatus{
+					AvailableReplicas:  2,
+					UpdatedReplicas:    3,
+					ObservedGeneration: 5,
+					Conditions: []appsv1.DeploymentCondition{
+						{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, Reason: "NewReplicaSetAvailable"},
+					},
+				},
+			},
+			pods: []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "apiserver-1", Namespace: "openshift-apiserver", CreationTimestamp: metav1.NewTime(time.Now().Add(-8 * time.Minute))},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodReady, Status: corev1.ConditionTrue, LastTransitionTime: metav1.NewTime(time.Now().Add(-10 * time.Second))},
+						},
+					},
+				},
+			},
+			validateOperatorStatus: func(actualStatus *operatorv1.OperatorStatus) error {
+				expectedConditions := []operatorv1.OperatorCondition{
+					{
+						Type:   fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeAvailable),
+						Status: operatorv1.ConditionTrue,
+						Reason: "AsExpected",
+					},
+					{
+						Type:   fmt.Sprintf("%sWorkloadDegraded", defaultControllerName),
+						Status: operatorv1.ConditionFalse,
+					},
+					{
+						Type:   fmt.Sprintf("%sDeploymentDegraded", defaultControllerName),
+						Status: operatorv1.ConditionFalse,
+						Reason: "AsExpected",
+					},
+					{
+						Type:   fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
+						Status: operatorv1.ConditionFalse,
+						Reason: "AsExpected",
+					},
+				}
+				return areCondidtionsEqual(expectedConditions, actualStatus.Conditions)
+			},
+		},
+		{
+			// MinReadySeconds=60, ProgressDeadlineSeconds defaults to 600.
+			// Combined deadline: 600+60 = 660s (11m).
+			// Pod created 20m ago → past combined deadline → check is relevant.
+			// LastTransitionTime 5m ago > MinReadySeconds (60s) → stable → not degraded.
+			name: "scenario: stably ready pod after successful rollout past combined deadline not flagged as flapping",
+			workload: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "apiserver",
+					Namespace:  "openshift-apiserver",
+					Generation: 5,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas:        ptr.To[int32](3),
+					MinReadySeconds: 60,
+				},
+				Status: appsv1.DeploymentStatus{
+					AvailableReplicas:  2,
+					UpdatedReplicas:    3,
+					ObservedGeneration: 5,
+					Conditions: []appsv1.DeploymentCondition{
+						{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, Reason: "NewReplicaSetAvailable"},
+					},
+				},
+			},
+			pods: []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "apiserver-1", Namespace: "openshift-apiserver", CreationTimestamp: metav1.NewTime(time.Now().Add(-20 * time.Minute))},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodReady, Status: corev1.ConditionTrue, LastTransitionTime: metav1.NewTime(time.Now().Add(-5 * time.Minute))},
+						},
+					},
+				},
+				// Young pod within combined deadline. This makes AvailableReplicas count realistic,
+				// because the steady pod is available. But we need AvailableReplicas < desired,
+				// otherwise the desired code path is not hit.
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "apiserver-2", Namespace: "openshift-apiserver", CreationTimestamp: metav1.NewTime(time.Now().Add(-10 * time.Second))},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodReady, Status: corev1.ConditionTrue, LastTransitionTime: metav1.NewTime(time.Now().Add(-10 * time.Second))},
+						},
+					},
+				},
+			},
+			validateOperatorStatus: func(actualStatus *operatorv1.OperatorStatus) error {
+				expectedConditions := []operatorv1.OperatorCondition{
+					{
+						Type:   fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeAvailable),
+						Status: operatorv1.ConditionTrue,
+						Reason: "AsExpected",
+					},
+					{
+						Type:   fmt.Sprintf("%sWorkloadDegraded", defaultControllerName),
+						Status: operatorv1.ConditionFalse,
+					},
+					{
+						Type:   fmt.Sprintf("%sDeploymentDegraded", defaultControllerName),
+						Status: operatorv1.ConditionFalse,
+						Reason: "AsExpected",
+					},
+					{
+						Type:   fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
+						Status: operatorv1.ConditionFalse,
+						Reason: "AsExpected",
 					},
 				}
 				return areCondidtionsEqual(expectedConditions, actualStatus.Conditions)
@@ -570,73 +1136,20 @@ func TestUpdateOperatorStatus(t *testing.T) {
 						Type:    fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
 						Status:  operatorv1.ConditionTrue,
 						Reason:  "PodsUpdating",
-						Message: "deployment/apiserver.openshift-apiserver: 1/3 pods have been updated to the latest generation and 2/3 pods are available",
+						Message: "deployment/apiserver.openshift-apiserver: 1/3 pods have been updated to the latest revision and 2/3 pods are available",
 					},
 				}
 				return areCondidtionsEqual(expectedConditions, actualStatus.Conditions)
 			},
 		},
 		{
-			name: "progressing==false for a longer time shouldn't make the otherwise fine workload degraded",
+			name: "scenario: all pods updated but not all available yet",
 			workload: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "apiserver",
 					Namespace: "openshift-apiserver",
 				},
 				Spec: appsv1.DeploymentSpec{
-					Replicas: ptr.To[int32](3),
-				},
-				Status: appsv1.DeploymentStatus{
-					AvailableReplicas: 3,
-					UpdatedReplicas:   3,
-					Conditions: []appsv1.DeploymentCondition{
-						{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, LastUpdateTime: metav1.Now(), LastTransitionTime: metav1.Now(), Reason: "NewReplicaSetAvailable", Message: "has successfully progressed"},
-					},
-				},
-			},
-			previousConditions: []operatorv1.OperatorCondition{
-				{
-					Type:               fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
-					Status:             operatorv1.ConditionFalse,
-					Reason:             "AsExpected",
-					LastTransitionTime: metav1.NewTime(time.Now().Add(-10 * time.Minute)),
-				},
-			},
-			validateOperatorStatus: func(actualStatus *operatorv1.OperatorStatus) error {
-				expectedConditions := []operatorv1.OperatorCondition{
-					{
-						Type:   fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeAvailable),
-						Status: operatorv1.ConditionTrue,
-						Reason: "AsExpected",
-					},
-					{
-						Type:   fmt.Sprintf("%sWorkloadDegraded", defaultControllerName),
-						Status: operatorv1.ConditionFalse,
-					},
-					{
-						Type:   fmt.Sprintf("%sDeploymentDegraded", defaultControllerName),
-						Status: operatorv1.ConditionFalse,
-						Reason: "AsExpected",
-					},
-					{
-						Type:   fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
-						Status: operatorv1.ConditionFalse,
-						Reason: "AsExpected",
-					},
-				}
-				return areCondidtionsEqual(expectedConditions, actualStatus.Conditions)
-			},
-		},
-		{
-			name: "some pods rolled out and waiting for old terminating pod before we can progress further",
-			workload: &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "apiserver",
-					Namespace: "openshift-apiserver",
-				},
-				Spec: appsv1.DeploymentSpec{
-					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
-					Template: corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"foo": "bar"}}},
 					Replicas: ptr.To[int32](3),
 				},
 				Status: appsv1.DeploymentStatus{
@@ -670,11 +1183,254 @@ func TestUpdateOperatorStatus(t *testing.T) {
 						Type:    fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
 						Status:  operatorv1.ConditionTrue,
 						Reason:  "PodsUpdating",
-						Message: "deployment/apiserver.openshift-apiserver: 3/3 pods have been updated to the latest generation and 2/3 pods are available",
+						Message: "deployment/apiserver.openshift-apiserver: 3/3 pods have been updated to the latest revision and 2/3 pods are available",
 					},
 				}
 				return areCondidtionsEqual(expectedConditions, actualStatus.Conditions)
 			},
+		},
+		{
+			name: "scenario: available workload with progress deadline exceeded",
+			workload: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "apiserver",
+					Namespace:  "openshift-apiserver",
+					Generation: 2,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: ptr.To[int32](3),
+				},
+				Status: appsv1.DeploymentStatus{
+					AvailableReplicas:  2,
+					UpdatedReplicas:    1,
+					ObservedGeneration: 2,
+					Conditions: []appsv1.DeploymentCondition{
+						{
+							Type:               appsv1.DeploymentProgressing,
+							Status:             corev1.ConditionFalse,
+							Reason:             "ProgressDeadlineExceeded",
+							Message:            "deployment has timed out",
+							LastUpdateTime:     metav1.Now(),
+							LastTransitionTime: metav1.Now(),
+						},
+					},
+				},
+			},
+			validateOperatorStatus: func(actualStatus *operatorv1.OperatorStatus) error {
+				expectedConditions := []operatorv1.OperatorCondition{
+					{
+						Type:   fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeAvailable),
+						Status: operatorv1.ConditionTrue,
+						Reason: "AsExpected",
+					},
+					{
+						Type:   fmt.Sprintf("%sWorkloadDegraded", defaultControllerName),
+						Status: operatorv1.ConditionFalse,
+					},
+					{
+						Type:    fmt.Sprintf("%sDeploymentDegraded", defaultControllerName),
+						Status:  operatorv1.ConditionTrue,
+						Reason:  "ProgressDeadlineExceeded",
+						Message: "deployment/apiserver.openshift-apiserver has timed out progressing: deployment has timed out",
+					},
+					{
+						Type:    fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
+						Status:  operatorv1.ConditionFalse,
+						Reason:  "ProgressDeadlineExceeded",
+						Message: "deployment/apiserver.openshift-apiserver has timed out progressing: deployment has timed out",
+					},
+				}
+				return areCondidtionsEqual(expectedConditions, actualStatus.Conditions)
+			},
+		},
+		{
+			name: "scenario: workload rollout with maxSurge (4 of 3 replicas available)",
+			workload: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "apiserver",
+					Namespace:  "openshift-apiserver",
+					Generation: 5,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: ptr.To[int32](3),
+				},
+				Status: appsv1.DeploymentStatus{
+					Replicas:           4,
+					AvailableReplicas:  4,
+					UpdatedReplicas:    2,
+					ObservedGeneration: 5,
+					Conditions: []appsv1.DeploymentCondition{
+						{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, LastUpdateTime: metav1.Now(), LastTransitionTime: metav1.Now(), Reason: "ReplicaSetUpdated", Message: "progressing"},
+					},
+				},
+			},
+			validateOperatorStatus: func(actualStatus *operatorv1.OperatorStatus) error {
+				expectedConditions := []operatorv1.OperatorCondition{
+					{
+						Type:    fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeAvailable),
+						Status:  operatorv1.ConditionTrue,
+						Reason:  "AsExpected",
+						Message: "",
+					},
+					{
+						Type:   fmt.Sprintf("%sWorkloadDegraded", defaultControllerName),
+						Status: operatorv1.ConditionFalse,
+					},
+					{
+						Type:    fmt.Sprintf("%sDeploymentDegraded", defaultControllerName),
+						Status:  operatorv1.ConditionFalse,
+						Reason:  "AsExpected",
+						Message: "",
+					},
+					{
+						Type:    fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
+						Status:  operatorv1.ConditionTrue,
+						Reason:  "PodsUpdating",
+						Message: "deployment/apiserver.openshift-apiserver: 2/3 pods have been updated to the latest revision and 4/3 pods are available",
+					},
+				}
+				return areCondidtionsEqual(expectedConditions, actualStatus.Conditions)
+			},
+		},
+		{
+			name: "scenario: workload recovering from progress deadline exceeded",
+			workload: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "apiserver",
+					Namespace:  "openshift-apiserver",
+					Generation: 3,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: ptr.To[int32](3),
+				},
+				Status: appsv1.DeploymentStatus{
+					AvailableReplicas:  3,
+					UpdatedReplicas:    3,
+					ObservedGeneration: 3,
+					Conditions: []appsv1.DeploymentCondition{
+						{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, LastUpdateTime: metav1.Now(), LastTransitionTime: metav1.Now(), Reason: "NewReplicaSetAvailable", Message: "has successfully progressed"},
+					},
+				},
+			},
+			previousConditions: []operatorv1.OperatorCondition{
+				{
+					Type:               fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
+					Status:             operatorv1.ConditionFalse,
+					Reason:             "ProgressDeadlineExceeded",
+					Message:            "deployment has timed out",
+					LastTransitionTime: metav1.NewTime(time.Now().Add(-5 * time.Minute)),
+				},
+				{
+					Type:               fmt.Sprintf("%sDeploymentDegraded", defaultControllerName),
+					Status:             operatorv1.ConditionTrue,
+					Reason:             "ProgressDeadlineExceeded",
+					LastTransitionTime: metav1.NewTime(time.Now().Add(-5 * time.Minute)),
+				},
+			},
+			validateOperatorStatus: func(actualStatus *operatorv1.OperatorStatus) error {
+				expectedConditions := []operatorv1.OperatorCondition{
+					{
+						Type:   fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeAvailable),
+						Status: operatorv1.ConditionTrue,
+						Reason: "AsExpected",
+					},
+					{
+						Type:   fmt.Sprintf("%sWorkloadDegraded", defaultControllerName),
+						Status: operatorv1.ConditionFalse,
+					},
+					{
+						Type:   fmt.Sprintf("%sDeploymentDegraded", defaultControllerName),
+						Status: operatorv1.ConditionFalse,
+						Reason: "AsExpected",
+					},
+					{
+						Type:   fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
+						Status: operatorv1.ConditionFalse,
+						Reason: "AsExpected",
+					},
+				}
+				return areCondidtionsEqual(expectedConditions, actualStatus.Conditions)
+			},
+		},
+		{
+			name:                            "version recorded when at highest revision",
+			operatorConfigAtHighestRevision: true,
+			workload: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "apiserver", Namespace: "openshift-apiserver", Generation: 1},
+				Spec:       appsv1.DeploymentSpec{Replicas: ptr.To[int32](1)},
+				Status: appsv1.DeploymentStatus{
+					AvailableReplicas: 1, UpdatedReplicas: 1, ObservedGeneration: 1,
+					Conditions: []appsv1.DeploymentCondition{
+						{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, Reason: "NewReplicaSetAvailable"},
+					},
+				},
+			},
+			validateOperatorStatus:  func(*operatorv1.OperatorStatus) error { return nil },
+			validateVersionRecorder: expectVersionRecorded,
+		},
+		{
+			name:                            "version not recorded when not at highest revision",
+			operatorConfigAtHighestRevision: false,
+			workload: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "apiserver", Namespace: "openshift-apiserver", Generation: 1},
+				Spec:       appsv1.DeploymentSpec{Replicas: ptr.To[int32](1)},
+				Status: appsv1.DeploymentStatus{
+					AvailableReplicas: 1, UpdatedReplicas: 1, ObservedGeneration: 1,
+					Conditions: []appsv1.DeploymentCondition{
+						{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, Reason: "NewReplicaSetAvailable"},
+					},
+				},
+			},
+			validateOperatorStatus:  func(*operatorv1.OperatorStatus) error { return nil },
+			validateVersionRecorder: expectVersionNotRecorded,
+		},
+		{
+			name:                            "version not recorded when generation != observed generation",
+			operatorConfigAtHighestRevision: true,
+			workload: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "apiserver", Namespace: "openshift-apiserver", Generation: 2},
+				Spec:       appsv1.DeploymentSpec{Replicas: ptr.To[int32](1)},
+				Status: appsv1.DeploymentStatus{
+					AvailableReplicas: 1, UpdatedReplicas: 1, ObservedGeneration: 1,
+					Conditions: []appsv1.DeploymentCondition{
+						{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, Reason: "NewReplicaSetAvailable"},
+					},
+				},
+			},
+			validateOperatorStatus:  func(*operatorv1.OperatorStatus) error { return nil },
+			validateVersionRecorder: expectVersionNotRecorded,
+		},
+		{
+			name:                            "version not recorded when available replicas < desired",
+			operatorConfigAtHighestRevision: true,
+			workload: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "apiserver", Namespace: "openshift-apiserver", Generation: 1},
+				Spec:       appsv1.DeploymentSpec{Replicas: ptr.To[int32](3)},
+				Status: appsv1.DeploymentStatus{
+					AvailableReplicas: 2, UpdatedReplicas: 3, ObservedGeneration: 1,
+					Conditions: []appsv1.DeploymentCondition{
+						{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, Reason: "NewReplicaSetAvailable"},
+					},
+				},
+			},
+			validateOperatorStatus:  func(*operatorv1.OperatorStatus) error { return nil },
+			validateVersionRecorder: expectVersionNotRecorded,
+		},
+		{
+			name:                            "version not recorded when updated replicas < desired",
+			operatorConfigAtHighestRevision: true,
+			workload: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "apiserver", Namespace: "openshift-apiserver", Generation: 1},
+				Spec:       appsv1.DeploymentSpec{Replicas: ptr.To[int32](3)},
+				Status: appsv1.DeploymentStatus{
+					AvailableReplicas: 3, UpdatedReplicas: 2, ObservedGeneration: 1,
+					Conditions: []appsv1.DeploymentCondition{
+						{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, Reason: "NewReplicaSetAvailable"},
+					},
+				},
+			},
+			validateOperatorStatus:  func(*operatorv1.OperatorStatus) error { return nil },
+			validateVersionRecorder: expectVersionNotRecorded,
 		},
 	}
 
@@ -704,16 +1460,20 @@ func TestUpdateOperatorStatus(t *testing.T) {
 				syncErrrors:             scenario.errors,
 			}
 
+			recorder := &fakeVersionRecorder{}
+
 			// act
 			target := &Controller{
-				operatorClient:  fakeOperatorClient,
-				targetNamespace: targetNs,
-				podsLister:      &fakePodLister{pods: scenario.pods},
-				delegate:        delegate,
+				operatorClient:       fakeOperatorClient,
+				targetNamespace:      targetNs,
+				targetOperandVersion: "v1.0.0-test",
+				podsLister:           &fakePodLister{pods: scenario.pods, err: scenario.podListErr},
+				delegate:             delegate,
+				versionRecorder:      recorder,
 			}
 
 			err := target.sync(context.TODO(), factory.NewSyncContext("workloadcontroller_test", events.NewInMemoryRecorder("workloadcontroller_test", clocktesting.NewFakePassiveClock(time.Now()))))
-			if err != nil && len(scenario.errors) == 0 {
+			if err != nil && len(scenario.errors) == 0 && scenario.podListErr == nil {
 				t.Fatal(err)
 			}
 
@@ -726,12 +1486,18 @@ func TestUpdateOperatorStatus(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			if scenario.validateVersionRecorder != nil {
+				if err := scenario.validateVersionRecorder(recorder); err != nil {
+					t.Fatal(err)
+				}
+			}
 		})
 	}
 }
 
 type fakePodLister struct {
 	pods []*corev1.Pod
+	err  error
 }
 
 type fakePodNamespaceLister struct {
@@ -739,7 +1505,7 @@ type fakePodNamespaceLister struct {
 }
 
 func (f *fakePodNamespaceLister) List(selector labels.Selector) (ret []*corev1.Pod, err error) {
-	return f.lister.pods, nil
+	return f.lister.pods, f.lister.err
 }
 
 func (f *fakePodNamespaceLister) Get(name string) (*corev1.Pod, error) {
@@ -747,13 +1513,44 @@ func (f *fakePodNamespaceLister) Get(name string) (*corev1.Pod, error) {
 }
 
 func (f *fakePodLister) List(selector labels.Selector) (ret []*corev1.Pod, err error) {
-	return f.pods, nil
+	return f.pods, f.err
 }
 
 func (f *fakePodLister) Pods(namespace string) corev1listers.PodNamespaceLister {
 	return &fakePodNamespaceLister{
 		lister: f,
 	}
+}
+
+type setVersionCall struct {
+	OperandName, Version string
+}
+
+type fakeVersionRecorder struct {
+	setVersionCalls []setVersionCall
+}
+
+func (f *fakeVersionRecorder) SetVersion(operandName, version string) {
+	f.setVersionCalls = append(f.setVersionCalls, setVersionCall{operandName, version})
+}
+
+func (f *fakeVersionRecorder) UnsetVersion(_ string)                  {}
+func (f *fakeVersionRecorder) GetVersions() map[string]string         { return nil }
+func (f *fakeVersionRecorder) VersionChangedChannel() <-chan struct{} { return nil }
+
+func expectVersionRecorded(r *fakeVersionRecorder) error {
+	expected := []setVersionCall{{OperandName: "apiserver", Version: "v1.0.0-test"}}
+	if d := cmp.Diff(expected, r.setVersionCalls); d != "" {
+		return fmt.Errorf("unexpected SetVersion calls (-want +got):\n%s", d)
+	}
+	return nil
+}
+
+func expectVersionNotRecorded(r *fakeVersionRecorder) error {
+	if d := cmp.Diff([]setVersionCall(nil), r.setVersionCalls); d != "" {
+		return fmt.Errorf("unexpected SetVersion calls (-want +got):\n%s", d)
+	}
+	return nil
 }
 
 func areCondidtionsEqual(expectedConditions []operatorv1.OperatorCondition, actualConditions []operatorv1.OperatorCondition) error {

--- a/pkg/operator/apiserver/controller/workload/workload_test.go
+++ b/pkg/operator/apiserver/controller/workload/workload_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	corev1listers "k8s.io/client-go/listers/core/v1"
@@ -57,13 +59,15 @@ func TestUpdateOperatorStatus(t *testing.T) {
 
 		workload                        *appsv1.Deployment
 		pods                            []*corev1.Pod
+		podListErr                      error
 		operatorConfigAtHighestRevision bool
 		operatorPreconditionsNotReady   bool
 		preconditionError               error
 		errors                          []error
 		previousConditions              []operatorv1.OperatorCondition
 
-		validateOperatorStatus func(*operatorv1.OperatorStatus) error
+		validateOperatorStatus  func(*operatorv1.OperatorStatus) error
+		validateVersionRecorder func(*fakeVersionRecorder) error
 	}{
 		{
 			name: "scenario: no workload, no errors thus we are degraded and we are progressing",
@@ -133,7 +137,7 @@ func TestUpdateOperatorStatus(t *testing.T) {
 			},
 		},
 		{
-			name: "scenario: we have an unavailable workload being updated for too long and no errors thus we are degraded",
+			name: "scenario: unavailable workload with progress deadline exceeded",
 			workload: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "apiserver",
@@ -183,7 +187,7 @@ func TestUpdateOperatorStatus(t *testing.T) {
 						Type:    fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeAvailable),
 						Status:  operatorv1.ConditionFalse,
 						Reason:  "NoPod",
-						Message: "no apiserver.openshift-apiserver pods available on any node.",
+						Message: "no apiserver.openshift-apiserver pods available on any node",
 					},
 					{
 						Type:   fmt.Sprintf("%sWorkloadDegraded", defaultControllerName),
@@ -192,21 +196,21 @@ func TestUpdateOperatorStatus(t *testing.T) {
 					{
 						Type:    fmt.Sprintf("%sDeploymentDegraded", defaultControllerName),
 						Status:  operatorv1.ConditionTrue,
-						Reason:  "UnavailablePod",
-						Message: "3 of 3 requested instances are unavailable for apiserver.openshift-apiserver (container is waiting in pending apiserver pod)",
+						Reason:  "ProgressDeadlineExceeded",
+						Message: "deployment/apiserver.openshift-apiserver has timed out progressing: timed out",
 					},
 					{
 						Type:    fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
-						Status:  operatorv1.ConditionTrue,
-						Reason:  "PodsUpdating",
-						Message: "deployment/apiserver.openshift-apiserver: 0/3 pods have been updated to the latest generation and 0/3 pods are available",
+						Status:  operatorv1.ConditionFalse,
+						Reason:  "ProgressDeadlineExceeded",
+						Message: "deployment/apiserver.openshift-apiserver has timed out progressing: timed out",
 					},
 				}
 				return areConditionsEqual(expectedConditions, actualStatus.Conditions)
 			},
 		},
 		{
-			name: "scenario: we have an unavailable workload being updated for a short time and no errors so we are progressing",
+			name: "scenario: unavailable workload progressing normally",
 			workload: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "apiserver",
@@ -233,8 +237,7 @@ func TestUpdateOperatorStatus(t *testing.T) {
 								Ready: false,
 								State: corev1.ContainerState{
 									Waiting: &corev1.ContainerStateWaiting{
-										Reason:  "ImagePull",
-										Message: "slow registry",
+										Reason: "ContainerCreating",
 									},
 								},
 							},
@@ -256,7 +259,7 @@ func TestUpdateOperatorStatus(t *testing.T) {
 						Type:    fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeAvailable),
 						Status:  operatorv1.ConditionFalse,
 						Reason:  "NoPod",
-						Message: "no apiserver.openshift-apiserver pods available on any node.",
+						Message: "no apiserver.openshift-apiserver pods available on any node",
 					},
 					{
 						Type:   fmt.Sprintf("%sWorkloadDegraded", defaultControllerName),
@@ -271,14 +274,75 @@ func TestUpdateOperatorStatus(t *testing.T) {
 						Type:    fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
 						Status:  operatorv1.ConditionTrue,
 						Reason:  "PodsUpdating",
-						Message: "deployment/apiserver.openshift-apiserver: 0/3 pods have been updated to the latest generation and 0/3 pods are available",
+						Message: "deployment/apiserver.openshift-apiserver: 0/3 pods have been updated to the latest revision and 0/3 pods are available",
 					},
 				}
 				return areConditionsEqual(expectedConditions, actualStatus.Conditions)
 			},
 		},
 		{
-			name: "scenario: we have an incomplete workload and no errors thus we are available and degraded (missing 1 replica)",
+			name: "scenario: unavailable workload that previously progressed successfully",
+			workload: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "apiserver",
+					Namespace:  "openshift-apiserver",
+					Generation: 5,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: ptr.To[int32](3),
+				},
+				Status: appsv1.DeploymentStatus{
+					AvailableReplicas:  0,
+					UpdatedReplicas:    3,
+					ObservedGeneration: 5,
+					Conditions: []appsv1.DeploymentCondition{
+						{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, LastUpdateTime: metav1.Now(), LastTransitionTime: metav1.Now(), Reason: "NewReplicaSetAvailable", Message: "has successfully progressed"},
+					},
+				},
+			},
+			pods: []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "apiserver-1", Namespace: "openshift-apiserver", CreationTimestamp: metav1.NewTime(time.Now().Add(-20 * time.Minute))},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodReady, Status: corev1.ConditionFalse},
+						},
+						ContainerStatuses: []corev1.ContainerStatus{
+							{Name: "apiserver", Ready: false, RestartCount: 8},
+						},
+					},
+				},
+			},
+			validateOperatorStatus: func(actualStatus *operatorv1.OperatorStatus) error {
+				expectedConditions := []operatorv1.OperatorCondition{
+					{
+						Type:    fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeAvailable),
+						Status:  operatorv1.ConditionFalse,
+						Reason:  "NoPod",
+						Message: "no apiserver.openshift-apiserver pods available on any node",
+					},
+					{
+						Type:   fmt.Sprintf("%sWorkloadDegraded", defaultControllerName),
+						Status: operatorv1.ConditionFalse,
+					},
+					{
+						Type:    fmt.Sprintf("%sDeploymentDegraded", defaultControllerName),
+						Status:  operatorv1.ConditionTrue,
+						Reason:  "UnavailablePod",
+						Message: "3 of 3 requested instances are unavailable for apiserver.openshift-apiserver (container is crashlooping in apiserver-1 pod)",
+					},
+					{
+						Type:   fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
+						Status: operatorv1.ConditionFalse,
+						Reason: "AsExpected",
+					},
+				}
+				return areConditionsEqual(expectedConditions, actualStatus.Conditions)
+			},
+		},
+		{
+			name: "scenario: partially available workload with failing pod",
 			workload: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "apiserver",
@@ -297,20 +361,26 @@ func TestUpdateOperatorStatus(t *testing.T) {
 			},
 			pods: []*corev1.Pod{
 				{
-					ObjectMeta: metav1.ObjectMeta{Name: "apiserver", Namespace: "openshift-apiserver"},
+					ObjectMeta: metav1.ObjectMeta{Name: "apiserver-ready", Namespace: "openshift-apiserver", CreationTimestamp: metav1.NewTime(time.Now().Add(-20 * time.Minute))},
 					Status: corev1.PodStatus{
-						Phase: corev1.PodSucceeded,
+						Phase: corev1.PodRunning,
+						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+						},
 						ContainerStatuses: []corev1.ContainerStatus{
-							{
-								Name:  "test",
-								Ready: true,
-								State: corev1.ContainerState{
-									Terminated: &corev1.ContainerStateTerminated{
-										Reason:  "PodKilled",
-										Message: "john wick was here",
-									},
-								},
-							},
+							{Name: "test", Ready: true},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "apiserver-crash", Namespace: "openshift-apiserver", CreationTimestamp: metav1.NewTime(time.Now().Add(-20 * time.Minute))},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodReady, Status: corev1.ConditionFalse},
+						},
+						ContainerStatuses: []corev1.ContainerStatus{
+							{Name: "test", Ready: false, RestartCount: 5},
 						},
 					},
 				},
@@ -331,7 +401,7 @@ func TestUpdateOperatorStatus(t *testing.T) {
 						Type:    fmt.Sprintf("%sDeploymentDegraded", defaultControllerName),
 						Status:  operatorv1.ConditionTrue,
 						Reason:  "UnavailablePod",
-						Message: "1 of 3 requested instances are unavailable for apiserver.openshift-apiserver ()",
+						Message: "1 of 3 requested instances are unavailable for apiserver.openshift-apiserver (container is crashlooping in apiserver-crash pod)",
 					},
 					{
 						Type:    fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
@@ -390,7 +460,7 @@ func TestUpdateOperatorStatus(t *testing.T) {
 			},
 		},
 		{
-			name: "scenario: we have an outdated (generation) workload and no errors thus we are available and we are progressing",
+			name: "scenario: workload scaling with generation mismatch",
 			workload: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "apiserver",
@@ -398,7 +468,7 @@ func TestUpdateOperatorStatus(t *testing.T) {
 					Generation: 100,
 				},
 				Spec: appsv1.DeploymentSpec{
-					Replicas: ptr.To[int32](3),
+					Replicas: ptr.To[int32](5),
 				},
 				Status: appsv1.DeploymentStatus{
 					Replicas:           3,
@@ -431,17 +501,16 @@ func TestUpdateOperatorStatus(t *testing.T) {
 					},
 					{
 						Type:    fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
-						Status:  operatorv1.ConditionTrue,
-						Reason:  "NewGeneration",
-						Message: "deployment/apiserver.openshift-apiserver: observed generation is 99, desired generation is 100.",
+						Status:  operatorv1.ConditionFalse,
+						Reason:  "AsExpected",
+						Message: "",
 					},
 				}
 				return areConditionsEqual(expectedConditions, actualStatus.Conditions)
 			},
 		},
-
 		{
-			name: "scenario: rare case when we have an outdated (generation) workload and one old replica failing is but it will be picked up soon by the new rollout thus we are available and we are progressing",
+			name: "scenario: partially available during scale-up, pods starting",
 			workload: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "apiserver",
@@ -452,13 +521,96 @@ func TestUpdateOperatorStatus(t *testing.T) {
 					Replicas: ptr.To[int32](3),
 				},
 				Status: appsv1.DeploymentStatus{
-					Replicas:           3,
-					ReadyReplicas:      2,
-					AvailableReplicas:  2,
+					AvailableReplicas:  1,
+					UpdatedReplicas:    1,
+					ObservedGeneration: 99,
+					Conditions: []appsv1.DeploymentCondition{
+						{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, Reason: "NewReplicaSetAvailable"},
+					},
+				},
+			},
+			pods: []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "apiserver-new-1", Namespace: "openshift-apiserver", CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Minute))},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodPending,
+						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodReady, Status: corev1.ConditionFalse},
+						},
+						ContainerStatuses: []corev1.ContainerStatus{
+							{Name: "test", Ready: false, RestartCount: 0, State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "ContainerCreating"}}},
+						},
+					},
+				},
+			},
+			validateOperatorStatus: func(actualStatus *operatorv1.OperatorStatus) error {
+				expectedConditions := []operatorv1.OperatorCondition{
+					{
+						Type:   fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeAvailable),
+						Status: operatorv1.ConditionTrue,
+						Reason: "AsExpected",
+					},
+					{
+						Type:   fmt.Sprintf("%sWorkloadDegraded", defaultControllerName),
+						Status: operatorv1.ConditionFalse,
+					},
+					{
+						Type:   fmt.Sprintf("%sDeploymentDegraded", defaultControllerName),
+						Status: operatorv1.ConditionFalse,
+						Reason: "AsExpected",
+					},
+					{
+						Type:   fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
+						Status: operatorv1.ConditionFalse,
+						Reason: "AsExpected",
+					},
+				}
+				return areConditionsEqual(expectedConditions, actualStatus.Conditions)
+			},
+		},
+		{
+			name: "scenario: partially available during scale-up, new pods failing",
+			workload: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "apiserver",
+					Namespace:  "openshift-apiserver",
+					Generation: 100,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: ptr.To[int32](5),
+				},
+				Status: appsv1.DeploymentStatus{
+					AvailableReplicas:  3,
 					UpdatedReplicas:    3,
 					ObservedGeneration: 99,
 					Conditions: []appsv1.DeploymentCondition{
-						{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, LastUpdateTime: metav1.Now(), LastTransitionTime: metav1.Now(), Reason: "NewReplicaSetAvailable", Message: "has successfully progressed"},
+						{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, Reason: "NewReplicaSetAvailable"},
+					},
+				},
+			},
+			pods: []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "apiserver-fail-1", Namespace: "openshift-apiserver", CreationTimestamp: metav1.NewTime(time.Now().Add(-20 * time.Minute))},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodReady, Status: corev1.ConditionFalse},
+						},
+						ContainerStatuses: []corev1.ContainerStatus{
+							{Name: "test", Ready: false, RestartCount: 3},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "apiserver-fail-2", Namespace: "openshift-apiserver", CreationTimestamp: metav1.NewTime(time.Now().Add(-20 * time.Minute))},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodReady, Status: corev1.ConditionFalse},
+						},
+						ContainerStatuses: []corev1.ContainerStatus{
+							{Name: "test", Ready: false, RestartCount: 3},
+						},
 					},
 				},
 			},
@@ -476,15 +628,432 @@ func TestUpdateOperatorStatus(t *testing.T) {
 					},
 					{
 						Type:    fmt.Sprintf("%sDeploymentDegraded", defaultControllerName),
+						Status:  operatorv1.ConditionTrue,
+						Reason:  "UnavailablePod",
+						Message: "2 of 5 requested instances are unavailable for apiserver.openshift-apiserver (container is crashlooping in apiserver-fail-1 pod, container is crashlooping in apiserver-fail-2 pod)",
+					},
+					{
+						Type:    fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
 						Status:  operatorv1.ConditionFalse,
 						Reason:  "AsExpected",
 						Message: "",
 					},
+				}
+				return areConditionsEqual(expectedConditions, actualStatus.Conditions)
+			},
+		},
+		{
+			name: "scenario: partially available during active rollout, pods starting",
+			workload: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "apiserver",
+					Namespace: "openshift-apiserver",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: ptr.To[int32](3),
+				},
+				Status: appsv1.DeploymentStatus{
+					AvailableReplicas: 2,
+					UpdatedReplicas:   1,
+					Conditions: []appsv1.DeploymentCondition{
+						{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, Reason: "ReplicaSetUpdated", Message: "progressing"},
+					},
+				},
+			},
+			pods: []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "apiserver-new", Namespace: "openshift-apiserver"},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodPending,
+						ContainerStatuses: []corev1.ContainerStatus{
+							{Name: "test", Ready: false, RestartCount: 0, State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "ContainerCreating"}}},
+						},
+					},
+				},
+			},
+			validateOperatorStatus: func(actualStatus *operatorv1.OperatorStatus) error {
+				expectedConditions := []operatorv1.OperatorCondition{
+					{
+						Type:   fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeAvailable),
+						Status: operatorv1.ConditionTrue,
+						Reason: "AsExpected",
+					},
+					{
+						Type:   fmt.Sprintf("%sWorkloadDegraded", defaultControllerName),
+						Status: operatorv1.ConditionFalse,
+					},
+					{
+						Type:   fmt.Sprintf("%sDeploymentDegraded", defaultControllerName),
+						Status: operatorv1.ConditionFalse,
+						Reason: "AsExpected",
+					},
 					{
 						Type:    fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
 						Status:  operatorv1.ConditionTrue,
-						Reason:  "NewGeneration",
-						Message: "deployment/apiserver.openshift-apiserver: observed generation is 99, desired generation is 100.",
+						Reason:  "PodsUpdating",
+						Message: "deployment/apiserver.openshift-apiserver: 1/3 pods have been updated to the latest revision and 2/3 pods are available",
+					},
+				}
+				return areConditionsEqual(expectedConditions, actualStatus.Conditions)
+			},
+		},
+		{
+			name: "scenario: zero available replicas, no pods exist",
+			workload: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "apiserver",
+					Namespace:  "openshift-apiserver",
+					Generation: 5,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: ptr.To[int32](3),
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{"app": "apiserver"},
+						},
+					},
+				},
+				Status: appsv1.DeploymentStatus{
+					AvailableReplicas:  0,
+					UpdatedReplicas:    0,
+					ObservedGeneration: 5,
+					Conditions: []appsv1.DeploymentCondition{
+						{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, Reason: "NewReplicaSetAvailable"},
+					},
+				},
+			},
+			pods: []*corev1.Pod{},
+			validateOperatorStatus: func(actualStatus *operatorv1.OperatorStatus) error {
+				expectedConditions := []operatorv1.OperatorCondition{
+					{
+						Type:    fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeAvailable),
+						Status:  operatorv1.ConditionFalse,
+						Reason:  "NoPod",
+						Message: "no apiserver.openshift-apiserver pods available on any node",
+					},
+					{
+						Type:   fmt.Sprintf("%sWorkloadDegraded", defaultControllerName),
+						Status: operatorv1.ConditionFalse,
+					},
+					{
+						Type:    fmt.Sprintf("%sDeploymentDegraded", defaultControllerName),
+						Status:  operatorv1.ConditionTrue,
+						Reason:  "UnavailablePod",
+						Message: `3 of 3 requested instances are unavailable for apiserver.openshift-apiserver (no pods found with labels "app=apiserver")`,
+					},
+					{
+						Type:   fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
+						Status: operatorv1.ConditionFalse,
+						Reason: "AsExpected",
+					},
+				}
+				return areConditionsEqual(expectedConditions, actualStatus.Conditions)
+			},
+		},
+		{
+			name: "scenario: pod list error",
+			workload: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "apiserver",
+					Namespace: "openshift-apiserver",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: ptr.To[int32](3),
+				},
+				Status: appsv1.DeploymentStatus{
+					AvailableReplicas: 2,
+					UpdatedReplicas:   3,
+					Conditions: []appsv1.DeploymentCondition{
+						{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, Reason: "NewReplicaSetAvailable", Message: "has successfully progressed"},
+					},
+				},
+			},
+			podListErr: fmt.Errorf("fake list error"),
+			validateOperatorStatus: func(actualStatus *operatorv1.OperatorStatus) error {
+				expectedConditions := []operatorv1.OperatorCondition{
+					{
+						Type:   fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeAvailable),
+						Status: operatorv1.ConditionTrue,
+						Reason: "AsExpected",
+					},
+					{
+						Type:    fmt.Sprintf("%sWorkloadDegraded", defaultControllerName),
+						Status:  operatorv1.ConditionTrue,
+						Reason:  "SyncError",
+						Message: "fake list error",
+					},
+					{
+						Type:   fmt.Sprintf("%sDeploymentDegraded", defaultControllerName),
+						Status: operatorv1.ConditionFalse,
+						Reason: "AsExpected",
+					},
+					{
+						Type:   fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
+						Status: operatorv1.ConditionFalse,
+						Reason: "AsExpected",
+					},
+				}
+				return areConditionsEqual(expectedConditions, actualStatus.Conditions)
+			},
+		},
+		{
+			name: "scenario: terminating pod past deadline is not reported as failing",
+			workload: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "apiserver",
+					Namespace:  "openshift-apiserver",
+					Generation: 5,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: ptr.To[int32](3),
+				},
+				Status: appsv1.DeploymentStatus{
+					AvailableReplicas:  2,
+					UpdatedReplicas:    3,
+					ObservedGeneration: 5,
+					Conditions: []appsv1.DeploymentCondition{
+						{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, Reason: "NewReplicaSetAvailable"},
+					},
+				},
+			},
+			pods: []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:                       "apiserver-old",
+						Namespace:                  "openshift-apiserver",
+						CreationTimestamp:          metav1.NewTime(time.Now().Add(-20 * time.Minute)),
+						DeletionTimestamp:          ptr.To(metav1.NewTime(time.Now().Add(-1 * time.Minute))),
+						DeletionGracePeriodSeconds: ptr.To[int64](30),
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodReady, Status: corev1.ConditionFalse},
+						},
+						ContainerStatuses: []corev1.ContainerStatus{
+							{Name: "test", Ready: false, RestartCount: 10},
+						},
+					},
+				},
+			},
+			validateOperatorStatus: func(actualStatus *operatorv1.OperatorStatus) error {
+				expectedConditions := []operatorv1.OperatorCondition{
+					{
+						Type:   fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeAvailable),
+						Status: operatorv1.ConditionTrue,
+						Reason: "AsExpected",
+					},
+					{
+						Type:   fmt.Sprintf("%sWorkloadDegraded", defaultControllerName),
+						Status: operatorv1.ConditionFalse,
+					},
+					{
+						Type:   fmt.Sprintf("%sDeploymentDegraded", defaultControllerName),
+						Status: operatorv1.ConditionFalse,
+						Reason: "AsExpected",
+					},
+					{
+						Type:   fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
+						Status: operatorv1.ConditionFalse,
+						Reason: "AsExpected",
+					},
+				}
+				return areConditionsEqual(expectedConditions, actualStatus.Conditions)
+			},
+		},
+		{
+			// MinReadySeconds=60, ProgressDeadlineSeconds defaults to 600.
+			// Combined deadline: 600+60 = 660s (11m).
+			// Pod created 15m ago → past combined deadline → check is relevant.
+			// LastTransitionTime 10s ago < MinReadySeconds (60s) → flapping → degraded.
+			name: "scenario: pod with flapping Ready condition after successful rollout detected as failing",
+			workload: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "apiserver",
+					Namespace:  "openshift-apiserver",
+					Generation: 5,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas:        ptr.To[int32](3),
+					MinReadySeconds: 60,
+				},
+				Status: appsv1.DeploymentStatus{
+					AvailableReplicas:  2,
+					UpdatedReplicas:    3,
+					ObservedGeneration: 5,
+					Conditions: []appsv1.DeploymentCondition{
+						{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, Reason: "NewReplicaSetAvailable"},
+					},
+				},
+			},
+			pods: []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "apiserver-flap", Namespace: "openshift-apiserver", CreationTimestamp: metav1.NewTime(time.Now().Add(-15 * time.Minute))},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodReady, Status: corev1.ConditionTrue, LastTransitionTime: metav1.NewTime(time.Now().Add(-10 * time.Second))},
+						},
+						ContainerStatuses: []corev1.ContainerStatus{
+							{Name: "apiserver", Ready: true, RestartCount: 12},
+						},
+					},
+				},
+			},
+			validateOperatorStatus: func(actualStatus *operatorv1.OperatorStatus) error {
+				expectedConditions := []operatorv1.OperatorCondition{
+					{
+						Type:   fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeAvailable),
+						Status: operatorv1.ConditionTrue,
+						Reason: "AsExpected",
+					},
+					{
+						Type:   fmt.Sprintf("%sWorkloadDegraded", defaultControllerName),
+						Status: operatorv1.ConditionFalse,
+					},
+					{
+						Type:    fmt.Sprintf("%sDeploymentDegraded", defaultControllerName),
+						Status:  operatorv1.ConditionTrue,
+						Reason:  "UnavailablePod",
+						Message: "1 of 3 requested instances are unavailable for apiserver.openshift-apiserver",
+					},
+					{
+						Type:   fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
+						Status: operatorv1.ConditionFalse,
+						Reason: "AsExpected",
+					},
+				}
+				return areConditionsEqual(expectedConditions, actualStatus.Conditions)
+			},
+		},
+		{
+			// MinReadySeconds=300, ProgressDeadlineSeconds defaults to 600.
+			// Combined deadline: 600+300 = 900s (15m).
+			// Pod created 8m ago → still within combined deadline → check not relevant → not degraded.
+			name: "scenario: pod with flapping Ready condition after successful rollout within combined deadline not flagged",
+			workload: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "apiserver",
+					Namespace:  "openshift-apiserver",
+					Generation: 5,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas:        ptr.To[int32](3),
+					MinReadySeconds: 300,
+				},
+				Status: appsv1.DeploymentStatus{
+					AvailableReplicas:  2,
+					UpdatedReplicas:    3,
+					ObservedGeneration: 5,
+					Conditions: []appsv1.DeploymentCondition{
+						{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, Reason: "NewReplicaSetAvailable"},
+					},
+				},
+			},
+			pods: []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "apiserver-1", Namespace: "openshift-apiserver", CreationTimestamp: metav1.NewTime(time.Now().Add(-8 * time.Minute))},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodReady, Status: corev1.ConditionTrue, LastTransitionTime: metav1.NewTime(time.Now().Add(-10 * time.Second))},
+						},
+					},
+				},
+			},
+			validateOperatorStatus: func(actualStatus *operatorv1.OperatorStatus) error {
+				expectedConditions := []operatorv1.OperatorCondition{
+					{
+						Type:   fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeAvailable),
+						Status: operatorv1.ConditionTrue,
+						Reason: "AsExpected",
+					},
+					{
+						Type:   fmt.Sprintf("%sWorkloadDegraded", defaultControllerName),
+						Status: operatorv1.ConditionFalse,
+					},
+					{
+						Type:   fmt.Sprintf("%sDeploymentDegraded", defaultControllerName),
+						Status: operatorv1.ConditionFalse,
+						Reason: "AsExpected",
+					},
+					{
+						Type:   fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
+						Status: operatorv1.ConditionFalse,
+						Reason: "AsExpected",
+					},
+				}
+				return areConditionsEqual(expectedConditions, actualStatus.Conditions)
+			},
+		},
+		{
+			// MinReadySeconds=60, ProgressDeadlineSeconds defaults to 600.
+			// Combined deadline: 600+60 = 660s (11m).
+			// Pod created 20m ago → past combined deadline → check is relevant.
+			// LastTransitionTime 5m ago > MinReadySeconds (60s) → stable → not degraded.
+			name: "scenario: stably ready pod after successful rollout past combined deadline not flagged as flapping",
+			workload: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "apiserver",
+					Namespace:  "openshift-apiserver",
+					Generation: 5,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas:        ptr.To[int32](3),
+					MinReadySeconds: 60,
+				},
+				Status: appsv1.DeploymentStatus{
+					AvailableReplicas:  2,
+					UpdatedReplicas:    3,
+					ObservedGeneration: 5,
+					Conditions: []appsv1.DeploymentCondition{
+						{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, Reason: "NewReplicaSetAvailable"},
+					},
+				},
+			},
+			pods: []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "apiserver-1", Namespace: "openshift-apiserver", CreationTimestamp: metav1.NewTime(time.Now().Add(-20 * time.Minute))},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodReady, Status: corev1.ConditionTrue, LastTransitionTime: metav1.NewTime(time.Now().Add(-5 * time.Minute))},
+						},
+					},
+				},
+				// Young pod within combined deadline. This makes AvailableReplicas count realistic,
+				// because the steady pod is available. But we need AvailableReplicas < desired,
+				// otherwise the desired code path is not hit.
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "apiserver-2", Namespace: "openshift-apiserver", CreationTimestamp: metav1.NewTime(time.Now().Add(-10 * time.Second))},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodReady, Status: corev1.ConditionTrue, LastTransitionTime: metav1.NewTime(time.Now().Add(-10 * time.Second))},
+						},
+					},
+				},
+			},
+			validateOperatorStatus: func(actualStatus *operatorv1.OperatorStatus) error {
+				expectedConditions := []operatorv1.OperatorCondition{
+					{
+						Type:   fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeAvailable),
+						Status: operatorv1.ConditionTrue,
+						Reason: "AsExpected",
+					},
+					{
+						Type:   fmt.Sprintf("%sWorkloadDegraded", defaultControllerName),
+						Status: operatorv1.ConditionFalse,
+					},
+					{
+						Type:   fmt.Sprintf("%sDeploymentDegraded", defaultControllerName),
+						Status: operatorv1.ConditionFalse,
+						Reason: "AsExpected",
+					},
+					{
+						Type:   fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
+						Status: operatorv1.ConditionFalse,
+						Reason: "AsExpected",
 					},
 				}
 				return areConditionsEqual(expectedConditions, actualStatus.Conditions)
@@ -567,65 +1136,14 @@ func TestUpdateOperatorStatus(t *testing.T) {
 						Type:    fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
 						Status:  operatorv1.ConditionTrue,
 						Reason:  "PodsUpdating",
-						Message: "deployment/apiserver.openshift-apiserver: 1/3 pods have been updated to the latest generation and 2/3 pods are available",
+						Message: "deployment/apiserver.openshift-apiserver: 1/3 pods have been updated to the latest revision and 2/3 pods are available",
 					},
 				}
 				return areConditionsEqual(expectedConditions, actualStatus.Conditions)
 			},
 		},
 		{
-			name: "progressing==false for a longer time shouldn't make the otherwise fine workload degraded",
-			workload: &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "apiserver",
-					Namespace: "openshift-apiserver",
-				},
-				Spec: appsv1.DeploymentSpec{
-					Replicas: ptr.To[int32](3),
-				},
-				Status: appsv1.DeploymentStatus{
-					AvailableReplicas: 3,
-					UpdatedReplicas:   3,
-					Conditions: []appsv1.DeploymentCondition{
-						{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, LastUpdateTime: metav1.Now(), LastTransitionTime: metav1.Now(), Reason: "NewReplicaSetAvailable", Message: "has successfully progressed"},
-					},
-				},
-			},
-			previousConditions: []operatorv1.OperatorCondition{
-				{
-					Type:               fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
-					Status:             operatorv1.ConditionFalse,
-					Reason:             "AsExpected",
-					LastTransitionTime: metav1.NewTime(time.Now().Add(-10 * time.Minute)),
-				},
-			},
-			validateOperatorStatus: func(actualStatus *operatorv1.OperatorStatus) error {
-				expectedConditions := []operatorv1.OperatorCondition{
-					{
-						Type:   fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeAvailable),
-						Status: operatorv1.ConditionTrue,
-						Reason: "AsExpected",
-					},
-					{
-						Type:   fmt.Sprintf("%sWorkloadDegraded", defaultControllerName),
-						Status: operatorv1.ConditionFalse,
-					},
-					{
-						Type:   fmt.Sprintf("%sDeploymentDegraded", defaultControllerName),
-						Status: operatorv1.ConditionFalse,
-						Reason: "AsExpected",
-					},
-					{
-						Type:   fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
-						Status: operatorv1.ConditionFalse,
-						Reason: "AsExpected",
-					},
-				}
-				return areConditionsEqual(expectedConditions, actualStatus.Conditions)
-			},
-		},
-		{
-			name: "some pods rolled out and waiting for old terminating pod before we can progress further",
+			name: "scenario: all pods updated but not all available yet",
 			workload: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "apiserver",
@@ -665,11 +1183,254 @@ func TestUpdateOperatorStatus(t *testing.T) {
 						Type:    fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
 						Status:  operatorv1.ConditionTrue,
 						Reason:  "PodsUpdating",
-						Message: "deployment/apiserver.openshift-apiserver: 3/3 pods have been updated to the latest generation and 2/3 pods are available",
+						Message: "deployment/apiserver.openshift-apiserver: 3/3 pods have been updated to the latest revision and 2/3 pods are available",
 					},
 				}
 				return areConditionsEqual(expectedConditions, actualStatus.Conditions)
 			},
+		},
+		{
+			name: "scenario: available workload with progress deadline exceeded",
+			workload: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "apiserver",
+					Namespace:  "openshift-apiserver",
+					Generation: 2,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: ptr.To[int32](3),
+				},
+				Status: appsv1.DeploymentStatus{
+					AvailableReplicas:  2,
+					UpdatedReplicas:    1,
+					ObservedGeneration: 2,
+					Conditions: []appsv1.DeploymentCondition{
+						{
+							Type:               appsv1.DeploymentProgressing,
+							Status:             corev1.ConditionFalse,
+							Reason:             "ProgressDeadlineExceeded",
+							Message:            "deployment has timed out",
+							LastUpdateTime:     metav1.Now(),
+							LastTransitionTime: metav1.Now(),
+						},
+					},
+				},
+			},
+			validateOperatorStatus: func(actualStatus *operatorv1.OperatorStatus) error {
+				expectedConditions := []operatorv1.OperatorCondition{
+					{
+						Type:   fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeAvailable),
+						Status: operatorv1.ConditionTrue,
+						Reason: "AsExpected",
+					},
+					{
+						Type:   fmt.Sprintf("%sWorkloadDegraded", defaultControllerName),
+						Status: operatorv1.ConditionFalse,
+					},
+					{
+						Type:    fmt.Sprintf("%sDeploymentDegraded", defaultControllerName),
+						Status:  operatorv1.ConditionTrue,
+						Reason:  "ProgressDeadlineExceeded",
+						Message: "deployment/apiserver.openshift-apiserver has timed out progressing: deployment has timed out",
+					},
+					{
+						Type:    fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
+						Status:  operatorv1.ConditionFalse,
+						Reason:  "ProgressDeadlineExceeded",
+						Message: "deployment/apiserver.openshift-apiserver has timed out progressing: deployment has timed out",
+					},
+				}
+				return areConditionsEqual(expectedConditions, actualStatus.Conditions)
+			},
+		},
+		{
+			name: "scenario: workload rollout with maxSurge (4 of 3 replicas available)",
+			workload: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "apiserver",
+					Namespace:  "openshift-apiserver",
+					Generation: 5,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: ptr.To[int32](3),
+				},
+				Status: appsv1.DeploymentStatus{
+					Replicas:           4,
+					AvailableReplicas:  4,
+					UpdatedReplicas:    2,
+					ObservedGeneration: 5,
+					Conditions: []appsv1.DeploymentCondition{
+						{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, LastUpdateTime: metav1.Now(), LastTransitionTime: metav1.Now(), Reason: "ReplicaSetUpdated", Message: "progressing"},
+					},
+				},
+			},
+			validateOperatorStatus: func(actualStatus *operatorv1.OperatorStatus) error {
+				expectedConditions := []operatorv1.OperatorCondition{
+					{
+						Type:    fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeAvailable),
+						Status:  operatorv1.ConditionTrue,
+						Reason:  "AsExpected",
+						Message: "",
+					},
+					{
+						Type:   fmt.Sprintf("%sWorkloadDegraded", defaultControllerName),
+						Status: operatorv1.ConditionFalse,
+					},
+					{
+						Type:    fmt.Sprintf("%sDeploymentDegraded", defaultControllerName),
+						Status:  operatorv1.ConditionFalse,
+						Reason:  "AsExpected",
+						Message: "",
+					},
+					{
+						Type:    fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
+						Status:  operatorv1.ConditionTrue,
+						Reason:  "PodsUpdating",
+						Message: "deployment/apiserver.openshift-apiserver: 2/3 pods have been updated to the latest revision and 4/3 pods are available",
+					},
+				}
+				return areConditionsEqual(expectedConditions, actualStatus.Conditions)
+			},
+		},
+		{
+			name: "scenario: workload recovering from progress deadline exceeded",
+			workload: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "apiserver",
+					Namespace:  "openshift-apiserver",
+					Generation: 3,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: ptr.To[int32](3),
+				},
+				Status: appsv1.DeploymentStatus{
+					AvailableReplicas:  3,
+					UpdatedReplicas:    3,
+					ObservedGeneration: 3,
+					Conditions: []appsv1.DeploymentCondition{
+						{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, LastUpdateTime: metav1.Now(), LastTransitionTime: metav1.Now(), Reason: "NewReplicaSetAvailable", Message: "has successfully progressed"},
+					},
+				},
+			},
+			previousConditions: []operatorv1.OperatorCondition{
+				{
+					Type:               fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
+					Status:             operatorv1.ConditionFalse,
+					Reason:             "ProgressDeadlineExceeded",
+					Message:            "deployment has timed out",
+					LastTransitionTime: metav1.NewTime(time.Now().Add(-5 * time.Minute)),
+				},
+				{
+					Type:               fmt.Sprintf("%sDeploymentDegraded", defaultControllerName),
+					Status:             operatorv1.ConditionTrue,
+					Reason:             "ProgressDeadlineExceeded",
+					LastTransitionTime: metav1.NewTime(time.Now().Add(-5 * time.Minute)),
+				},
+			},
+			validateOperatorStatus: func(actualStatus *operatorv1.OperatorStatus) error {
+				expectedConditions := []operatorv1.OperatorCondition{
+					{
+						Type:   fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeAvailable),
+						Status: operatorv1.ConditionTrue,
+						Reason: "AsExpected",
+					},
+					{
+						Type:   fmt.Sprintf("%sWorkloadDegraded", defaultControllerName),
+						Status: operatorv1.ConditionFalse,
+					},
+					{
+						Type:   fmt.Sprintf("%sDeploymentDegraded", defaultControllerName),
+						Status: operatorv1.ConditionFalse,
+						Reason: "AsExpected",
+					},
+					{
+						Type:   fmt.Sprintf("%sDeployment%s", defaultControllerName, operatorv1.OperatorStatusTypeProgressing),
+						Status: operatorv1.ConditionFalse,
+						Reason: "AsExpected",
+					},
+				}
+				return areConditionsEqual(expectedConditions, actualStatus.Conditions)
+			},
+		},
+		{
+			name:                            "version recorded when at highest revision",
+			operatorConfigAtHighestRevision: true,
+			workload: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "apiserver", Namespace: "openshift-apiserver", Generation: 1},
+				Spec:       appsv1.DeploymentSpec{Replicas: ptr.To[int32](1)},
+				Status: appsv1.DeploymentStatus{
+					AvailableReplicas: 1, UpdatedReplicas: 1, ObservedGeneration: 1,
+					Conditions: []appsv1.DeploymentCondition{
+						{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, Reason: "NewReplicaSetAvailable"},
+					},
+				},
+			},
+			validateOperatorStatus:  func(*operatorv1.OperatorStatus) error { return nil },
+			validateVersionRecorder: expectVersionRecorded,
+		},
+		{
+			name:                            "version not recorded when not at highest revision",
+			operatorConfigAtHighestRevision: false,
+			workload: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "apiserver", Namespace: "openshift-apiserver", Generation: 1},
+				Spec:       appsv1.DeploymentSpec{Replicas: ptr.To[int32](1)},
+				Status: appsv1.DeploymentStatus{
+					AvailableReplicas: 1, UpdatedReplicas: 1, ObservedGeneration: 1,
+					Conditions: []appsv1.DeploymentCondition{
+						{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, Reason: "NewReplicaSetAvailable"},
+					},
+				},
+			},
+			validateOperatorStatus:  func(*operatorv1.OperatorStatus) error { return nil },
+			validateVersionRecorder: expectVersionNotRecorded,
+		},
+		{
+			name:                            "version not recorded when generation != observed generation",
+			operatorConfigAtHighestRevision: true,
+			workload: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "apiserver", Namespace: "openshift-apiserver", Generation: 2},
+				Spec:       appsv1.DeploymentSpec{Replicas: ptr.To[int32](1)},
+				Status: appsv1.DeploymentStatus{
+					AvailableReplicas: 1, UpdatedReplicas: 1, ObservedGeneration: 1,
+					Conditions: []appsv1.DeploymentCondition{
+						{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, Reason: "NewReplicaSetAvailable"},
+					},
+				},
+			},
+			validateOperatorStatus:  func(*operatorv1.OperatorStatus) error { return nil },
+			validateVersionRecorder: expectVersionNotRecorded,
+		},
+		{
+			name:                            "version not recorded when available replicas < desired",
+			operatorConfigAtHighestRevision: true,
+			workload: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "apiserver", Namespace: "openshift-apiserver", Generation: 1},
+				Spec:       appsv1.DeploymentSpec{Replicas: ptr.To[int32](3)},
+				Status: appsv1.DeploymentStatus{
+					AvailableReplicas: 2, UpdatedReplicas: 3, ObservedGeneration: 1,
+					Conditions: []appsv1.DeploymentCondition{
+						{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, Reason: "NewReplicaSetAvailable"},
+					},
+				},
+			},
+			validateOperatorStatus:  func(*operatorv1.OperatorStatus) error { return nil },
+			validateVersionRecorder: expectVersionNotRecorded,
+		},
+		{
+			name:                            "version not recorded when updated replicas < desired",
+			operatorConfigAtHighestRevision: true,
+			workload: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "apiserver", Namespace: "openshift-apiserver", Generation: 1},
+				Spec:       appsv1.DeploymentSpec{Replicas: ptr.To[int32](3)},
+				Status: appsv1.DeploymentStatus{
+					AvailableReplicas: 3, UpdatedReplicas: 2, ObservedGeneration: 1,
+					Conditions: []appsv1.DeploymentCondition{
+						{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, Reason: "NewReplicaSetAvailable"},
+					},
+				},
+			},
+			validateOperatorStatus:  func(*operatorv1.OperatorStatus) error { return nil },
+			validateVersionRecorder: expectVersionNotRecorded,
 		},
 	}
 
@@ -699,16 +1460,20 @@ func TestUpdateOperatorStatus(t *testing.T) {
 				syncErrrors:             scenario.errors,
 			}
 
+			recorder := &fakeVersionRecorder{}
+
 			// act
 			target := &Controller{
-				operatorClient:  fakeOperatorClient,
-				targetNamespace: targetNs,
-				podsLister:      &fakePodLister{pods: scenario.pods},
-				delegate:        delegate,
+				operatorClient:       fakeOperatorClient,
+				targetNamespace:      targetNs,
+				targetOperandVersion: "v1.0.0-test",
+				podsLister:           &fakePodLister{pods: scenario.pods, err: scenario.podListErr},
+				delegate:             delegate,
+				versionRecorder:      recorder,
 			}
 
 			err := target.sync(context.TODO(), factory.NewSyncContext("workloadcontroller_test", events.NewInMemoryRecorder("workloadcontroller_test", clocktesting.NewFakePassiveClock(time.Now()))))
-			if err != nil && len(scenario.errors) == 0 {
+			if err != nil && len(scenario.errors) == 0 && scenario.podListErr == nil {
 				t.Fatal(err)
 			}
 
@@ -721,12 +1486,18 @@ func TestUpdateOperatorStatus(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			if scenario.validateVersionRecorder != nil {
+				if err := scenario.validateVersionRecorder(recorder); err != nil {
+					t.Fatal(err)
+				}
+			}
 		})
 	}
 }
 
 type fakePodLister struct {
 	pods []*corev1.Pod
+	err  error
 }
 
 type fakePodNamespaceLister struct {
@@ -734,7 +1505,7 @@ type fakePodNamespaceLister struct {
 }
 
 func (f *fakePodNamespaceLister) List(selector labels.Selector) (ret []*corev1.Pod, err error) {
-	return f.lister.pods, nil
+	return f.lister.pods, f.lister.err
 }
 
 func (f *fakePodNamespaceLister) Get(name string) (*corev1.Pod, error) {
@@ -742,13 +1513,44 @@ func (f *fakePodNamespaceLister) Get(name string) (*corev1.Pod, error) {
 }
 
 func (f *fakePodLister) List(selector labels.Selector) (ret []*corev1.Pod, err error) {
-	return f.pods, nil
+	return f.pods, f.err
 }
 
 func (f *fakePodLister) Pods(namespace string) corev1listers.PodNamespaceLister {
 	return &fakePodNamespaceLister{
 		lister: f,
 	}
+}
+
+type setVersionCall struct {
+	OperandName, Version string
+}
+
+type fakeVersionRecorder struct {
+	setVersionCalls []setVersionCall
+}
+
+func (f *fakeVersionRecorder) SetVersion(operandName, version string) {
+	f.setVersionCalls = append(f.setVersionCalls, setVersionCall{operandName, version})
+}
+
+func (f *fakeVersionRecorder) UnsetVersion(_ string)                  {}
+func (f *fakeVersionRecorder) GetVersions() map[string]string         { return nil }
+func (f *fakeVersionRecorder) VersionChangedChannel() <-chan struct{} { return nil }
+
+func expectVersionRecorded(r *fakeVersionRecorder) error {
+	expected := []setVersionCall{{OperandName: "apiserver", Version: "v1.0.0-test"}}
+	if d := cmp.Diff(expected, r.setVersionCalls); d != "" {
+		return fmt.Errorf("unexpected SetVersion calls (-want +got):\n%s", d)
+	}
+	return nil
+}
+
+func expectVersionNotRecorded(r *fakeVersionRecorder) error {
+	if d := cmp.Diff([]setVersionCall(nil), r.setVersionCalls); d != "" {
+		return fmt.Errorf("unexpected SetVersion calls (-want +got):\n%s", d)
+	}
+	return nil
 }
 
 func areConditionsEqual(expectedConditions []operatorv1.OperatorCondition, actualConditions []operatorv1.OperatorCondition) error {

--- a/pr-split.md
+++ b/pr-split.md
@@ -1,0 +1,101 @@
+# PR Split Plan for `workload-condition-overwrites`
+
+## PR 1: Cleanup / Refactoring (no behavior change) — MERGED
+
+https://github.com/openshift/library-go/pull/2197
+
+- Replace inline error message loops with `errors.Join`
+- Use `ptr.Deref` for replicas
+- Fix `areCondidtionsEqual` typo
+- Remove unnecessary `Template`/`Labels` from test fixtures
+
+---
+
+## PR 2: Rework of the progressing condition
+
+Based on PR 1.
+
+### New function in `pkg/apps/deployment/`
+- `DeploymentProgressingCondition(deployment, pods []*corev1.Pod) → operatorv1.OperatorCondition`
+  - Computes the Progressing condition from deployment status and pod state
+  - Internally uses unexported helpers: `hasDeploymentProgressed`, `hasDeploymentTimedOutProgressing`
+
+### Source changes in `pkg/operator/apiserver/controller/workload/`
+- Call the new helper instead of computing the progressing condition inline
+- Remove `workloadAtHighestGeneration` as a signal for `Progressing`
+- Replace `v1helpers.IsUpdatingTooLong()` with deployment-native `ProgressDeadlineExceeded`
+- Add `ProgressDeadlineExceeded` as a new Progressing=False reason
+- Change wording "latest generation" → "latest revision" in PodsUpdating message
+
+### Test infrastructure (carried with this PR)
+- Add `podListErr` field to test struct and wire through `fakePodLister`
+
+### Test scenarios added/updated
+- "unavailable workload with progress deadline exceeded" (was "updated for too long")
+- "unavailable workload progressing normally" (was "updated for a short time")
+- "partially available during active rollout, pods starting"
+- "all pods updated but not all available yet"
+- "available workload with progress deadline exceeded"
+- "workload rollout with maxSurge"
+- "workload recovering from progress deadline exceeded"
+
+---
+
+## PR 3: Rework of the degraded condition
+
+Based on PR 2.
+
+### New function in `pkg/apps/deployment/`
+- `DeploymentDegradedCondition(deployment, pods []*corev1.Pod) → operatorv1.OperatorCondition`
+  - Computes the Degraded condition from deployment status and pod state
+  - Internally uses unexported helpers: `hasFailingPods`, `findPodReadyCondition`
+
+### Source changes in `pkg/operator/apiserver/controller/workload/`
+- Call the new helper instead of computing the degraded condition inline
+- When `workload == nil`, also set `WorkloadDegraded`
+- Use `defer` to apply SyncError to `workloadDegradedCondition`
+- When `ProgressDeadlineExceeded`, also report `DeploymentDegraded`
+- Degraded only when pods are actually failing, not during normal rollouts
+- Remove trailing period from "no pods available on any node" message
+
+### Test scenarios added/updated
+- "unavailable workload that previously progressed successfully"
+- "partially available workload with failing pod"
+- "partially available during scale-up, new pods failing"
+- "zero available replicas, no pods exist"
+- "pod list error"
+- "terminating pod past deadline is not reported as failing"
+- "pod with flapping Ready condition detected as failing"
+- "pod with flapping Ready within combined deadline not flagged"
+- "stably ready pod past combined deadline not flagged as flapping"
+
+---
+
+## PR 4: Changes related to version recording
+
+Based on PR 2.
+
+### Source changes
+- Inline the version-recording guard: replace `workloadAtHighestGeneration && workloadHasAllPodsAvailable && workloadHasAllPodsUpdated` intermediate variables with direct field comparisons at the recording site
+- This is required because `workloadAtHighestGeneration` was removed from progressing logic in PR 2, but the generation check is still needed here
+
+### Test infrastructure (carried with this PR)
+- Wire `versionRecorder` (`status.NewVersionGetter()`) and `targetOperandVersion` into test controller setup
+
+### Test scenarios added
+- "version recorded when at highest revision"
+- "version not recorded when not at highest revision"
+- "version not recorded when generation != observed generation"
+- "version not recorded when available replicas < desired"
+- "version not recorded when updated replicas < desired"
+
+---
+
+## Dependency order
+
+```
+PR 1 (cleanup, MERGED) → PR 2 (progressing) → PR 3 (degraded)
+                                             → PR 4 (version)
+```
+
+PR 1 is merged. PR 2 builds on PR 1. PRs 3 and 4 both build on PR 2 and are independent of each other. Test infrastructure additions (podListErr, version recorder, targetOperandVersion) are carried with PR 2 since they are first needed there.

--- a/pr-split.md
+++ b/pr-split.md
@@ -38,36 +38,42 @@ Based on PR 1.
 
 ## PR 3: Rework of the degraded condition
 
-Based on PR 2.
+Based on PR 2. Branch: `pr3-degraded-rework`.
 
-### New function in `pkg/apps/deployment/`
-- `DeploymentDegradedCondition(deployment, pods []*corev1.Pod) → operatorv1.OperatorCondition`
-  - Computes the Degraded condition from deployment status and pod state
-  - Internally uses unexported helpers: `hasFailingPods`, `findPodReadyCondition`
+### New helpers in `pkg/apps/deployment/degraded.go`
+- `DeploymentDegradedCondition(deployment *appsv1.Deployment, podsLister, now) → (operatorv1.OperatorCondition, error)`
+  - `ProgressDeadlineExceeded` → `True/ProgressDeadlineExceeded`
+  - Progressed + unavailable + failing pods → `True/UnavailablePod`
+  - Otherwise → `False/AsExpected`
+- `HasFailingPods(deployment, podsLister, now) (bool, error)` (exported): lists pods by `Spec.Selector`, skips terminating pods, applies `ProgressDeadlineSeconds` deadline and MinReadySeconds-based flapping detection
+- `findPodReadyCondition` (unexported)
 
-### Source changes in `pkg/operator/apiserver/controller/workload/`
-- Call the new helper instead of computing the degraded condition inline
-- When `workload == nil`, also set `WorkloadDegraded`
-- Use `defer` to apply SyncError to `workloadDegradedCondition`
-- When `ProgressDeadlineExceeded`, also report `DeploymentDegraded`
-- Degraded only when pods are actually failing, not during normal rollouts
+Note: `progressing.go` from PR 2 is retained — not rolled back. `pkg/apps/deployment` becomes a coherent library of deployment→operator-condition mappings.
+
+### Source changes in `pkg/operator/apiserver/controller/workload/workload.go`
+- Call `DeploymentDegradedCondition` instead of inline switch
+- Add `defer` for SyncError so errors appended during degraded computation surface on `WorkloadDegraded`
+- When `workload == nil`, also set `WorkloadDegraded=True/NoDeployment`
+- `ProgressDeadlineExceeded` now also reports `DeploymentDegraded=True`
+- Degraded only when pods are actually failing past `ProgressDeadlineSeconds`, not during normal rollouts
 - Remove trailing period from "no pods available on any node" message
+- Add `errMessage` helper; add `"time"` import; remove `"strings"` import
 
 ### Test infrastructure (carried with this PR)
-- Add `podListErr` field to test struct and wire through `fakePodLister`
+- Add `podListErr` field to scenario struct and wire through `fakePodLister`
+- Add `previousConditions` field to seed prior operator status
+- Unit tests for helpers in `pkg/apps/deployment/degraded_test.go`
 
 ### Test scenarios added/updated
-- "unavailable workload that previously progressed successfully"
-- "partially available during active rollout, pods starting"
-- "workload recovering from progress deadline exceeded"
-- "partially available workload with failing pod"
-- "partially available during scale-up, new pods failing"
+- "unavailable workload that previously progressed successfully" (replaces old "incomplete workload")
+- "partially available workload with failing pod" (replaces old "zero available after successful rollout")
 - "zero available replicas, no pods exist"
 - "pod list error"
 - "terminating pod past deadline is not reported as failing"
 - "pod with flapping Ready condition detected as failing"
 - "pod with flapping Ready within combined deadline not flagged"
 - "stably ready pod past combined deadline not flagged as flapping"
+- "workload recovering from progress deadline exceeded"
 
 ---
 

--- a/pr-split.md
+++ b/pr-split.md
@@ -16,9 +16,9 @@ https://github.com/openshift/library-go/pull/2197
 Based on PR 1.
 
 ### New function in `pkg/apps/deployment/`
-- `DeploymentProgressingCondition(deployment, pods []*corev1.Pod) → operatorv1.OperatorCondition`
-  - Computes the Progressing condition from deployment status and pod state
-  - Internally uses unexported helpers: `hasDeploymentProgressed`, `hasDeploymentTimedOutProgressing`
+- `DeploymentProgressingCondition(deployment *appsv1.Deployment) → operatorv1.OperatorCondition`
+  - Computes the Progressing condition from deployment status and replica counts
+  - Uses exported helpers: `HasDeploymentProgressed`, `HasDeploymentTimedOutProgressing`
 
 ### Source changes in `pkg/operator/apiserver/controller/workload/`
 - Call the new helper instead of computing the progressing condition inline
@@ -27,17 +27,12 @@ Based on PR 1.
 - Add `ProgressDeadlineExceeded` as a new Progressing=False reason
 - Change wording "latest generation" → "latest revision" in PodsUpdating message
 
-### Test infrastructure (carried with this PR)
-- Add `podListErr` field to test struct and wire through `fakePodLister`
-
 ### Test scenarios added/updated
 - "unavailable workload with progress deadline exceeded" (was "updated for too long")
 - "unavailable workload progressing normally" (was "updated for a short time")
-- "partially available during active rollout, pods starting"
 - "all pods updated but not all available yet"
 - "available workload with progress deadline exceeded"
 - "workload rollout with maxSurge"
-- "workload recovering from progress deadline exceeded"
 
 ---
 
@@ -58,8 +53,13 @@ Based on PR 2.
 - Degraded only when pods are actually failing, not during normal rollouts
 - Remove trailing period from "no pods available on any node" message
 
+### Test infrastructure (carried with this PR)
+- Add `podListErr` field to test struct and wire through `fakePodLister`
+
 ### Test scenarios added/updated
 - "unavailable workload that previously progressed successfully"
+- "partially available during active rollout, pods starting"
+- "workload recovering from progress deadline exceeded"
 - "partially available workload with failing pod"
 - "partially available during scale-up, new pods failing"
 - "zero available replicas, no pods exist"
@@ -98,4 +98,4 @@ PR 1 (cleanup, MERGED) → PR 2 (progressing) → PR 3 (degraded)
                                              → PR 4 (version)
 ```
 
-PR 1 is merged. PR 2 builds on PR 1. PRs 3 and 4 both build on PR 2 and are independent of each other. Test infrastructure additions (podListErr, version recorder, targetOperandVersion) are carried with PR 2 since they are first needed there.
+PR 1 is merged. PR 2 builds on PR 1. PRs 3 and 4 both build on PR 2 and are independent of each other. `podListErr` test infra is carried with PR 3 (first needed there); `versionRecorder` and `targetOperandVersion` are carried with PR 4.


### PR DESCRIPTION
Reworks how the workload controller computes Degraded, Progressing, and Available conditions to fix false positives during scaling and improve failure detection.

**Progressing/Degraded no longer consult Deployment generation.** Previously, a generation mismatch (e.g. from a scale-up) would immediately set Progressing=True and could trigger Degraded. Now the controller relies solely on the Deployment's own Progressing condition:
- Progressing=True when the deployment has not yet reported `NewReplicaSetAvailable` and hasn't timed out.
- `ProgressDeadlineExceeded` is detected from the Deployment's Progressing condition and surfaces as both Progressing=False and DeploymentDegraded=True.

**DeploymentDegraded now detects failing pods** (when not mid-rollout). A pod is considered failing when it is not Ready past its ProgressDeadlineSeconds since creation, or (when MinReadySeconds > 0) its Ready condition is flapping — currently Ready but the last transition is too recent to count as available, checked only after ProgressDeadlineSeconds + MinReadySeconds have elapsed. Terminating pods are excluded to avoid false positives from the old ReplicaSet during rollouts. Diagnostic messages use `deployment.PodContainersStatus` to describe container states.

**WorkloadDegraded SyncError is set via defer** to ensure it is applied regardless of the return path.

This affects `authentication-operator` and `openshift-apiserver-operator`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Centralized status error messaging and clearer Progressing state handling with improved timeout detection and explicit timed-out messaging.
  * More accurate Degraded reporting: better detection of failing pods and concise "N of M unavailable" messages; preserves "AsExpected" when appropriate.
  * Stricter version recording gated on observed generation and replica alignment; pod-list errors now surface as SyncError in status.

* **Tests**
  * Expanded and rewritten status scenarios covering timeouts, multi-pod failures, pod-list errors, recovery paths, and version-recording validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->