### PR TITLE
OCPBUGS-78016: Add SkipInClusterAuthenticationLookup to skip front-proxy auth configmap read

### DIFF
--- a/pkg/config/serving/server.go
+++ b/pkg/config/serving/server.go
@@ -23,7 +23,7 @@ import (
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 )
 
-func ToServerConfig(ctx context.Context, servingInfo configv1.HTTPServingInfo, authenticationConfig operatorv1alpha1.DelegatedAuthentication, authorizationConfig operatorv1alpha1.DelegatedAuthorization, kubeConfigFile string, kubeClient *kubernetes.Clientset, le *configv1.LeaderElection, enableHTTP2 bool, versionInfo *version.Info) (*genericapiserver.Config, error) {
+func ToServerConfig(ctx context.Context, servingInfo configv1.HTTPServingInfo, authenticationConfig operatorv1alpha1.DelegatedAuthentication, authorizationConfig operatorv1alpha1.DelegatedAuthorization, kubeConfigFile string, kubeClient *kubernetes.Clientset, le *configv1.LeaderElection, enableHTTP2 bool, skipInClusterAuthLookup bool, versionInfo *version.Info) (*genericapiserver.Config, error) {
 	scheme := runtime.NewScheme()
 	metav1.AddToGroupVersion(scheme, metav1.SchemeGroupVersion)
 	config := genericapiserver.NewConfig(serializer.NewCodecFactory(scheme))
@@ -45,6 +45,7 @@ func ToServerConfig(ctx context.Context, servingInfo configv1.HTTPServingInfo, a
 		authenticationOptions.RemoteKubeConfigFile = kubeConfigFile
 		// the platform generally uses 30s for /metrics scraping, avoid API request for every other /metrics request to the component
 		authenticationOptions.CacheTTL = 35 * time.Second
+		authenticationOptions.SkipInClusterLookup = skipInClusterAuthLookup
 
 		// In some cases the API server can return connection refused when getting the "extension-apiserver-authentication"
 		// config map.

--- a/pkg/controller/controllercmd/builder.go
+++ b/pkg/controller/controllercmd/builder.go
@@ -104,6 +104,8 @@ type ControllerBuilder struct {
 
 	// Allow enabling HTTP2
 	enableHTTP2 bool
+
+	skipInClusterAuthLookup bool
 }
 
 type TopologyDetector interface {
@@ -214,6 +216,13 @@ func (b *ControllerBuilder) WithHTTP2() *ControllerBuilder {
 	return b
 }
 
+// WithSkipInClusterAuthenticationLookup skips the synchronous read of the
+// extension-apiserver-authentication configmap during serving setup.
+func (b *ControllerBuilder) WithSkipInClusterAuthenticationLookup() *ControllerBuilder {
+	b.skipInClusterAuthLookup = true
+	return b
+}
+
 // WithHealthChecks adds a list of healthchecks to the server
 func (b *ControllerBuilder) WithHealthChecks(healthChecks ...healthz.HealthChecker) *ControllerBuilder {
 	b.healthChecks = append(b.healthChecks, healthChecks...)
@@ -311,7 +320,7 @@ func (b *ControllerBuilder) Run(ctx context.Context, config *unstructured.Unstru
 
 	var server *genericapiserver.GenericAPIServer
 	if b.servingInfo != nil {
-		serverConfig, err := serving.ToServerConfig(ctx, *b.servingInfo, *b.authenticationConfig, *b.authorizationConfig, kubeConfig, kubeClient, b.leaderElection, b.enableHTTP2, b.versionInfo)
+		serverConfig, err := serving.ToServerConfig(ctx, *b.servingInfo, *b.authenticationConfig, *b.authorizationConfig, kubeConfig, kubeClient, b.leaderElection, b.enableHTTP2, b.skipInClusterAuthLookup, b.versionInfo)
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/controllercmd/cmd.go
+++ b/pkg/controller/controllercmd/cmd.go
@@ -56,6 +56,13 @@ type ControllerCommandConfig struct {
 	// DisableLeaderElection allows leader election to be suspended
 	DisableLeaderElection bool
 
+	// SkipInClusterAuthenticationLookup skips the synchronous read of the
+	// extension-apiserver-authentication configmap during serving setup.
+	// Use this for sidecar controllers that serve metrics/health but don't
+	// need request-header (front-proxy) authentication from the aggregation layer.
+	// Bearer-token authentication via TokenReview is preserved.
+	SkipInClusterAuthenticationLookup bool
+
 	// LeaseDuration is the duration that non-leader candidates will
 	// wait to force acquire leadership. This is measured against time of
 	// last observed ack.
@@ -340,6 +347,9 @@ func (c *ControllerCommandConfig) StartController(ctx context.Context) error {
 		builder = builder.WithServer(config.ServingInfo, config.Authentication, config.Authorization)
 		if c.EnableHTTP2 {
 			builder = builder.WithHTTP2()
+		}
+		if c.SkipInClusterAuthenticationLookup {
+			builder = builder.WithSkipInClusterAuthenticationLookup()
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Static pod sidecar controllers (check-endpoints, cert-regeneration, cert-recovery) set `DisableServing=true` to work around a startup race where the authentication setup synchronously reads the `extension-apiserver-authentication` configmap before kube-apiserver has created it.
- `DisableServing=true` is a sledgehammer that also kills metrics, health checks, and readiness probes.
- Plumb the upstream `DelegatingAuthenticationOptions.SkipInClusterLookup` field through the serving stack (`server.go` → `builder.go` → `cmd.go`) so sidecars can skip the configmap read while preserving bearer-token authentication via TokenReview.

## Usage
```go
controllerConfig := controllercmd.NewControllerCommandConfig(...)
controllerConfig.SkipInClusterAuthenticationLookup = true
// DisableServing can now be removed (defaults to false)
```

## Test plan
- [x] `go build ./...` compiles
- [x] `go test ./pkg/controller/controllercmd/...` passes
- [x] `go vet ./pkg/config/serving/ ./pkg/controller/controllercmd/` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration option to skip in-cluster authentication lookup during server initialization, enabling more flexible authentication setup while maintaining bearer token authentication support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->