### PR TITLE
NO-JIRA: Move AdditionalAnnotations to pkg/operator/tlsartifact

### DIFF
--- a/pkg/certs/cert-inspection/certgraphanalysis/metadata_options.go
+++ b/pkg/certs/cert-inspection/certgraphanalysis/metadata_options.go
@@ -11,7 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openshift/library-go/pkg/certs/cert-inspection/certgraphapi"
-	"github.com/openshift/library-go/pkg/operator/certrotation"
+	"github.com/openshift/library-go/pkg/operator/tlsartifact"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -172,7 +172,7 @@ var (
 )
 
 func humanizeRefreshPeriodFromMetadata(annotations map[string]string) {
-	period, ok := annotations[certrotation.CertificateRefreshPeriodAnnotation]
+	period, ok := annotations[tlsartifact.CertificateRefreshPeriodAnnotation]
 	if !ok {
 		return
 	}
@@ -182,7 +182,7 @@ func humanizeRefreshPeriodFromMetadata(annotations map[string]string) {
 		return
 	}
 	humanReadableDate := durationToHumanReadableString(d)
-	annotations[certrotation.CertificateRefreshPeriodAnnotation] = humanReadableDate
+	annotations[tlsartifact.CertificateRefreshPeriodAnnotation] = humanReadableDate
 	annotations[rewritePrefix+"RewriteRefreshPeriod"] = period
 	return
 }

--- a/pkg/operator/certrotation/cabundle.go
+++ b/pkg/operator/certrotation/cabundle.go
@@ -22,6 +22,7 @@ import (
 	"github.com/openshift/library-go/pkg/crypto"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcehelper"
+	"github.com/openshift/library-go/pkg/operator/tlsartifact"
 )
 
 // CABundleConfigMap maintains a CA bundle config map, by adding new CA certs coming from RotatedSigningCASecret, and by removing expired old ones.
