### PR TITLE
CNTRLPLANE-3237: test/library/encryption/kms: add mock KMS plugin wrapper binary

### DIFF
--- a/test/library/encryption/kms/k8s-mock-plugin/Dockerfile
+++ b/test/library/encryption/kms/k8s-mock-plugin/Dockerfile
@@ -1,0 +1,13 @@
+ARG UPSTREAM_IMAGE=k8s-mock-kms-plugin-upstream
+
+FROM golang:1.25 AS builder
+WORKDIR /workspace
+COPY . .
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -mod=vendor \
+    -o mock-kms-plugin-wrapper \
+    ./test/library/encryption/kms/k8s-mock-plugin/wrapper/
+
+FROM ${UPSTREAM_IMAGE}
+COPY --from=builder /workspace/mock-kms-plugin-wrapper /usr/local/bin/vault-kube-kms
+ENTRYPOINT ["/usr/local/bin/vault-kube-kms"]

--- a/test/library/encryption/kms/k8s-mock-plugin/README.md
+++ b/test/library/encryption/kms/k8s-mock-plugin/README.md
@@ -1,6 +1,11 @@
 # k8s-mock-kms-plugin
 
-Builds the Kubernetes mock KMS plugin image from upstream source.
+Builds the Kubernetes mock KMS plugin image from upstream source
+and layers a thin wrapper binary on top.
+
+The final image contains both:
+- `/usr/local/bin/mock-kms-plugin` — the upstream binary (unchanged)
+- `/usr/local/bin/vault-kube-kms` — wrapper that accepts extra flags and execs the upstream binary
 
 ## Building
 
@@ -14,6 +19,15 @@ Optionally specify a different Kubernetes branch:
 
 ```bash
 K8S_BRANCH=release-1.34 ./build-from-k8s.sh
+```
+
+## Wrapper
+
+The wrapper initializes SoftHSM from embedded assets, validates
+flags, and execs the upstream binary.
+
+```bash
+vault-kube-kms -vault-address=https://vault.example.com -listen-address=unix:///var/run/kmsplugin/kms.sock
 ```
 
 ## Pushing to registry

--- a/test/library/encryption/kms/k8s-mock-plugin/build-from-k8s.sh
+++ b/test/library/encryption/kms/k8s-mock-plugin/build-from-k8s.sh
@@ -2,9 +2,11 @@
 set -euo pipefail
 
 readonly K8S_REPO_URL="https://github.com/kubernetes/kubernetes.git"
