### PR TITLE
CNTRLPLANE-3237: Introduce KMSProviderConfig in encryption-config Secret

### DIFF
--- a/pkg/operator/encryption/controllers/key_controller_test.go
+++ b/pkg/operator/encryption/controllers/key_controller_test.go
@@ -43,22 +43,8 @@ func TestKeyController(t *testing.T) {
 	apiServerWithAESGCM := simpleAPIServer.DeepCopy()
 	apiServerWithAESGCM.Spec.Encryption = configv1.APIServerEncryption{Type: "aesgcm"}
 
-	dummyKMSConfig := &configv1.KMSConfig{
-		Type: configv1.VaultKMSProvider,
-		Vault: configv1.VaultKMSConfig{
-			KMSPluginImage: "registry.example.com/kms-plugin@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
-			VaultAddress:   "https://vault.example.com",
-			Authentication: configv1.VaultAuthentication{
-				Type: configv1.VaultAuthenticationTypeAppRole,
-				AppRole: configv1.VaultAppRoleAuthentication{
-					Secret: configv1.VaultSecretReference{Name: "vault-approle-secret"},
-				},
-			},
-			TransitKey: "test-transit-key",
-		},
-	}
 	apiServerWithKMS := simpleAPIServer.DeepCopy()
-	apiServerWithKMS.Spec.Encryption = configv1.APIServerEncryption{Type: "KMS", KMS: dummyKMSConfig}
+	apiServerWithKMS.Spec.Encryption = configv1.APIServerEncryption{Type: "KMS", KMS: encryptiontesting.DefaultKMSProviderConfig}
 
 	scenarios := []struct {
 		name                     string
@@ -387,7 +373,7 @@ func TestKeyController(t *testing.T) {
 
 						// Verify KMS provider config content
 						kmsProviderConfigData := actualSecret.Data["encryption.apiserver.operator.openshift.io-kms-provider-config"]
-						expectedProviderConfig, err := encoding.EncodeKMSConfig(dummyKMSConfig)
+						expectedProviderConfig, err := encoding.EncodeKMSConfig(encryptiontesting.DefaultKMSProviderConfig)
 						if err != nil {
 							ts.Fatalf("failed to encode KMS config: %v", err)
 						}
@@ -465,7 +451,7 @@ func TestKeyController(t *testing.T) {
 
 						// Verify KMS provider config content
 						kmsProviderConfigData := actualSecret.Data["encryption.apiserver.operator.openshift.io-kms-provider-config"]
-						expectedProviderConfig, err := encoding.EncodeKMSConfig(dummyKMSConfig)
+						expectedProviderConfig, err := encoding.EncodeKMSConfig(encryptiontesting.DefaultKMSProviderConfig)
 						if err != nil {
 							ts.Fatalf("failed to encode KMS config: %v", err)
 						}
@@ -559,7 +545,7 @@ func TestKeyController(t *testing.T) {
 
 						// Verify KMS provider config content
 						kmsProviderConfigData := actualSecret.Data["encryption.apiserver.operator.openshift.io-kms-provider-config"]
-						expectedProviderConfig, err := encoding.EncodeKMSConfig(dummyKMSConfig)
+						expectedProviderConfig, err := encoding.EncodeKMSConfig(encryptiontesting.DefaultKMSProviderConfig)
 						if err != nil {
 							ts.Fatalf("failed to encode KMS config: %v", err)
 						}

--- a/pkg/operator/encryption/controllers/state_controller_test.go
+++ b/pkg/operator/encryption/controllers/state_controller_test.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	clientgotesting "k8s.io/client-go/testing"
 
+	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	configv1clientfake "github.com/openshift/client-go/config/clientset/versioned/fake"
 	configv1informers "github.com/openshift/client-go/config/informers/externalversions"
@@ -724,25 +725,28 @@ func TestStateController(t *testing.T) {
 				encryptiontesting.CreateEncryptionKeySecretWithKMSConfig("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 1),
 			},
 			expectedActions: []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config-managed", "create:secrets:openshift-config-managed", "create:events:kms", "create:events:kms"},
-			expectedEncryptionCfg: &encryptiondata.Config{Encryption: &apiserverconfigv1.EncryptionConfiguration{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "EncryptionConfiguration",
-					APIVersion: "apiserver.config.k8s.io/v1",
-				},
-				Resources: []apiserverconfigv1.ResourceConfiguration{{
-					Resources: []string{"secrets"},
-					Providers: []apiserverconfigv1.ProviderConfiguration{{
-						Identity: &apiserverconfigv1.IdentityConfiguration{},
-					}, {
-						KMS: &apiserverconfigv1.KMSConfiguration{
-							APIVersion: "v2",
-							Name:       "1_secrets",
-							Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
-							Timeout:    &metav1.Duration{Duration: 10 * time.Second},
-						},
+			expectedEncryptionCfg: &encryptiondata.Config{
+				Encryption: &apiserverconfigv1.EncryptionConfiguration{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "EncryptionConfiguration",
+						APIVersion: "apiserver.config.k8s.io/v1",
+					},
+					Resources: []apiserverconfigv1.ResourceConfiguration{{
+						Resources: []string{"secrets"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{{
+							Identity: &apiserverconfigv1.IdentityConfiguration{},
+						}, {
+							KMS: &apiserverconfigv1.KMSConfiguration{
+								APIVersion: "v2",
+								Name:       "1_secrets",
+								Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
+								Timeout:    &metav1.Duration{Duration: 10 * time.Second},
+							},
+						}},
 					}},
-				}},
-			}},
+				},
+				KMSProviders: map[string]*configv1.KMSConfig{"1": encryptiontesting.DefaultKMSProviderConfig},
+			},
 			validateFunc: func(ts *testing.T, actions []clientgotesting.Action, destName string, expectedEncryptionCfg *encryptiondata.Config) {
 				wasSecretValidated := false
 				for _, action := range actions {
@@ -793,25 +797,28 @@ func TestStateController(t *testing.T) {
 					return ecs
 				}(),
 			},
-			expectedEncryptionCfg: &encryptiondata.Config{Encryption: &apiserverconfigv1.EncryptionConfiguration{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "EncryptionConfiguration",
-					APIVersion: "apiserver.config.k8s.io/v1",
-				},
-				Resources: []apiserverconfigv1.ResourceConfiguration{{
-					Resources: []string{"secrets"},
-					Providers: []apiserverconfigv1.ProviderConfiguration{{
-						KMS: &apiserverconfigv1.KMSConfiguration{
-							APIVersion: "v2",
-							Name:       "1_secrets",
-							Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
-							Timeout:    &metav1.Duration{Duration: 10 * time.Second},
-						},
-					}, {
-						Identity: &apiserverconfigv1.IdentityConfiguration{},
+			expectedEncryptionCfg: &encryptiondata.Config{
+				Encryption: &apiserverconfigv1.EncryptionConfiguration{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "EncryptionConfiguration",
+						APIVersion: "apiserver.config.k8s.io/v1",
+					},
+					Resources: []apiserverconfigv1.ResourceConfiguration{{
+						Resources: []string{"secrets"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{{
+							KMS: &apiserverconfigv1.KMSConfiguration{
+								APIVersion: "v2",
+								Name:       "1_secrets",
+								Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
+								Timeout:    &metav1.Duration{Duration: 10 * time.Second},
+							},
+						}, {
+							Identity: &apiserverconfigv1.IdentityConfiguration{},
+						}},
 					}},
-				}},
-			}},
+				},
+				KMSProviders: map[string]*configv1.KMSConfig{"1": encryptiontesting.DefaultKMSProviderConfig},
+			},
 			expectedActions: []string{
 				"list:pods:kms",
 				"get:secrets:kms",
@@ -852,40 +859,46 @@ func TestStateController(t *testing.T) {
 				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
 				encryptiontesting.CreateMigratedEncryptionKeySecretWithKMSConfig("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 1, time.Now()),
 				func() *corev1.Secret {
-					ec := &encryptiondata.Config{Encryption: &apiserverconfigv1.EncryptionConfiguration{
-						Resources: []apiserverconfigv1.ResourceConfiguration{{
-							Resources: []string{"secrets"},
-							Providers: []apiserverconfigv1.ProviderConfiguration{{
-								KMS: &apiserverconfigv1.KMSConfiguration{
-									APIVersion: "v2",
-									Name:       "1_secrets",
-									Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
-									Timeout:    &metav1.Duration{Duration: 10 * time.Second},
-								},
-							}, {
-								Identity: &apiserverconfigv1.IdentityConfiguration{},
+					ec := &encryptiondata.Config{
+						Encryption: &apiserverconfigv1.EncryptionConfiguration{
+							Resources: []apiserverconfigv1.ResourceConfiguration{{
+								Resources: []string{"secrets"},
+								Providers: []apiserverconfigv1.ProviderConfiguration{{
+									KMS: &apiserverconfigv1.KMSConfiguration{
+										APIVersion: "v2",
+										Name:       "1_secrets",
+										Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
+										Timeout:    &metav1.Duration{Duration: 10 * time.Second},
+									},
+								}, {
+									Identity: &apiserverconfigv1.IdentityConfiguration{},
+								}},
 							}},
-						}},
-					}}
+						},
+						KMSProviders: map[string]*configv1.KMSConfig{"1": encryptiontesting.DefaultKMSProviderConfig},
+					}
 					ecs := createEncryptionCfgSecret(t, "kms", "1", ec)
 					return ecs
 				}(),
 				func() *corev1.Secret {
-					ec := &encryptiondata.Config{Encryption: &apiserverconfigv1.EncryptionConfiguration{
-						Resources: []apiserverconfigv1.ResourceConfiguration{{
-							Resources: []string{"secrets"},
-							Providers: []apiserverconfigv1.ProviderConfiguration{{
-								KMS: &apiserverconfigv1.KMSConfiguration{
-									APIVersion: "v2",
-									Name:       "1_secrets",
-									Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
-									Timeout:    &metav1.Duration{Duration: 10 * time.Second},
-								},
-							}, {
-								Identity: &apiserverconfigv1.IdentityConfiguration{},
+					ec := &encryptiondata.Config{
+						Encryption: &apiserverconfigv1.EncryptionConfiguration{
+							Resources: []apiserverconfigv1.ResourceConfiguration{{
+								Resources: []string{"secrets"},
+								Providers: []apiserverconfigv1.ProviderConfiguration{{
+									KMS: &apiserverconfigv1.KMSConfiguration{
+										APIVersion: "v2",
+										Name:       "1_secrets",
+										Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
+										Timeout:    &metav1.Duration{Duration: 10 * time.Second},
+									},
+								}, {
+									Identity: &apiserverconfigv1.IdentityConfiguration{},
+								}},
 							}},
-						}},
-					}}
+						},
+						KMSProviders: map[string]*configv1.KMSConfig{"1": encryptiontesting.DefaultKMSProviderConfig},
+					}
 					ecs := createEncryptionCfgSecret(t, "openshift-config-managed", "1", ec)
 					ecs.Name = "encryption-config-kms"
 					return ecs
@@ -904,7 +917,20 @@ func TestStateController(t *testing.T) {
 			initialResources: []runtime.Object{
 				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
 				encryptiontesting.CreateExpiredMigratedEncryptionKeySecretWithKMSConfig("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 1),
-				encryptiontesting.CreateEncryptionKeySecretWithKMSConfig("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 2),
+				encryptiontesting.CreateEncryptionKeySecretWithCustomKMSConfig("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 2, &configv1.KMSConfig{
+					Type: configv1.VaultKMSProvider,
+					Vault: configv1.VaultKMSConfig{
+						KMSPluginImage: "registry.example.com/kms-plugin@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+						VaultAddress:   "https://vault2.example.com",
+						Authentication: configv1.VaultAuthentication{
+							Type: configv1.VaultAuthenticationTypeAppRole,
+							AppRole: configv1.VaultAppRoleAuthentication{
+								Secret: configv1.VaultSecretReference{Name: "vault-approle-secret-2"},
+							},
+						},
+						TransitKey: "test-transit-key-2",
+					},
+				}),
 				func() *corev1.Secret { // encryption config in kms namespace
 					ec := &encryptiondata.Config{Encryption: &apiserverconfigv1.EncryptionConfiguration{
 						Resources: []apiserverconfigv1.ResourceConfiguration{{
@@ -959,32 +985,51 @@ func TestStateController(t *testing.T) {
 					return ecs
 				}(),
 			},
-			expectedEncryptionCfg: &encryptiondata.Config{Encryption: &apiserverconfigv1.EncryptionConfiguration{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "EncryptionConfiguration",
-					APIVersion: "apiserver.config.k8s.io/v1",
-				},
-				Resources: []apiserverconfigv1.ResourceConfiguration{{
-					Resources: []string{"secrets"},
-					Providers: []apiserverconfigv1.ProviderConfiguration{{
-						KMS: &apiserverconfigv1.KMSConfiguration{
-							APIVersion: "v2",
-							Name:       "2_secrets",
-							Endpoint:   "unix:///var/run/kmsplugin/kms-2.sock",
-							Timeout:    &metav1.Duration{Duration: 10 * time.Second},
-						},
-					}, {
-						KMS: &apiserverconfigv1.KMSConfiguration{
-							APIVersion: "v2",
-							Name:       "1_secrets",
-							Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
-							Timeout:    &metav1.Duration{Duration: 10 * time.Second},
-						},
-					}, {
-						Identity: &apiserverconfigv1.IdentityConfiguration{},
+			expectedEncryptionCfg: &encryptiondata.Config{
+				Encryption: &apiserverconfigv1.EncryptionConfiguration{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "EncryptionConfiguration",
+						APIVersion: "apiserver.config.k8s.io/v1",
+					},
+					Resources: []apiserverconfigv1.ResourceConfiguration{{
+						Resources: []string{"secrets"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{{
+							KMS: &apiserverconfigv1.KMSConfiguration{
+								APIVersion: "v2",
+								Name:       "2_secrets",
+								Endpoint:   "unix:///var/run/kmsplugin/kms-2.sock",
+								Timeout:    &metav1.Duration{Duration: 10 * time.Second},
+							},
+						}, {
+							KMS: &apiserverconfigv1.KMSConfiguration{
+								APIVersion: "v2",
+								Name:       "1_secrets",
+								Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
+								Timeout:    &metav1.Duration{Duration: 10 * time.Second},
+							},
+						}, {
+							Identity: &apiserverconfigv1.IdentityConfiguration{},
+						}},
 					}},
-				}},
-			}},
+				},
+				KMSProviders: map[string]*configv1.KMSConfig{
+					"1": encryptiontesting.DefaultKMSProviderConfig,
+					"2": {
+						Type: configv1.VaultKMSProvider,
+						Vault: configv1.VaultKMSConfig{
+							KMSPluginImage: "registry.example.com/kms-plugin@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+							VaultAddress:   "https://vault2.example.com",
+							Authentication: configv1.VaultAuthentication{
+								Type: configv1.VaultAuthenticationTypeAppRole,
+								AppRole: configv1.VaultAppRoleAuthentication{
+									Secret: configv1.VaultSecretReference{Name: "vault-approle-secret-2"},
+								},
+							},
+							TransitKey: "test-transit-key-2",
+						},
+					},
+				},
+			},
 			expectedActions: []string{
 				"list:pods:kms",
 				"get:secrets:kms",
@@ -1055,32 +1100,48 @@ func TestStateController(t *testing.T) {
 					return ecs
 				}(),
 			},
-			expectedEncryptionCfg: &encryptiondata.Config{Encryption: &apiserverconfigv1.EncryptionConfiguration{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "EncryptionConfiguration",
-					APIVersion: "apiserver.config.k8s.io/v1",
-				},
-				Resources: []apiserverconfigv1.ResourceConfiguration{{
-					Resources: []string{"secrets"},
-					Providers: []apiserverconfigv1.ProviderConfiguration{{
-						AESCBC: &apiserverconfigv1.AESConfiguration{
-							Keys: []apiserverconfigv1.Key{{
-								Name:   "1",
-								Secret: "NjFkZWY5NjRmYjk2N2Y1ZDdjNDRhMmFmOGRhYjY4NjU=", // # notsecret
-							}},
-						},
-					}, {
-						KMS: &apiserverconfigv1.KMSConfiguration{
-							APIVersion: "v2",
-							Name:       "2_secrets",
-							Endpoint:   "unix:///var/run/kmsplugin/kms-2.sock",
-							Timeout:    &metav1.Duration{Duration: 10 * time.Second},
-						},
-					}, {
-						Identity: &apiserverconfigv1.IdentityConfiguration{},
+			expectedEncryptionCfg: &encryptiondata.Config{
+				Encryption: &apiserverconfigv1.EncryptionConfiguration{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "EncryptionConfiguration",
+						APIVersion: "apiserver.config.k8s.io/v1",
+					},
+					Resources: []apiserverconfigv1.ResourceConfiguration{{
+						Resources: []string{"secrets"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{{
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "1",
+									Secret: "NjFkZWY5NjRmYjk2N2Y1ZDdjNDRhMmFmOGRhYjY4NjU=", // # notsecret
+								}},
+							},
+						}, {
+							KMS: &apiserverconfigv1.KMSConfiguration{
+								APIVersion: "v2",
+								Name:       "2_secrets",
+								Endpoint:   "unix:///var/run/kmsplugin/kms-2.sock",
+								Timeout:    &metav1.Duration{Duration: 10 * time.Second},
+							},
+						}, {
+							Identity: &apiserverconfigv1.IdentityConfiguration{},
+						}},
 					}},
+				},
+				KMSProviders: map[string]*configv1.KMSConfig{"2": {
+					Type: configv1.VaultKMSProvider,
+					Vault: configv1.VaultKMSConfig{
+						KMSPluginImage: "registry.example.com/kms-plugin@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+						VaultAddress:   "https://vault.example.com",
+						Authentication: configv1.VaultAuthentication{
+							Type: configv1.VaultAuthenticationTypeAppRole,
+							AppRole: configv1.VaultAppRoleAuthentication{
+								Secret: configv1.VaultSecretReference{Name: "vault-approle-secret"},
+							},
+						},
+						TransitKey: "test-transit-key",
+					},
 				}},
-			}},
+			},
 			expectedActions: []string{
 				"list:pods:kms",
 				"get:secrets:kms",

--- a/pkg/operator/encryption/encryptiondata/config.go
+++ b/pkg/operator/encryption/encryptiondata/config.go
@@ -11,6 +11,8 @@ import (
 	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
 	"k8s.io/klog/v2"
 
+	configv1 "github.com/openshift/api/config/v1"
+
 	"github.com/openshift/library-go/pkg/operator/encryption/crypto"
 	"github.com/openshift/library-go/pkg/operator/encryption/secrets"
 	"github.com/openshift/library-go/pkg/operator/encryption/state"
@@ -24,6 +26,9 @@ var (
 // encryption state that doesn't fit into the upstream type.
 type Config struct {
 	Encryption *apiserverconfigv1.EncryptionConfiguration
+	// KMSProviders maps keyID to provider-specific configuration,
+	// carried from Key Secrets into the encryption-config Secret.
+	KMSProviders map[string]*configv1.KMSConfig
 }
 
 func (c *Config) HasEncryptionConfiguration() bool {
@@ -33,12 +38,29 @@ func (c *Config) HasEncryptionConfiguration() bool {
 // FromEncryptionState converts encryption state to Config.
 func FromEncryptionState(encryptionState map[schema.GroupResource]state.GroupResourceState) *Config {
 	resourceConfigs := make([]apiserverconfigv1.ResourceConfiguration, 0, len(encryptionState))
+	var kmsProviders map[string]*configv1.KMSConfig
 
 	for gr, grKeys := range encryptionState {
 		resourceConfigs = append(resourceConfigs, apiserverconfigv1.ResourceConfiguration{
 			Resources: []string{gr.String()}, // we are forced to lose data here because this API is broken
 			Providers: stateToProviders(gr.Resource, grKeys),
 		})
+
+		// Collect KMS provider configs from read keys (which already include the write key).
+		// We iterate over encryptionState which is keyed by GroupResource, so the same
+		// keyID is seen once per resource (e.g. key "1" for secrets and key "1" for configmaps).
+		// Since all resources share the same Key Secret, the provider config is identical
+		// across duplicates and we only need to keep the first occurrence.
+		for _, key := range grKeys.ReadKeys {
+			if key.HasKMSProvider() {
+				if kmsProviders == nil {
+					kmsProviders = map[string]*configv1.KMSConfig{}
+				}
+				if _, exists := kmsProviders[key.Key.Name]; !exists {
+					kmsProviders[key.Key.Name] = key.KMSConfig.Provider
+				}
+			}
+		}
 	}
 
 	// make sure our output is stable
@@ -46,7 +68,10 @@ func FromEncryptionState(encryptionState map[schema.GroupResource]state.GroupRes
 		return resourceConfigs[i].Resources[0] < resourceConfigs[j].Resources[0] // each resource has its own keys
 	})
 
-	return &Config{Encryption: &apiserverconfigv1.EncryptionConfiguration{Resources: resourceConfigs}}
+	return &Config{
+		Encryption:   &apiserverconfigv1.EncryptionConfiguration{Resources: resourceConfigs},
+		KMSProviders: kmsProviders,
+	}
 }
 
 // ToEncryptionState converts config to state.

--- a/pkg/operator/encryption/encryptiondata/config_test.go
+++ b/pkg/operator/encryption/encryptiondata/config_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
 	encryptiontesting "github.com/openshift/library-go/pkg/operator/encryption/testing"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -702,4 +703,111 @@ func newFakeIdentityEncodedKeyForTest() string {
 
 func newFakeIdentityKeyForTest() []byte {
 	return make([]byte, 16)
+}
+
+func TestSecretRoundtrip(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *encryptiondata.Config
+	}{
+		{
+			name: "aescbc without KMS providers",
+			cfg: &encryptiondata.Config{
+				Encryption: &apiserverconfigv1.EncryptionConfiguration{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "EncryptionConfiguration",
+						APIVersion: "apiserver.config.k8s.io/v1",
+					},
+					Resources: []apiserverconfigv1.ResourceConfiguration{{
+						Resources: []string{"secrets"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{{
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{Name: "1", Secret: "dGVzdA=="}},
+							},
+						}, {
+							Identity: &apiserverconfigv1.IdentityConfiguration{},
+						}},
+					}},
+				},
+			},
+		},
+		{
+			name: "KMS with provider config",
+			cfg: &encryptiondata.Config{
+				Encryption: &apiserverconfigv1.EncryptionConfiguration{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "EncryptionConfiguration",
+						APIVersion: "apiserver.config.k8s.io/v1",
+					},
+					Resources: []apiserverconfigv1.ResourceConfiguration{{
+						Resources: []string{"secrets"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{{
+							KMS: &apiserverconfigv1.KMSConfiguration{
+								APIVersion: "v2",
+								Name:       "1_secrets",
+								Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
+								Timeout:    &metav1.Duration{Duration: 10 * time.Second},
+							},
+						}, {
+							Identity: &apiserverconfigv1.IdentityConfiguration{},
+						}},
+					}},
+				},
+				KMSProviders: map[string]*configv1.KMSConfig{
+					"1": encryptiontesting.DefaultKMSProviderConfig,
+				},
+			},
+		},
+		{
+			name: "KMS with multiple provider configs",
+			cfg: &encryptiondata.Config{
+				Encryption: &apiserverconfigv1.EncryptionConfiguration{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "EncryptionConfiguration",
+						APIVersion: "apiserver.config.k8s.io/v1",
+					},
+					Resources: []apiserverconfigv1.ResourceConfiguration{{
+						Resources: []string{"secrets"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{{
+							KMS: &apiserverconfigv1.KMSConfiguration{
+								APIVersion: "v2",
+								Name:       "2_secrets",
+								Endpoint:   "unix:///var/run/kmsplugin/kms-2.sock",
+								Timeout:    &metav1.Duration{Duration: 10 * time.Second},
+							},
+						}, {
+							KMS: &apiserverconfigv1.KMSConfiguration{
+								APIVersion: "v2",
+								Name:       "1_secrets",
+								Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
+								Timeout:    &metav1.Duration{Duration: 10 * time.Second},
+							},
+						}, {
+							Identity: &apiserverconfigv1.IdentityConfiguration{},
+						}},
+					}},
+				},
+				KMSProviders: map[string]*configv1.KMSConfig{
+					"1": encryptiontesting.DefaultKMSProviderConfig,
+					"2": encryptiontesting.DefaultKMSProviderConfig,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			secret, err := encryptiondata.ToSecret("openshift-config-managed", "encryption-config-test", tt.cfg)
+			if err != nil {
+				t.Fatalf("ToSecret() error: %v", err)
+			}
+			got, err := encryptiondata.FromSecret(secret)
+			if err != nil {
+				t.Fatalf("FromSecret() error: %v", err)
+			}
+			if !cmp.Equal(tt.cfg, got) {
+				t.Errorf("roundtrip mismatch:\n%s", cmp.Diff(tt.cfg, got))
+			}
+		})
+	}
 }

--- a/pkg/operator/encryption/encryptiondata/secret.go
+++ b/pkg/operator/encryption/encryptiondata/secret.go
@@ -6,7 +6,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	configv1 "github.com/openshift/api/config/v1"
+
 	"github.com/openshift/library-go/pkg/operator/encryption/encoding"
+	"github.com/openshift/library-go/pkg/operator/encryption/kms"
 	"github.com/openshift/library-go/pkg/operator/encryption/state"
 )
 
@@ -25,7 +28,28 @@ func FromSecret(encryptionConfigSecret *corev1.Secret) (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Config{Encryption: encryptionConfig}, nil
+	var kmsProviders map[string]*configv1.KMSConfig
+	for key, value := range encryptionConfigSecret.Data {
+		// Not all data keys are provider configs — the Secret also contains the
+		// encryption-config entry, so skip keys that don't match the pattern.
+		keyID, found, err := kms.KeyIDFromProviderConfigSecretDataKey(key)
+		if err != nil {
+			return nil, fmt.Errorf("failed to extract keyID from data key %s: %w", key, err)
+		}
+		if !found {
+			continue
+		}
+		providerConfig, err := encoding.DecodeKMSConfig(value)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode KMS provider config for key %s: %w", keyID, err)
+		}
+		if kmsProviders == nil {
+			kmsProviders = map[string]*configv1.KMSConfig{}
+		}
+		kmsProviders[keyID] = providerConfig
+	}
+
+	return &Config{Encryption: encryptionConfig, KMSProviders: kmsProviders}, nil
 }
 
 func ToSecret(ns, name string, secretData *Config) (*corev1.Secret, error) {
@@ -38,7 +62,7 @@ func ToSecret(ns, name string, secretData *Config) (*corev1.Secret, error) {
 		return nil, fmt.Errorf("failed to encode the encryption config: %v", err)
 	}
 
-	return &corev1.Secret{
+	s := &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Secret",
 			APIVersion: corev1.SchemeGroupVersion.String(),
@@ -55,5 +79,19 @@ func ToSecret(ns, name string, secretData *Config) (*corev1.Secret, error) {
 			EncryptionConfSecretName: rawEncryptionCfg,
 		},
 		Type: corev1.SecretTypeOpaque,
-	}, nil
+	}
+
+	for keyID, providerConfig := range secretData.KMSProviders {
+		encodedProvider, err := encoding.EncodeKMSConfig(providerConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode KMS provider config for key %s: %w", keyID, err)
+		}
+		dataKey, err := kms.ToProviderConfigSecretDataKeyFor(keyID)
+		if err != nil {
+			return nil, err
+		}
+		s.Data[dataKey] = encodedProvider
+	}
+
+	return s, nil
 }

--- a/pkg/operator/encryption/kms/helpers.go
+++ b/pkg/operator/encryption/kms/helpers.go
@@ -2,11 +2,37 @@ package kms
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/openshift/api/features"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	corev1 "k8s.io/api/core/v1"
 )
+
+const providerConfigDataKeyPrefix = "kms-provider-config-"
+
+// ToProviderConfigSecretDataKeyFor constructs the data key for storing a KMS provider config in the encryption-config Secret.
+// The keyID must be a valid non-negative integer string.
+func ToProviderConfigSecretDataKeyFor(keyID string) (string, error) {
+	if _, err := strconv.ParseUint(keyID, 10, 64); err != nil {
+		return "", fmt.Errorf("invalid keyID %q: must be a non-negative integer", keyID)
+	}
+	return providerConfigDataKeyPrefix + keyID, nil
+}
+
+// KeyIDFromProviderConfigSecretDataKey extracts the keyID from a kms-provider-config data key.
+// Returns the keyID and true if the key matches the "kms-provider-config-<keyID>" pattern.
+func KeyIDFromProviderConfigSecretDataKey(dataKey string) (string, bool, error) {
+	keyID, found := strings.CutPrefix(dataKey, providerConfigDataKeyPrefix)
+	if !found || len(keyID) == 0 {
+		return "", false, nil
+	}
+	if _, err := strconv.ParseUint(keyID, 10, 64); err != nil {
+		return "", false, fmt.Errorf("invalid keyID %q: must be a non-negative integer", keyID)
+	}
+	return keyID, true, nil
+}
 
 // AddKMSPluginVolumeAndMountToPodSpec conditionally adds the KMS plugin volume mount to the specified container.
 // It assumes the pod spec does not already contain the KMS volume or mount; no deduplication is performed.

--- a/pkg/operator/encryption/kms/helpers_test.go
+++ b/pkg/operator/encryption/kms/helpers_test.go
@@ -12,6 +12,108 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestKeyIDFromProviderConfigSecretDataKey(t *testing.T) {
+	tests := []struct {
+		name      string
+		dataKey   string
+		wantKeyID string
+		wantFound bool
+		wantError bool
+	}{
+		{
+			name:      "valid key",
+			dataKey:   "kms-provider-config-1",
+			wantKeyID: "1",
+			wantFound: true,
+		},
+		{
+			name:      "valid key with large ID",
+			dataKey:   "kms-provider-config-42",
+			wantKeyID: "42",
+			wantFound: true,
+		},
+		{
+			name:    "encryption-config key",
+			dataKey: "encryption-config",
+		},
+		{
+			name:      "non-integer keyID",
+			dataKey:   "kms-provider-config-abc",
+			wantError: true,
+		},
+		{
+			name:    "missing keyID",
+			dataKey: "kms-provider-config-",
+		},
+		{
+			name:    "empty string",
+			dataKey: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			keyID, found, err := KeyIDFromProviderConfigSecretDataKey(tt.dataKey)
+			if tt.wantError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantFound, found)
+			if found {
+				require.Equal(t, tt.wantKeyID, keyID)
+			}
+		})
+	}
+}
+
+func TestToProviderConfigSecretDataKeyFor(t *testing.T) {
+	tests := []struct {
+		name      string
+		keyID     string
+		wantKey   string
+		wantError bool
+	}{
+		{
+			name:    "valid keyID",
+			keyID:   "1",
+			wantKey: "kms-provider-config-1",
+		},
+		{
+			name:    "valid large keyID",
+			keyID:   "42",
+			wantKey: "kms-provider-config-42",
+		},
+		{
+			name:      "non-integer keyID",
+			keyID:     "abc",
+			wantError: true,
+		},
+		{
+			name:      "empty keyID",
+			keyID:     "",
+			wantError: true,
+		},
+		{
+			name:      "negative keyID",
+			keyID:     "-1",
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ToProviderConfigSecretDataKeyFor(tt.keyID)
+			if tt.wantError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantKey, got)
+		})
+	}
+}
+
 func TestAddKMSPluginVolume(t *testing.T) {
 	directoryOrCreate := corev1.HostPathDirectoryOrCreate
 

--- a/pkg/operator/encryption/secrets/secrets_test.go
+++ b/pkg/operator/encryption/secrets/secrets_test.go
@@ -15,6 +15,21 @@ import (
 	"github.com/openshift/library-go/pkg/operator/encryption/state"
 )
 
+var defaultKMSProviderConfig = &configv1.KMSConfig{
+	Type: configv1.VaultKMSProvider,
+	Vault: configv1.VaultKMSConfig{
+		KMSPluginImage: "registry.example.com/kms-plugin@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+		VaultAddress:   "https://vault.example.com",
+		Authentication: configv1.VaultAuthentication{
+			Type: configv1.VaultAuthenticationTypeAppRole,
+			AppRole: configv1.VaultAppRoleAuthentication{
+				Secret: configv1.VaultSecretReference{Name: "vault-approle-secret"},
+			},
+		},
+		TransitKey: "test-transit-key",
+	},
+}
+
 func TestRoundtrip(t *testing.T) {
 	now, _ := time.Parse(time.RFC3339, time.Now().Format(time.RFC3339))
 
@@ -132,7 +147,7 @@ func TestRoundtrip(t *testing.T) {
 						Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
 						Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 					},
-					Provider: &configv1.KMSConfig{},
+					Provider: defaultKMSProviderConfig,
 				},
 				Migrated: state.MigrationState{
 					Timestamp: now,
@@ -163,7 +178,7 @@ func TestRoundtrip(t *testing.T) {
 						Endpoint:   "unix:///var/run/kmsplugin/kms-2.sock",
 						Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 					},
-					Provider: &configv1.KMSConfig{},
+					Provider: defaultKMSProviderConfig,
 				},
 			},
 		},

--- a/pkg/operator/encryption/testing/helpers.go
+++ b/pkg/operator/encryption/testing/helpers.go
@@ -98,7 +98,36 @@ func CreateExpiredMigratedEncryptionKeySecretWithRawKey(targetNS string, grs []s
 	return CreateMigratedEncryptionKeySecretWithRawKey(targetNS, grs, keyID, rawKey, time.Now().Add(-(time.Hour*24*7 + time.Hour)))
 }
 
+var DefaultKMSProviderConfig = &configv1.KMSConfig{
+	Type: configv1.VaultKMSProvider,
+	Vault: configv1.VaultKMSConfig{
+		KMSPluginImage: "registry.example.com/kms-plugin@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+		VaultAddress:   "https://vault.example.com",
+		Authentication: configv1.VaultAuthentication{
+			Type: configv1.VaultAuthenticationTypeAppRole,
+			AppRole: configv1.VaultAppRoleAuthentication{
+				Secret: configv1.VaultSecretReference{Name: "vault-approle-secret"},
+			},
+		},
+		TransitKey: "test-transit-key",
+	},
+}
+
 func CreateEncryptionKeySecretWithKMSConfig(targetNS string, grs []schema.GroupResource, keyID uint64) *corev1.Secret {
+	return CreateEncryptionKeySecretWithCustomKMSConfig(targetNS, grs, keyID, DefaultKMSProviderConfig)
+}
+
+func CreateMigratedEncryptionKeySecretWithKMSConfig(targetNS string, grs []schema.GroupResource, keyID uint64, ts time.Time) *corev1.Secret {
+	secret := CreateEncryptionKeySecretWithKMSConfig(targetNS, grs, keyID)
+	secret.Annotations[encryptionSecretMigratedTimestampForTest] = ts.Format(time.RFC3339)
+	return secret
+}
+
+func CreateExpiredMigratedEncryptionKeySecretWithKMSConfig(targetNS string, grs []schema.GroupResource, keyID uint64) *corev1.Secret {
+	return CreateMigratedEncryptionKeySecretWithKMSConfig(targetNS, grs, keyID, time.Now().Add(-(time.Hour*24*7 + time.Hour)))
+}
+
+func CreateEncryptionKeySecretWithCustomKMSConfig(targetNS string, grs []schema.GroupResource, keyID uint64, providerConfig *configv1.KMSConfig) *corev1.Secret {
 	emptyKey := make([]byte, 16)
 	secret := CreateEncryptionKeySecretWithRawKeyWithMode(targetNS, grs, keyID, emptyKey, "KMS")
 	kmsConfig := &apiserverconfigv1.KMSConfiguration{
@@ -112,22 +141,12 @@ func CreateEncryptionKeySecretWithKMSConfig(targetNS string, grs []schema.GroupR
 		panic(fmt.Sprintf("failed to encode KMS encryption config: %v", err))
 	}
 	secret.Data[encryptionSecretKMSEncryptionConfigForTest] = encData
-	provData, err := encoding.EncodeKMSConfig(&configv1.KMSConfig{})
+	provData, err := encoding.EncodeKMSConfig(providerConfig)
 	if err != nil {
 		panic(fmt.Sprintf("failed to encode KMS provider config: %v", err))
 	}
 	secret.Data[encryptionSecretKMSProviderConfigForTest] = provData
 	return secret
-}
-
-func CreateMigratedEncryptionKeySecretWithKMSConfig(targetNS string, grs []schema.GroupResource, keyID uint64, ts time.Time) *corev1.Secret {
-	secret := CreateEncryptionKeySecretWithKMSConfig(targetNS, grs, keyID)
-	secret.Annotations[encryptionSecretMigratedTimestampForTest] = ts.Format(time.RFC3339)
-	return secret
-}
-
-func CreateExpiredMigratedEncryptionKeySecretWithKMSConfig(targetNS string, grs []schema.GroupResource, keyID uint64) *corev1.Secret {
-	return CreateMigratedEncryptionKeySecretWithKMSConfig(targetNS, grs, keyID, time.Now().Add(-(time.Hour*24*7 + time.Hour)))
 }
 
 func CreateDummyKubeAPIPod(name, namespace string, nodeName string) *corev1.Pod {

--- a/test/e2e-encryption/encryption_test.go
+++ b/test/e2e-encryption/encryption_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/encryption/controllers"
 	"github.com/openshift/library-go/pkg/operator/encryption/controllers/migrators"
 	"github.com/openshift/library-go/pkg/operator/encryption/encoding"
+	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
 	"github.com/openshift/library-go/pkg/operator/encryption/secrets"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/genericoperatorclient"
@@ -266,6 +267,45 @@ func TestEncryptionIntegration(tt *testing.T) {
 		require.NoError(t, err)
 	}
 
+	verifyKMSProviders := func() {
+		t.Helper()
+		encryptionConfigSecret, err := kubeClient.CoreV1().Secrets("openshift-config-managed").Get(ctx, fmt.Sprintf("encryption-config-%s", component), metav1.GetOptions{})
+		require.NoError(t, err)
+		cfg, err := encryptiondata.FromSecret(encryptionConfigSecret)
+		require.NoError(t, err)
+
+		expectedKeyIDs := map[string]bool{}
+		for _, rc := range cfg.Encryption.Resources {
+			for _, p := range rc.Providers {
+				if p.KMS != nil {
+					parts := strings.SplitN(p.KMS.Name, "_", 2)
+					require.Len(t, parts, 2, "unexpected KMS provider name format: %s", p.KMS.Name)
+					expectedKeyIDs[parts[0]] = true
+				}
+			}
+		}
+
+		for keyID := range expectedKeyIDs {
+			providerConfig, ok := cfg.KMSProviders[keyID]
+			if !ok {
+				t.Fatalf("expected kms-provider-config for keyID %s but not found in encryption-config secret", keyID)
+			}
+
+			keySecret, err := kubeClient.CoreV1().Secrets("openshift-config-managed").Get(ctx, fmt.Sprintf("encryption-key-%s-%s", component, keyID), metav1.GetOptions{})
+			require.NoError(t, err)
+			keyProviderData := keySecret.Data[secrets.EncryptionSecretKMSProviderConfig]
+			require.NotEmpty(t, keyProviderData, "key secret %s missing kms-provider-config data", keyID)
+			keyProviderConfig, err := encoding.DecodeKMSConfig(keyProviderData)
+			require.NoError(t, err)
+			require.Equal(t, *keyProviderConfig, *providerConfig, "kms-provider-config for keyID %s in encryption-config secret does not match key secret", keyID)
+		}
+		for keyID := range cfg.KMSProviders {
+			if !expectedKeyIDs[keyID] {
+				t.Fatalf("unexpected kms-provider-config for keyID %s in encryption-config secret", keyID)
+			}
+		}
+	}
+
 	t.Logf("Wait for initial Encrypted condition")
 	waitForConditionStatus("Encrypted", operatorv1.ConditionFalse)
 
@@ -426,6 +466,7 @@ func TestEncryptionIntegration(tt *testing.T) {
 	)
 	waitForMigration("8")
 	waitForConditionStatus("Encrypted", operatorv1.ConditionTrue)
+	verifyKMSProviders()
 
 	t.Logf("Verify KMS key secret contains provider config")
 	kmsKeySecret, err := kubeClient.CoreV1().Secrets("openshift-config-managed").Get(ctx, fmt.Sprintf("encryption-key-%s-8", component), metav1.GetOptions{})
@@ -448,6 +489,7 @@ func TestEncryptionIntegration(tt *testing.T) {
 		fmt.Sprintf("kubeapiservers.operator.openshift.io=aescbc:9,kms:%s,identity;kubeschedulers.operator.openshift.io=aescbc:9,kms:%s,identity", kms8, kms8Sched),
 	)
 	waitForConditionStatus("Encrypted", operatorv1.ConditionTrue)
+	verifyKMSProviders()
 
 	t.Logf("Switch back to KMS")
 	_, err = fakeApiServerClient.Patch(ctx, "cluster", types.MergePatchType, []byte(`{"spec":{"encryption":{"type":"KMS","kms":{"type":"Vault","vault":{"kmsPluginImage":"registry.example.com/kms-plugin@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890","vaultAddress":"https://vault.example.com","authentication":{"type":"AppRole","appRole":{"secret":{"name":"vault-approle-secret"}}},"transitKey":"test-transit-key"}}}}}`), metav1.PatchOptions{})
@@ -462,6 +504,7 @@ func TestEncryptionIntegration(tt *testing.T) {
 	)
 	waitForMigration("10")
 	waitForConditionStatus("Encrypted", operatorv1.ConditionTrue)
+	verifyKMSProviders()
 
 	t.Logf("Rotate KMS key via aescbc (KMS->AESCBC->KMS)")
 	_, err = fakeApiServerClient.Patch(ctx, "cluster", types.MergePatchType, []byte(`{"spec":{"encryption":{"type":"aescbc","kms":null}}}`), metav1.PatchOptions{})
@@ -473,6 +516,7 @@ func TestEncryptionIntegration(tt *testing.T) {
 		fmt.Sprintf("kubeapiservers.operator.openshift.io=aescbc:11,kms:%s,identity;kubeschedulers.operator.openshift.io=aescbc:11,kms:%s,identity", kms10, kms10Sched),
 	)
 	waitForConditionStatus("Encrypted", operatorv1.ConditionTrue)
+	verifyKMSProviders()
 
 	t.Logf("Switch back to KMS after rotation")
 	_, err = fakeApiServerClient.Patch(ctx, "cluster", types.MergePatchType, []byte(`{"spec":{"encryption":{"type":"KMS","kms":{"type":"Vault","vault":{"kmsPluginImage":"registry.example.com/kms-plugin@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890","vaultAddress":"https://vault.example.com","authentication":{"type":"AppRole","appRole":{"secret":{"name":"vault-approle-secret"}}},"transitKey":"test-transit-key"}}}}}`), metav1.PatchOptions{})
@@ -487,6 +531,7 @@ func TestEncryptionIntegration(tt *testing.T) {
 	)
 	waitForMigration("12")
 	waitForConditionStatus("Encrypted", operatorv1.ConditionTrue)
+	verifyKMSProviders()
 
 	t.Logf("Delete the encryption-config while in KMS mode")
 	_, err = kubeClient.CoreV1().Secrets("openshift-config-managed").Patch(ctx, fmt.Sprintf("encryption-config-%s", component), types.JSONPatchType, []byte(`[{"op":"remove","path":"/metadata/finalizers"}]`), metav1.PatchOptions{})


### PR DESCRIPTION
This is continuation of https://github.com/openshift/library-go/pull/2186 for the work that is described https://github.com/openshift/enhancements/pull/1960

This PR carries the kms-provider-config into encryption-config Secret.