@@ -37,7 +38,7 @@ type CABundleConfigMap struct {
 	// Owner is an optional reference to add to the secret that this rotator creates.
 	Owner *metav1.OwnerReference
 	// AdditionalAnnotations is a collection of annotations set for the secret
-	AdditionalAnnotations AdditionalAnnotations
+	AdditionalAnnotations tlsartifact.AdditionalAnnotations
 	// Plumbing:
 	Informer      corev1informers.ConfigMapInformer
 	Lister        corev1listers.ConfigMapLister
@@ -58,7 +59,7 @@ func (c CABundleConfigMap) EnsureConfigMapCABundle(ctx context.Context, signingC
 	caBundleConfigMap := originalCABundleConfigMap.DeepCopy()
 	if apierrors.IsNotFound(err) {
 		// create an empty one
-		caBundleConfigMap = &corev1.ConfigMap{ObjectMeta: NewTLSArtifactObjectMeta(
+		caBundleConfigMap = &corev1.ConfigMap{ObjectMeta: tlsartifact.NewTLSArtifactObjectMeta(
 			c.Name,
 			c.Namespace,
 			c.AdditionalAnnotations,

--- a/pkg/operator/certrotation/client_cert_rotation_controller_test.go
+++ b/pkg/operator/certrotation/client_cert_rotation_controller_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openshift/api/annotations"
 	"github.com/openshift/library-go/pkg/crypto"
 	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/tlsartifact"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -280,7 +281,7 @@ func TestCertRotationController_SyncWorker(t *testing.T) {
 					Lister:        informerFactory.Core().V1().ConfigMaps().Lister(),
 					Client:        fakeClient.CoreV1(),
 					EventRecorder: events.NewInMemoryRecorder("test", clock.RealClock{}),
-					AdditionalAnnotations: AdditionalAnnotations{
+					AdditionalAnnotations: tlsartifact.AdditionalAnnotations{
 						JiraComponent: "test",
 					},
 				},

--- a/pkg/operator/certrotation/metadata.go
+++ b/pkg/operator/certrotation/metadata.go
@@ -1,11 +1,12 @@
 package certrotation
 
 import (
+	"github.com/openshift/library-go/pkg/operator/tlsartifact"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func ensureOwnerRefAndTLSAnnotations(secret *corev1.Secret, owner *metav1.OwnerReference, additionalAnnotations AdditionalAnnotations) bool {
+func ensureOwnerRefAndTLSAnnotations(secret *corev1.Secret, owner *metav1.OwnerReference, additionalAnnotations tlsartifact.AdditionalAnnotations) bool {
 	needsMetadataUpdate := false
 	// no ownerReference set
 	if owner != nil {

--- a/pkg/operator/certrotation/signer.go
+++ b/pkg/operator/certrotation/signer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/library-go/pkg/crypto"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcehelper"
+	"github.com/openshift/library-go/pkg/operator/tlsartifact"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,7 +47,7 @@ type RotatedSigningCASecret struct {
 	Owner *metav1.OwnerReference
 
 	// AdditionalAnnotations is a collection of annotations set for the secret
-	AdditionalAnnotations AdditionalAnnotations
+	AdditionalAnnotations tlsartifact.AdditionalAnnotations
 
 	// Plumbing:
 	Informer      corev1informers.SecretInformer
@@ -68,7 +69,7 @@ func (c RotatedSigningCASecret) EnsureSigningCertKeyPair(ctx context.Context) (*
 	if apierrors.IsNotFound(err) {
 		// create an empty one
 		signingCertKeyPairSecret = &corev1.Secret{
-			ObjectMeta: NewTLSArtifactObjectMeta(
+			ObjectMeta: tlsartifact.NewTLSArtifactObjectMeta(
 				c.Name,
 				c.Namespace,
 				c.AdditionalAnnotations,
@@ -179,7 +180,7 @@ func needNewSigningCertKeyPair(secret *corev1.Secret, refresh time.Duration, ref
 }
 
 func getValidityFromAnnotations(annotations map[string]string) (notBefore time.Time, notAfter time.Time, reason string) {
-	notAfterString := annotations[CertificateNotAfterAnnotation]
+	notAfterString := annotations[tlsartifact.CertificateNotAfterAnnotation]
 	if len(notAfterString) == 0 {
 		return notBefore, notAfter, "missing notAfter"
 	}
@@ -187,7 +188,7 @@ func getValidityFromAnnotations(annotations map[string]string) (notBefore time.T
 	if err != nil {
 		return notBefore, notAfter, fmt.Sprintf("bad expiry: %q", notAfterString)
 	}
-	notBeforeString := annotations[CertificateNotBeforeAnnotation]
+	notBeforeString := annotations[tlsartifact.CertificateNotBeforeAnnotation]
 	if len(notBeforeString) == 0 {
 		return notBefore, notAfter, "missing notBefore"
 	}
@@ -201,7 +202,7 @@ func getValidityFromAnnotations(annotations map[string]string) (notBefore time.T
 
 // setSigningCertKeyPairSecretAndTLSAnnotations generates a new signing certificate and key pair,
 // stores them in the specified secret, and adds predefined TLS annotations to that secret.
-func setSigningCertKeyPairSecretAndTLSAnnotations(signingCertKeyPairSecret *corev1.Secret, validity, refresh time.Duration, tlsAnnotations AdditionalAnnotations) error {
+func setSigningCertKeyPairSecretAndTLSAnnotations(signingCertKeyPairSecret *corev1.Secret, validity, refresh time.Duration, tlsAnnotations tlsartifact.AdditionalAnnotations) error {
 	ca, err := setSigningCertKeyPairSecret(signingCertKeyPairSecret, validity)
 	if err != nil {
 		return err
@@ -243,8 +244,8 @@ func setSigningCertKeyPairSecret(signingCertKeyPairSecret *corev1.Secret, validi
 //
 // These assumptions are safe because this function is only called after the secret
 // has been initialized in setSigningCertKeyPairSecret.
-func setTLSAnnotationsOnSigningCertKeyPairSecret(signingCertKeyPairSecret *corev1.Secret, ca *crypto.TLSCertificateConfig, refresh time.Duration, tlsAnnotations AdditionalAnnotations) {
-	signingCertKeyPairSecret.Annotations[CertificateIssuer] = ca.Certs[0].Issuer.CommonName
+func setTLSAnnotationsOnSigningCertKeyPairSecret(signingCertKeyPairSecret *corev1.Secret, ca *crypto.TLSCertificateConfig, refresh time.Duration, tlsAnnotations tlsartifact.AdditionalAnnotations) {
+	signingCertKeyPairSecret.Annotations[tlsartifact.CertificateIssuer] = ca.Certs[0].Issuer.CommonName
 
 	tlsAnnotations.NotBefore = ca.Certs[0].NotBefore.Format(time.RFC3339)
 	tlsAnnotations.NotAfter = ca.Certs[0].NotAfter.Format(time.RFC3339)

--- a/pkg/operator/certrotation/signer_test.go
+++ b/pkg/operator/certrotation/signer_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/openshift/api/annotations"
 	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/tlsartifact"
 )
 
 func TestEnsureSigningCertKeyPair(t *testing.T) {
@@ -260,7 +261,7 @@ func TestEnsureSigningCertKeyPair(t *testing.T) {
 				Client:        client.CoreV1(),
 				Lister:        corev1listers.NewSecretLister(indexer),
 				EventRecorder: recorder,
-				AdditionalAnnotations: AdditionalAnnotations{
+				AdditionalAnnotations: tlsartifact.AdditionalAnnotations{
 					JiraComponent: "test",
 				},
 				Owner: &metav1.OwnerReference{

--- a/pkg/operator/certrotation/target.go
+++ b/pkg/operator/certrotation/target.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openshift/library-go/pkg/crypto"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcehelper"
+	"github.com/openshift/library-go/pkg/operator/tlsartifact"
 	corev1informers "k8s.io/client-go/informers/core/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
@@ -59,7 +60,7 @@ type RotatedSelfSignedCertKeySecret struct {
 	Owner *metav1.OwnerReference
 
 	// AdditionalAnnotations is a collection of annotations set for the secret
-	AdditionalAnnotations AdditionalAnnotations
+	AdditionalAnnotations tlsartifact.AdditionalAnnotations
 
 	// CertCreator does the actual cert generation.
 	CertCreator TargetCertCreator
@@ -102,7 +103,7 @@ func (c RotatedSelfSignedCertKeySecret) EnsureTargetCertKeyPair(ctx context.Cont
 	if apierrors.IsNotFound(err) {
 		// create an empty one
 		targetCertKeyPairSecret = &corev1.Secret{
-			ObjectMeta: NewTLSArtifactObjectMeta(
+			ObjectMeta: tlsartifact.NewTLSArtifactObjectMeta(
 				c.Name,
 				c.Namespace,
 				c.AdditionalAnnotations,
@@ -170,7 +171,7 @@ func needNewTargetCertKeyPair(secret *corev1.Secret, signer *crypto.CA, caBundle
 	}
 
 	// check the signer common name against all the common names in our ca bundle so we don't refresh early
-	signerCommonName := annotations[CertificateIssuer]
+	signerCommonName := annotations[tlsartifact.CertificateIssuer]
 	if len(signerCommonName) == 0 {
 		return "missing issuer name"
 	}
@@ -239,7 +240,7 @@ func needNewTargetCertKeyPairForTime(annotations map[string]string, signer *cryp
 
 // setTargetCertKeyPairSecretAndTLSAnnotations generates a new cert/key pair,
 // stores them in the specified secret, and adds predefined TLS annotations to that secret.
-func setTargetCertKeyPairSecretAndTLSAnnotations(targetCertKeyPairSecret *corev1.Secret, validity, refresh time.Duration, signer *crypto.CA, certCreator TargetCertCreator, tlsAnnotations AdditionalAnnotations) error {
+func setTargetCertKeyPairSecretAndTLSAnnotations(targetCertKeyPairSecret *corev1.Secret, validity, refresh time.Duration, signer *crypto.CA, certCreator TargetCertCreator, tlsAnnotations tlsartifact.AdditionalAnnotations) error {
 	certKeyPair, err := setTargetCertKeyPairSecret(targetCertKeyPairSecret, validity, signer, certCreator)
 	if err != nil {
 		return err
@@ -282,8 +283,8 @@ func setTargetCertKeyPairSecret(targetCertKeyPairSecret *corev1.Secret, validity
 //
 // These assumptions are safe because this function is only called after the secret
 // has been initialized in setTargetCertKeyPairSecret.
-func setTLSAnnotationsOnTargetCertKeyPairSecret(targetCertKeyPairSecret *corev1.Secret, certKeyPair *crypto.TLSCertificateConfig, certCreator TargetCertCreator, refresh time.Duration, tlsAnnotations AdditionalAnnotations) {
-	targetCertKeyPairSecret.Annotations[CertificateIssuer] = certKeyPair.Certs[0].Issuer.CommonName
+func setTLSAnnotationsOnTargetCertKeyPairSecret(targetCertKeyPairSecret *corev1.Secret, certKeyPair *crypto.TLSCertificateConfig, certCreator TargetCertCreator, refresh time.Duration, tlsAnnotations tlsartifact.AdditionalAnnotations) {
+	targetCertKeyPairSecret.Annotations[tlsartifact.CertificateIssuer] = certKeyPair.Certs[0].Issuer.CommonName
 
 	tlsAnnotations.NotBefore = certKeyPair.Certs[0].NotBefore.Format(time.RFC3339)
 	tlsAnnotations.NotAfter = certKeyPair.Certs[0].NotAfter.Format(time.RFC3339)
@@ -336,7 +337,7 @@ func (r *ServingRotation) NeedNewTargetCertKeyPair(currentCertSecret *corev1.Sec
 }
 
 func (r *ServingRotation) missingHostnames(annotations map[string]string) string {
-	existingHostnames := sets.New(strings.Split(annotations[CertificateHostnames], ",")...)
+	existingHostnames := sets.New(strings.Split(annotations[tlsartifact.CertificateHostnames], ",")...)
 	requiredHostnames := sets.New(r.Hostnames()...)
 	if !existingHostnames.Equal(requiredHostnames) {
 		existingNotRequired := existingHostnames.Difference(requiredHostnames)
@@ -357,7 +358,7 @@ func (r *ServingRotation) SetAnnotations(cert *crypto.TLSCertificateConfig, anno
 	}
 
 	// List does a sort so that we have a consistent representation
-	annotations[CertificateHostnames] = strings.Join(sets.List(hostnames), ",")
+	annotations[tlsartifact.CertificateHostnames] = strings.Join(sets.List(hostnames), ",")
 	return annotations
 }
 

--- a/pkg/operator/certrotation/target_test.go
+++ b/pkg/operator/certrotation/target_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openshift/api/annotations"
 	"github.com/openshift/library-go/pkg/crypto"
 	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/tlsartifact"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -59,8 +60,8 @@ func TestNeedNewTargetCertKeyPairForTime(t *testing.T) {
 		{
 			name: "malformed",
 			annotations: map[string]string{
-				CertificateNotAfterAnnotation:  "malformed",
-				CertificateNotBeforeAnnotation: now.Add(-45 * time.Minute).Format(time.RFC3339),
+				tlsartifact.CertificateNotAfterAnnotation:  "malformed",
+				tlsartifact.CertificateNotBeforeAnnotation: now.Add(-45 * time.Minute).Format(time.RFC3339),
 			},
 			signerFn: func() (*crypto.CA, error) {
 				return nowCert, nil
@@ -71,8 +72,8 @@ func TestNeedNewTargetCertKeyPairForTime(t *testing.T) {
 		{
 			name: "past midpoint and cert is ready",
 			annotations: map[string]string{
-				CertificateNotAfterAnnotation:  now.Add(45 * time.Minute).Format(time.RFC3339),
-				CertificateNotBeforeAnnotation: now.Add(-45 * time.Minute).Format(time.RFC3339),
+				tlsartifact.CertificateNotAfterAnnotation:  now.Add(45 * time.Minute).Format(time.RFC3339),
+				tlsartifact.CertificateNotBeforeAnnotation: now.Add(-45 * time.Minute).Format(time.RFC3339),
 			},
 			signerFn: func() (*crypto.CA, error) {
 				return elevenMinutesBeforeNowCert, nil
@@ -83,8 +84,8 @@ func TestNeedNewTargetCertKeyPairForTime(t *testing.T) {
 		{
 			name: "past midpoint and cert is new",
 			annotations: map[string]string{
-				CertificateNotAfterAnnotation:  now.Add(45 * time.Minute).Format(time.RFC3339),
-				CertificateNotBeforeAnnotation: now.Add(-45 * time.Minute).Format(time.RFC3339),
+				tlsartifact.CertificateNotAfterAnnotation:  now.Add(45 * time.Minute).Format(time.RFC3339),
+				tlsartifact.CertificateNotBeforeAnnotation: now.Add(-45 * time.Minute).Format(time.RFC3339),
 			},
 			signerFn: func() (*crypto.CA, error) {
 				return nowCert, nil
@@ -95,8 +96,8 @@ func TestNeedNewTargetCertKeyPairForTime(t *testing.T) {
 		{
 			name: "past refresh but not expired",
 			annotations: map[string]string{
-				CertificateNotAfterAnnotation:  now.Add(45 * time.Minute).Format(time.RFC3339),
-				CertificateNotBeforeAnnotation: now.Add(-45 * time.Minute).Format(time.RFC3339),
+				tlsartifact.CertificateNotAfterAnnotation:  now.Add(45 * time.Minute).Format(time.RFC3339),
+				tlsartifact.CertificateNotBeforeAnnotation: now.Add(-45 * time.Minute).Format(time.RFC3339),
 			},
 			signerFn: func() (*crypto.CA, error) {
 				return nowCert, nil
@@ -108,8 +109,8 @@ func TestNeedNewTargetCertKeyPairForTime(t *testing.T) {
 		{
 			name: "already expired",
 			annotations: map[string]string{
-				CertificateNotAfterAnnotation:  now.Add(-1 * time.Millisecond).Format(time.RFC3339),
-				CertificateNotBeforeAnnotation: now.Add(-45 * time.Minute).Format(time.RFC3339),
+				tlsartifact.CertificateNotAfterAnnotation:  now.Add(-1 * time.Millisecond).Format(time.RFC3339),
+				tlsartifact.CertificateNotBeforeAnnotation: now.Add(-45 * time.Minute).Format(time.RFC3339),
 			},
 			signerFn: func() (*crypto.CA, error) {
 				return nowCert, nil
@@ -222,8 +223,8 @@ func TestEnsureTargetCertKeyPair(t *testing.T) {
 				if len(actual.Data["tls.crt"]) == 0 || len(actual.Data["tls.key"]) == 0 {
 					t.Error(actual.Data)
 				}
-				if actual.Annotations[CertificateHostnames] != "bar,foo" {
-					t.Error(actual.Annotations[CertificateHostnames])
+				if actual.Annotations[tlsartifact.CertificateHostnames] != "bar,foo" {
+					t.Error(actual.Annotations[tlsartifact.CertificateHostnames])
 				}
 				if len(actual.OwnerReferences) != 1 {
 					t.Errorf("expected to have exactly one owner reference")
@@ -288,7 +289,7 @@ func TestEnsureTargetCertKeyPair(t *testing.T) {
 				Client:        client.CoreV1(),
 				Lister:        corev1listers.NewSecretLister(indexer),
 				EventRecorder: events.NewInMemoryRecorder("test", clocktesting.NewFakePassiveClock(time.Now())),
-				AdditionalAnnotations: AdditionalAnnotations{
+				AdditionalAnnotations: tlsartifact.AdditionalAnnotations{
 					JiraComponent: "test",
 				},
 				Owner: &metav1.OwnerReference{
@@ -362,7 +363,7 @@ func TestServerHostnameCheck(t *testing.T) {
 			r := &ServingRotation{
 				Hostnames: func() []string { return test.requiredHostnames },
 			}
-			actual := r.missingHostnames(map[string]string{CertificateHostnames: test.existingHostnames})
+			actual := r.missingHostnames(map[string]string{tlsartifact.CertificateHostnames: test.existingHostnames})
 			if actual != test.expected {
 				t.Fatal(actual)
 			}
@@ -547,9 +548,9 @@ func TestNeedNewTargetCertKeyPair(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						CertificateNotAfterAnnotation:  now.Add(1 * time.Hour).Format(time.RFC3339),
-						CertificateNotBeforeAnnotation: now.Add(-1 * time.Hour).Format(time.RFC3339),
-						CertificateIssuer:              "test-ca",
+						tlsartifact.CertificateNotAfterAnnotation:  now.Add(1 * time.Hour).Format(time.RFC3339),
+						tlsartifact.CertificateNotBeforeAnnotation: now.Add(-1 * time.Hour).Format(time.RFC3339),
+						tlsartifact.CertificateIssuer:              "test-ca",
 					},
 				},
 			},
@@ -564,9 +565,9 @@ func TestNeedNewTargetCertKeyPair(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						CertificateNotAfterAnnotation:  now.Add(-1 * time.Minute).Format(time.RFC3339),
-						CertificateNotBeforeAnnotation: now.Add(2 * time.Hour).Format(time.RFC3339),
-						CertificateIssuer:              "test-ca",
+						tlsartifact.CertificateNotAfterAnnotation:  now.Add(-1 * time.Minute).Format(time.RFC3339),
+						tlsartifact.CertificateNotBeforeAnnotation: now.Add(2 * time.Hour).Format(time.RFC3339),
+						tlsartifact.CertificateIssuer:              "test-ca",
 					},
 				},
 			},
@@ -581,9 +582,9 @@ func TestNeedNewTargetCertKeyPair(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						CertificateNotAfterAnnotation:  now.Add(1 * time.Hour).Format(time.RFC3339), // not expired
-						CertificateNotBeforeAnnotation: now.Add(-1 * time.Hour).Format(time.RFC3339),
-						CertificateIssuer:              "test-ca",
+						tlsartifact.CertificateNotAfterAnnotation:  now.Add(1 * time.Hour).Format(time.RFC3339), // not expired
+						tlsartifact.CertificateNotBeforeAnnotation: now.Add(-1 * time.Hour).Format(time.RFC3339),
+						tlsartifact.CertificateIssuer:              "test-ca",
 					},
 				},
 			},
@@ -599,9 +600,9 @@ func TestNeedNewTargetCertKeyPair(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						CertificateNotAfterAnnotation:  now.Add(-1 * time.Hour).Format(time.RFC3339), // expired
-						CertificateNotBeforeAnnotation: now.Add(1 * time.Hour).Format(time.RFC3339),
-						CertificateIssuer:              "test-ca",
+						tlsartifact.CertificateNotAfterAnnotation:  now.Add(-1 * time.Hour).Format(time.RFC3339), // expired
+						tlsartifact.CertificateNotBeforeAnnotation: now.Add(1 * time.Hour).Format(time.RFC3339),
+						tlsartifact.CertificateIssuer:              "test-ca",
 					},
 				},
 			},
@@ -617,9 +618,9 @@ func TestNeedNewTargetCertKeyPair(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						CertificateNotAfterAnnotation:  now.Add(2 * time.Hour).Format(time.RFC3339),
-						CertificateNotBeforeAnnotation: now.Add(-1 * time.Hour).Format(time.RFC3339),
-						// CertificateIssuer unset
+						tlsartifact.CertificateNotAfterAnnotation:  now.Add(2 * time.Hour).Format(time.RFC3339),
+						tlsartifact.CertificateNotBeforeAnnotation: now.Add(-1 * time.Hour).Format(time.RFC3339),
+						// tlsartifact.CertificateIssuer unset
 					},
 				},
 			},
@@ -634,9 +635,9 @@ func TestNeedNewTargetCertKeyPair(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						CertificateNotAfterAnnotation:  now.Add(2 * time.Hour).Format(time.RFC3339),
-						CertificateNotBeforeAnnotation: now.Add(-1 * time.Hour).Format(time.RFC3339),
-						CertificateIssuer:              "test-ca",
+						tlsartifact.CertificateNotAfterAnnotation:  now.Add(2 * time.Hour).Format(time.RFC3339),
+						tlsartifact.CertificateNotBeforeAnnotation: now.Add(-1 * time.Hour).Format(time.RFC3339),
+						tlsartifact.CertificateIssuer:              "test-ca",
 					},
 				},
 			},
@@ -651,9 +652,9 @@ func TestNeedNewTargetCertKeyPair(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						CertificateNotAfterAnnotation:  now.Add(2 * time.Hour).Format(time.RFC3339),
-						CertificateNotBeforeAnnotation: now.Add(-1 * time.Hour).Format(time.RFC3339),
-						CertificateIssuer:              "old-ca-name", // not in bundle
+						tlsartifact.CertificateNotAfterAnnotation:  now.Add(2 * time.Hour).Format(time.RFC3339),
+						tlsartifact.CertificateNotBeforeAnnotation: now.Add(-1 * time.Hour).Format(time.RFC3339),
+						tlsartifact.CertificateIssuer:              "old-ca-name", // not in bundle
 					},
 				},
 			},
@@ -668,9 +669,9 @@ func TestNeedNewTargetCertKeyPair(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						CertificateNotAfterAnnotation:  now.Add(2 * time.Hour).Format(time.RFC3339),
-						CertificateNotBeforeAnnotation: now.Add(-1 * time.Hour).Format(time.RFC3339),
-						CertificateIssuer:              "other-ca",
+						tlsartifact.CertificateNotAfterAnnotation:  now.Add(2 * time.Hour).Format(time.RFC3339),
+						tlsartifact.CertificateNotBeforeAnnotation: now.Add(-1 * time.Hour).Format(time.RFC3339),
+						tlsartifact.CertificateIssuer:              "other-ca",
 					},
 				},
 			},

--- a/pkg/operator/csr/cert_controller.go
+++ b/pkg/operator/csr/cert_controller.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/openshift/library-go/pkg/controller/factory"
-	"github.com/openshift/library-go/pkg/operator/certrotation"
 	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/tlsartifact"
 
 	certificates "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -67,7 +67,7 @@ type ClientCertOption struct {
 	// AdditonalSecretData contains data that will be added into client certificate secret besides tls.key/tls.crt
 	AdditonalSecretData map[string][]byte
 	// AdditionalAnnotations is a collection of annotations set for the secret
-	AdditionalAnnotations certrotation.AdditionalAnnotations
+	AdditionalAnnotations tlsartifact.AdditionalAnnotations
 }
 
 // clientCertificateController implements the common logic of hub client certification creation/rotation. It
@@ -154,7 +154,7 @@ func (c *clientCertificateController) sync(ctx context.Context, syncCtx factory.
 	switch {
 	case errors.IsNotFound(err):
 		secret = &corev1.Secret{
-			ObjectMeta: certrotation.NewTLSArtifactObjectMeta(
+			ObjectMeta: tlsartifact.NewTLSArtifactObjectMeta(
 				c.SecretName,
 				c.SecretNamespace,
 				c.AdditionalAnnotations,

--- a/pkg/operator/csr/cert_controller_test.go
+++ b/pkg/operator/csr/cert_controller_test.go
@@ -9,9 +9,9 @@ import (
 	"time"
 
 	"github.com/openshift/api/annotations"
-	"github.com/openshift/library-go/pkg/operator/certrotation"
 	"github.com/openshift/library-go/pkg/operator/csr/csrtestinghelpers"
 	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/tlsartifact"
 	"github.com/stretchr/testify/require"
 
 	certificates "k8s.io/api/certificates/v1"
@@ -113,7 +113,7 @@ func TestControllerSync(t *testing.T) {
 		{
 			name: "secret with metadata update",
 			ctrlPrepare: func(ctrl *clientCertificateController) {
-				ctrl.AdditionalAnnotations = certrotation.AdditionalAnnotations{
+				ctrl.AdditionalAnnotations = tlsartifact.AdditionalAnnotations{
 					JiraComponent: "test-component",
 				}
 			},
@@ -212,7 +212,7 @@ func newTestController(client *fake.Clientset) *clientCertificateController {
 		SecretNamespace:     testControllerNamespace,
 		SecretName:          testControllerSecretName,
 		AdditonalSecretData: map[string][]byte{"test": []byte("data")},
-		AdditionalAnnotations: certrotation.AdditionalAnnotations{
+		AdditionalAnnotations: tlsartifact.AdditionalAnnotations{
 			JiraComponent: "test-component",
 		},
 	}

--- a/pkg/operator/resourcesynccontroller/core.go
+++ b/pkg/operator/resourcesynccontroller/core.go
@@ -11,10 +11,10 @@ import (
 	"k8s.io/client-go/util/cert"
 
 	"github.com/openshift/library-go/pkg/crypto"
-	"github.com/openshift/library-go/pkg/operator/certrotation"
+	"github.com/openshift/library-go/pkg/operator/tlsartifact"
 )
 
-func CombineCABundleConfigMaps(destinationConfigMap ResourceLocation, lister corev1listers.ConfigMapLister, additionalAnnotations certrotation.AdditionalAnnotations, inputConfigMaps ...ResourceLocation) (*corev1.ConfigMap, error) {
+func CombineCABundleConfigMaps(destinationConfigMap ResourceLocation, lister corev1listers.ConfigMapLister, additionalAnnotations tlsartifact.AdditionalAnnotations, inputConfigMaps ...ResourceLocation) (*corev1.ConfigMap, error) {
 	certificates := []*x509.Certificate{}
 	for _, input := range inputConfigMaps {
 		inputConfigMap, err := lister.ConfigMaps(input.Namespace).Get(input.Name)
@@ -59,7 +59,7 @@ func CombineCABundleConfigMaps(destinationConfigMap ResourceLocation, lister cor
 	}
 
 	cm := &corev1.ConfigMap{
-		ObjectMeta: certrotation.NewTLSArtifactObjectMeta(
+		ObjectMeta: tlsartifact.NewTLSArtifactObjectMeta(
 			destinationConfigMap.Name,
 			destinationConfigMap.Namespace,
 			additionalAnnotations,
@@ -71,7 +71,7 @@ func CombineCABundleConfigMaps(destinationConfigMap ResourceLocation, lister cor
 	return cm, nil
 }
 
-func CombineCABundleConfigMapsOptimistically(destinationConfigMap *corev1.ConfigMap, lister corev1listers.ConfigMapLister, additionalAnnotations certrotation.AdditionalAnnotations, inputConfigMaps ...ResourceLocation) (*corev1.ConfigMap, bool, error) {
+func CombineCABundleConfigMapsOptimistically(destinationConfigMap *corev1.ConfigMap, lister corev1listers.ConfigMapLister, additionalAnnotations tlsartifact.AdditionalAnnotations, inputConfigMaps ...ResourceLocation) (*corev1.ConfigMap, bool, error) {
 	var cm *corev1.ConfigMap
 	if destinationConfigMap == nil {
 		cm = &corev1.ConfigMap{}

--- a/pkg/operator/resourcesynccontroller/core_test.go
+++ b/pkg/operator/resourcesynccontroller/core_test.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/openshift/api/annotations"
 	"github.com/openshift/library-go/pkg/crypto"
-	"github.com/openshift/library-go/pkg/operator/certrotation"
+	"github.com/openshift/library-go/pkg/operator/tlsartifact"
 )
 
 // mockConfigMapLister is a mock implementation of the ConfigMapLister interface for testing
@@ -106,7 +106,7 @@ func TestCombineCABundleConfigMapsOptimistically(t *testing.T) {
 		destinationConfigMap  *corev1.ConfigMap
 		mockConfigMaps        map[string]map[string]*corev1.ConfigMap
 		inputLocations        []ResourceLocation
-		additionalAnnotations certrotation.AdditionalAnnotations
+		additionalAnnotations tlsartifact.AdditionalAnnotations
 		expectModified        bool
 		expectedCABundle      *corev1.ConfigMap
 	}{
@@ -132,7 +132,7 @@ func TestCombineCABundleConfigMapsOptimistically(t *testing.T) {
 				{Namespace: "ns1", Name: "cm1"},
 				{Namespace: "ns2", Name: "cm2"},
 			},
-			additionalAnnotations: certrotation.AdditionalAnnotations{},
+			additionalAnnotations: tlsartifact.AdditionalAnnotations{},
 			expectModified:        true,
 			expectedCABundle: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -169,7 +169,7 @@ func TestCombineCABundleConfigMapsOptimistically(t *testing.T) {
 			inputLocations: []ResourceLocation{
 				{Namespace: "ns1", Name: "cm1"},
 			},
-			additionalAnnotations: certrotation.AdditionalAnnotations{},
+			additionalAnnotations: tlsartifact.AdditionalAnnotations{},
 			expectModified:        true,
 			expectedCABundle: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -199,7 +199,7 @@ func TestCombineCABundleConfigMapsOptimistically(t *testing.T) {
 			inputLocations: []ResourceLocation{
 				{Namespace: "ns1", Name: "cm1"},
 			},
-			additionalAnnotations: certrotation.AdditionalAnnotations{
+			additionalAnnotations: tlsartifact.AdditionalAnnotations{
 				JiraComponent: jiraComponent,
 			},
 			expectModified:   false,
@@ -228,7 +228,7 @@ func TestCombineCABundleConfigMapsOptimistically(t *testing.T) {
 			inputLocations: []ResourceLocation{
 				{Namespace: "ns1", Name: "cm1"},
 			},
-			additionalAnnotations: certrotation.AdditionalAnnotations{
+			additionalAnnotations: tlsartifact.AdditionalAnnotations{
 				JiraComponent: jiraComponent,
 			},
 			expectModified:   true,
@@ -249,7 +249,7 @@ func TestCombineCABundleConfigMapsOptimistically(t *testing.T) {
 			inputLocations: []ResourceLocation{
 				{Namespace: "ns1", Name: "cm1"},
 			},
-			additionalAnnotations: certrotation.AdditionalAnnotations{
+			additionalAnnotations: tlsartifact.AdditionalAnnotations{
 				JiraComponent: jiraComponent,
 			},
 			expectModified: true,

--- a/pkg/operator/tlsartifact/annotations.go
+++ b/pkg/operator/tlsartifact/annotations.go
@@ -1,4 +1,4 @@
-package certrotation
+package tlsartifact
 
 import (
 	"github.com/google/go-cmp/cmp"
@@ -25,6 +25,9 @@ const (
 	CertificateRefreshPeriodAnnotation string = "certificates.openshift.io/refresh-period"
 )
 
+// AdditionalAnnotations holds TLS artifact metadata annotations as defined by
+// the TLS Artifacts Registry enhancement. These annotations identify the
+// owning component, purpose, and lifecycle of managed TLS artifacts.
 type AdditionalAnnotations struct {
 	// JiraComponent annotates tls artifacts so that owner could be easily found
 	JiraComponent string


### PR DESCRIPTION
## Overview

Moves the `AdditionalAnnotations` type, `Certificate*` annotation constants, and `NewTLSArtifactObjectMeta` helper from `pkg/operator/certrotation` to `pkg/operator/tlsartifact`.

This avoids circular dependencies — these types are used by packages that have no relation to cert rotation and should not need to import it:
- `pkg/operator/resourcesynccontroller` — CA bundle ConfigMap management
- `pkg/operator/csr` — CSR-based certificate management
- `pkg/certs/cert-inspection` — TLS registry analysis

All consumers now import `tlsartifact` directly.