### PR TITLE
pkg/operator/staticpod/startupmonitor: fix 100% cpu for loop

### DIFF
--- a/pkg/operator/staticpod/startupmonitor/cmd.go
+++ b/pkg/operator/staticpod/startupmonitor/cmd.go
@@ -3,6 +3,7 @@ package startupmonitor
 import (
 	"context"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"time"
@@ -201,6 +202,7 @@ func (o *Options) suicide(installerLock Locker) {
 	installerLock.Unlock()
 	klog.Info("Waiting for SIGTERM...")
 	for {
+		<-time.After(time.Duration(math.MaxInt64))
 	}
 }
 


### PR DESCRIPTION
This fixes an empty `for` loop that would grab 100% cpu. The loop remains, but it now has to wait 300 years before looping.