### PR TITLE
WIP: Introduce carrying KMS provider configurations

### DIFF
--- a/pkg/operator/encryption/controllers/key_controller.go
+++ b/pkg/operator/encryption/controllers/key_controller.go
@@ -20,7 +20,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 
-	v1 "github.com/openshift/api/config/v1"
+	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
@@ -260,7 +260,7 @@ func (c *keyController) validateExistingSecret(ctx context.Context, keySecret *c
 	return nil // we made this key earlier
 }
 
-func (c *keyController) generateKeySecret(keyID uint64, currentMode state.Mode, apiServerEncryption v1.APIServerEncryption, internalReason, externalReason string) (*corev1.Secret, error) {
+func (c *keyController) generateKeySecret(keyID uint64, currentMode state.Mode, apiServerEncryption configv1.APIServerEncryption, internalReason, externalReason string) (*corev1.Secret, error) {
 	bs := crypto.ModeToNewKeyFunc[currentMode]()
 	ks := state.KeyState{
 		Key: apiserverv1.Key{
@@ -285,36 +285,37 @@ func (c *keyController) generateKeySecret(keyID uint64, currentMode state.Mode, 
 	return secrets.FromKeyState(c.instanceName, ks)
 }
 
-func (c *keyController) getCurrentModeReasonAndEncryptionConfig(ctx context.Context) (state.Mode, string, v1.APIServerEncryption, error) {
+func (c *keyController) getCurrentModeReasonAndEncryptionConfig(ctx context.Context) (state.Mode, string, configv1.APIServerEncryption, error) {
 	apiServer, err := c.apiServerClient.Get(ctx, "cluster", metav1.GetOptions{})
 	if err != nil {
-		return "", "", v1.APIServerEncryption{}, err
+		return "", "", configv1.APIServerEncryption{}, err
 	}
 
 	operatorSpec, _, _, err := c.operatorClient.GetOperatorState()
 	if err != nil {
-		return "", "", v1.APIServerEncryption{}, err
+		return "", "", configv1.APIServerEncryption{}, err
 	}
 
 	encryptionConfig, err := structuredUnsupportedConfigFrom(operatorSpec.UnsupportedConfigOverrides.Raw, c.unsupportedConfigPrefix)
 	if err != nil {
-		return "", "", v1.APIServerEncryption{}, err
+		return "", "", configv1.APIServerEncryption{}, err
 	}
 
 	encryption := apiServer.Spec.Encryption
+	// TODO: we'll allow updating some values such as via unsupportedconfig overrides.
 	reason := encryptionConfig.Encryption.Reason
 	switch currentMode := state.Mode(encryption.Type); currentMode {
 	case state.AESCBC, state.AESGCM, state.Identity: // secretbox is disabled for now
 		return currentMode, reason, encryption, nil
 	case state.KMS:
 		if encryption.KMS == nil {
-			return "", "", v1.APIServerEncryption{}, fmt.Errorf("invalid encryption mode %q: KMS config is required", encryption.Type)
+			return "", "", configv1.APIServerEncryption{}, fmt.Errorf("invalid encryption mode %q: KMS config is required", encryption.Type)
 		}
 		return currentMode, reason, encryption, nil
 	case "": // unspecified means use the default (which can change over time)
 		return state.DefaultMode, reason, encryption, nil
 	default:
-		return "", "", v1.APIServerEncryption{}, fmt.Errorf("unknown encryption mode configured: %s", currentMode)
+		return "", "", configv1.APIServerEncryption{}, fmt.Errorf("unknown encryption mode configured: %s", currentMode)
 	}
 }
 

--- a/pkg/operator/encryption/controllers/key_controller_test.go
+++ b/pkg/operator/encryption/controllers/key_controller_test.go
@@ -373,11 +373,7 @@ func TestKeyController(t *testing.T) {
 
 						// Verify KMS provider config content
 						kmsProviderConfigData := actualSecret.Data["encryption.apiserver.operator.openshift.io-kms-provider-config"]
-<<<<<<< HEAD
-						expectedProviderConfig, err := encoding.EncodeKMSConfig(dummyKMSConfig)
-=======
-						expectedProviderConfig, err := json.Marshal(encryptiontesting.DefaultKMSProviderConfig)
->>>>>>> 639dafc7a (Carry kms-provider-config into encryption-config Secret)
+						expectedProviderConfig, err := encoding.EncodeKMSConfig(encryptiontesting.DefaultKMSProviderConfig)
 						if err != nil {
 							ts.Fatalf("failed to encode KMS config: %v", err)
 						}
@@ -455,11 +451,7 @@ func TestKeyController(t *testing.T) {
 
 						// Verify KMS provider config content
 						kmsProviderConfigData := actualSecret.Data["encryption.apiserver.operator.openshift.io-kms-provider-config"]
-<<<<<<< HEAD
-						expectedProviderConfig, err := encoding.EncodeKMSConfig(dummyKMSConfig)
-=======
-						expectedProviderConfig, err := json.Marshal(encryptiontesting.DefaultKMSProviderConfig)
->>>>>>> 639dafc7a (Carry kms-provider-config into encryption-config Secret)
+						expectedProviderConfig, err := encoding.EncodeKMSConfig(encryptiontesting.DefaultKMSProviderConfig)
 						if err != nil {
 							ts.Fatalf("failed to encode KMS config: %v", err)
 						}
@@ -553,11 +545,7 @@ func TestKeyController(t *testing.T) {
 
 						// Verify KMS provider config content
 						kmsProviderConfigData := actualSecret.Data["encryption.apiserver.operator.openshift.io-kms-provider-config"]
-<<<<<<< HEAD
-						expectedProviderConfig, err := encoding.EncodeKMSConfig(dummyKMSConfig)
-=======
-						expectedProviderConfig, err := json.Marshal(encryptiontesting.DefaultKMSProviderConfig)
->>>>>>> 639dafc7a (Carry kms-provider-config into encryption-config Secret)
+						expectedProviderConfig, err := encoding.EncodeKMSConfig(encryptiontesting.DefaultKMSProviderConfig)
 						if err != nil {
 							ts.Fatalf("failed to encode KMS config: %v", err)
 						}

--- a/pkg/operator/encryption/controllers/key_controller_test.go
+++ b/pkg/operator/encryption/controllers/key_controller_test.go
@@ -43,22 +43,8 @@ func TestKeyController(t *testing.T) {
 	apiServerWithAESGCM := simpleAPIServer.DeepCopy()
 	apiServerWithAESGCM.Spec.Encryption = configv1.APIServerEncryption{Type: "aesgcm"}
 
-	dummyKMSConfig := &configv1.KMSConfig{
-		Type: configv1.VaultKMSProvider,
-		Vault: configv1.VaultKMSConfig{
-			KMSPluginImage: "registry.example.com/kms-plugin@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
-			VaultAddress:   "https://vault.example.com",
-			Authentication: configv1.VaultAuthentication{
-				Type: configv1.VaultAuthenticationTypeAppRole,
-				AppRole: configv1.VaultAppRoleAuthentication{
-					Secret: configv1.VaultSecretReference{Name: "vault-approle-secret"},
-				},
-			},
-			TransitKey: "test-transit-key",
-		},
-	}
 	apiServerWithKMS := simpleAPIServer.DeepCopy()
-	apiServerWithKMS.Spec.Encryption = configv1.APIServerEncryption{Type: "KMS", KMS: dummyKMSConfig}
+	apiServerWithKMS.Spec.Encryption = configv1.APIServerEncryption{Type: "KMS", KMS: encryptiontesting.DefaultKMSProviderConfig}
 
 	scenarios := []struct {
 		name                     string
@@ -387,7 +373,11 @@ func TestKeyController(t *testing.T) {
 
 						// Verify KMS provider config content
 						kmsProviderConfigData := actualSecret.Data["encryption.apiserver.operator.openshift.io-kms-provider-config"]
+<<<<<<< HEAD
 						expectedProviderConfig, err := encoding.EncodeKMSConfig(dummyKMSConfig)
+=======
+						expectedProviderConfig, err := json.Marshal(encryptiontesting.DefaultKMSProviderConfig)
+>>>>>>> 639dafc7a (Carry kms-provider-config into encryption-config Secret)
 						if err != nil {
 							ts.Fatalf("failed to encode KMS config: %v", err)
 						}
@@ -465,7 +455,11 @@ func TestKeyController(t *testing.T) {
 
 						// Verify KMS provider config content
 						kmsProviderConfigData := actualSecret.Data["encryption.apiserver.operator.openshift.io-kms-provider-config"]
+<<<<<<< HEAD
 						expectedProviderConfig, err := encoding.EncodeKMSConfig(dummyKMSConfig)
+=======
+						expectedProviderConfig, err := json.Marshal(encryptiontesting.DefaultKMSProviderConfig)
+>>>>>>> 639dafc7a (Carry kms-provider-config into encryption-config Secret)
 						if err != nil {
 							ts.Fatalf("failed to encode KMS config: %v", err)
 						}
@@ -559,7 +553,11 @@ func TestKeyController(t *testing.T) {
 
 						// Verify KMS provider config content
 						kmsProviderConfigData := actualSecret.Data["encryption.apiserver.operator.openshift.io-kms-provider-config"]
+<<<<<<< HEAD
 						expectedProviderConfig, err := encoding.EncodeKMSConfig(dummyKMSConfig)
+=======
+						expectedProviderConfig, err := json.Marshal(encryptiontesting.DefaultKMSProviderConfig)
+>>>>>>> 639dafc7a (Carry kms-provider-config into encryption-config Secret)
 						if err != nil {
 							ts.Fatalf("failed to encode KMS config: %v", err)
 						}

--- a/pkg/operator/encryption/controllers/state_controller_test.go
+++ b/pkg/operator/encryption/controllers/state_controller_test.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	clientgotesting "k8s.io/client-go/testing"
 
+	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	configv1clientfake "github.com/openshift/client-go/config/clientset/versioned/fake"
 	configv1informers "github.com/openshift/client-go/config/informers/externalversions"
@@ -724,25 +725,28 @@ func TestStateController(t *testing.T) {
 				encryptiontesting.CreateEncryptionKeySecretWithKMSConfig("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 1),
 			},
 			expectedActions: []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config-managed", "create:secrets:openshift-config-managed", "create:events:kms", "create:events:kms"},
-			expectedEncryptionCfg: &encryptiondata.Config{Encryption: &apiserverconfigv1.EncryptionConfiguration{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "EncryptionConfiguration",
-					APIVersion: "apiserver.config.k8s.io/v1",
-				},
-				Resources: []apiserverconfigv1.ResourceConfiguration{{
-					Resources: []string{"secrets"},
-					Providers: []apiserverconfigv1.ProviderConfiguration{{
-						Identity: &apiserverconfigv1.IdentityConfiguration{},
-					}, {
-						KMS: &apiserverconfigv1.KMSConfiguration{
-							APIVersion: "v2",
-							Name:       "1_secrets",
-							Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
-							Timeout:    &metav1.Duration{Duration: 10 * time.Second},
-						},
+			expectedEncryptionCfg: &encryptiondata.Config{
+				Encryption: &apiserverconfigv1.EncryptionConfiguration{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "EncryptionConfiguration",
+						APIVersion: "apiserver.config.k8s.io/v1",
+					},
+					Resources: []apiserverconfigv1.ResourceConfiguration{{
+						Resources: []string{"secrets"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{{
+							Identity: &apiserverconfigv1.IdentityConfiguration{},
+						}, {
+							KMS: &apiserverconfigv1.KMSConfiguration{
+								APIVersion: "v2",
+								Name:       "1_secrets",
+								Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
+								Timeout:    &metav1.Duration{Duration: 10 * time.Second},
+							},
+						}},
 					}},
-				}},
-			}},
+				},
+				KMSProviders: map[string]*configv1.KMSConfig{"1": encryptiontesting.DefaultKMSProviderConfig},
+			},
 			validateFunc: func(ts *testing.T, actions []clientgotesting.Action, destName string, expectedEncryptionCfg *encryptiondata.Config) {
 				wasSecretValidated := false
 				for _, action := range actions {
@@ -793,25 +797,28 @@ func TestStateController(t *testing.T) {
 					return ecs
 				}(),
 			},
-			expectedEncryptionCfg: &encryptiondata.Config{Encryption: &apiserverconfigv1.EncryptionConfiguration{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "EncryptionConfiguration",
-					APIVersion: "apiserver.config.k8s.io/v1",
-				},
-				Resources: []apiserverconfigv1.ResourceConfiguration{{
-					Resources: []string{"secrets"},
-					Providers: []apiserverconfigv1.ProviderConfiguration{{
-						KMS: &apiserverconfigv1.KMSConfiguration{
-							APIVersion: "v2",
-							Name:       "1_secrets",
-							Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
-							Timeout:    &metav1.Duration{Duration: 10 * time.Second},
-						},
-					}, {
-						Identity: &apiserverconfigv1.IdentityConfiguration{},
+			expectedEncryptionCfg: &encryptiondata.Config{
+				Encryption: &apiserverconfigv1.EncryptionConfiguration{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "EncryptionConfiguration",
+						APIVersion: "apiserver.config.k8s.io/v1",
+					},
+					Resources: []apiserverconfigv1.ResourceConfiguration{{
+						Resources: []string{"secrets"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{{
+							KMS: &apiserverconfigv1.KMSConfiguration{
+								APIVersion: "v2",
+								Name:       "1_secrets",
+								Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
+								Timeout:    &metav1.Duration{Duration: 10 * time.Second},
+							},
+						}, {
+							Identity: &apiserverconfigv1.IdentityConfiguration{},
+						}},
 					}},
-				}},
-			}},
+				},
+				KMSProviders: map[string]*configv1.KMSConfig{"1": encryptiontesting.DefaultKMSProviderConfig},
+			},
 			expectedActions: []string{
 				"list:pods:kms",
 				"get:secrets:kms",
@@ -852,40 +859,46 @@ func TestStateController(t *testing.T) {
 				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
 				encryptiontesting.CreateMigratedEncryptionKeySecretWithKMSConfig("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 1, time.Now()),
 				func() *corev1.Secret {
-					ec := &encryptiondata.Config{Encryption: &apiserverconfigv1.EncryptionConfiguration{
-						Resources: []apiserverconfigv1.ResourceConfiguration{{
-							Resources: []string{"secrets"},
-							Providers: []apiserverconfigv1.ProviderConfiguration{{
-								KMS: &apiserverconfigv1.KMSConfiguration{
-									APIVersion: "v2",
-									Name:       "1_secrets",
-									Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
-									Timeout:    &metav1.Duration{Duration: 10 * time.Second},
-								},
-							}, {
-								Identity: &apiserverconfigv1.IdentityConfiguration{},
+					ec := &encryptiondata.Config{
+						Encryption: &apiserverconfigv1.EncryptionConfiguration{
+							Resources: []apiserverconfigv1.ResourceConfiguration{{
+								Resources: []string{"secrets"},
+								Providers: []apiserverconfigv1.ProviderConfiguration{{
+									KMS: &apiserverconfigv1.KMSConfiguration{
+										APIVersion: "v2",
+										Name:       "1_secrets",
+										Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
+										Timeout:    &metav1.Duration{Duration: 10 * time.Second},
+									},
+								}, {
+									Identity: &apiserverconfigv1.IdentityConfiguration{},
+								}},
 							}},
-						}},
-					}}
+						},
+						KMSProviders: map[string]*configv1.KMSConfig{"1": encryptiontesting.DefaultKMSProviderConfig},
+					}
 					ecs := createEncryptionCfgSecret(t, "kms", "1", ec)
 					return ecs
 				}(),
 				func() *corev1.Secret {
-					ec := &encryptiondata.Config{Encryption: &apiserverconfigv1.EncryptionConfiguration{
-						Resources: []apiserverconfigv1.ResourceConfiguration{{
-							Resources: []string{"secrets"},
-							Providers: []apiserverconfigv1.ProviderConfiguration{{
-								KMS: &apiserverconfigv1.KMSConfiguration{
-									APIVersion: "v2",
-									Name:       "1_secrets",
-									Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
-									Timeout:    &metav1.Duration{Duration: 10 * time.Second},
-								},
-							}, {
-								Identity: &apiserverconfigv1.IdentityConfiguration{},
+					ec := &encryptiondata.Config{
+						Encryption: &apiserverconfigv1.EncryptionConfiguration{
+							Resources: []apiserverconfigv1.ResourceConfiguration{{
+								Resources: []string{"secrets"},
+								Providers: []apiserverconfigv1.ProviderConfiguration{{
+									KMS: &apiserverconfigv1.KMSConfiguration{
+										APIVersion: "v2",
+										Name:       "1_secrets",
+										Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
+										Timeout:    &metav1.Duration{Duration: 10 * time.Second},
+									},
+								}, {
+									Identity: &apiserverconfigv1.IdentityConfiguration{},
+								}},
 							}},
-						}},
-					}}
+						},
+						KMSProviders: map[string]*configv1.KMSConfig{"1": encryptiontesting.DefaultKMSProviderConfig},
+					}
 					ecs := createEncryptionCfgSecret(t, "openshift-config-managed", "1", ec)
 					ecs.Name = "encryption-config-kms"
 					return ecs
@@ -904,7 +917,20 @@ func TestStateController(t *testing.T) {
 			initialResources: []runtime.Object{
 				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
 				encryptiontesting.CreateExpiredMigratedEncryptionKeySecretWithKMSConfig("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 1),
-				encryptiontesting.CreateEncryptionKeySecretWithKMSConfig("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 2),
+				encryptiontesting.CreateEncryptionKeySecretWithCustomKMSConfig("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 2, &configv1.KMSConfig{
+					Type: configv1.VaultKMSProvider,
+					Vault: configv1.VaultKMSConfig{
+						KMSPluginImage: "registry.example.com/kms-plugin@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+						VaultAddress:   "https://vault2.example.com",
+						Authentication: configv1.VaultAuthentication{
+							Type: configv1.VaultAuthenticationTypeAppRole,
+							AppRole: configv1.VaultAppRoleAuthentication{
+								Secret: configv1.VaultSecretReference{Name: "vault-approle-secret-2"},
+							},
+						},
+						TransitKey: "test-transit-key-2",
+					},
+				}),
 				func() *corev1.Secret { // encryption config in kms namespace
 					ec := &encryptiondata.Config{Encryption: &apiserverconfigv1.EncryptionConfiguration{
 						Resources: []apiserverconfigv1.ResourceConfiguration{{
@@ -959,32 +985,51 @@ func TestStateController(t *testing.T) {
 					return ecs
 				}(),
 			},
-			expectedEncryptionCfg: &encryptiondata.Config{Encryption: &apiserverconfigv1.EncryptionConfiguration{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "EncryptionConfiguration",
-					APIVersion: "apiserver.config.k8s.io/v1",
-				},
-				Resources: []apiserverconfigv1.ResourceConfiguration{{
-					Resources: []string{"secrets"},
-					Providers: []apiserverconfigv1.ProviderConfiguration{{
-						KMS: &apiserverconfigv1.KMSConfiguration{
-							APIVersion: "v2",
-							Name:       "2_secrets",
-							Endpoint:   "unix:///var/run/kmsplugin/kms-2.sock",
-							Timeout:    &metav1.Duration{Duration: 10 * time.Second},
-						},
-					}, {
-						KMS: &apiserverconfigv1.KMSConfiguration{
-							APIVersion: "v2",
-							Name:       "1_secrets",
-							Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
-							Timeout:    &metav1.Duration{Duration: 10 * time.Second},
-						},
-					}, {
-						Identity: &apiserverconfigv1.IdentityConfiguration{},
+			expectedEncryptionCfg: &encryptiondata.Config{
+				Encryption: &apiserverconfigv1.EncryptionConfiguration{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "EncryptionConfiguration",
+						APIVersion: "apiserver.config.k8s.io/v1",
+					},
+					Resources: []apiserverconfigv1.ResourceConfiguration{{
+						Resources: []string{"secrets"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{{
+							KMS: &apiserverconfigv1.KMSConfiguration{
+								APIVersion: "v2",
+								Name:       "2_secrets",
+								Endpoint:   "unix:///var/run/kmsplugin/kms-2.sock",
+								Timeout:    &metav1.Duration{Duration: 10 * time.Second},
+							},
+						}, {
+							KMS: &apiserverconfigv1.KMSConfiguration{
+								APIVersion: "v2",
+								Name:       "1_secrets",
+								Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
+								Timeout:    &metav1.Duration{Duration: 10 * time.Second},
+							},
+						}, {
+							Identity: &apiserverconfigv1.IdentityConfiguration{},
+						}},
 					}},
-				}},
-			}},
+				},
+				KMSProviders: map[string]*configv1.KMSConfig{
+					"1": encryptiontesting.DefaultKMSProviderConfig,
+					"2": {
+						Type: configv1.VaultKMSProvider,
+						Vault: configv1.VaultKMSConfig{
+							KMSPluginImage: "registry.example.com/kms-plugin@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+							VaultAddress:   "https://vault2.example.com",
+							Authentication: configv1.VaultAuthentication{
+								Type: configv1.VaultAuthenticationTypeAppRole,
+								AppRole: configv1.VaultAppRoleAuthentication{
+									Secret: configv1.VaultSecretReference{Name: "vault-approle-secret-2"},
+								},
+							},
+							TransitKey: "test-transit-key-2",
+						},
+					},
+				},
+			},
 			expectedActions: []string{
 				"list:pods:kms",
 				"get:secrets:kms",
@@ -1055,32 +1100,48 @@ func TestStateController(t *testing.T) {
 					return ecs
 				}(),
 			},
-			expectedEncryptionCfg: &encryptiondata.Config{Encryption: &apiserverconfigv1.EncryptionConfiguration{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "EncryptionConfiguration",
-					APIVersion: "apiserver.config.k8s.io/v1",
-				},
-				Resources: []apiserverconfigv1.ResourceConfiguration{{
-					Resources: []string{"secrets"},
-					Providers: []apiserverconfigv1.ProviderConfiguration{{
-						AESCBC: &apiserverconfigv1.AESConfiguration{
-							Keys: []apiserverconfigv1.Key{{
-								Name:   "1",
-								Secret: "NjFkZWY5NjRmYjk2N2Y1ZDdjNDRhMmFmOGRhYjY4NjU=", // # notsecret
-							}},
-						},
-					}, {
-						KMS: &apiserverconfigv1.KMSConfiguration{
-							APIVersion: "v2",
-							Name:       "2_secrets",
-							Endpoint:   "unix:///var/run/kmsplugin/kms-2.sock",
-							Timeout:    &metav1.Duration{Duration: 10 * time.Second},
-						},
-					}, {
-						Identity: &apiserverconfigv1.IdentityConfiguration{},
+			expectedEncryptionCfg: &encryptiondata.Config{
+				Encryption: &apiserverconfigv1.EncryptionConfiguration{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "EncryptionConfiguration",
+						APIVersion: "apiserver.config.k8s.io/v1",
+					},
+					Resources: []apiserverconfigv1.ResourceConfiguration{{
+						Resources: []string{"secrets"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{{
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "1",
+									Secret: "NjFkZWY5NjRmYjk2N2Y1ZDdjNDRhMmFmOGRhYjY4NjU=", // # notsecret
+								}},
+							},
+						}, {
+							KMS: &apiserverconfigv1.KMSConfiguration{
+								APIVersion: "v2",
+								Name:       "2_secrets",
+								Endpoint:   "unix:///var/run/kmsplugin/kms-2.sock",
+								Timeout:    &metav1.Duration{Duration: 10 * time.Second},
+							},
+						}, {
+							Identity: &apiserverconfigv1.IdentityConfiguration{},
+						}},
 					}},
+				},
+				KMSProviders: map[string]*configv1.KMSConfig{"2": {
+					Type: configv1.VaultKMSProvider,
+					Vault: configv1.VaultKMSConfig{
+						KMSPluginImage: "registry.example.com/kms-plugin@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+						VaultAddress:   "https://vault.example.com",
+						Authentication: configv1.VaultAuthentication{
+							Type: configv1.VaultAuthenticationTypeAppRole,
+							AppRole: configv1.VaultAppRoleAuthentication{
+								Secret: configv1.VaultSecretReference{Name: "vault-approle-secret"},
+							},
+						},
+						TransitKey: "test-transit-key",
+					},
 				}},
-			}},
+			},
 			expectedActions: []string{
 				"list:pods:kms",
 				"get:secrets:kms",

--- a/pkg/operator/encryption/encryptiondata/config.go
+++ b/pkg/operator/encryption/encryptiondata/config.go
@@ -11,6 +11,8 @@ import (
 	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
 	"k8s.io/klog/v2"
 
+	configv1 "github.com/openshift/api/config/v1"
+
 	"github.com/openshift/library-go/pkg/operator/encryption/crypto"
 	"github.com/openshift/library-go/pkg/operator/encryption/secrets"
 	"github.com/openshift/library-go/pkg/operator/encryption/state"
@@ -24,6 +26,9 @@ var (
 // encryption state that doesn't fit into the upstream type.
 type Config struct {
 	Encryption *apiserverconfigv1.EncryptionConfiguration
+	// KMSProviders maps keyID to provider-specific configuration,
+	// carried from Key Secrets into the encryption-config Secret.
+	KMSProviders map[string]*configv1.KMSConfig
 }
 
 func (c *Config) HasEncryptionConfiguration() bool {
@@ -33,12 +38,27 @@ func (c *Config) HasEncryptionConfiguration() bool {
 // FromEncryptionState converts encryption state to Config.
 func FromEncryptionState(encryptionState map[schema.GroupResource]state.GroupResourceState) *Config {
 	resourceConfigs := make([]apiserverconfigv1.ResourceConfiguration, 0, len(encryptionState))
+	var kmsProviders map[string]*configv1.KMSConfig
 
 	for gr, grKeys := range encryptionState {
 		resourceConfigs = append(resourceConfigs, apiserverconfigv1.ResourceConfiguration{
 			Resources: []string{gr.String()}, // we are forced to lose data here because this API is broken
 			Providers: stateToProviders(gr.Resource, grKeys),
 		})
+
+		// Collect KMS provider configs from read keys (which already include the write key).
+		// The same keyID appears across multiple resources (e.g. secrets and configmaps),
+		// so we skip duplicates since they share the same provider config.
+		for _, key := range grKeys.ReadKeys {
+			if key.HasKMSProvider() {
+				if kmsProviders == nil {
+					kmsProviders = map[string]*configv1.KMSConfig{}
+				}
+				if _, exists := kmsProviders[key.Key.Name]; !exists {
+					kmsProviders[key.Key.Name] = key.KMSConfig.Provider
+				}
+			}
+		}
 	}
 
 	// make sure our output is stable
@@ -46,7 +66,10 @@ func FromEncryptionState(encryptionState map[schema.GroupResource]state.GroupRes
 		return resourceConfigs[i].Resources[0] < resourceConfigs[j].Resources[0] // each resource has its own keys
 	})
 
-	return &Config{Encryption: &apiserverconfigv1.EncryptionConfiguration{Resources: resourceConfigs}}
+	return &Config{
+		Encryption:   &apiserverconfigv1.EncryptionConfiguration{Resources: resourceConfigs},
+		KMSProviders: kmsProviders,
+	}
 }
 
 // ToEncryptionState converts config to state.

--- a/pkg/operator/encryption/encryptiondata/secret.go
+++ b/pkg/operator/encryption/encryptiondata/secret.go
@@ -1,12 +1,19 @@
 package encryptiondata
 
 import (
+	"encoding/json"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+<<<<<<< HEAD
 	"github.com/openshift/library-go/pkg/operator/encryption/encoding"
+=======
+	configv1 "github.com/openshift/api/config/v1"
+
+	"github.com/openshift/library-go/pkg/operator/encryption/kms"
+>>>>>>> 639dafc7a (Carry kms-provider-config into encryption-config Secret)
 	"github.com/openshift/library-go/pkg/operator/encryption/state"
 )
 
@@ -25,7 +32,33 @@ func FromSecret(encryptionConfigSecret *corev1.Secret) (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
+<<<<<<< HEAD
 	return &Config{Encryption: encryptionConfig}, nil
+=======
+
+	encryptionConfig, ok := encryptionConfigObj.(*apiserverconfigv1.EncryptionConfiguration)
+	if !ok {
+		return nil, fmt.Errorf("unexpected wrong type %T", encryptionConfigObj)
+	}
+
+	var kmsProviders map[string]*configv1.KMSConfig
+	for key, value := range encryptionConfigSecret.Data {
+		keyID, ok := kms.ProviderConfigKeyID(key)
+		if !ok {
+			continue
+		}
+		providerConfig := &configv1.KMSConfig{}
+		if err := json.Unmarshal(value, providerConfig); err != nil {
+			return nil, fmt.Errorf("failed to decode KMS provider config for key %s: %w", keyID, err)
+		}
+		if kmsProviders == nil {
+			kmsProviders = map[string]*configv1.KMSConfig{}
+		}
+		kmsProviders[keyID] = providerConfig
+	}
+
+	return &Config{Encryption: encryptionConfig, KMSProviders: kmsProviders}, nil
+>>>>>>> 639dafc7a (Carry kms-provider-config into encryption-config Secret)
 }
 
 func ToSecret(ns, name string, secretData *Config) (*corev1.Secret, error) {
@@ -38,7 +71,7 @@ func ToSecret(ns, name string, secretData *Config) (*corev1.Secret, error) {
 		return nil, fmt.Errorf("failed to encode the encryption config: %v", err)
 	}
 
-	return &corev1.Secret{
+	s := &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Secret",
 			APIVersion: corev1.SchemeGroupVersion.String(),
@@ -55,5 +88,15 @@ func ToSecret(ns, name string, secretData *Config) (*corev1.Secret, error) {
 			EncryptionConfSecretName: rawEncryptionCfg,
 		},
 		Type: corev1.SecretTypeOpaque,
-	}, nil
+	}
+
+	for keyID, providerConfig := range secretData.KMSProviders {
+		providerJSON, err := json.Marshal(providerConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode KMS provider config for key %s: %v", keyID, err)
+		}
+		s.Data[kms.ProviderConfigDataKey(keyID)] = providerJSON
+	}
+
+	return s, nil
 }

--- a/pkg/operator/encryption/encryptiondata/secret.go
+++ b/pkg/operator/encryption/encryptiondata/secret.go
@@ -7,13 +7,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-<<<<<<< HEAD
-	"github.com/openshift/library-go/pkg/operator/encryption/encoding"
-=======
 	configv1 "github.com/openshift/api/config/v1"
 
+	"github.com/openshift/library-go/pkg/operator/encryption/encoding"
 	"github.com/openshift/library-go/pkg/operator/encryption/kms"
->>>>>>> 639dafc7a (Carry kms-provider-config into encryption-config Secret)
 	"github.com/openshift/library-go/pkg/operator/encryption/state"
 )
 
@@ -32,15 +29,6 @@ func FromSecret(encryptionConfigSecret *corev1.Secret) (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
-<<<<<<< HEAD
-	return &Config{Encryption: encryptionConfig}, nil
-=======
-
-	encryptionConfig, ok := encryptionConfigObj.(*apiserverconfigv1.EncryptionConfiguration)
-	if !ok {
-		return nil, fmt.Errorf("unexpected wrong type %T", encryptionConfigObj)
-	}
-
 	var kmsProviders map[string]*configv1.KMSConfig
 	for key, value := range encryptionConfigSecret.Data {
 		keyID, ok := kms.ProviderConfigKeyID(key)
@@ -58,7 +46,6 @@ func FromSecret(encryptionConfigSecret *corev1.Secret) (*Config, error) {
 	}
 
 	return &Config{Encryption: encryptionConfig, KMSProviders: kmsProviders}, nil
->>>>>>> 639dafc7a (Carry kms-provider-config into encryption-config Secret)
 }
 
 func ToSecret(ns, name string, secretData *Config) (*corev1.Secret, error) {

--- a/pkg/operator/encryption/encryptiondata/secret.go
+++ b/pkg/operator/encryption/encryptiondata/secret.go
@@ -1,7 +1,6 @@
 package encryptiondata
 
 import (
-	"encoding/json"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -35,8 +34,8 @@ func FromSecret(encryptionConfigSecret *corev1.Secret) (*Config, error) {
 		if !ok {
 			continue
 		}
-		providerConfig := &configv1.KMSConfig{}
-		if err := json.Unmarshal(value, providerConfig); err != nil {
+		providerConfig, err := encoding.DecodeKMSConfig(value)
+		if err != nil {
 			return nil, fmt.Errorf("failed to decode KMS provider config for key %s: %w", keyID, err)
 		}
 		if kmsProviders == nil {
@@ -78,7 +77,7 @@ func ToSecret(ns, name string, secretData *Config) (*corev1.Secret, error) {
 	}
 
 	for keyID, providerConfig := range secretData.KMSProviders {
-		providerJSON, err := json.Marshal(providerConfig)
+		providerJSON, err := encoding.EncodeKMSConfig(providerConfig)
 		if err != nil {
 			return nil, fmt.Errorf("failed to encode KMS provider config for key %s: %v", keyID, err)
 		}

--- a/pkg/operator/encryption/kms/helpers.go
+++ b/pkg/operator/encryption/kms/helpers.go
@@ -2,11 +2,31 @@ package kms
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/openshift/api/features"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	corev1 "k8s.io/api/core/v1"
 )
+
+const providerConfigDataKeyFormat = "kms-provider-config-%s"
+
+var providerConfigKeyRegex = regexp.MustCompile(`^kms-provider-config-(\d+)$`)
+
+// ProviderConfigDataKey constructs the data key for storing a KMS provider config in the encryption-config Secret.
+func ProviderConfigDataKey(keyID string) string {
+	return fmt.Sprintf(providerConfigDataKeyFormat, keyID)
+}
+
+// ProviderConfigKeyID extracts the keyID from a kms-provider-config data key.
+// Returns the keyID and true if the key matches the "kms-provider-config-<keyID>" pattern.
+func ProviderConfigKeyID(dataKey string) (string, bool) {
+	matches := providerConfigKeyRegex.FindStringSubmatch(dataKey)
+	if len(matches) != 2 {
+		return "", false
+	}
+	return matches[1], true
+}
 
 // AddKMSPluginVolumeAndMountToPodSpec conditionally adds the KMS plugin volume mount to the specified container.
 // It assumes the pod spec does not already contain the KMS volume or mount; no deduplication is performed.

--- a/pkg/operator/encryption/kms/helpers_test.go
+++ b/pkg/operator/encryption/kms/helpers_test.go
@@ -12,6 +12,58 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestProviderConfigKeyID(t *testing.T) {
+	tests := []struct {
+		name      string
+		dataKey   string
+		wantKeyID string
+		wantOK    bool
+	}{
+		{
+			name:      "valid key",
+			dataKey:   "kms-provider-config-1",
+			wantKeyID: "1",
+			wantOK:    true,
+		},
+		{
+			name:      "valid key with large ID",
+			dataKey:   "kms-provider-config-42",
+			wantKeyID: "42",
+			wantOK:    true,
+		},
+		{
+			name:    "encryption-config key",
+			dataKey: "encryption-config",
+			wantOK:  false,
+		},
+		{
+			name:    "non-integer keyID",
+			dataKey: "kms-provider-config-abc",
+			wantOK:  false,
+		},
+		{
+			name:    "missing keyID",
+			dataKey: "kms-provider-config-",
+			wantOK:  false,
+		},
+		{
+			name:    "empty string",
+			dataKey: "",
+			wantOK:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			keyID, ok := ProviderConfigKeyID(tt.dataKey)
+			require.Equal(t, tt.wantOK, ok)
+			if ok {
+				require.Equal(t, tt.wantKeyID, keyID)
+			}
+		})
+	}
+}
+
 func TestAddKMSPluginVolume(t *testing.T) {
 	directoryOrCreate := corev1.HostPathDirectoryOrCreate
 

--- a/pkg/operator/encryption/secrets/secrets.go
+++ b/pkg/operator/encryption/secrets/secrets.go
@@ -8,6 +8,10 @@ import (
 	"strconv"
 	"time"
 
+<<<<<<< HEAD
+=======
+	configv1 "github.com/openshift/api/config/v1"
+>>>>>>> 639dafc7a (Carry kms-provider-config into encryption-config Secret)
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -77,8 +81,13 @@ func ToKeyState(s *corev1.Secret) (state.KeyState, error) {
 			return state.KeyState{}, fmt.Errorf("%s can not be empty, when mode is KMS", EncryptionSecretKMSEncryptionConfig)
 		}
 		if v, ok := s.Data[EncryptionSecretKMSProviderConfig]; ok && len(v) > 0 {
+<<<<<<< HEAD
 			kmsConfig, err := encoding.DecodeKMSConfig(v)
 			if err != nil {
+=======
+			providerConfig := &configv1.KMSConfig{}
+			if err := json.Unmarshal(v, providerConfig); err != nil {
+>>>>>>> 639dafc7a (Carry kms-provider-config into encryption-config Secret)
 				return state.KeyState{}, fmt.Errorf("secret %s/%s has invalid %s data: %w", s.Namespace, s.Name, EncryptionSecretKMSProviderConfig, err)
 			}
 			key.KMSConfig.Provider = kmsConfig

--- a/pkg/operator/encryption/secrets/secrets.go
+++ b/pkg/operator/encryption/secrets/secrets.go
@@ -8,10 +8,6 @@ import (
 	"strconv"
 	"time"
 
-<<<<<<< HEAD
-=======
-	configv1 "github.com/openshift/api/config/v1"
->>>>>>> 639dafc7a (Carry kms-provider-config into encryption-config Secret)
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -81,13 +77,8 @@ func ToKeyState(s *corev1.Secret) (state.KeyState, error) {
 			return state.KeyState{}, fmt.Errorf("%s can not be empty, when mode is KMS", EncryptionSecretKMSEncryptionConfig)
 		}
 		if v, ok := s.Data[EncryptionSecretKMSProviderConfig]; ok && len(v) > 0 {
-<<<<<<< HEAD
 			kmsConfig, err := encoding.DecodeKMSConfig(v)
 			if err != nil {
-=======
-			providerConfig := &configv1.KMSConfig{}
-			if err := json.Unmarshal(v, providerConfig); err != nil {
->>>>>>> 639dafc7a (Carry kms-provider-config into encryption-config Secret)
 				return state.KeyState{}, fmt.Errorf("secret %s/%s has invalid %s data: %w", s.Namespace, s.Name, EncryptionSecretKMSProviderConfig, err)
 			}
 			key.KMSConfig.Provider = kmsConfig

--- a/pkg/operator/encryption/secrets/secrets_test.go
+++ b/pkg/operator/encryption/secrets/secrets_test.go
@@ -15,6 +15,21 @@ import (
 	"github.com/openshift/library-go/pkg/operator/encryption/state"
 )
 
+var defaultKMSProviderConfig = &configv1.KMSConfig{
+	Type: configv1.VaultKMSProvider,
+	Vault: configv1.VaultKMSConfig{
+		KMSPluginImage: "registry.example.com/kms-plugin@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+		VaultAddress:   "https://vault.example.com",
+		Authentication: configv1.VaultAuthentication{
+			Type: configv1.VaultAuthenticationTypeAppRole,
+			AppRole: configv1.VaultAppRoleAuthentication{
+				Secret: configv1.VaultSecretReference{Name: "vault-approle-secret"},
+			},
+		},
+		TransitKey: "test-transit-key",
+	},
+}
+
 func TestRoundtrip(t *testing.T) {
 	now, _ := time.Parse(time.RFC3339, time.Now().Format(time.RFC3339))
 
@@ -132,7 +147,7 @@ func TestRoundtrip(t *testing.T) {
 						Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
 						Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 					},
-					Provider: &configv1.KMSConfig{},
+					Provider: defaultKMSProviderConfig,
 				},
 				Migrated: state.MigrationState{
 					Timestamp: now,
@@ -163,7 +178,7 @@ func TestRoundtrip(t *testing.T) {
 						Endpoint:   "unix:///var/run/kmsplugin/kms-2.sock",
 						Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 					},
-					Provider: &configv1.KMSConfig{},
+					Provider: defaultKMSProviderConfig,
 				},
 			},
 		},

--- a/pkg/operator/encryption/state/types.go
+++ b/pkg/operator/encryption/state/types.go
@@ -3,7 +3,7 @@ package state
 import (
 	"time"
 
-	v1 "github.com/openshift/api/config/v1"
+	configv1 "github.com/openshift/api/config/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
 )
@@ -59,7 +59,7 @@ type KMSConfig struct {
 	Encryption *apiserverconfigv1.KMSConfiguration
 
 	// Provider stores KMS provider specific configurations
-	Provider *v1.KMSConfig
+	Provider *configv1.KMSConfig
 }
 
 type MigrationState struct {

--- a/pkg/operator/encryption/testing/helpers.go
+++ b/pkg/operator/encryption/testing/helpers.go
@@ -114,29 +114,7 @@ var DefaultKMSProviderConfig = &configv1.KMSConfig{
 }
 
 func CreateEncryptionKeySecretWithKMSConfig(targetNS string, grs []schema.GroupResource, keyID uint64) *corev1.Secret {
-<<<<<<< HEAD
-	emptyKey := make([]byte, 16)
-	secret := CreateEncryptionKeySecretWithRawKeyWithMode(targetNS, grs, keyID, emptyKey, "KMS")
-	kmsConfig := &apiserverconfigv1.KMSConfiguration{
-		APIVersion: "v2",
-		Name:       fmt.Sprintf("%d", keyID),
-		Endpoint:   fmt.Sprintf("unix:///var/run/kmsplugin/kms-%d.sock", keyID),
-		Timeout:    &metav1.Duration{Duration: 10 * time.Second},
-	}
-	encData, err := encoding.EncodeKMSConfiguration(kmsConfig)
-	if err != nil {
-		panic(fmt.Sprintf("failed to encode KMS encryption config: %v", err))
-	}
-	secret.Data[encryptionSecretKMSEncryptionConfigForTest] = encData
-	provData, err := encoding.EncodeKMSConfig(&configv1.KMSConfig{})
-	if err != nil {
-		panic(fmt.Sprintf("failed to encode KMS provider config: %v", err))
-	}
-	secret.Data[encryptionSecretKMSProviderConfigForTest] = provData
-	return secret
-=======
 	return CreateEncryptionKeySecretWithCustomKMSConfig(targetNS, grs, keyID, DefaultKMSProviderConfig)
->>>>>>> 639dafc7a (Carry kms-provider-config into encryption-config Secret)
 }
 
 func CreateMigratedEncryptionKeySecretWithKMSConfig(targetNS string, grs []schema.GroupResource, keyID uint64, ts time.Time) *corev1.Secret {
@@ -158,10 +136,16 @@ func CreateEncryptionKeySecretWithCustomKMSConfig(targetNS string, grs []schema.
 		Endpoint:   fmt.Sprintf("unix:///var/run/kmsplugin/kms-%d.sock", keyID),
 		Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 	}
-	kmsConfigJSON, _ := json.Marshal(kmsConfig)
-	secret.Data[encryptionSecretKMSEncryptionConfigForTest] = kmsConfigJSON
-	providerConfigJSON, _ := json.Marshal(providerConfig)
-	secret.Data[encryptionSecretKMSProviderConfigForTest] = providerConfigJSON
+	encData, err := encoding.EncodeKMSConfiguration(kmsConfig)
+	if err != nil {
+		panic(fmt.Sprintf("failed to encode KMS encryption config: %v", err))
+	}
+	secret.Data[encryptionSecretKMSEncryptionConfigForTest] = encData
+	provData, err := encoding.EncodeKMSConfig(providerConfig)
+	if err != nil {
+		panic(fmt.Sprintf("failed to encode KMS provider config: %v", err))
+	}
+	secret.Data[encryptionSecretKMSProviderConfigForTest] = provData
 	return secret
 }
 

--- a/pkg/operator/encryption/testing/helpers.go
+++ b/pkg/operator/encryption/testing/helpers.go
@@ -98,7 +98,23 @@ func CreateExpiredMigratedEncryptionKeySecretWithRawKey(targetNS string, grs []s
 	return CreateMigratedEncryptionKeySecretWithRawKey(targetNS, grs, keyID, rawKey, time.Now().Add(-(time.Hour*24*7 + time.Hour)))
 }
 
+var DefaultKMSProviderConfig = &configv1.KMSConfig{
+	Type: configv1.VaultKMSProvider,
+	Vault: configv1.VaultKMSConfig{
+		KMSPluginImage: "registry.example.com/kms-plugin@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+		VaultAddress:   "https://vault.example.com",
+		Authentication: configv1.VaultAuthentication{
+			Type: configv1.VaultAuthenticationTypeAppRole,
+			AppRole: configv1.VaultAppRoleAuthentication{
+				Secret: configv1.VaultSecretReference{Name: "vault-approle-secret"},
+			},
+		},
+		TransitKey: "test-transit-key",
+	},
+}
+
 func CreateEncryptionKeySecretWithKMSConfig(targetNS string, grs []schema.GroupResource, keyID uint64) *corev1.Secret {
+<<<<<<< HEAD
 	emptyKey := make([]byte, 16)
 	secret := CreateEncryptionKeySecretWithRawKeyWithMode(targetNS, grs, keyID, emptyKey, "KMS")
 	kmsConfig := &apiserverconfigv1.KMSConfiguration{
@@ -118,6 +134,9 @@ func CreateEncryptionKeySecretWithKMSConfig(targetNS string, grs []schema.GroupR
 	}
 	secret.Data[encryptionSecretKMSProviderConfigForTest] = provData
 	return secret
+=======
+	return CreateEncryptionKeySecretWithCustomKMSConfig(targetNS, grs, keyID, DefaultKMSProviderConfig)
+>>>>>>> 639dafc7a (Carry kms-provider-config into encryption-config Secret)
 }
 
 func CreateMigratedEncryptionKeySecretWithKMSConfig(targetNS string, grs []schema.GroupResource, keyID uint64, ts time.Time) *corev1.Secret {
@@ -128,6 +147,22 @@ func CreateMigratedEncryptionKeySecretWithKMSConfig(targetNS string, grs []schem
 
 func CreateExpiredMigratedEncryptionKeySecretWithKMSConfig(targetNS string, grs []schema.GroupResource, keyID uint64) *corev1.Secret {
 	return CreateMigratedEncryptionKeySecretWithKMSConfig(targetNS, grs, keyID, time.Now().Add(-(time.Hour*24*7 + time.Hour)))
+}
+
+func CreateEncryptionKeySecretWithCustomKMSConfig(targetNS string, grs []schema.GroupResource, keyID uint64, providerConfig *configv1.KMSConfig) *corev1.Secret {
+	emptyKey := make([]byte, 16)
+	secret := CreateEncryptionKeySecretWithRawKeyWithMode(targetNS, grs, keyID, emptyKey, "KMS")
+	kmsConfig := &apiserverconfigv1.KMSConfiguration{
+		APIVersion: "v2",
+		Name:       fmt.Sprintf("%d", keyID),
+		Endpoint:   fmt.Sprintf("unix:///var/run/kmsplugin/kms-%d.sock", keyID),
+		Timeout:    &metav1.Duration{Duration: 10 * time.Second},
+	}
+	kmsConfigJSON, _ := json.Marshal(kmsConfig)
+	secret.Data[encryptionSecretKMSEncryptionConfigForTest] = kmsConfigJSON
+	providerConfigJSON, _ := json.Marshal(providerConfig)
+	secret.Data[encryptionSecretKMSProviderConfigForTest] = providerConfigJSON
+	return secret
 }
 
 func CreateDummyKubeAPIPod(name, namespace string, nodeName string) *corev1.Pod {

--- a/test/e2e-encryption/encryption_test.go
+++ b/test/e2e-encryption/encryption_test.go
@@ -38,7 +38,11 @@ import (
 	"github.com/openshift/library-go/pkg/operator/encryption"
 	"github.com/openshift/library-go/pkg/operator/encryption/controllers"
 	"github.com/openshift/library-go/pkg/operator/encryption/controllers/migrators"
+<<<<<<< HEAD
 	"github.com/openshift/library-go/pkg/operator/encryption/encoding"
+=======
+	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
+>>>>>>> 639dafc7a (Carry kms-provider-config into encryption-config Secret)
 	"github.com/openshift/library-go/pkg/operator/encryption/secrets"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/genericoperatorclient"
@@ -266,6 +270,45 @@ func TestEncryptionIntegration(tt *testing.T) {
 		require.NoError(t, err)
 	}
 
+	verifyKMSProviders := func() {
+		t.Helper()
+		encryptionConfigSecret, err := kubeClient.CoreV1().Secrets("openshift-config-managed").Get(ctx, fmt.Sprintf("encryption-config-%s", component), metav1.GetOptions{})
+		require.NoError(t, err)
+		cfg, err := encryptiondata.FromSecret(encryptionConfigSecret)
+		require.NoError(t, err)
+
+		expectedKeyIDs := map[string]bool{}
+		for _, rc := range cfg.Encryption.Resources {
+			for _, p := range rc.Providers {
+				if p.KMS != nil {
+					parts := strings.SplitN(p.KMS.Name, "_", 2)
+					require.Len(t, parts, 2, "unexpected KMS provider name format: %s", p.KMS.Name)
+					expectedKeyIDs[parts[0]] = true
+				}
+			}
+		}
+
+		for keyID := range expectedKeyIDs {
+			providerConfig, ok := cfg.KMSProviders[keyID]
+			if !ok {
+				t.Fatalf("expected kms-provider-config for keyID %s but not found in encryption-config secret", keyID)
+			}
+
+			keySecret, err := kubeClient.CoreV1().Secrets("openshift-config-managed").Get(ctx, fmt.Sprintf("encryption-key-%s-%s", component, keyID), metav1.GetOptions{})
+			require.NoError(t, err)
+			keyProviderData := keySecret.Data[secrets.EncryptionSecretKMSProviderConfig]
+			require.NotEmpty(t, keyProviderData, "key secret %s missing kms-provider-config data", keyID)
+			var keyProviderConfig configv1.KMSConfig
+			require.NoError(t, json.Unmarshal(keyProviderData, &keyProviderConfig))
+			require.Equal(t, keyProviderConfig, *providerConfig, "kms-provider-config for keyID %s in encryption-config secret does not match key secret", keyID)
+		}
+		for keyID := range cfg.KMSProviders {
+			if !expectedKeyIDs[keyID] {
+				t.Fatalf("unexpected kms-provider-config for keyID %s in encryption-config secret", keyID)
+			}
+		}
+	}
+
 	t.Logf("Wait for initial Encrypted condition")
 	waitForConditionStatus("Encrypted", operatorv1.ConditionFalse)
 
@@ -426,6 +469,7 @@ func TestEncryptionIntegration(tt *testing.T) {
 	)
 	waitForMigration("8")
 	waitForConditionStatus("Encrypted", operatorv1.ConditionTrue)
+	verifyKMSProviders()
 
 	t.Logf("Verify KMS key secret contains provider config")
 	kmsKeySecret, err := kubeClient.CoreV1().Secrets("openshift-config-managed").Get(ctx, fmt.Sprintf("encryption-key-%s-8", component), metav1.GetOptions{})
@@ -448,6 +492,7 @@ func TestEncryptionIntegration(tt *testing.T) {
 		fmt.Sprintf("kubeapiservers.operator.openshift.io=aescbc:9,kms:%s,identity;kubeschedulers.operator.openshift.io=aescbc:9,kms:%s,identity", kms8, kms8Sched),
 	)
 	waitForConditionStatus("Encrypted", operatorv1.ConditionTrue)
+	verifyKMSProviders()
 
 	t.Logf("Switch back to KMS")
 	_, err = fakeApiServerClient.Patch(ctx, "cluster", types.MergePatchType, []byte(`{"spec":{"encryption":{"type":"KMS","kms":{"type":"Vault","vault":{"kmsPluginImage":"registry.example.com/kms-plugin@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890","vaultAddress":"https://vault.example.com","authentication":{"type":"AppRole","appRole":{"secret":{"name":"vault-approle-secret"}}},"transitKey":"test-transit-key"}}}}}`), metav1.PatchOptions{})
@@ -462,6 +507,7 @@ func TestEncryptionIntegration(tt *testing.T) {
 	)
 	waitForMigration("10")
 	waitForConditionStatus("Encrypted", operatorv1.ConditionTrue)
+	verifyKMSProviders()
 
 	t.Logf("Rotate KMS key via aescbc (KMS->AESCBC->KMS)")
 	_, err = fakeApiServerClient.Patch(ctx, "cluster", types.MergePatchType, []byte(`{"spec":{"encryption":{"type":"aescbc","kms":null}}}`), metav1.PatchOptions{})
@@ -473,6 +519,7 @@ func TestEncryptionIntegration(tt *testing.T) {
 		fmt.Sprintf("kubeapiservers.operator.openshift.io=aescbc:11,kms:%s,identity;kubeschedulers.operator.openshift.io=aescbc:11,kms:%s,identity", kms10, kms10Sched),
 	)
 	waitForConditionStatus("Encrypted", operatorv1.ConditionTrue)
+	verifyKMSProviders()
 
 	t.Logf("Switch back to KMS after rotation")
 	_, err = fakeApiServerClient.Patch(ctx, "cluster", types.MergePatchType, []byte(`{"spec":{"encryption":{"type":"KMS","kms":{"type":"Vault","vault":{"kmsPluginImage":"registry.example.com/kms-plugin@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890","vaultAddress":"https://vault.example.com","authentication":{"type":"AppRole","appRole":{"secret":{"name":"vault-approle-secret"}}},"transitKey":"test-transit-key"}}}}}`), metav1.PatchOptions{})
@@ -487,6 +534,7 @@ func TestEncryptionIntegration(tt *testing.T) {
 	)
 	waitForMigration("12")
 	waitForConditionStatus("Encrypted", operatorv1.ConditionTrue)
+	verifyKMSProviders()
 
 	t.Logf("Delete the encryption-config while in KMS mode")
 	_, err = kubeClient.CoreV1().Secrets("openshift-config-managed").Patch(ctx, fmt.Sprintf("encryption-config-%s", component), types.JSONPatchType, []byte(`[{"op":"remove","path":"/metadata/finalizers"}]`), metav1.PatchOptions{})

--- a/test/e2e-encryption/encryption_test.go
+++ b/test/e2e-encryption/encryption_test.go
@@ -38,11 +38,8 @@ import (
 	"github.com/openshift/library-go/pkg/operator/encryption"
 	"github.com/openshift/library-go/pkg/operator/encryption/controllers"
 	"github.com/openshift/library-go/pkg/operator/encryption/controllers/migrators"
-<<<<<<< HEAD
 	"github.com/openshift/library-go/pkg/operator/encryption/encoding"
-=======
 	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
->>>>>>> 639dafc7a (Carry kms-provider-config into encryption-config Secret)
 	"github.com/openshift/library-go/pkg/operator/encryption/secrets"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/genericoperatorclient"
@@ -298,9 +295,9 @@ func TestEncryptionIntegration(tt *testing.T) {
 			require.NoError(t, err)
 			keyProviderData := keySecret.Data[secrets.EncryptionSecretKMSProviderConfig]
 			require.NotEmpty(t, keyProviderData, "key secret %s missing kms-provider-config data", keyID)
-			var keyProviderConfig configv1.KMSConfig
-			require.NoError(t, json.Unmarshal(keyProviderData, &keyProviderConfig))
-			require.Equal(t, keyProviderConfig, *providerConfig, "kms-provider-config for keyID %s in encryption-config secret does not match key secret", keyID)
+			keyProviderConfig, err := encoding.DecodeKMSConfig(keyProviderData)
+			require.NoError(t, err)
+			require.Equal(t, *keyProviderConfig, *providerConfig, "kms-provider-config for keyID %s in encryption-config secret does not match key secret", keyID)
 		}
 		for keyID := range cfg.KMSProviders {
 			if !expectedKeyIDs[keyID] {


### PR DESCRIPTION
This is a fork of https://github.com/openshift/library-go/pull/2163 for testing purposes.

Do not review.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Encryption config and key secrets now include explicit per-key KMS provider configurations for accurate provider wiring and validation.
  * Integration tests enhanced to verify KMS provider wiring across multiple encryption-mode transitions.

* **Refactor**
  * Internal config handling and test utilities standardized for consistent KMS provider configuration encoding.

* **Tests**
  * Added unit tests for KMS provider config key parsing and expanded test scenarios for KMS provider coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->