### PR TITLE
pkg/operator/encryption/controllers: NewKMSPreflightController scaffolding

### DIFF
--- a/pkg/operator/encryption/controllers/kms_preflight_controller.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller.go
@@ -1,0 +1,166 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
+	applyoperatorv1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+type kmsPreflightController struct {
+	controllerInstanceName string
+
+	operatorClient  operatorv1helpers.OperatorClient
+	apiServerClient configv1client.APIServerInterface
+
+	provider                 Provider
+	preconditionsFulfilledFn preconditionsFulfilled
+}
+
+// NewKMSPreflightController validates KMS configuration before a key is created.
+//
+// Coordination with the key-controller:
+//
+// The key-controller writes a hash of the current KMS config to operator status
+// as the EncryptionKMSPreflightRequired condition (hash in the message).
+// This controller reads that hash, runs preflight checks, and on success sets
+// the EncryptionKMSPreflightSucceeded condition (same hash in the message).
+// The key-controller waits for the two hashes to match before creating a key.
+//
+// This is the same pattern used by the revision and installer controllers:
+// the revision controller writes LatestAvailableRevision, the installer
+// controller reads it and acts.
+//
+// Without this protocol the following race can occur:
+//  1. Preflight passes for config A, hash A written to operator status.
+//  2. Key-controller reads hash A, starts creating a key for config A.
+//  3. Config changes to B.
+//  4. Preflight controller syncs, sees config B, does not yet see the key
+//     for A (key-controller is in the process of creating the key),
+//     runs preflight for B, overwrites status with hash B.
+//  5. The key created in step 2 was for config A but status now says B.
+//
+// Letting the key-controller own EncryptionKMSPreflightRequired and this
+// controller own EncryptionKMSPreflightSucceeded solves this. If the config
+// changes mid-flight the key-controller posts a new hash and the preflight
+// controller sees the mismatch and waits.
+//
+// Example 1: config changes before key is created
+//  1. User creates KMS config A.
+//  2. Key-controller computes hash A, writes EncryptionKMSPreflightRequired=A.
+//  3. Preflight controller sees required=A, starts checking A.
+//  4. User changes config to A2 (minor variation, different hash).
+//  5. Key-controller computes hash A2, writes EncryptionKMSPreflightRequired=A2.
+//  6. Preflight controller sees required=A2, starts checking A2.
+//  7. Key-controller does not create a key until succeeded=A2.
+//
+// Example 2: config changes after key is created
+//  1. User creates KMS config A.
+//  2. Key-controller computes hash A, writes EncryptionKMSPreflightRequired=A.
+//  3. Preflight controller checks A, succeeds, writes EncryptionKMSPreflightSucceeded=A.
+//  4. Key-controller sees required=A matches succeeded=A, creates key for A.
+//  5. User changes config to A2 (or B).
+//  6. Key-controller waits until the key for A completes the full cycle
+//     (read, write, migrated) before creating a new key. No preflight done
+//     at this stage.
+//
+// Preflight workload:
+//
+// A deployer interface abstracts the workload creation. Each operator provides
+// its own implementation that knows how to install, get status, clean up the
+// preflight workload, and wire the credentials needed to update pod status.
+// The workload type matches the API server it validates (static pod for kas-o,
+// Deployment for aggregated API servers).
+//
+// When an existing KMS plugin is already configured, the checker runs the new
+// plugin alongside the existing one to catch co-existence issues (e.g., metric
+// port collisions). When no plugin is configured yet, it runs the new plugin alone.
+// The sync method reads existing encryption key secrets to determine whether
+// a plugin is already configured.
+//
+// The pod uses readiness gates to post check results back to the controller.
+// To set the readiness gate condition, the pod PATCHes its own status using
+// credentials wired by the deployer.
+// The controller reads these enhanced pod statuses to update its own operator
+// status, which is propagated to end users.
+//
+// After a successful check the preflight pod is kept for a short period (e.g. 1h)
+// so that its logs can be inspected, then cleaned up by a subsequent sync.
+func NewKMSPreflightController(
+	instanceName string,
+	provider Provider,
+	preconditionsFulfilledFn preconditionsFulfilled,
+	operatorClient operatorv1helpers.OperatorClient,
+	apiServerClient configv1client.APIServerInterface,
+	apiServerInformer configv1informers.APIServerInformer,
+	eventRecorder events.Recorder,
+) factory.Controller {
+	c := &kmsPreflightController{
+		controllerInstanceName: factory.ControllerInstanceName(instanceName, "EncryptionKMSPreflight"),
+
+		operatorClient:  operatorClient,
+		apiServerClient: apiServerClient,
+
+		provider:                 provider,
+		preconditionsFulfilledFn: preconditionsFulfilledFn,
+	}
+
+	return factory.New().
+		WithSync(c.sync).
+		WithControllerInstanceName(c.controllerInstanceName).
+		ResyncEvery(time.Minute).
+		WithInformers(
+			apiServerInformer.Informer(),
+			operatorClient.Informer(),
+		).ToController(
+		c.controllerInstanceName,
+		eventRecorder.WithComponentSuffix("encryption-kms-preflight-controller"),
+	)
+}
+
+func (c *kmsPreflightController) sync(ctx context.Context, syncCtx factory.SyncContext) (err error) {
+	degradedCondition := applyoperatorv1.OperatorCondition().WithType("EncryptionKMSPreflightControllerDegraded")
+
+	defer func() {
+		if degradedCondition == nil {
+			return
+		}
+		status := applyoperatorv1.OperatorStatus().WithConditions(degradedCondition)
+		if applyError := c.operatorClient.ApplyOperatorStatus(ctx, c.controllerInstanceName, status); applyError != nil {
+			err = applyError
+		}
+	}()
+
+	if ready, err := shouldRunEncryptionController(c.operatorClient, c.preconditionsFulfilledFn, c.provider.ShouldRunEncryptionControllers); err != nil || !ready {
+		if err != nil {
+			degradedCondition = nil
+		} else {
+			degradedCondition = degradedCondition.WithStatus(operatorv1.ConditionFalse)
+		}
+		return err // we will get re-kicked when the operator status updates
+	}
+
+	preflightErr := c.runPreflightChecks(ctx)
+	if preflightErr != nil {
+		degradedCondition = degradedCondition.
+			WithStatus(operatorv1.ConditionTrue).
+			WithReason("Error").
+			WithMessage(preflightErr.Error())
+	} else {
+		degradedCondition = degradedCondition.
+			WithStatus(operatorv1.ConditionFalse)
+	}
+	return preflightErr
+}
+
+func (c *kmsPreflightController) runPreflightChecks(ctx context.Context) error {
+	return fmt.Errorf("implement me")
+}