+readonly UPSTREAM_IMAGE_TAG="k8s-mock-kms-plugin-upstream"
 readonly IMAGE_TAG="k8s-mock-kms-plugin"
 K8S_BRANCH="${K8S_BRANCH:-master}"
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TMP_DIR="$(mktemp -d)"
 cleanup() {
   rm -rf "${TMP_DIR}"
@@ -17,11 +19,19 @@ git clone --depth 1 --branch "${K8S_BRANCH}" "${K8S_REPO_URL}" "${TMP_DIR}/kuber
 CONTEXT_DIR="${TMP_DIR}/kubernetes/staging/src/k8s.io"
 DOCKERFILE_PATH="${CONTEXT_DIR}/kms/internal/plugins/_mock/Dockerfile"
 
-echo "Building image ${IMAGE_TAG}..."
+echo "Building upstream image ${UPSTREAM_IMAGE_TAG}..."
+docker build \
+  --platform linux/amd64 \
+  -t "${UPSTREAM_IMAGE_TAG}" \
+  -f "${DOCKERFILE_PATH}" \
+  "${CONTEXT_DIR}"
+
+echo "Building wrapper image ${IMAGE_TAG}..."
 docker build \
   --platform linux/amd64 \
   -t "${IMAGE_TAG}" \
-  -f "${DOCKERFILE_PATH}" \
-  "${CONTEXT_DIR}"
+  --build-arg "UPSTREAM_IMAGE=${UPSTREAM_IMAGE_TAG}" \
+  -f "${SCRIPT_DIR}/Dockerfile" \
+  "${SCRIPT_DIR}/../../../../.."
 
 echo "Done. Image built: ${IMAGE_TAG}"

--- a/test/library/encryption/kms/k8s-mock-plugin/wrapper/main.go
+++ b/test/library/encryption/kms/k8s-mock-plugin/wrapper/main.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+
+	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
+	kmstesting "github.com/openshift/library-go/test/library/encryption/kms"
+)
+
+const upstreamBinary = "/usr/local/bin/mock-kms-plugin"
+
+const (
+	defaultConfigPath = "/etc/softhsm-config.json"
+	defaultTokensDir  = "/var/lib/softhsm/tokens"
+)
+
+type options struct {
+	listenAddress       string
+	vaultAddress        string
+	vaultNamespace      string
+	transitMount        string
+	transitKey          string
+	logLevel            string
+	approleRoleID       string
+	approleSecretIDPath string
+}
+
+func main() {
+	o := &options{}
+
+	flag.StringVar(&o.listenAddress, "listen-address", "", "Listen address for the KMS plugin (e.g. unix:///var/run/kmsplugin/kms.sock)")
+	flag.StringVar(&o.vaultAddress, "vault-address", "", "Vault server address")
+	flag.StringVar(&o.vaultNamespace, "vault-namespace", "", "Vault namespace")
+	flag.StringVar(&o.transitMount, "transit-mount", "", "Vault transit secret engine mount path")
+	flag.StringVar(&o.transitKey, "transit-key", "", "Vault transit key name")
+	flag.StringVar(&o.logLevel, "log-level", "", "Log level (optional, valid value: debug-extended)")
+	flag.StringVar(&o.approleRoleID, "approle-role-id", "", "Vault AppRole role ID")
+	flag.StringVar(&o.approleSecretIDPath, "approle-secret-id-path", "", "Path to file containing Vault AppRole secret ID")
+	flag.Parse()
+
+	flag.VisitAll(func(f *flag.Flag) {
+		log.Printf("FLAG: --%s=%q", f.Name, f.Value)
+	})
+
+	if err := o.validate(); err != nil {
+		log.Fatal(err)
+	}
+	if err := o.run(context.Background()); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func (o *options) validate() error {
+	if o.listenAddress == "" {
+		return fmt.Errorf("--listen-address must be set")
+	}
+	if o.vaultAddress == "" {
+		return fmt.Errorf("--vault-address must be set")
+	}
+	if o.vaultNamespace == "" {
+		return fmt.Errorf("--vault-namespace must be set")
+	}
+	if o.transitMount == "" {
+		return fmt.Errorf("--transit-mount must be set")
+	}
+	if o.transitKey == "" {
+		return fmt.Errorf("--transit-key must be set")
+	}
+	if o.logLevel != "" && o.logLevel != "debug-extended" {
+		return fmt.Errorf("--log-level must be empty or \"debug-extended\", got %q", o.logLevel)
+	}
+	if o.approleRoleID == "" {
+		return fmt.Errorf("--approle-role-id must be set")
+	}
+	if o.approleSecretIDPath == "" {
+		return fmt.Errorf("--approle-secret-id-path must be set")
+	}
+	return nil
+}
+
+func (o *options) run(ctx context.Context) error {
+	log.Printf("Initializing SoftHSM")
+	if err := initSoftHSM(ctx); err != nil {
+		return fmt.Errorf("failed to initialize SoftHSM: %w", err)
+	}
+
+	upstreamArgs := []string{
+		"-listen-addr=" + o.listenAddress,
+		"-config-file-path=" + defaultConfigPath,
+	}
+	log.Printf("Executing %s %v", upstreamBinary, upstreamArgs)
+	argv := append([]string{upstreamBinary}, upstreamArgs...)
+	return syscall.Exec(upstreamBinary, argv, os.Environ())
+}
+
+func initSoftHSM(ctx context.Context) error {
+	raw, err := kmstesting.ReadAsset("k8s_mock_kms_plugin_configmap.yaml")
+	if err != nil {
+		return fmt.Errorf("failed to read configmap asset: %w", err)
+	}
+	data := resourceread.ReadConfigMapV1OrDie(raw).Data
+
+	if err := os.WriteFile(defaultConfigPath, []byte(data["softhsm-config.json"]), 0644); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(defaultTokensDir, 0755); err != nil {
+		return err
+	}
+
+	tokensB64 := data["softhsm-tokens.tar.gz.b64"]
+	cmd := exec.CommandContext(ctx, "sh", "-c", "base64 -d | tar xzf -")
+	cmd.Dir = defaultTokensDir
+	cmd.Stdin = strings.NewReader(strings.Join(strings.Fields(tokensB64), ""))
+	return cmd.Run()
+}

--- a/test/library/encryption/kms/k8s_mock_kms_plugin_deployer.go
+++ b/test/library/encryption/kms/k8s_mock_kms_plugin_deployer.go
@@ -29,7 +29,7 @@ const (
 	WellKnownUpstreamMockKMSPluginNamespace = "k8s-mock-plugin"
 
 	// WellKnownUpstreamMockKMSPluginImage is the pre-built mock KMS plugin image.
-	WellKnownUpstreamMockKMSPluginImage = "quay.io/openshifttest/mock-kms-plugin@sha256:998e1d48eba257f589ab86c30abd5043f662213e9aeff253e1c308301879d48a"
+	WellKnownUpstreamMockKMSPluginImage = "quay.io/openshifttest/mock-kms-plugin@sha256:76444d7e37d0d2d0f4dfae31893e937f766439ce07036bf19325050b594d2e2c"
 
 	// DefaultKMSPluginCount is the default number of KMS plugin instances to deploy.
 	DefaultKMSPluginCount = 10
@@ -53,6 +53,12 @@ type yamlTemplateData struct {
 	Namespace string
 	Image     string
 	Index     int
+}
+
+// ReadAsset reads the given embedded asset YAML template and renders it.
+func ReadAsset(assetName string) ([]byte, error) {
+	assetFunc := wrapAssetWithTemplateDataFunc(yamlTemplateData{Namespace: "default"})
+	return assetFunc(assetName)
 }
 
 // DeployUpstreamMockKMSPlugin deploys count instances of the upstream mock KMS v2 plugin


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a lightweight wrapper executable in the mock KMS image that initializes SoftHSM, validates required flags, and launches the upstream plugin.

* **Documentation**
  * README updated to document both binaries, wrapper behavior, and a sample invocation.

* **Chores**
  * Image build split into upstream and wrapper stages; build script and deploy tooling updated to produce and reference both images and to load embedded test assets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->