### PR TITLE
OCPBUGS-84536: Update MakeServerCert to use time.Duration instead of days

### DIFF
--- a/pkg/controller/controllercmd/cmd.go
+++ b/pkg/controller/controllercmd/cmd.go
@@ -280,7 +280,7 @@ func (c *ControllerCommandConfig) AddDefaultRotationToConfig(config *operatorv1a
 			config.ServingInfo.CertFile = filepath.Join(temporaryCertDir, "tls.crt")
 			config.ServingInfo.KeyFile = filepath.Join(temporaryCertDir, "tls.key")
 			// nothing can trust this, so we don't really care about hostnames
-			servingCert, err := ca.MakeServerCert(sets.New("localhost"), 30)
+			servingCert, err := ca.MakeServerCert(sets.New("localhost"), time.Hour*24*30)
 			if err != nil {
 				return nil, nil, err
 			}


### PR DESCRIPTION
Backport of https://github.com/openshift/library-go/pull/2155(code fix for the bug) and https://github.com/openshift/library-go/pull/2182(unit test for the code change).

library-go crypto MakeSelfSignedCA and MakeServerCert were updated to use time.Duration instead of days, Update MakeServerCert() call in AddDefaultRotationToConfig() to reflect this change (https://github.com/openshift/library-go/pull/1943 that introduced this change)