### PR TITLE
CNTRLPLANE-3237: Add KMS preflight checker scaffolding

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	k8s.io/client-go v0.35.1
 	k8s.io/component-base v0.35.1
 	k8s.io/klog/v2 v2.130.1
+	k8s.io/kms v0.35.1
 	k8s.io/kube-aggregator v0.35.1
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4
 	sigs.k8s.io/kube-storage-version-migrator v0.0.6-0.20230721195810-5c8923c5ff96
@@ -131,7 +132,6 @@ require (
 	google.golang.org/protobuf v1.36.8 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/kms v0.35.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect

--- a/pkg/operator/encryption/kms/preflight/assets/kms-preflight-pod.yaml
+++ b/pkg/operator/encryption/kms/preflight/assets/kms-preflight-pod.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{.PodName}}
+  namespace: {{.Namespace}}
+spec:
+  # This is a one-shot preflight check, not a long-running pod.
+  # The operator creates it, waits for completion, and inspects the result.
+  restartPolicy: Never
+  containers:
+    - name: kms-preflight-check
+      image: {{.OperatorImage}}
+      command: [{{.Command}}]
+      args:
+        - --kms-call-timeout={{.KMSCallTimeout}}
+      # TODO: figure out good resource request values.
+      resources:
+        requests:
+          memory: 50Mi
+          cpu: 5m

--- a/pkg/operator/encryption/kms/preflight/bindata.go
+++ b/pkg/operator/encryption/kms/preflight/bindata.go
@@ -1,0 +1,16 @@
+package preflight
+
+import (
+	"embed"
+)
+
+//go:embed assets/*
+var f embed.FS
+
+func mustAsset(name string) []byte {
+	data, err := f.ReadFile(name)
+	if err != nil {
+		panic(err)
+	}
+	return data
+}

