### PR TITLE
CNTRLPLANE-3237: Encapsulate all kms config under a single field in KeyState

### DIFF
--- a/pkg/operator/encryption/controllers/key_controller.go
+++ b/pkg/operator/encryption/controllers/key_controller.go
@@ -271,11 +271,13 @@ func (c *keyController) generateKeySecret(keyID uint64, currentMode state.Mode, 
 		ExternalReason: externalReason,
 	}
 	if currentMode == state.KMS {
-		ks.KMSEncryptionConfig = &apiserverv1.KMSConfiguration{
-			APIVersion: "v2",
-			Name:       fmt.Sprintf("%d", keyID),
-			Endpoint:   fmt.Sprintf(kmsEndpointFormat, keyID),
-			Timeout:    &metav1.Duration{Duration: defaultKMSTimeout},
+		ks.KMS = &state.KMSConfig{
+			EncryptionConfig: &apiserverv1.KMSConfiguration{
+				APIVersion: "v2",
+				Name:       fmt.Sprintf("%d", keyID),
+				Endpoint:   fmt.Sprintf(kmsEndpointFormat, keyID),
+				Timeout:    &metav1.Duration{Duration: defaultKMSTimeout},
+			},
 		}
 	}
 	return secrets.FromKeyState(c.instanceName, ks)

--- a/pkg/operator/encryption/encryptiondata/config.go
+++ b/pkg/operator/encryption/encryptiondata/config.go
@@ -215,12 +215,12 @@ func stateToProviders(resource string, desired state.GroupResourceState) []apise
 				},
 			})
 		case state.KMS:
-			if key.KMSEncryptionConfig == nil {
-				klog.Infof("skipping key %s for %s in KMS mode as its KMSEncryptionConfig is nil", key.Key.Name, resource)
+			if key.KMS == nil || key.KMS.EncryptionConfig == nil {
+				klog.Infof("skipping key %s for %s in KMS mode as its KMS.EncryptionConfig is nil", key.Key.Name, resource)
 				continue // this should never happen
 			}
 			// In order to preserve the uniqueness, we should insert resource name
-			kmsCopy := key.KMSEncryptionConfig.DeepCopy()
+			kmsCopy := key.KMS.EncryptionConfig.DeepCopy()
 			kmsCopy.Name = createKMSProviderName(key.Key.Name, resource)
 			provider := apiserverconfigv1.ProviderConfiguration{
 				KMS: kmsCopy,

--- a/pkg/operator/encryption/secrets/secrets.go
+++ b/pkg/operator/encryption/secrets/secrets.go
@@ -63,12 +63,13 @@ func ToKeyState(s *corev1.Secret) (state.KeyState, error) {
 	case state.AESCBC, state.AESGCM, state.SecretBox, state.Identity:
 		key.Mode = keyMode
 	case state.KMS:
+		key.KMS = new(state.KMSConfig)
 		if v, ok := s.Data[EncryptionSecretKMSEncryptionConfig]; ok && len(v) > 0 {
 			kmsConfiguration := &apiserverconfigv1.KMSConfiguration{}
 			if err := json.Unmarshal(v, kmsConfiguration); err != nil {
 				return state.KeyState{}, fmt.Errorf("secret %s/%s has invalid %s data: %w", s.Namespace, s.Name, EncryptionSecretKMSEncryptionConfig, err)
 			}
-			key.KMSEncryptionConfig = kmsConfiguration
+			key.KMS.EncryptionConfig = kmsConfiguration
 		} else {
 			// encryption.apiserver.operator.openshift.io-kms-encryption-config data field is required for KMS
 			// encryption mode.
@@ -126,8 +127,8 @@ func FromKeyState(component string, ks state.KeyState) (*corev1.Secret, error) {
 		s.Annotations[EncryptionSecretMigratedResources] = string(bs)
 	}
 
-	if ks.KMSEncryptionConfig != nil {
-		kmsEncCfgJSON, err := json.Marshal(ks.KMSEncryptionConfig)
+	if ks.KMS != nil && ks.KMS.EncryptionConfig != nil {
+		kmsEncCfgJSON, err := json.Marshal(ks.KMS.EncryptionConfig)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/operator/encryption/secrets/secrets_test.go
+++ b/pkg/operator/encryption/secrets/secrets_test.go
@@ -123,10 +123,12 @@ func TestRoundtrip(t *testing.T) {
 				},
 				Backed: true,
 				Mode:   "KMS",
-				KMSEncryptionConfig: &v1.KMSConfiguration{
-					APIVersion: "v2",
-					Name:       "1",
-					Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
+				KMS: &state.KMSConfig{
+					EncryptionConfig: &v1.KMSConfiguration{
+						APIVersion: "v2",
+						Name:       "1",
+						Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
+					},
 				},
 				Migrated: state.MigrationState{
 					Timestamp: now,
@@ -150,10 +152,12 @@ func TestRoundtrip(t *testing.T) {
 				},
 				Backed: true,
 				Mode:   "KMS",
-				KMSEncryptionConfig: &v1.KMSConfiguration{
-					APIVersion: "v2",
-					Name:       "2",
-					Endpoint:   "unix:///var/run/kmsplugin/kms-2.sock",
+				KMS: &state.KMSConfig{
+					EncryptionConfig: &v1.KMSConfiguration{
+						APIVersion: "v2",
+						Name:       "2",
+						Endpoint:   "unix:///var/run/kmsplugin/kms-2.sock",
+					},
 				},
 			},
 		},

--- a/pkg/operator/encryption/state/types.go
+++ b/pkg/operator/encryption/state/types.go
@@ -40,8 +40,14 @@ type KeyState struct {
 	InternalReason string
 	// the user via unsupportConfigOverrides.encryption.reason triggered this key.
 	ExternalReason string
-	// Encoded KMSEncryptionConfig that stores the KMS related fields
-	KMSEncryptionConfig *apiserverconfigv1.KMSConfiguration
+	// stores the all KMS encryption mode related configurations
+	KMS *KMSConfig
+}
+
+// KMSConfig stores all KMS encryption mode related configurations
+type KMSConfig struct {
+	// Encoded EncryptionConfig that stores the KMS related fields
+	EncryptionConfig *apiserverconfigv1.KMSConfiguration
 }
 
 type MigrationState struct {


### PR DESCRIPTION
This PR is continuation of https://github.com/openshift/library-go/pull/2172 to add https://github.com/openshift/library-go/pull/2163#discussion_r3116059379. 

Thanks to that we'll add all kms specific fields under single KMSConfig field to better manage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Restructured internal KMS configuration state management to improve code organization and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->