### PR TITLE
Update MakeServerCert() call to use time.Duration (4.19)

### DIFF
--- a/pkg/controller/controllercmd/cmd.go
+++ b/pkg/controller/controllercmd/cmd.go
@@ -3,11 +3,12 @@ package controllercmd
 import (
 	"context"
 	"fmt"
-	"k8s.io/utils/clock"
 	"math/rand"
 	"os"
 	"path/filepath"
 	"time"
+
+	"k8s.io/utils/clock"
 
 	"github.com/spf13/cobra"
 	"k8s.io/apiserver/pkg/server/healthz"
@@ -280,7 +281,7 @@ func (c *ControllerCommandConfig) AddDefaultRotationToConfig(config *operatorv1a
 			config.ServingInfo.CertFile = filepath.Join(temporaryCertDir, "tls.crt")
 			config.ServingInfo.KeyFile = filepath.Join(temporaryCertDir, "tls.key")
 			// nothing can trust this, so we don't really care about hostnames
-			servingCert, err := ca.MakeServerCert(sets.New("localhost"), 30)
+			servingCert, err := ca.MakeServerCert(sets.New("localhost"), time.Hour*24*30)
 			if err != nil {
 				return nil, nil, err
 			}


### PR DESCRIPTION
## Summary

Backport of #2155 to release-4.19.

Fixes the bug where `MakeServerCert(..., 30)` generates a certificate with 30 nanoseconds (~1 second) validity instead of 30 days.

**Root Cause:**
The `MakeServerCert()` function signature changed from `int` (days) to `time.Duration`, but the call site in `pkg/controller/controllercmd/cmd.go:283` was not updated, resulting in `30` being interpreted as 30 nanoseconds.

**Fix:**
Update the call to use `time.Hour*24*30` for 30 days validity.

**Changes:**
- pkg/controller/controllercmd/cmd.go: Changed `MakeServerCert(..., 30)` to `MakeServerCert(..., time.Hour*24*30)`

## Related
- Customer issue: kube-apiserver-check-endpoints container certificate valid for only 1 second

🤖 Generated with [Claude Code](https://claude.com/claude-code)