--- a/pkg/operator/encryption/kms/preflight/checker.go
+++ b/pkg/operator/encryption/kms/preflight/checker.go
@@ -1,0 +1,108 @@
+package preflight
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+	kmsservice "k8s.io/kms/pkg/service"
+)
+
+// healthzOK is the value the KMS plugin returns when healthy.
+// See https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kms/apis/v2/api.proto#L39
+const healthzOK = "ok"
+
+// checker runs the preflight check against a KMS plugin by calling
+// Status, Encrypt, and Decrypt on the kmsservice.Service interface.
+// this is the same interface the apiserver uses.
+type checker struct {
+	service        kmsservice.Service
+	randReader     io.Reader
+	statusTimeout  time.Duration
+	statusInterval time.Duration
+}
+
+func newChecker(service kmsservice.Service) *checker {
+	return &checker{
+		service:        service,
+		randReader:     rand.Reader,
+		statusTimeout:  30 * time.Second,
+		statusInterval: 2 * time.Second,
+	}
+}
+
+func (c *checker) check(ctx context.Context) error {
+	if err := c.checkStatus(ctx); err != nil {
+		return err
+	}
+	return c.checkEncryptDecrypt(ctx)
+}
+
+// checkStatus polls the KMS plugin status endpoint until it reports healthy.
+// The plugin may not be immediately available after startup, so we retry
+// before reporting a failure.
+func (c *checker) checkStatus(ctx context.Context) error {
+	klog.Infof("[1/3] Checking KMS plugin status endpoint (interval %v, timeout %v)", c.statusInterval, c.statusTimeout)
+	return wait.PollUntilContextTimeout(ctx, c.statusInterval, c.statusTimeout, true, func(ctx context.Context) (bool, error) {
+		start := time.Now()
+		resp, err := c.service.Status(ctx)
+		elapsed := time.Since(start)
+		if err != nil {
+			klog.Infof("  not ready: %v, latency=%v", err, elapsed)
+			return false, nil
+		}
+		// we only check healthz here.
+		// version and keyID validation is the apiserver's responsibility,
+		// the preflight check just confirms the plugin is reachable and healthy.
+		if resp.Healthz != healthzOK {
+			klog.Infof("  not ready: healthz=%q, latency=%v", resp.Healthz, elapsed)
+			return false, nil
+		}
+		klog.Infof("  Status: healthz=%q, version=%q, keyID=%q, latency=%v", resp.Healthz, resp.Version, resp.KeyID, elapsed)
+		return true, nil
+	})
+}
+
+func (c *checker) checkEncryptDecrypt(ctx context.Context) error {
+	klog.Info("[2/3] Checking KMS plugin encrypt endpoint")
+	plainText := make([]byte, 32)
+	if _, err := io.ReadFull(c.randReader, plainText); err != nil {
+		return fmt.Errorf("failed to generate random plaintext: %w", err)
+	}
+	// unique per run, used for tracing
+	uid := fmt.Sprintf("preflight-check-%x", plainText[:4])
+	start := time.Now()
+	encResp, err := c.service.Encrypt(ctx, uid, plainText)
+	elapsed := time.Since(start)
+	if err != nil {
+		return fmt.Errorf("encrypt call failed, latency=%v: %w", elapsed, err)
+	}
+	if bytes.Equal(encResp.Ciphertext, plainText) {
+		return fmt.Errorf("encrypt returned plaintext unchanged, expected encrypted data")
+	}
+	var annotations []string
+	for k, v := range encResp.Annotations {
+		annotations = append(annotations, fmt.Sprintf("%s=%q", k, v))
+	}
+	klog.Infof("  Encrypt: keyID=%q, ciphertext=%d bytes, annotations=[%s], latency=%v", encResp.KeyID, len(encResp.Ciphertext), strings.Join(annotations, ", "), elapsed)
+
+	klog.Info("[3/3] Checking KMS plugin decrypt endpoint")
+	decryptReq := &kmsservice.DecryptRequest{Ciphertext: encResp.Ciphertext, KeyID: encResp.KeyID, Annotations: encResp.Annotations}
+	start = time.Now()
+	decrypted, err := c.service.Decrypt(ctx, uid, decryptReq)
+	elapsed = time.Since(start)
+	if err != nil {
+		return fmt.Errorf("decrypt call failed, latency=%v: %w", elapsed, err)
+	}
+	if !bytes.Equal(decrypted, plainText) {
+		return fmt.Errorf("decrypt roundtrip mismatch: got %q, want %q", decrypted, plainText)
+	}
+	klog.Infof("  Decrypt: plaintext=%d bytes, latency=%v", len(decrypted), elapsed)
+	return nil
+}

