### PR TITLE
CNTRLPLANE-3237: Deploy dynamic number of kms plugin daemonsets

### DIFF
--- a/pkg/operator/encryption/controllers/key_controller.go
+++ b/pkg/operator/encryption/controllers/key_controller.go
@@ -39,7 +39,7 @@ import (
 // greater than the last key's ID (the first key has a key ID of 1).
 const (
 	encryptionSecretMigrationInterval = time.Hour * 24 * 7 // one week
-	defaultKMSEndpoint                = "unix:///var/run/kmsplugin/kms.sock"
+	defaultKMSEndpoint                = "unix:///var/run/kmsplugin/kms-1.sock"
 	defaultKMSTimeout                 = 10 * time.Second
 )
 

--- a/pkg/operator/encryption/controllers/key_controller_test.go
+++ b/pkg/operator/encryption/controllers/key_controller_test.go
@@ -356,7 +356,7 @@ func TestKeyController(t *testing.T) {
 						if kmsConfig == "" {
 							ts.Error("expected kms-config annotation to be present")
 						}
-						if kmsConfig != `{"apiVersion":"v2","name":"1","endpoint":"unix:///var/run/kmsplugin/kms.sock","timeout":"10s"}` {
+						if kmsConfig != `{"apiVersion":"v2","name":"1","endpoint":"unix:///var/run/kmsplugin/kms-1.sock","timeout":"10s"}` {
 							ts.Errorf("unexpected kms-config: %s", kmsConfig)
 						}
 
@@ -415,7 +415,7 @@ func TestKeyController(t *testing.T) {
 
 						// Verify KMS config annotation exists
 						kmsConfig := actualSecret.Annotations["encryption.apiserver.operator.openshift.io/kms-config"]
-						if kmsConfig != `{"apiVersion":"v2","name":"6","endpoint":"unix:///var/run/kmsplugin/kms.sock","timeout":"10s"}` {
+						if kmsConfig != `{"apiVersion":"v2","name":"6","endpoint":"unix:///var/run/kmsplugin/kms-1.sock","timeout":"10s"}` {
 							ts.Errorf("unexpected kms-config: %s", kmsConfig)
 						}
 
@@ -490,7 +490,7 @@ func TestKeyController(t *testing.T) {
 
 						// Verify KMS config annotation exists
 						kmsConfig := actualSecret.Annotations["encryption.apiserver.operator.openshift.io/kms-config"]
-						if kmsConfig != `{"apiVersion":"v2","name":"6","endpoint":"unix:///var/run/kmsplugin/kms.sock","timeout":"10s"}` {
+						if kmsConfig != `{"apiVersion":"v2","name":"6","endpoint":"unix:///var/run/kmsplugin/kms-1.sock","timeout":"10s"}` {
 							ts.Errorf("unexpected kms-config: %s", kmsConfig)
 						}
 

--- a/pkg/operator/encryption/controllers/state_controller_test.go
+++ b/pkg/operator/encryption/controllers/state_controller_test.go
@@ -736,7 +736,7 @@ func TestStateController(t *testing.T) {
 						KMS: &apiserverconfigv1.KMSConfiguration{
 							APIVersion: "v2",
 							Name:       "1_secrets",
-							Endpoint:   "unix:///var/run/kmsplugin/kms.sock",
+							Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
 							Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 						},
 					}},
@@ -782,7 +782,7 @@ func TestStateController(t *testing.T) {
 								KMS: &apiserverconfigv1.KMSConfiguration{
 									APIVersion: "v2",
 									Name:       "1_secrets",
-									Endpoint:   "unix:///var/run/kmsplugin/kms.sock",
+									Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
 									Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 								},
 							}},
@@ -803,7 +803,7 @@ func TestStateController(t *testing.T) {
 						KMS: &apiserverconfigv1.KMSConfiguration{
 							APIVersion: "v2",
 							Name:       "1_secrets",
-							Endpoint:   "unix:///var/run/kmsplugin/kms.sock",
+							Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
 							Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 						},
 					}, {
@@ -858,7 +858,7 @@ func TestStateController(t *testing.T) {
 								KMS: &apiserverconfigv1.KMSConfiguration{
 									APIVersion: "v2",
 									Name:       "1_secrets",
-									Endpoint:   "unix:///var/run/kmsplugin/kms.sock",
+									Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
 									Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 								},
 							}, {
@@ -877,7 +877,7 @@ func TestStateController(t *testing.T) {
 								KMS: &apiserverconfigv1.KMSConfiguration{
 									APIVersion: "v2",
 									Name:       "1_secrets",
-									Endpoint:   "unix:///var/run/kmsplugin/kms.sock",
+									Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
 									Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 								},
 							}, {
@@ -912,14 +912,14 @@ func TestStateController(t *testing.T) {
 								KMS: &apiserverconfigv1.KMSConfiguration{
 									APIVersion: "v2",
 									Name:       "1_secrets",
-									Endpoint:   "unix:///var/run/kmsplugin/kms.sock",
+									Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
 									Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 								},
 							}, {
 								KMS: &apiserverconfigv1.KMSConfiguration{
 									APIVersion: "v2",
 									Name:       "2_secrets",
-									Endpoint:   "unix:///var/run/kmsplugin/kms.sock",
+									Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
 									Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 								},
 							}, {
@@ -938,14 +938,14 @@ func TestStateController(t *testing.T) {
 								KMS: &apiserverconfigv1.KMSConfiguration{
 									APIVersion: "v2",
 									Name:       "1_secrets",
-									Endpoint:   "unix:///var/run/kmsplugin/kms.sock",
+									Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
 									Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 								},
 							}, {
 								KMS: &apiserverconfigv1.KMSConfiguration{
 									APIVersion: "v2",
 									Name:       "2_secrets",
-									Endpoint:   "unix:///var/run/kmsplugin/kms.sock",
+									Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
 									Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 								},
 							}, {
@@ -969,14 +969,14 @@ func TestStateController(t *testing.T) {
 						KMS: &apiserverconfigv1.KMSConfiguration{
 							APIVersion: "v2",
 							Name:       "2_secrets",
-							Endpoint:   "unix:///var/run/kmsplugin/kms.sock",
+							Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
 							Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 						},
 					}, {
 						KMS: &apiserverconfigv1.KMSConfiguration{
 							APIVersion: "v2",
 							Name:       "1_secrets",
-							Endpoint:   "unix:///var/run/kmsplugin/kms.sock",
+							Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
 							Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 						},
 					}, {
@@ -1072,7 +1072,7 @@ func TestStateController(t *testing.T) {
 						KMS: &apiserverconfigv1.KMSConfiguration{
 							APIVersion: "v2",
 							Name:       "2_secrets",
-							Endpoint:   "unix:///var/run/kmsplugin/kms.sock",
+							Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
 							Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 						},
 					}, {

--- a/pkg/operator/encryption/encryptionconfig/config_test.go
+++ b/pkg/operator/encryption/encryptionconfig/config_test.go
@@ -687,7 +687,7 @@ func keyToKMSConfiguration(key *corev1.Secret, resource string) *apiserverconfig
 	return &apiserverconfigv1.KMSConfiguration{
 		APIVersion: "v2",
 		Name:       fmt.Sprintf("%d_%s", keyID, resource),
-		Endpoint:   "unix:///var/run/kmsplugin/kms.sock",
+		Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
 		Timeout: &metav1.Duration{
 			Duration: 10 * time.Second,
 		},

--- a/pkg/operator/encryption/secrets/secrets_test.go
+++ b/pkg/operator/encryption/secrets/secrets_test.go
@@ -126,7 +126,7 @@ func TestRoundtrip(t *testing.T) {
 				KMSConfiguration: &v1.KMSConfiguration{
 					APIVersion: "v2",
 					Name:       "1",
-					Endpoint:   "unix:///var/run/kmsplugin/kms.sock",
+					Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
 				},
 				Migrated: state.MigrationState{
 					Timestamp: now,
@@ -153,7 +153,7 @@ func TestRoundtrip(t *testing.T) {
 				KMSConfiguration: &v1.KMSConfiguration{
 					APIVersion: "v2",
 					Name:       "2",
-					Endpoint:   "unix:///var/run/kmsplugin/kms.sock",
+					Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
 				},
 			},
 		},

--- a/pkg/operator/encryption/statemachine/transition_test.go
+++ b/pkg/operator/encryption/statemachine/transition_test.go
@@ -1005,7 +1005,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 							KMS: &apiserverconfigv1.KMSConfiguration{
 								APIVersion: "v2",
 								Name:       "1_secrets",
-								Endpoint:   "unix:///var/run/kmsplugin/kms.sock",
+								Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
 								Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 							},
 						}},
@@ -1052,7 +1052,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 							KMS: &apiserverconfigv1.KMSConfiguration{
 								APIVersion: "v2",
 								Name:       "2_secrets",
-								Endpoint:   "unix:///var/run/kmsplugin/kms.sock",
+								Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
 								Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 							},
 						}, {
@@ -1072,14 +1072,14 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 							KMS: &apiserverconfigv1.KMSConfiguration{
 								APIVersion: "v2",
 								Name:       "1_secrets",
-								Endpoint:   "unix:///var/run/kmsplugin/kms.sock",
+								Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
 								Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 							},
 						}, {
 							KMS: &apiserverconfigv1.KMSConfiguration{
 								APIVersion: "v2",
 								Name:       "2_secrets",
-								Endpoint:   "unix:///var/run/kmsplugin/kms.sock",
+								Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
 								Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 							},
 						}, {
@@ -1102,14 +1102,14 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 							KMS: &apiserverconfigv1.KMSConfiguration{
 								APIVersion: "v2",
 								Name:       "2_secrets",
-								Endpoint:   "unix:///var/run/kmsplugin/kms.sock",
+								Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
 								Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 							},
 						}, {
 							KMS: &apiserverconfigv1.KMSConfiguration{
 								APIVersion: "v2",
 								Name:       "1_secrets",
-								Endpoint:   "unix:///var/run/kmsplugin/kms.sock",
+								Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
 								Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 							},
 						}, {
@@ -1129,14 +1129,14 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 							KMS: &apiserverconfigv1.KMSConfiguration{
 								APIVersion: "v2",
 								Name:       "2_secrets",
-								Endpoint:   "unix:///var/run/kmsplugin/kms.sock",
+								Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
 								Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 							},
 						}, {
 							KMS: &apiserverconfigv1.KMSConfiguration{
 								APIVersion: "v2",
 								Name:       "1_secrets",
-								Endpoint:   "unix:///var/run/kmsplugin/kms.sock",
+								Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
 								Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 							},
 						}, {
@@ -1158,14 +1158,14 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 						KMS: &apiserverconfigv1.KMSConfiguration{
 							APIVersion: "v2",
 							Name:       "2_secrets",
-							Endpoint:   "unix:///var/run/kmsplugin/kms.sock",
+							Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
 							Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 						},
 					}, {
 						KMS: &apiserverconfigv1.KMSConfiguration{
 							APIVersion: "v2",
 							Name:       "1_secrets",
-							Endpoint:   "unix:///var/run/kmsplugin/kms.sock",
+							Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
 							Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 						},
 					}, {
@@ -1184,7 +1184,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 							KMS: &apiserverconfigv1.KMSConfiguration{
 								APIVersion: "v2",
 								Name:       "2_secrets",
-								Endpoint:   "unix:///var/run/kmsplugin/kms.sock",
+								Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
 								Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 							},
 						}, {
@@ -1213,7 +1213,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 						KMS: &apiserverconfigv1.KMSConfiguration{
 							APIVersion: "v2",
 							Name:       "2_secrets",
-							Endpoint:   "unix:///var/run/kmsplugin/kms.sock",
+							Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
 							Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 						},
 					}, {
@@ -1246,7 +1246,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 							KMS: &apiserverconfigv1.KMSConfiguration{
 								APIVersion: "v2",
 								Name:       "1_secrets",
-								Endpoint:   "unix:///var/run/kmsplugin/kms.sock",
+								Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
 								Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 							},
 						}, {
@@ -1275,7 +1275,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 						KMS: &apiserverconfigv1.KMSConfiguration{
 							APIVersion: "v2",
 							Name:       "1_secrets",
-							Endpoint:   "unix:///var/run/kmsplugin/kms.sock",
+							Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
 							Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 						},
 					}, {

--- a/pkg/operator/encryption/testing/helpers.go
+++ b/pkg/operator/encryption/testing/helpers.go
@@ -101,7 +101,7 @@ func CreateEncryptionKeySecretWithKMSConfig(targetNS string, grs []schema.GroupR
 	kmsConfig := &apiserverconfigv1.KMSConfiguration{
 		APIVersion: "v2",
 		Name:       fmt.Sprintf("%d", keyID),
-		Endpoint:   "unix:///var/run/kmsplugin/kms.sock",
+		Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
 		Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 	}
 	kmsConfigJSON, _ := json.Marshal(kmsConfig)
@@ -273,7 +273,7 @@ func createProviderCfg(mode string, resource string, key apiserverconfigv1.Key) 
 			KMS: &apiserverconfigv1.KMSConfiguration{
 				APIVersion: "v2",
 				Name:       fmt.Sprintf("%s_%s", key.Name, resource),
-				Endpoint:   "unix:///var/run/kmsplugin/kms.sock",
+				Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
 				Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 			},
 		}

--- a/test/library/encryption/kms/assets/k8s_mock_kms_plugin_daemonset.yaml
+++ b/test/library/encryption/kms/assets/k8s_mock_kms_plugin_daemonset.yaml
@@ -1,16 +1,16 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: k8s-mock-kms-plugin
+  name: k8s-mock-kms-plugin-{{ .Index }}
   namespace: {{ .Namespace }}
 spec:
   selector:
     matchLabels:
-      app: k8s-mock-kms-plugin
+      app: k8s-mock-kms-plugin-{{ .Index }}
   template:
     metadata:
       labels:
-        app: k8s-mock-kms-plugin
+        app: k8s-mock-kms-plugin-{{ .Index }}
     spec:
       nodeSelector:
         node-role.kubernetes.io/control-plane: ""
@@ -61,10 +61,8 @@ spec:
             - -c
           args:
             - |
-              # remove the socket to prevent "bind: address already in use"
-              # not sure this is the best way
-              rm -f /var/run/kmsplugin/kms.sock
-              exec /usr/local/bin/mock-kms-plugin -listen-addr=unix:///var/run/kmsplugin/kms.sock -config-file-path=/etc/softhsm-config.json
+              rm -f /var/run/kmsplugin/kms-{{ .Index }}.sock
+              exec /usr/local/bin/mock-kms-plugin -listen-addr=unix:///var/run/kmsplugin/kms-{{ .Index }}.sock -config-file-path=/etc/softhsm-config.json
           volumeMounts:
             - name: socket
               mountPath: /var/run/kmsplugin

--- a/test/library/encryption/kms/k8s_mock_kms_plugin_deployer.go
+++ b/test/library/encryption/kms/k8s_mock_kms_plugin_deployer.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"embed"
+	"fmt"
 	"path/filepath"
 	"testing"
 	"text/template"
@@ -30,11 +31,14 @@ const (
 	// WellKnownUpstreamMockKMSPluginImage is the pre-built mock KMS plugin image.
 	WellKnownUpstreamMockKMSPluginImage = "quay.io/openshifttest/mock-kms-plugin@sha256:998e1d48eba257f589ab86c30abd5043f662213e9aeff253e1c308301879d48a"
 
+	// DefaultKMSPluginCount is the default number of KMS plugin instances to deploy.
+	DefaultKMSPluginCount = 10
+
 	// defaultPollTimeout the default poll timeout used by the deployer
 	defaultPollTimeout = 2 * time.Minute
 )
 
-var manifestFilesToApplyDirectly = []string{
+var sharedManifestFiles = []string{
 	"k8s_mock_kms_plugin_namespace.yaml",
 	"k8s_mock_kms_plugin_serviceaccount.yaml",
 	"k8s_mock_kms_plugin_rolebinding.yaml",
@@ -48,26 +52,35 @@ var daemonSetManifestFile = "k8s_mock_kms_plugin_daemonset.yaml"
 type yamlTemplateData struct {
 	Namespace string
 	Image     string
+	Index     int
 }
 
-// DeployUpstreamMockKMSPlugin deploys the upstream mock KMS v2 plugin using embedded YAML assets.
-func DeployUpstreamMockKMSPlugin(ctx context.Context, t testing.TB, kubeClient kubernetes.Interface, namespace, image string) {
+// DeployUpstreamMockKMSPlugin deploys count instances of the upstream mock KMS v2 plugin
+func DeployUpstreamMockKMSPlugin(ctx context.Context, t testing.TB, kubeClient kubernetes.Interface, namespace, image string, count int) {
 	t.Helper()
 
-	t.Logf("Deploying upstream mock KMS v2 plugin in namespace %q using image %s", namespace, image)
-	daemonSetName, err := applyUpstreamMockKMSPluginManifests(ctx, t, kubeClient, namespace, image)
-	if err != nil {
-		t.Fatalf("Failed to apply manifests: %v", err)
+	t.Logf("Deploying %d upstream mock KMS v2 plugin instance(s) in namespace %q using image %s", count, namespace, image)
+
+	if err := applySharedManifests(ctx, t, kubeClient, namespace, image); err != nil {
+		t.Fatalf("Failed to apply shared manifests: %v", err)
 	}
-	if err := waitForDaemonSetReady(ctx, t, kubeClient, namespace, daemonSetName); err != nil {
-		t.Fatalf("DaemonSet not ready: %v", err)
+
+	for i := 1; i <= count; i++ {
+		daemonSetName, err := applyDaemonSetManifest(ctx, t, kubeClient, namespace, image, i)
+		if err != nil {
+			t.Fatalf("Failed to apply DaemonSet manifest for instance %d: %v", i, err)
+		}
+		if err := waitForDaemonSetReady(ctx, t, kubeClient, namespace, daemonSetName); err != nil {
+			t.Fatalf("DaemonSet %s not ready: %v", daemonSetName, err)
+		}
 	}
-	t.Logf("Upstream mock KMS v2 plugin deployed successfully!")
+
+	t.Logf("All %d upstream mock KMS v2 plugin instance(s) deployed successfully!", count)
 }
 
-// applyUpstreamMockKMSPluginManifests applies all the KMS plugin manifests.
-// Returns the DaemonSet name on success.
-func applyUpstreamMockKMSPluginManifests(ctx context.Context, t testing.TB, kubeClient kubernetes.Interface, namespace, image string) (string, error) {
+// applySharedManifests applies the shared resources (namespace, serviceaccount, rolebinding, configmap)
+// that are common across all KMS plugin instances.
+func applySharedManifests(ctx context.Context, t testing.TB, kubeClient kubernetes.Interface, namespace, image string) error {
 	t.Helper()
 
 	data := yamlTemplateData{
@@ -79,14 +92,31 @@ func applyUpstreamMockKMSPluginManifests(ctx context.Context, t testing.TB, kube
 	assetFunc := wrapAssetWithTemplateDataFunc(data)
 
 	clientHolder := resourceapply.NewKubeClientHolder(kubeClient)
-	results := resourceapply.ApplyDirectly(ctx, clientHolder, recorder, resourceapply.NewResourceCache(), assetFunc, manifestFilesToApplyDirectly...)
+	results := resourceapply.ApplyDirectly(ctx, clientHolder, recorder, resourceapply.NewResourceCache(), assetFunc, sharedManifestFiles...)
 
 	for _, result := range results {
 		if result.Error != nil {
-			return "", result.Error
+			return result.Error
 		}
 		t.Logf("Applied %s (changed=%v)", result.File, result.Changed)
 	}
+
+	return nil
+}
+
+// applyDaemonSetManifest applies a single indexed DaemonSet manifest.
+// Returns the DaemonSet name on success.
+func applyDaemonSetManifest(ctx context.Context, t testing.TB, kubeClient kubernetes.Interface, namespace, image string, index int) (string, error) {
+	t.Helper()
+
+	data := yamlTemplateData{
+		Namespace: namespace,
+		Image:     image,
+		Index:     index,
+	}
+
+	recorder := events.NewInMemoryRecorder(fmt.Sprintf("k8s-mock-kms-plugin-deployer-%d", index), clock.RealClock{})
+	assetFunc := wrapAssetWithTemplateDataFunc(data)
 
 	rawDaemonSet, err := assetFunc(daemonSetManifestFile)
 	if err != nil {


### PR DESCRIPTION
This PR applies the mechanism suggested in https://github.com/openshift/library-go/pull/2161#discussion_r3099797803

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for deploying multiple mock KMS plugin instances with a configurable count (default: 10) for improved testing.

* **Improvements**
  * Each mock KMS instance is independently identified and uses per-instance endpoints, enabling parallel multi-instance encryption testing and clearer instance isolation.

* **Tests**
  * Test expectations and helpers updated to align with per-instance endpoints and multi-instance deployment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->