### PR TITLE
CNTRLPLANE-3237: Rename to Encryption by dropping Config suffix

### DIFF
--- a/pkg/operator/encryption/controllers/key_controller.go
+++ b/pkg/operator/encryption/controllers/key_controller.go
@@ -271,8 +271,8 @@ func (c *keyController) generateKeySecret(keyID uint64, currentMode state.Mode, 
 		ExternalReason: externalReason,
 	}
 	if currentMode == state.KMS {
-		ks.KMS = &state.KMSConfig{
-			EncryptionConfig: &apiserverv1.KMSConfiguration{
+		ks.KMSConfig = &state.KMSConfig{
+			Encryption: &apiserverv1.KMSConfiguration{
 				APIVersion: "v2",
 				Name:       fmt.Sprintf("%d", keyID),
 				Endpoint:   fmt.Sprintf(kmsEndpointFormat, keyID),

--- a/pkg/operator/encryption/encryptiondata/config.go
+++ b/pkg/operator/encryption/encryptiondata/config.go
@@ -219,12 +219,12 @@ func stateToProviders(resource string, desired state.GroupResourceState) []apise
 				},
 			})
 		case state.KMS:
-			if key.KMS == nil || key.KMS.EncryptionConfig == nil {
-				klog.Infof("skipping key %s for %s in KMS mode as its KMS.EncryptionConfig is nil", key.Key.Name, resource)
+			if !key.HasKMSEncryption() {
+				klog.Infof("skipping key %s for %s in KMS mode as its either KMSConfig or KMSConfig.Encryption is nil", key.Key.Name, resource)
 				continue // this should never happen
 			}
 			// In order to preserve the uniqueness, we should insert resource name
-			kmsCopy := key.KMS.EncryptionConfig.DeepCopy()
+			kmsCopy := key.KMSConfig.Encryption.DeepCopy()
 			kmsCopy.Name = createKMSProviderName(key.Key.Name, resource)
 			provider := apiserverconfigv1.ProviderConfiguration{
 				KMS: kmsCopy,

--- a/pkg/operator/encryption/secrets/secrets.go
+++ b/pkg/operator/encryption/secrets/secrets.go
@@ -68,8 +68,8 @@ func ToKeyState(s *corev1.Secret) (state.KeyState, error) {
 			if err := json.Unmarshal(v, kmsConfiguration); err != nil {
 				return state.KeyState{}, fmt.Errorf("secret %s/%s has invalid %s data: %w", s.Namespace, s.Name, EncryptionSecretKMSEncryptionConfig, err)
 			}
-			key.KMS = &state.KMSConfig{
-				EncryptionConfig: kmsConfiguration,
+			key.KMSConfig = &state.KMSConfig{
+				Encryption: kmsConfiguration,
 			}
 		} else {
 			// encryption.apiserver.operator.openshift.io-kms-encryption-config data field is required for KMS
@@ -128,8 +128,8 @@ func FromKeyState(component string, ks state.KeyState) (*corev1.Secret, error) {
 		s.Annotations[EncryptionSecretMigratedResources] = string(bs)
 	}
 
-	if ks.HasKMSEncryptionConfig() {
-		kmsEncCfgJSON, err := json.Marshal(ks.KMS.EncryptionConfig)
+	if ks.HasKMSEncryption() {
+		kmsEncCfgJSON, err := json.Marshal(ks.KMSConfig.Encryption)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/operator/encryption/secrets/secrets_test.go
+++ b/pkg/operator/encryption/secrets/secrets_test.go
@@ -123,8 +123,8 @@ func TestRoundtrip(t *testing.T) {
 				},
 				Backed: true,
 				Mode:   "KMS",
-				KMS: &state.KMSConfig{
-					EncryptionConfig: &v1.KMSConfiguration{
+				KMSConfig: &state.KMSConfig{
+					Encryption: &v1.KMSConfiguration{
 						APIVersion: "v2",
 						Name:       "1",
 						Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
@@ -152,8 +152,8 @@ func TestRoundtrip(t *testing.T) {
 				},
 				Backed: true,
 				Mode:   "KMS",
-				KMS: &state.KMSConfig{
-					EncryptionConfig: &v1.KMSConfiguration{
+				KMSConfig: &state.KMSConfig{
+					Encryption: &v1.KMSConfiguration{
 						APIVersion: "v2",
 						Name:       "2",
 						Endpoint:   "unix:///var/run/kmsplugin/kms-2.sock",

--- a/pkg/operator/encryption/state/types.go
+++ b/pkg/operator/encryption/state/types.go
@@ -41,17 +41,17 @@ type KeyState struct {
 	// the user via unsupportConfigOverrides.encryption.reason triggered this key.
 	ExternalReason string
 	// stores all the KMS encryption mode related configurations
-	KMS *KMSConfig
+	KMSConfig *KMSConfig
 }
 
-func (k *KeyState) HasKMSEncryptionConfig() bool {
-	return k != nil && k.KMS != nil && k.KMS.EncryptionConfig != nil
+func (k *KeyState) HasKMSEncryption() bool {
+	return k != nil && k.KMSConfig != nil && k.KMSConfig.Encryption != nil
 }
 
 // KMSConfig stores all KMS encryption mode related configurations
 type KMSConfig struct {
 	// Encoded EncryptionConfig that stores the KMS related fields
-	EncryptionConfig *apiserverconfigv1.KMSConfiguration
+	Encryption *apiserverconfigv1.KMSConfiguration
 }
 
 type MigrationState struct {


### PR DESCRIPTION
This PR addresses the change requested in https://github.com/openshift/library-go/pull/2186#discussion_r3152782018

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal KMS encryption configuration was renamed and reorganized for consistency; behavior unchanged for users.
  * Secret serialization and state conversions for KMS-backed keys were updated to match the new structure.
* **Tests**
  * Test fixtures updated to reflect the configuration rename; no functional changes expected in production.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->