--- a/pkg/operator/encryption/kms/preflight/checker_test.go
+++ b/pkg/operator/encryption/kms/preflight/checker_test.go
@@ -1,0 +1,172 @@
+package preflight
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	kmsservice "k8s.io/kms/pkg/service"
+)
+
+type fakeService struct {
+	StatusFn  func(ctx context.Context) (*kmsservice.StatusResponse, error)
+	EncryptFn func(ctx context.Context, uid string, data []byte) (*kmsservice.EncryptResponse, error)
+	DecryptFn func(ctx context.Context, uid string, req *kmsservice.DecryptRequest) ([]byte, error)
+}
+
+func (f *fakeService) Status(ctx context.Context) (*kmsservice.StatusResponse, error) {
+	return f.StatusFn(ctx)
+}
+
+func (f *fakeService) Encrypt(ctx context.Context, uid string, data []byte) (*kmsservice.EncryptResponse, error) {
+	return f.EncryptFn(ctx, uid, data)
+}
+
+func (f *fakeService) Decrypt(ctx context.Context, uid string, req *kmsservice.DecryptRequest) ([]byte, error) {
+	return f.DecryptFn(ctx, uid, req)
+}
+
+func newTestChecker(service *fakeService) *checker {
+	return &checker{
+		service: service,
+		// deterministic reader so encrypt/decrypt assertions are predictable
+		randReader: bytes.NewReader(bytes.Repeat([]byte{0xAB}, 32)),
+		// short values to keep tests fast while still exercising the retry loop
+		statusTimeout:  100 * time.Millisecond,
+		statusInterval: 10 * time.Millisecond,
+	}
+}
+
+func healthyFakeService() *fakeService {
+	var plaintext []byte
+	return &fakeService{
+		StatusFn: func(ctx context.Context) (*kmsservice.StatusResponse, error) {
+			return &kmsservice.StatusResponse{Healthz: "ok", Version: "v2", KeyID: "key-1"}, nil
+		},
+		EncryptFn: func(ctx context.Context, uid string, data []byte) (*kmsservice.EncryptResponse, error) {
+			plaintext = data
+			return &kmsservice.EncryptResponse{Ciphertext: []byte("ciphertext"), KeyID: "key-1"}, nil
+		},
+		DecryptFn: func(ctx context.Context, uid string, req *kmsservice.DecryptRequest) ([]byte, error) {
+			return plaintext, nil
+		},
+	}
+}
+
+func TestCheck(t *testing.T) {
+	scenarios := []struct {
+		name      string
+		service   *fakeService
+		expectErr string
+	}{
+		{
+			name:    "happy path",
+			service: healthyFakeService(),
+		},
+		{
+			name: "healthy after transient status error",
+			service: func() *fakeService {
+				svc := healthyFakeService()
+				callCount := 0
+				svc.StatusFn = func(ctx context.Context) (*kmsservice.StatusResponse, error) {
+					callCount++
+					if callCount == 1 {
+						return nil, fmt.Errorf("connection refused")
+					}
+					return &kmsservice.StatusResponse{Healthz: "ok", Version: "v2", KeyID: "key-1"}, nil
+				}
+				return svc
+			}(),
+		},
+		{
+			name: "persistent status error exceeds timeout",
+			service: &fakeService{
+				StatusFn: func(ctx context.Context) (*kmsservice.StatusResponse, error) {
+					return nil, fmt.Errorf("connection refused")
+				},
+			},
+			expectErr: "context deadline exceeded",
+		},
+		{
+			name: "persistent unhealthy status exceeds timeout",
+			service: &fakeService{
+				StatusFn: func(ctx context.Context) (*kmsservice.StatusResponse, error) {
+					return &kmsservice.StatusResponse{Healthz: "not-ready"}, nil
+				},
+			},
+			expectErr: "context deadline exceeded",
+		},
+		{
+			name: "encrypt error",
+			service: &fakeService{
+				StatusFn: func(ctx context.Context) (*kmsservice.StatusResponse, error) {
+					return &kmsservice.StatusResponse{Healthz: "ok", Version: "v2", KeyID: "key-1"}, nil
+				},
+				EncryptFn: func(ctx context.Context, uid string, data []byte) (*kmsservice.EncryptResponse, error) {
+					return nil, fmt.Errorf("key not found")
+				},
+			},
+			expectErr: "encrypt call failed",
+		},
+		{
+			name: "encrypt returns plaintext unchanged",
+			service: &fakeService{
+				StatusFn: func(ctx context.Context) (*kmsservice.StatusResponse, error) {
+					return &kmsservice.StatusResponse{Healthz: "ok", Version: "v2", KeyID: "key-1"}, nil
+				},
+				EncryptFn: func(ctx context.Context, uid string, data []byte) (*kmsservice.EncryptResponse, error) {
+					return &kmsservice.EncryptResponse{Ciphertext: data, KeyID: "key-1"}, nil
+				},
+			},
+			expectErr: "encrypt returned plaintext unchanged",
+		},
+		{
+			name: "decrypt error",
+			service: &fakeService{
+				StatusFn: func(ctx context.Context) (*kmsservice.StatusResponse, error) {
+					return &kmsservice.StatusResponse{Healthz: "ok", Version: "v2", KeyID: "key-1"}, nil
+				},
+				EncryptFn: func(ctx context.Context, uid string, data []byte) (*kmsservice.EncryptResponse, error) {
+					return &kmsservice.EncryptResponse{Ciphertext: []byte("ciphertext"), KeyID: "key-1"}, nil
+				},
+				DecryptFn: func(ctx context.Context, uid string, req *kmsservice.DecryptRequest) ([]byte, error) {
+					return nil, fmt.Errorf("decryption failed")
+				},
+			},
+			expectErr: "decrypt call failed",
+		},
+		{
+			name: "decrypt roundtrip mismatch",
+			service: &fakeService{
+				StatusFn: func(ctx context.Context) (*kmsservice.StatusResponse, error) {
+					return &kmsservice.StatusResponse{Healthz: "ok", Version: "v2", KeyID: "key-1"}, nil
+				},
+				EncryptFn: func(ctx context.Context, uid string, data []byte) (*kmsservice.EncryptResponse, error) {
+					return &kmsservice.EncryptResponse{Ciphertext: []byte("ciphertext"), KeyID: "key-1"}, nil
+				},
+				DecryptFn: func(ctx context.Context, uid string, req *kmsservice.DecryptRequest) ([]byte, error) {
+					return []byte("wrong-plaintext"), nil
+				},
+			},
+			expectErr: "decrypt roundtrip mismatch",
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			target := newTestChecker(scenario.service)
+
+			err := target.check(context.Background())
+
+			if scenario.expectErr == "" && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if scenario.expectErr != "" && (err == nil || !strings.Contains(err.Error(), scenario.expectErr)) {
+				t.Fatalf("expected error containing %q, got: %v", scenario.expectErr, err)
+			}
+		})
+	}
+}

