### PR TITLE
NO-JIRA:encryption: accept testing.TB instead of *testing.T in test helpers

### DIFF
--- a/test/library/encryption/e_log.go
+++ b/test/library/encryption/e_log.go
@@ -10,7 +10,7 @@ import (
 // E is like testing.T except it overloads some methods to print to stdout
 // when the encryption tests are run from a local machine
 type E struct {
-	*testing.T
+	testing.TB
 	local        bool
 	tearDownFunc func(testing.TB, bool)
 }
@@ -21,8 +21,8 @@ func PrintEventsOnFailure(namespace string) func(*E) {
 	}
 }
 
-func NewE(t *testing.T, options ...func(*E)) *E {
-	e := &E{T: t}
+func NewE(t testing.TB, options ...func(*E)) *E {
+	e := &E{TB: t}
 	// the test logger only prints text if a test fails or the -v flag is set
 	// that means we don't have any visibility when running the tests from a local machine
 	//
@@ -49,7 +49,7 @@ func (e *E) Logf(format string, args ...interface{}) {
 		fmt.Println(fmt.Sprintf(format, args...))
 		return
 	}
-	e.T.Logf(format, args...)
+	e.TB.Logf(format, args...)
 }
 
 func (e *E) Errorf(format string, args ...interface{}) {
@@ -60,7 +60,7 @@ func (e *E) Errorf(format string, args ...interface{}) {
 	}
 
 	format, args = withTimeStamp(format, args...)
-	e.T.Errorf(format, args...)
+	e.TB.Errorf(format, args...)
 	e.handleTearDown(e.Failed())
 }
 

--- a/test/library/encryption/scenarios.go
+++ b/test/library/encryption/scenarios.go
@@ -25,40 +25,40 @@ type BasicScenario struct {
 	AssertFunc                      func(t testing.TB, clientSet ClientSet, expectedMode configv1.EncryptionType, namespace, labelSelector string)
 }
 
-func TestEncryptionTypeIdentity(t *testing.T, scenario BasicScenario) {
+func TestEncryptionTypeIdentity(t testing.TB, scenario BasicScenario) {
 	e := NewE(t, PrintEventsOnFailure(scenario.OperatorNamespace))
 	clientSet := SetAndWaitForEncryptionType(e, configv1.EncryptionTypeIdentity, scenario.TargetGRs, scenario.Namespace, scenario.LabelSelector)
 	scenario.AssertFunc(e, clientSet, configv1.EncryptionTypeIdentity, scenario.Namespace, scenario.LabelSelector)
 }
 
-func TestEncryptionTypeUnset(t *testing.T, scenario BasicScenario) {
+func TestEncryptionTypeUnset(t testing.TB, scenario BasicScenario) {
 	e := NewE(t, PrintEventsOnFailure(scenario.OperatorNamespace))
 	clientSet := SetAndWaitForEncryptionType(e, "", scenario.TargetGRs, scenario.Namespace, scenario.LabelSelector)
 	scenario.AssertFunc(e, clientSet, configv1.EncryptionTypeIdentity, scenario.Namespace, scenario.LabelSelector)
 }
 
-func TestEncryptionTypeAESCBC(t *testing.T, scenario BasicScenario) {
+func TestEncryptionTypeAESCBC(t testing.TB, scenario BasicScenario) {
 	e := NewE(t, PrintEventsOnFailure(scenario.OperatorNamespace))
 	clientSet := SetAndWaitForEncryptionType(e, configv1.EncryptionTypeAESCBC, scenario.TargetGRs, scenario.Namespace, scenario.LabelSelector)
 	scenario.AssertFunc(e, clientSet, configv1.EncryptionTypeAESCBC, scenario.Namespace, scenario.LabelSelector)
 	AssertEncryptionConfig(e, clientSet, scenario.EncryptionConfigSecretName, scenario.EncryptionConfigSecretNamespace, scenario.TargetGRs)
 }
 
-func TestEncryptionTypeAESGCM(t *testing.T, scenario BasicScenario) {
+func TestEncryptionTypeAESGCM(t testing.TB, scenario BasicScenario) {
 	e := NewE(t, PrintEventsOnFailure(scenario.OperatorNamespace))
 	clientSet := SetAndWaitForEncryptionType(e, configv1.EncryptionTypeAESGCM, scenario.TargetGRs, scenario.Namespace, scenario.LabelSelector)
 	scenario.AssertFunc(e, clientSet, configv1.EncryptionTypeAESGCM, scenario.Namespace, scenario.LabelSelector)
 	AssertEncryptionConfig(e, clientSet, scenario.EncryptionConfigSecretName, scenario.EncryptionConfigSecretNamespace, scenario.TargetGRs)
 }
 
-func TestEncryptionTypeKMS(t *testing.T, scenario BasicScenario) {
+func TestEncryptionTypeKMS(t testing.TB, scenario BasicScenario) {
 	e := NewE(t, PrintEventsOnFailure(scenario.OperatorNamespace))
 	clientSet := SetAndWaitForEncryptionType(e, configv1.EncryptionTypeKMS, scenario.TargetGRs, scenario.Namespace, scenario.LabelSelector)
 	scenario.AssertFunc(e, clientSet, configv1.EncryptionTypeKMS, scenario.Namespace, scenario.LabelSelector)
 	AssertEncryptionConfig(e, clientSet, scenario.EncryptionConfigSecretName, scenario.EncryptionConfigSecretNamespace, scenario.TargetGRs)
 }
 
-func TestEncryptionType(t *testing.T, scenario BasicScenario, provider configv1.EncryptionType) {
+func TestEncryptionType(t testing.TB, scenario BasicScenario, provider configv1.EncryptionType) {
 	switch provider {
 	case configv1.EncryptionTypeAESCBC:
 		TestEncryptionTypeAESCBC(t, scenario)
@@ -221,7 +221,7 @@ type RotationScenario struct {
 
 // TestEncryptionRotation first encrypts data with aescbc key
 // then it forces a key rotation by setting the "encyrption.Reason" in the operator's configuration file
-func TestEncryptionRotation(t *testing.T, scenario RotationScenario) {
+func TestEncryptionRotation(t testing.TB, scenario RotationScenario) {
 	// test data
 	ns := scenario.Namespace
 	labelSelector := scenario.LabelSelector


### PR DESCRIPTION
The encryption test helper functions (TestEncryptionTypeAESCBC, NewE, etc.) currently require *testing.T, which prevents them from being used with Ginkgo's GinkgoTB() in OTE (OpenShift Tests Extension) migrations.

Change the function signatures to accept testing.TB (the interface that both *testing.T and GinkgoTBWrapper satisfy) so consumers can call these helpers from both standard Go tests and Ginkgo specs.

Functions that use t.Run() (TestEncryptionTurnOnAndOff, TestEncryptionProvidersMigration) are left as *testing.T since Run() is not part of the testing.TB interface.

This is backward compatible: existing callers passing *testing.T continue to work without changes.

