### PR TITLE
CNTRLPLANE-3237: Add new KMS foundational mechanism in encryption controller

### DIFF
--- a/pkg/operator/encryption/controllers/key_controller.go
+++ b/pkg/operator/encryption/controllers/key_controller.go
@@ -39,7 +39,7 @@ import (
 // greater than the last key's ID (the first key has a key ID of 1).
 const (
 	encryptionSecretMigrationInterval = time.Hour * 24 * 7 // one week
-	defaultKMSEndpoint                = "unix:///var/run/kmsplugin/kms-1.sock"
+	kmsEndpointFormat                 = "unix:///var/run/kmsplugin/kms-%d.sock"
 	defaultKMSTimeout                 = 10 * time.Second
 )
 
@@ -271,10 +271,10 @@ func (c *keyController) generateKeySecret(keyID uint64, currentMode state.Mode, 
 		ExternalReason: externalReason,
 	}
 	if currentMode == state.KMS {
-		ks.KMSConfiguration = &apiserverv1.KMSConfiguration{
+		ks.KMSEncryptionConfig = &apiserverv1.KMSConfiguration{
 			APIVersion: "v2",
 			Name:       fmt.Sprintf("%d", keyID),
-			Endpoint:   defaultKMSEndpoint,
+			Endpoint:   fmt.Sprintf(kmsEndpointFormat, keyID),
 			Timeout:    &metav1.Duration{Duration: defaultKMSTimeout},
 		}
 	}

--- a/pkg/operator/encryption/controllers/key_controller_test.go
+++ b/pkg/operator/encryption/controllers/key_controller_test.go
@@ -351,13 +351,13 @@ func TestKeyController(t *testing.T) {
 							ts.Errorf("expected mode to be KMS, got %s", actualSecret.Annotations["encryption.apiserver.operator.openshift.io/mode"])
 						}
 
-						// Verify KMS config annotation exists
-						kmsConfig := actualSecret.Annotations["encryption.apiserver.operator.openshift.io/kms-config"]
-						if kmsConfig == "" {
-							ts.Error("expected kms-config annotation to be present")
+						// Verify KMS config is in data field
+						kmsConfigData := actualSecret.Data["encryption.apiserver.operator.openshift.io-kms-encryption-config"]
+						if len(kmsConfigData) == 0 {
+							ts.Error("expected kms-encryption-config data to be present")
 						}
-						if kmsConfig != `{"apiVersion":"v2","name":"1","endpoint":"unix:///var/run/kmsplugin/kms-1.sock","timeout":"10s"}` {
-							ts.Errorf("unexpected kms-config: %s", kmsConfig)
+						if string(kmsConfigData) != `{"apiVersion":"v2","name":"1","endpoint":"unix:///var/run/kmsplugin/kms-1.sock","timeout":"10s"}` {
+							ts.Errorf("unexpected kms-encryption-config: %s", kmsConfigData)
 						}
 
 						// Verify internal reason
@@ -413,10 +413,10 @@ func TestKeyController(t *testing.T) {
 							ts.Errorf("expected mode to be KMS, got %s", actualSecret.Annotations["encryption.apiserver.operator.openshift.io/mode"])
 						}
 
-						// Verify KMS config annotation exists
-						kmsConfig := actualSecret.Annotations["encryption.apiserver.operator.openshift.io/kms-config"]
-						if kmsConfig != `{"apiVersion":"v2","name":"6","endpoint":"unix:///var/run/kmsplugin/kms-1.sock","timeout":"10s"}` {
-							ts.Errorf("unexpected kms-config: %s", kmsConfig)
+						// Verify KMS config is in data field
+						kmsConfigData := actualSecret.Data["encryption.apiserver.operator.openshift.io-kms-encryption-config"]
+						if string(kmsConfigData) != `{"apiVersion":"v2","name":"6","endpoint":"unix:///var/run/kmsplugin/kms-6.sock","timeout":"10s"}` {
+							ts.Errorf("unexpected kms-encryption-config: %s", kmsConfigData)
 						}
 
 						// Verify internal reason is mode changed
@@ -488,10 +488,10 @@ func TestKeyController(t *testing.T) {
 							ts.Errorf("expected mode to be KMS, got %s", actualSecret.Annotations["encryption.apiserver.operator.openshift.io/mode"])
 						}
 
-						// Verify KMS config annotation exists
-						kmsConfig := actualSecret.Annotations["encryption.apiserver.operator.openshift.io/kms-config"]
-						if kmsConfig != `{"apiVersion":"v2","name":"6","endpoint":"unix:///var/run/kmsplugin/kms-1.sock","timeout":"10s"}` {
-							ts.Errorf("unexpected kms-config: %s", kmsConfig)
+						// Verify KMS config is in data field
+						kmsConfigData := actualSecret.Data["encryption.apiserver.operator.openshift.io-kms-encryption-config"]
+						if string(kmsConfigData) != `{"apiVersion":"v2","name":"6","endpoint":"unix:///var/run/kmsplugin/kms-6.sock","timeout":"10s"}` {
+							ts.Errorf("unexpected kms-encryption-config: %s", kmsConfigData)
 						}
 
 						// Verify internal reason is mode changed
@@ -538,9 +538,9 @@ func TestKeyController(t *testing.T) {
 							ts.Errorf("expected mode to be aescbc, got %s", actualSecret.Annotations["encryption.apiserver.operator.openshift.io/mode"])
 						}
 
-						// Verify KMS config annotation is removed (not present for AESCBC)
-						if kmsConfig, exists := actualSecret.Annotations["encryption.apiserver.operator.openshift.io/kms-config"]; exists {
-							ts.Errorf("expected kms-config annotation to be absent, got: %s", kmsConfig)
+						// Verify KMS config data is not present for AESCBC
+						if kmsConfigData, exists := actualSecret.Data["encryption.apiserver.operator.openshift.io-kms-encryption-config"]; exists {
+							ts.Errorf("expected kms-encryption-config data to be absent, got: %s", kmsConfigData)
 						}
 
 						// Verify internal reason is mode changed

--- a/pkg/operator/encryption/controllers/state_controller_test.go
+++ b/pkg/operator/encryption/controllers/state_controller_test.go
@@ -919,7 +919,7 @@ func TestStateController(t *testing.T) {
 								KMS: &apiserverconfigv1.KMSConfiguration{
 									APIVersion: "v2",
 									Name:       "2_secrets",
-									Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
+									Endpoint:   "unix:///var/run/kmsplugin/kms-2.sock",
 									Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 								},
 							}, {
@@ -945,7 +945,7 @@ func TestStateController(t *testing.T) {
 								KMS: &apiserverconfigv1.KMSConfiguration{
 									APIVersion: "v2",
 									Name:       "2_secrets",
-									Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
+									Endpoint:   "unix:///var/run/kmsplugin/kms-2.sock",
 									Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 								},
 							}, {
@@ -969,7 +969,7 @@ func TestStateController(t *testing.T) {
 						KMS: &apiserverconfigv1.KMSConfiguration{
 							APIVersion: "v2",
 							Name:       "2_secrets",
-							Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
+							Endpoint:   "unix:///var/run/kmsplugin/kms-2.sock",
 							Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 						},
 					}, {
@@ -1072,7 +1072,7 @@ func TestStateController(t *testing.T) {
 						KMS: &apiserverconfigv1.KMSConfiguration{
 							APIVersion: "v2",
 							Name:       "2_secrets",
-							Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
+							Endpoint:   "unix:///var/run/kmsplugin/kms-2.sock",
 							Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 						},
 					}, {

--- a/pkg/operator/encryption/encryptionconfig/config.go
+++ b/pkg/operator/encryption/encryptionconfig/config.go
@@ -209,12 +209,12 @@ func stateToProviders(resource string, desired state.GroupResourceState) []apise
 				},
 			})
 		case state.KMS:
-			if key.KMSConfiguration == nil {
-				klog.Infof("skipping key %s for %s in KMS mode as its KMSConfiguration is nil", key.Key.Name, resource)
+			if key.KMSEncryptionConfig == nil {
+				klog.Infof("skipping key %s for %s in KMS mode as its KMSEncryptionConfig is nil", key.Key.Name, resource)
 				continue // this should never happen
 			}
 			// In order to preserve the uniqueness, we should insert resource name
-			kmsCopy := key.KMSConfiguration.DeepCopy()
+			kmsCopy := key.KMSEncryptionConfig.DeepCopy()
 			kmsCopy.Name = createKMSProviderName(key.Key.Name, resource)
 			provider := apiserverconfigv1.ProviderConfiguration{
 				KMS: kmsCopy,

--- a/pkg/operator/encryption/encryptionconfig/config_test.go
+++ b/pkg/operator/encryption/encryptionconfig/config_test.go
@@ -687,7 +687,7 @@ func keyToKMSConfiguration(key *corev1.Secret, resource string) *apiserverconfig
 	return &apiserverconfigv1.KMSConfiguration{
 		APIVersion: "v2",
 		Name:       fmt.Sprintf("%d_%s", keyID, resource),
-		Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
+		Endpoint:   fmt.Sprintf("unix:///var/run/kmsplugin/kms-%d.sock", keyID),
 		Timeout: &metav1.Duration{
 			Duration: 10 * time.Second,
 		},

--- a/pkg/operator/encryption/secrets/secrets.go
+++ b/pkg/operator/encryption/secrets/secrets.go
@@ -58,21 +58,21 @@ func ToKeyState(s *corev1.Secret) (state.KeyState, error) {
 		key.ExternalReason = v
 	}
 
-	if v, ok := s.Annotations[EncryptionSecretKMSConfig]; ok && len(v) > 0 {
-		kmsConfiguration := &apiserverconfigv1.KMSConfiguration{}
-		if err := json.Unmarshal([]byte(v), kmsConfiguration); err != nil {
-			return state.KeyState{}, fmt.Errorf("secret %s/%s has invalid %s annotation: %v", s.Namespace, s.Name, EncryptionSecretKMSConfig, err)
-		}
-		key.KMSConfiguration = kmsConfiguration
-	}
-
 	keyMode := state.Mode(s.Annotations[encryptionSecretMode])
 	switch keyMode {
 	case state.AESCBC, state.AESGCM, state.SecretBox, state.Identity:
 		key.Mode = keyMode
 	case state.KMS:
-		if key.KMSConfiguration == nil {
-			return state.KeyState{}, fmt.Errorf("KMSConfiguration can not be nil, when mode is KMS")
+		if v, ok := s.Data[EncryptionSecretKMSEncryptionConfig]; ok && len(v) > 0 {
+			kmsConfiguration := &apiserverconfigv1.KMSConfiguration{}
+			if err := json.Unmarshal(v, kmsConfiguration); err != nil {
+				return state.KeyState{}, fmt.Errorf("secret %s/%s has invalid %s data: %w", s.Namespace, s.Name, EncryptionSecretKMSEncryptionConfig, err)
+			}
+			key.KMSEncryptionConfig = kmsConfiguration
+		} else {
+			// encryption.apiserver.operator.openshift.io-kms-encryption-config data field is required for KMS
+			// encryption mode.
+			return state.KeyState{}, fmt.Errorf("%s can not be empty, when mode is KMS", EncryptionSecretKMSEncryptionConfig)
 		}
 		key.Mode = keyMode
 	default:
@@ -126,12 +126,12 @@ func FromKeyState(component string, ks state.KeyState) (*corev1.Secret, error) {
 		s.Annotations[EncryptionSecretMigratedResources] = string(bs)
 	}
 
-	if ks.KMSConfiguration != nil {
-		ksJSON, err := json.Marshal(ks.KMSConfiguration)
+	if ks.KMSEncryptionConfig != nil {
+		kmsEncCfgJSON, err := json.Marshal(ks.KMSEncryptionConfig)
 		if err != nil {
 			return nil, err
 		}
-		s.Annotations[EncryptionSecretKMSConfig] = string(ksJSON)
+		s.Data[EncryptionSecretKMSEncryptionConfig] = kmsEncCfgJSON
 	}
 
 	return s, nil

--- a/pkg/operator/encryption/secrets/secrets_test.go
+++ b/pkg/operator/encryption/secrets/secrets_test.go
@@ -123,7 +123,7 @@ func TestRoundtrip(t *testing.T) {
 				},
 				Backed: true,
 				Mode:   "KMS",
-				KMSConfiguration: &v1.KMSConfiguration{
+				KMSEncryptionConfig: &v1.KMSConfiguration{
 					APIVersion: "v2",
 					Name:       "1",
 					Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
@@ -150,10 +150,10 @@ func TestRoundtrip(t *testing.T) {
 				},
 				Backed: true,
 				Mode:   "KMS",
-				KMSConfiguration: &v1.KMSConfiguration{
+				KMSEncryptionConfig: &v1.KMSConfiguration{
 					APIVersion: "v2",
 					Name:       "2",
-					Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
+					Endpoint:   "unix:///var/run/kmsplugin/kms-2.sock",
 				},
 			},
 		},

--- a/pkg/operator/encryption/secrets/types.go
+++ b/pkg/operator/encryption/secrets/types.go
@@ -50,8 +50,9 @@ const (
 	// deletion of secrets by enforcing a two phase delete.
 	EncryptionSecretFinalizer = "encryption.apiserver.operator.openshift.io/deletion-protection"
 
-	// EncryptionSecretKMSConfig is the annotation that stores the encoded KMS configuration.
-	EncryptionSecretKMSConfig = "encryption.apiserver.operator.openshift.io/kms-config"
+	// EncryptionSecretKMSEncryptionConfig is the data field key that stores the serialized KMS
+	// encryption configuration for KMS mode in the encryption-key secret.
+	EncryptionSecretKMSEncryptionConfig = "encryption.apiserver.operator.openshift.io-kms-encryption-config"
 )
 
 // MigratedGroupResources is the data structured stored in the

--- a/pkg/operator/encryption/state/types.go
+++ b/pkg/operator/encryption/state/types.go
@@ -40,8 +40,8 @@ type KeyState struct {
 	InternalReason string
 	// the user via unsupportConfigOverrides.encryption.reason triggered this key.
 	ExternalReason string
-	// Encoded KMSConfiguration that stores the KMS related fields
-	KMSConfiguration *apiserverconfigv1.KMSConfiguration
+	// Encoded KMSEncryptionConfig that stores the KMS related fields
+	KMSEncryptionConfig *apiserverconfigv1.KMSConfiguration
 }
 
 type MigrationState struct {

--- a/pkg/operator/encryption/statemachine/transition_test.go
+++ b/pkg/operator/encryption/statemachine/transition_test.go
@@ -1052,7 +1052,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 							KMS: &apiserverconfigv1.KMSConfiguration{
 								APIVersion: "v2",
 								Name:       "2_secrets",
-								Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
+								Endpoint:   "unix:///var/run/kmsplugin/kms-2.sock",
 								Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 							},
 						}, {
@@ -1079,7 +1079,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 							KMS: &apiserverconfigv1.KMSConfiguration{
 								APIVersion: "v2",
 								Name:       "2_secrets",
-								Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
+								Endpoint:   "unix:///var/run/kmsplugin/kms-2.sock",
 								Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 							},
 						}, {
@@ -1102,7 +1102,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 							KMS: &apiserverconfigv1.KMSConfiguration{
 								APIVersion: "v2",
 								Name:       "2_secrets",
-								Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
+								Endpoint:   "unix:///var/run/kmsplugin/kms-2.sock",
 								Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 							},
 						}, {
@@ -1129,7 +1129,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 							KMS: &apiserverconfigv1.KMSConfiguration{
 								APIVersion: "v2",
 								Name:       "2_secrets",
-								Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
+								Endpoint:   "unix:///var/run/kmsplugin/kms-2.sock",
 								Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 							},
 						}, {
@@ -1158,7 +1158,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 						KMS: &apiserverconfigv1.KMSConfiguration{
 							APIVersion: "v2",
 							Name:       "2_secrets",
-							Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
+							Endpoint:   "unix:///var/run/kmsplugin/kms-2.sock",
 							Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 						},
 					}, {
@@ -1184,7 +1184,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 							KMS: &apiserverconfigv1.KMSConfiguration{
 								APIVersion: "v2",
 								Name:       "2_secrets",
-								Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
+								Endpoint:   "unix:///var/run/kmsplugin/kms-2.sock",
 								Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 							},
 						}, {
@@ -1213,7 +1213,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 						KMS: &apiserverconfigv1.KMSConfiguration{
 							APIVersion: "v2",
 							Name:       "2_secrets",
-							Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
+							Endpoint:   "unix:///var/run/kmsplugin/kms-2.sock",
 							Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 						},
 					}, {

--- a/pkg/operator/encryption/testing/helpers.go
+++ b/pkg/operator/encryption/testing/helpers.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	encryptionSecretKeyDataForTest           = "encryption.apiserver.operator.openshift.io-key"
-	encryptionSecretMigratedTimestampForTest = "encryption.apiserver.operator.openshift.io/migrated-timestamp"
-	encryptionSecretMigratedResourcesForTest = "encryption.apiserver.operator.openshift.io/migrated-resources"
-	encryptionSecretKMSConfigForTest         = "encryption.apiserver.operator.openshift.io/kms-config"
+	encryptionSecretKeyDataForTest             = "encryption.apiserver.operator.openshift.io-key"
+	encryptionSecretMigratedTimestampForTest   = "encryption.apiserver.operator.openshift.io/migrated-timestamp"
+	encryptionSecretMigratedResourcesForTest   = "encryption.apiserver.operator.openshift.io/migrated-resources"
+	encryptionSecretKMSEncryptionConfigForTest = "encryption.apiserver.operator.openshift.io-kms-encryption-config"
 )
 
 func CreateEncryptionKeySecretNoData(targetNS string, grs []schema.GroupResource, keyID uint64) *corev1.Secret {
@@ -101,11 +101,11 @@ func CreateEncryptionKeySecretWithKMSConfig(targetNS string, grs []schema.GroupR
 	kmsConfig := &apiserverconfigv1.KMSConfiguration{
 		APIVersion: "v2",
 		Name:       fmt.Sprintf("%d", keyID),
-		Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
+		Endpoint:   fmt.Sprintf("unix:///var/run/kmsplugin/kms-%d.sock", keyID),
 		Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 	}
 	kmsConfigJSON, _ := json.Marshal(kmsConfig)
-	secret.Annotations[encryptionSecretKMSConfigForTest] = string(kmsConfigJSON)
+	secret.Data[encryptionSecretKMSEncryptionConfigForTest] = kmsConfigJSON
 	return secret
 }
 
@@ -273,7 +273,7 @@ func createProviderCfg(mode string, resource string, key apiserverconfigv1.Key) 
 			KMS: &apiserverconfigv1.KMSConfiguration{
 				APIVersion: "v2",
 				Name:       fmt.Sprintf("%s_%s", key.Name, resource),
-				Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
+				Endpoint:   fmt.Sprintf("unix:///var/run/kmsplugin/kms-%s.sock", key.Name),
 				Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 			},
 		}


### PR DESCRIPTION
This PR brings the minimal changes required for the KMS TPv2 work described here https://github.com/openshift/enhancements/pull/1960. 

Main aim is to store data in Data field of Secret instead of annotation, insert key id into unix domain socket path. This PR should work with plugin lifecycle smoothly. 

Changes here break KMS TP v1 functionality, so it must not be merged in release-4.22 code base (so that this can be merged after the branch cut of 4.23). 

This PR excludes;
* Track the changes in API side (whether new key is required or just in-place update)
* secret/configmap, kmsConfig propagation mechanism to Key Secret
* secret/configmap periodic sync

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * KMS encryption keys now use per-key Unix socket endpoints instead of a single shared socket
  * KMS configuration is stored in secret data fields (not annotations) and related identifiers updated
  * Test/KMS assets adjusted to run multiple per-key mock KMS instances

* **Tests**
  * Test suites updated to validate per-key endpoints and the new KMS config storage format
<!-- end of auto-generated comment: release notes by coderabbit.ai -->