--- a/pkg/operator/encryption/kms/preflight/cmd.go
+++ b/pkg/operator/encryption/kms/preflight/cmd.go
@@ -1,0 +1,69 @@
+package preflight
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	k8senvelopekmsv2 "k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2"
+	"k8s.io/klog/v2"
+)
+
+const kmsSocketEndpoint = "unix:///var/run/kmsplugin/kms.sock"
+
+type options struct {
+	kmsCallTimeout time.Duration
+}
+
+// NewCommand creates the kms-preflight cobra command.
+func NewCommand(ctx context.Context) *cobra.Command {
+	o := &options{}
+
+	cmd := &cobra.Command{
+		Use:   "kms-preflight",
+		Short: "Validates that the configured KMS plugin is functional.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.validate(); err != nil {
+				return err
+			}
+			return o.run(ctx)
+		},
+	}
+
+	o.addFlags(cmd.Flags())
+	return cmd
+}
+
+func (o *options) addFlags(fs *pflag.FlagSet) {
+	fs.DurationVar(&o.kmsCallTimeout, "kms-call-timeout", 0, "timeout for each gRPC call to the KMS plugin")
+}
+
+func (o *options) validate() error {
+	if o.kmsCallTimeout <= 0 {
+		return fmt.Errorf("--kms-call-timeout must be greater than 0")
+	}
+	return nil
+}
+
+func (o *options) run(ctx context.Context) error {
+	klog.Infof("Running KMS preflight check at %s", kmsSocketEndpoint)
+
+	// k8senvelopekmsv2.NewGRPCService is not a public API and may change.
+	// If it breaks, we can inline a minimal gRPC client using k8s.io/kms directly.
+	service, err := k8senvelopekmsv2.NewGRPCService(ctx, kmsSocketEndpoint, "preflight", o.kmsCallTimeout)
+	if err != nil {
+		return fmt.Errorf("failed to create KMS gRPC client: %w", err)
+	}
+
+	checker := newChecker(service)
+	start := time.Now()
+	if err = checker.check(ctx); err != nil {
+		return fmt.Errorf("kms preflight check failed: %w", err)
+	}
+
+	klog.Infof("KMS preflight check passed, total latency=%v", time.Since(start))
+	return nil
+}

