### PR TITLE
CNTRLPLANE-3237: Encapsulate more functions

### DIFF
--- a/pkg/operator/encryption/encryptiondata/config.go
+++ b/pkg/operator/encryption/encryptiondata/config.go
@@ -26,6 +26,10 @@ type Config struct {
 	Encryption *apiserverconfigv1.EncryptionConfiguration
 }
 
+func (c *Config) HasEncryptionConfiguration() bool {
+	return c != nil && c.Encryption != nil
+}
+
 // FromEncryptionState converts encryption state to Config.
 func FromEncryptionState(encryptionState map[schema.GroupResource]state.GroupResourceState) *Config {
 	resourceConfigs := make([]apiserverconfigv1.ResourceConfiguration, 0, len(encryptionState))
@@ -69,7 +73,7 @@ func ToEncryptionState(secretData *Config, keySecrets []*corev1.Secret) (map[sch
 	}
 	backedKeys = state.SortRecentFirst(backedKeys)
 
-	if secretData == nil || secretData.Encryption == nil {
+	if !secretData.HasEncryptionConfiguration() {
 		return nil, backedKeys
 	}
 

--- a/pkg/operator/encryption/encryptiondata/secret.go
+++ b/pkg/operator/encryption/encryptiondata/secret.go
@@ -48,7 +48,7 @@ func FromSecret(encryptionConfigSecret *corev1.Secret) (*Config, error) {
 }
 
 func ToSecret(ns, name string, secretData *Config) (*corev1.Secret, error) {
-	if secretData == nil || secretData.Encryption == nil {
+	if !secretData.HasEncryptionConfiguration() {
 		return nil, fmt.Errorf("secret %s/%s has no encryption config", ns, name)
 	}
 

--- a/pkg/operator/encryption/secrets/secrets.go
+++ b/pkg/operator/encryption/secrets/secrets.go
@@ -63,13 +63,14 @@ func ToKeyState(s *corev1.Secret) (state.KeyState, error) {
 	case state.AESCBC, state.AESGCM, state.SecretBox, state.Identity:
 		key.Mode = keyMode
 	case state.KMS:
-		key.KMS = new(state.KMSConfig)
 		if v, ok := s.Data[EncryptionSecretKMSEncryptionConfig]; ok && len(v) > 0 {
 			kmsConfiguration := &apiserverconfigv1.KMSConfiguration{}
 			if err := json.Unmarshal(v, kmsConfiguration); err != nil {
 				return state.KeyState{}, fmt.Errorf("secret %s/%s has invalid %s data: %w", s.Namespace, s.Name, EncryptionSecretKMSEncryptionConfig, err)
 			}
-			key.KMS.EncryptionConfig = kmsConfiguration
+			key.KMS = &state.KMSConfig{
+				EncryptionConfig: kmsConfiguration,
+			}
 		} else {
 			// encryption.apiserver.operator.openshift.io-kms-encryption-config data field is required for KMS
 			// encryption mode.
@@ -127,7 +128,7 @@ func FromKeyState(component string, ks state.KeyState) (*corev1.Secret, error) {
 		s.Annotations[EncryptionSecretMigratedResources] = string(bs)
 	}
 
-	if ks.KMS != nil && ks.KMS.EncryptionConfig != nil {
+	if ks.HasKMSEncryptionConfig() {
 		kmsEncCfgJSON, err := json.Marshal(ks.KMS.EncryptionConfig)
 		if err != nil {
 			return nil, err

--- a/pkg/operator/encryption/state/types.go
+++ b/pkg/operator/encryption/state/types.go
@@ -40,8 +40,12 @@ type KeyState struct {
 	InternalReason string
 	// the user via unsupportConfigOverrides.encryption.reason triggered this key.
 	ExternalReason string
-	// stores the all KMS encryption mode related configurations
+	// stores all the KMS encryption mode related configurations
 	KMS *KMSConfig
+}
+
+func (k *KeyState) HasKMSEncryptionConfig() bool {
+	return k != nil && k.KMS != nil && k.KMS.EncryptionConfig != nil
 }
 
 // KMSConfig stores all KMS encryption mode related configurations


### PR DESCRIPTION
This PR addresses some changes requested in https://github.com/openshift/library-go/pull/2179#discussion_r3152292197 and https://github.com/openshift/library-go/pull/2179#discussion_r3152329065

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized nil-safe checks for encryption and KMS configuration across the operator.
  * Made KMS configuration optional-at-read, only materializing it when present.
  * Added small helper predicates to centralize presence checks, improving consistency and reducing duplicate logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->