--- a/pkg/operator/encryption/controllers/kms_preflight_controller_test.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller_test.go
@@ -1,0 +1,114 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/fake"
+	clocktesting "k8s.io/utils/clock/testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	configv1clientfake "github.com/openshift/client-go/config/clientset/versioned/fake"
+	configv1informers "github.com/openshift/client-go/config/informers/externalversions"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
+	encryptiontesting "github.com/openshift/library-go/pkg/operator/encryption/testing"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+func TestKMSPreflightController(t *testing.T) {
+	scenarios := []struct {
+		name              string
+		apiServerObjects  []runtime.Object
+		preconditionsMet  bool
+		expectedError     bool
+		expectedCondition *operatorv1.OperatorCondition
+	}{
+		{
+			name:             "preconditions not met, clears degraded",
+			apiServerObjects: []runtime.Object{&configv1.APIServer{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}}},
+			preconditionsMet: false,
+			expectedError:    false,
+			expectedCondition: &operatorv1.OperatorCondition{
+				Type:   "EncryptionKMSPreflightControllerDegraded",
+				Status: "False",
+			},
+		},
+		{
+			name:             "preconditions met, sync returns error from stub",
+			apiServerObjects: []runtime.Object{&configv1.APIServer{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}}},
+			preconditionsMet: true,
+			expectedError:    true,
+			expectedCondition: &operatorv1.OperatorCondition{
+				Type:    "EncryptionKMSPreflightControllerDegraded",
+				Status:  "True",
+				Reason:  "Error",
+				Message: "implement me",
+			},
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			fakeOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(
+				&operatorv1.StaticPodOperatorSpec{
+					OperatorSpec: operatorv1.OperatorSpec{
+						ManagementState: operatorv1.Managed,
+					},
+				},
+				&operatorv1.StaticPodOperatorStatus{
+					OperatorStatus: operatorv1.OperatorStatus{
+						Conditions: []operatorv1.OperatorCondition{
+							{
+								Type:   "EncryptionKMSPreflightControllerDegraded",
+								Status: "False",
+							},
+						},
+					},
+				},
+				nil,
+				nil,
+			)
+
+			fakeKubeClient := fake.NewSimpleClientset()
+			eventRecorder := events.NewRecorder(fakeKubeClient.CoreV1().Events("test"), "test-kmsPreflightController", &corev1.ObjectReference{}, clocktesting.NewFakePassiveClock(time.Now()))
+
+			fakeConfigClient := configv1clientfake.NewSimpleClientset(scenario.apiServerObjects...)
+			fakeApiServerClient := fakeConfigClient.ConfigV1().APIServers()
+			fakeApiServerInformer := configv1informers.NewSharedInformerFactory(fakeConfigClient, time.Minute).Config().V1().APIServers()
+
+			preconditionsFn := func() (bool, error) { return scenario.preconditionsMet, nil }
+			provider := newTestProvider([]schema.GroupResource{{Group: "", Resource: "secrets"}})
+
+			target := NewKMSPreflightController(
+				"test",
+				provider,
+				preconditionsFn,
+				fakeOperatorClient,
+				fakeApiServerClient,
+				fakeApiServerInformer,
+				eventRecorder,
+			)
+
+			err := target.Sync(context.TODO(), factory.NewSyncContext("test", eventRecorder))
+
+			if scenario.expectedError && err == nil {
+				t.Fatal("expected error but got nil")
+			}
+			if !scenario.expectedError && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if scenario.expectedCondition != nil {
+				encryptiontesting.ValidateOperatorClientConditions(t, fakeOperatorClient, []operatorv1.OperatorCondition{*scenario.expectedCondition})
+			}
+		})
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a KMS preflight controller that performs periodic readiness checks for encryption, surfaces degraded/error status to the operator, and records events so administrators can observe preflight failures and readiness progress before encrypted operations are enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->