--- a/pkg/operator/encryption/kms/preflight/pod_template.go
+++ b/pkg/operator/encryption/kms/preflight/pod_template.go
@@ -1,0 +1,62 @@
+package preflight
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"text/template"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
+	encryptionkms "github.com/openshift/library-go/pkg/operator/encryption/kms"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
+)
+
+type kmsPreflightTemplate struct {
+	PodName        string
+	Namespace      string
+	OperatorImage  string
+	Command        string
+	KMSCallTimeout string
+}
+
+// GeneratePodTemplate renders the KMS preflight pod YAML template.
+// The pod has a single container that connects to the KMS plugin via
+// a hostPath-mounted unix socket at /var/run/kmsplugin.
+// The KMS plugin volume and mount are added via AddKMSPluginVolumeAndMountToPodSpec.
+func GeneratePodTemplate(namespace string, podName string, operatorImage string, operatorCommand []string, kmsCallTimeout time.Duration, featureGateAccessor featuregates.FeatureGateAccess) (*corev1.Pod, error) {
+	rawManifest := mustAsset("assets/kms-preflight-pod.yaml")
+
+	operatorCommandQuoted := make([]string, len(operatorCommand))
+	for i, cmd := range operatorCommand {
+		operatorCommandQuoted[i] = fmt.Sprintf("%q", cmd)
+	}
+
+	tmplVal := kmsPreflightTemplate{
+		PodName:        podName,
+		Namespace:      namespace,
+		OperatorImage:  operatorImage,
+		Command:        strings.Join(operatorCommandQuoted, ","),
+		KMSCallTimeout: kmsCallTimeout.String(),
+	}
+	tmpl, err := template.New("kms-preflight").Parse(string(rawManifest))
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	if err = tmpl.Execute(&buf, tmplVal); err != nil {
+		return nil, err
+	}
+
+	pod, err := resourceread.ReadPodV1(buf.Bytes())
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse rendered pod template: %w", err)
+	}
+	// TODO: once the KMS plugin lifecycle code is present, reuse it instead of AddKMSPluginVolumeAndMountToPodSpec.
+	if err = encryptionkms.AddKMSPluginVolumeAndMountToPodSpec(&pod.Spec, "kms-preflight-check", featureGateAccessor); err != nil {
+		return nil, fmt.Errorf("failed to add KMS plugin volume: %w", err)
+	}
+	return pod, nil
+}

--- a/pkg/operator/encryption/kms/preflight/pod_template_test.go
+++ b/pkg/operator/encryption/kms/preflight/pod_template_test.go
@@ -1,0 +1,66 @@
+package preflight
+
+import (
+	"testing"
+	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
+	"k8s.io/apimachinery/pkg/api/equality"
+)
+
+var expectedPodYAML = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: preflight-pod
+  namespace: test-ns
+spec:
+  restartPolicy: Never
+  containers:
+    - name: kms-preflight-check
+      image: quay.io/openshift/operator:latest
+      command: ["operator","kms-preflight"]
+      args:
+        - --kms-call-timeout=10s
+      resources:
+        requests:
+          memory: 50Mi
+          cpu: 5m
+      volumeMounts:
+        - name: kms-plugin-socket
+          mountPath: /var/run/kmsplugin
+  volumes:
+    - name: kms-plugin-socket
+      hostPath:
+        path: /var/run/kmsplugin
+        type: DirectoryOrCreate
+`
+
+func TestGeneratePodTemplate(t *testing.T) {
+	featureGateAccessor := featuregates.NewHardcodedFeatureGateAccess(
+		[]configv1.FeatureGateName{"KMSEncryption"},
+		nil,
+	)
+
+	pod, err := GeneratePodTemplate(
+		"test-ns",
+		"preflight-pod",
+		"quay.io/openshift/operator:latest",
+		[]string{"operator", "kms-preflight"},
+		10*time.Second,
+		featureGateAccessor,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expectedPod, err := resourceread.ReadPodV1([]byte(expectedPodYAML))
+	if err != nil {
+		t.Fatalf("failed to parse expected pod YAML: %v", err)
+	}
+	if !equality.Semantic.DeepEqual(pod, expectedPod) {
+		t.Fatalf("pod does not match expected:\ngot:  %+v\nwant: %+v", pod, expectedPod)
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a KMS preflight command to run a one-shot Pod that validates KMS provider connectivity and behavior.
  * Command accepts provider and timeout flags, validates inputs, and reports pass/fail with timing.
  * Preflight runs status, encrypt, and decrypt checks and logs detailed outcomes and latencies.
  * Uses an embedded, templated Pod manifest that launches a lightweight container with minimal CPU/memory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->