### PR TITLE
CNTRLPLANE-3364: utility for vault deployer

### DIFF
--- a/test/library/encryption/kms/assets/vault_configmap.yaml
+++ b/test/library/encryption/kms/assets/vault_configmap.yaml
@@ -1,0 +1,129 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vault-config
+  namespace: {{ .Namespace }}
+data:
+  vault.hcl: |
+    cluster_addr = "http://POD_IP:8201"
+    api_addr = "http://POD_IP:8200"
+
+    listener "tcp" {
+      tls_disable = 1
+      address = "[::]:8200"
+      cluster_address = "[::]:8201"
+    }
+
+    storage "raft" {
+      path = "/vault/data"
+      node_id = "vault-node-1"
+    }
+
+    disable_mlock = true
+
+  setup.sh: |
+    #!/bin/sh
+    set -e
+
+    VAULT_ADDR="http://127.0.0.1:8200"
+    export VAULT_ADDR
+
+    echo "Waiting for Vault to be ready..."
+    until vault status 2>&1 | grep -q 'Initialized'; do
+      sleep 2
+    done
+
+    if vault status 2>&1 | grep -q 'Initialized.*true'; then
+      echo "Vault already initialized, skipping setup."
+      sleep infinity
+    fi
+
+    echo "Initializing Vault..."
+    INIT_OUTPUT=$(vault operator init \
+      -key-shares=1 \
+      -key-threshold=1 \
+      -format=json 2>&1) || {
+      echo "Failed to initialize Vault"
+      echo "Output: $INIT_OUTPUT"
+      exit 1
+    }
+
+    UNSEAL_KEY=$(echo "$INIT_OUTPUT" | tr -d ' \n\t' | sed -n 's/.*"unseal_keys_b64":\["\([^"]*\)".*/\1/p')
+    ROOT_TOKEN=$(echo "$INIT_OUTPUT" | tr -d ' \n\t' | sed -n 's/.*"root_token":"\([^"]*\)".*/\1/p')
+
+    if [ -z "$UNSEAL_KEY" ] || [ -z "$ROOT_TOKEN" ]; then
+      echo "Failed to parse init output. Output was: $INIT_OUTPUT"
+      exit 1
+    fi
+
+    echo "Unsealing Vault..."
+    vault operator unseal "$UNSEAL_KEY"
+
+    export VAULT_TOKEN="$ROOT_TOKEN"
+    echo "Enabling transit secret engine..."
+    vault secrets enable -path=transit transit
+
+    echo "Creating transit encryption key..."
+    vault write -f transit/keys/kubernetes-encryption-key
+
+    echo "Enabling AppRole auth..."
+    vault auth enable approle
+
+    echo "Creating KMS policy..."
+    vault policy write kms-policy - <<'POLICY'
+    path "transit/encrypt/kubernetes-encryption-key" {
+      capabilities = ["update"]
+    }
+    path "transit/decrypt/kubernetes-encryption-key" {
+      capabilities = ["update"]
+    }
+    POLICY
+
+    echo "Creating AppRole role..."
+    vault write auth/approle/role/kms-plugin \
+      token_policies="kms-policy" \
+      token_ttl=1h \
+      token_max_ttl=4h
+
+    ROLE_ID=$(vault read -field=role_id auth/approle/role/kms-plugin/role-id)
+    SECRET_ID=$(vault write -field=secret_id -f auth/approle/role/kms-plugin/secret-id)
+
+    echo "Creating vault-credentials secret via K8s API..."
+    SA_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+    K8S_API="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}"
+    NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+    CA_CERT=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+
+    ROLE_ID_B64=$(echo -n "$ROLE_ID" | base64)
+    SECRET_ID_B64=$(echo -n "$SECRET_ID" | base64)
+    ROOT_TOKEN_B64=$(echo -n "$ROOT_TOKEN" | base64)
+    UNSEAL_KEY_B64=$(echo -n "$UNSEAL_KEY" | base64)
+
+    cat > /tmp/secret.json <<EOSECRET
+    {
+      "apiVersion": "v1",
+      "kind": "Secret",
+      "metadata": {
+        "name": "vault-credentials",
+        "namespace": "${NAMESPACE}"
+      },
+      "type": "Opaque",
+      "data": {
+        "role-id": "${ROLE_ID_B64}",
+        "secret-id": "${SECRET_ID_B64}",
+        "root-token": "${ROOT_TOKEN_B64}",
+        "unseal-key": "${UNSEAL_KEY_B64}"
+      }
+    }
+    EOSECRET
+
+    wget --header="Authorization: Bearer ${SA_TOKEN}" \
+         --header="Content-Type: application/json" \
+         --no-check-certificate \
+         --post-file=/tmp/secret.json \
+         -O- "${K8S_API}/api/v1/namespaces/${NAMESPACE}/secrets"
+
+    rm -f /tmp/secret.json
+
+    echo "Vault setup complete. Sidecar sleeping."
+    sleep infinity

--- a/test/library/encryption/kms/assets/vault_deployment.yaml
+++ b/test/library/encryption/kms/assets/vault_deployment.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vault
+  namespace: {{ .Namespace }}
+spec:
+  replicas: {{ .Replicas }}
+  selector:
+    matchLabels:
+      app: vault
+  template:
+    metadata:
+      labels:
+        app: vault
+    spec:
+      serviceAccountName: vault
+      containers:
+        - name: vault
+          image: {{ .Image }}
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - |
+              export POD_IP=$(hostname -i)
+              sed "s/POD_IP/${POD_IP}/g" /vault/config/vault.hcl > /tmp/vault.hcl
+              exec vault server -config=/tmp/vault.hcl
+          env:
+            - name: VAULT_ADDR
+              value: "http://127.0.0.1:8200"
+            - name: VAULT_API_ADDR
+              value: "http://$(POD_IP):8200"
+            - name: VAULT_LICENSE_PATH
+              value: "/vault/license/license"
+          ports:
+            - containerPort: 8200
+              name: http
+          readinessProbe:
+            httpGet:
+              path: /v1/sys/health?standbyok=true
+              port: 8200
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /v1/sys/health?standbyok=true
+              port: 8200
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          volumeMounts:
+            - name: data
+              mountPath: /vault/data
+            - name: config
+              mountPath: /vault/config
+            - name: license
+              mountPath: /vault/license
+        - name: vault-setup
+          image: {{ .Image }}
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "/vault/config/setup.sh"]
+          env:
+            - name: VAULT_ADDR
+              value: "http://127.0.0.1:8200"
+          volumeMounts:
+            - name: config
+              mountPath: /vault/config
+      volumes:
+        - name: config
+          configMap:
+            name: vault-config
+        - name: license
+          secret:
+            secretName: vault-license
+            optional: true
+        - name: data
+          emptyDir: {}

--- a/test/library/encryption/kms/assets/vault_namespace.yaml
+++ b/test/library/encryption/kms/assets/vault_namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Namespace }}

--- a/test/library/encryption/kms/assets/vault_role.yaml
+++ b/test/library/encryption/kms/assets/vault_role.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: vault-secret-creator
+  namespace: {{ .Namespace }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "get", "update"]

--- a/test/library/encryption/kms/assets/vault_role_binding.yaml
+++ b/test/library/encryption/kms/assets/vault_role_binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: vault-secret-creator
+  namespace: {{ .Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: vault-secret-creator
+subjects:
+  - kind: ServiceAccount
+    name: vault
+    namespace: {{ .Namespace }}

--- a/test/library/encryption/kms/assets/vault_scc_rolebinding.yaml
+++ b/test/library/encryption/kms/assets/vault_scc_rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: vault
+  namespace: {{ .Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:restricted
+subjects:
+  - kind: ServiceAccount
+    name: vault
+    namespace: {{ .Namespace }}

--- a/test/library/encryption/kms/assets/vault_service.yaml
+++ b/test/library/encryption/kms/assets/vault_service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: vault
+  namespace: {{ .Namespace }}
+  labels:
+    app: vault
+spec:
+  ports:
+    - name: http
+      port: 8200
+      targetPort: 8200
+  selector:
+    app: vault
+  clusterIP: None

--- a/test/library/encryption/kms/assets/vault_serviceaccount.yaml
+++ b/test/library/encryption/kms/assets/vault_serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vault
+  namespace: {{ .Namespace }}

--- a/test/library/encryption/kms/vault_kube_kms_deployer.go
+++ b/test/library/encryption/kms/vault_kube_kms_deployer.go
@@ -1,0 +1,288 @@
+package kms
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"text/template"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/clock"
+
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
+)
+
+const (
+	// WellKnownVaultNamespace is the default namespace where Vault runs.
+	WellKnownVaultNamespace = "vault-kms"
+
+	// WellKnownVaultImage is the default HashiCorp Vault Enterprise image.
+	WellKnownVaultImage = "docker.io/hashicorp/vault-enterprise:2.0.0-ent"
+
+	// WellKnownVaultServiceName is the name of the Vault service.
+	WellKnownVaultServiceName = "vault"
+
+	// DefaultVaultReplicas is the default number of Vault replicas to deploy.
+	DefaultVaultReplicas = 1
+
+	// VaultTransitMount is the default mount path for the transit secret engine.
+	VaultTransitMount = "transit"
+
+	// VaultTransitKeyName is the default key name in the transit engine.
+	VaultTransitKeyName = "kubernetes-encryption-key"
+
+	// vaultCredentialsSecretName is the name of the Secret created by the
+	// init container with the AppRole credentials and root token.
+	vaultCredentialsSecretName = "vault-credentials"
+
+	vaultPollTimeout = 5 * time.Minute
+)
+
+// vaultSharedManifestFiles are applied via ApplyDirectly before the Deployment.
+// Order matters: namespace first, then RBAC, then configmap and service.
+var vaultSharedManifestFiles = []string{
+	"vault_namespace.yaml",
+	"vault_serviceaccount.yaml",
+	"vault_scc_rolebinding.yaml",
+	"vault_role.yaml",
+	"vault_role_binding.yaml",
+	"vault_configmap.yaml",
+	"vault_service.yaml",
+}
+
+var vaultDeploymentManifestFile = "vault_deployment.yaml"
+
+// VaultConfig holds the configuration for Vault deployment.
+type VaultConfig struct {
+	Namespace string
+	Image     string
+	Replicas  int
+}
+
+// vaultTemplateData holds the template variables for Vault YAML manifests.
+type vaultTemplateData struct {
+	Namespace string
+	Image     string
+	Replicas  int
+}
+
+// VaultDeployer manages the deployment and lifecycle of HashiCorp Vault Enterprise
+// for KMS encryption testing. All init/unseal/configure logic runs inside the pod
+// as an init container; the Go deployer only applies manifests and reads results.
+type VaultDeployer struct {
+	config     *VaultConfig
+	kubeClient kubernetes.Interface
+	t          testing.TB
+}
+
+// NewVaultDeployer creates a new VaultDeployer with the given configuration.
+func NewVaultDeployer(t testing.TB, kubeClient kubernetes.Interface, config *VaultConfig) *VaultDeployer {
+	t.Helper()
+
+	if config == nil {
+		config = &VaultConfig{}
+	}
+	if config.Namespace == "" {
+		config.Namespace = WellKnownVaultNamespace
+	}
+	if config.Image == "" {
+		config.Image = WellKnownVaultImage
+	}
+	if config.Replicas == 0 {
+		config.Replicas = DefaultVaultReplicas
+	}
+
+	return &VaultDeployer{
+		config:     config,
+		kubeClient: kubeClient,
+		t:          t,
+	}
+}
+
+// Deploy deploys HashiCorp Vault Enterprise and waits for it to be fully
+// initialized, unsealed, and configured for KMS testing.
+//
+// The VAULT_LICENSE environment variable must be set with the Vault Enterprise
+// license. The deployer creates a K8s Secret from it, which is mounted into
+// the Vault pod. An init container handles initialization, unsealing, transit
+// engine setup, and AppRole configuration. Credentials are written to the
+// "vault-credentials" Secret by the init container.
+func (d *VaultDeployer) Deploy(ctx context.Context) error {
+	d.t.Helper()
+	d.t.Logf("Deploying Vault Enterprise in namespace %q (replicas: %d)", d.config.Namespace, d.config.Replicas)
+
+	if err := d.applyManifests(ctx); err != nil {
+		return fmt.Errorf("failed to apply manifests: %w", err)
+	}
+
+	if err := d.waitForDeploymentReady(ctx); err != nil {
+		return fmt.Errorf("vault deployment not ready: %w", err)
+	}
+
+	if err := d.readCredentials(ctx); err != nil {
+		return fmt.Errorf("failed to read vault credentials: %w", err)
+	}
+
+	return nil
+}
+
+// applyManifests creates the license secret from VAULT_LICENSE env var and
+// applies all static Vault Kubernetes manifests.
+func (d *VaultDeployer) applyManifests(ctx context.Context) error {
+	d.t.Helper()
+
+	templateData := vaultTemplateData{
+		Namespace: d.config.Namespace,
+		Image:     d.config.Image,
+		Replicas:  d.config.Replicas,
+	}
+
+	recorder := events.NewInMemoryRecorder("vault-deployer", clock.RealClock{})
+	assetFunc := wrapVaultAssetWithTemplateData(templateData)
+
+	clientHolder := resourceapply.NewKubeClientHolder(d.kubeClient)
+	results := resourceapply.ApplyDirectly(ctx, clientHolder, recorder, resourceapply.NewResourceCache(), assetFunc, vaultSharedManifestFiles...)
+	for _, result := range results {
+		if result.Error != nil {
+			return result.Error
+		}
+		d.t.Logf("Applied %s (changed=%v)", result.File, result.Changed)
+	}
+
+	if err := d.createLicenseSecret(ctx); err != nil {
+		return fmt.Errorf("failed to create license secret: %w", err)
+	}
+
+	rawDeployment, err := assetFunc(vaultDeploymentManifestFile)
+	if err != nil {
+		return fmt.Errorf("failed to read deployment manifest: %w", err)
+	}
+	deployment := resourceread.ReadDeploymentV1OrDie(rawDeployment)
+	_, changed, err := resourceapply.ApplyDeployment(ctx, d.kubeClient.AppsV1(), recorder, deployment, -1)
+	if err != nil {
+		return fmt.Errorf("failed to apply deployment: %w", err)
+	}
+	d.t.Logf("Applied %s (changed=%v)", vaultDeploymentManifestFile, changed)
+
+	return nil
+}
+
+// createLicenseSecret creates a Kubernetes Secret from the VAULT_LICENSE env var.
+func (d *VaultDeployer) createLicenseSecret(ctx context.Context) error {
+	d.t.Helper()
+
+	license := os.Getenv("VAULT_LICENSE")
+	if license == "" {
+		d.t.Logf("VAULT_LICENSE env var not set, skipping license secret creation")
+		return nil
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vault-license",
+			Namespace: d.config.Namespace,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"license": []byte(license),
+		},
+	}
+
+	_, err := d.kubeClient.CoreV1().Secrets(d.config.Namespace).Create(ctx, secret, metav1.CreateOptions{})
+	if err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			d.t.Logf("License secret already exists, updating")
+			_, err = d.kubeClient.CoreV1().Secrets(d.config.Namespace).Update(ctx, secret, metav1.UpdateOptions{})
+			return err
+		}
+		return err
+	}
+	d.t.Logf("Created vault-license secret from VAULT_LICENSE env var")
+	return nil
+}
+
+// waitForDeploymentReady waits for the Vault Deployment to have all replicas
+// ready, which implies the init container (vault-setup) has completed.
+func (d *VaultDeployer) waitForDeploymentReady(ctx context.Context) error {
+	d.t.Helper()
+	d.t.Logf("Waiting for Vault deployment to be ready...")
+
+	return wait.PollUntilContextTimeout(ctx, 2*time.Second, vaultPollTimeout, true, func(ctx context.Context) (bool, error) {
+		dep, err := d.kubeClient.AppsV1().Deployments(d.config.Namespace).Get(ctx, "vault", metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		desired := int32(d.config.Replicas)
+		d.t.Logf("Vault deployment: desired=%d ready=%d available=%d",
+			desired, dep.Status.ReadyReplicas, dep.Status.AvailableReplicas)
+		return dep.Status.ReadyReplicas >= desired, nil
+	})
+}
+
+// readCredentials reads the vault-credentials Secret created by the init
+// container and populates the VaultConfig with AppRole credentials.
+func (d *VaultDeployer) readCredentials(ctx context.Context) error {
+	d.t.Helper()
+	d.t.Logf("Reading vault credentials from secret %s/%s", d.config.Namespace, vaultCredentialsSecretName)
+
+	var secret *corev1.Secret
+	err := wait.PollUntilContextTimeout(ctx, 2*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+		var getErr error
+		secret, getErr = d.kubeClient.CoreV1().Secrets(d.config.Namespace).Get(ctx, vaultCredentialsSecretName, metav1.GetOptions{})
+		if getErr != nil {
+			if apierrors.IsNotFound(getErr) {
+				return false, nil
+			}
+			return false, getErr
+		}
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("timed out waiting for %s secret: %w", vaultCredentialsSecretName, err)
+	}
+
+	if _, ok := secret.Data["role-id"]; !ok {
+		return fmt.Errorf("vault-credentials secret missing role-id")
+	}
+	if _, ok := secret.Data["secret-id"]; !ok {
+		return fmt.Errorf("vault-credentials secret missing secret-id")
+	}
+
+	d.t.Logf("Vault AppRole credentials loaded from secret")
+	return nil
+}
+
+// wrapVaultAssetWithTemplateData returns an AssetFunc that templates Vault YAML with the given data.
+func wrapVaultAssetWithTemplateData(data vaultTemplateData) resourceapply.AssetFunc {
+	return func(name string) ([]byte, error) {
+		content, err := assetsFS.ReadFile(filepath.Join("assets", name))
+		if err != nil {
+			return nil, err
+		}
+
+		tmpl, err := template.New(name).Parse(string(content))
+		if err != nil {
+			return nil, err
+		}
+
+		var buf bytes.Buffer
+		if err := tmpl.Execute(&buf, data); err != nil {
+			return nil, err
+		}
+
+		return buf.Bytes(), nil
+	}
+}


### PR DESCRIPTION


Introduces a Kubernetes test deployer for local HashiCorp Vault Enterprise deployment, init/unseal, transit AppRole KMS configuration, unit and optional integration tests.


```
$ INTEGRATION_TEST=true VAULT_LICENSE=$(cat vault.hclic) go test -v -run TestVaultDeployerIntegration
=== RUN   TestVaultDeployerIntegration
    vault_kube_kms_deployer_test.go:62: Deploying Vault...
    vault_kube_kms_deployer_test.go:63: Deploying Vault Enterprise in namespace "vault-kms-test-20260430-194817" (replicas: 1)
    vault_kube_kms_deployer_test.go:63: Applied vault_namespace.yaml (changed=true)
    vault_kube_kms_deployer_test.go:63: Applied vault_serviceaccount.yaml (changed=true)
    vault_kube_kms_deployer_test.go:63: Applied vault_scc_rolebinding.yaml (changed=true)
    vault_kube_kms_deployer_test.go:63: Applied vault_role.yaml (changed=true)
    vault_kube_kms_deployer_test.go:63: Applied vault_role_binding.yaml (changed=true)
    vault_kube_kms_deployer_test.go:63: Applied vault_configmap.yaml (changed=true)
    vault_kube_kms_deployer_test.go:63: Applied vault_service.yaml (changed=true)
    vault_kube_kms_deployer_test.go:63: Created vault-license secret from VAULT_LICENSE env var
    vault_kube_kms_deployer_test.go:63: Applied vault_deployment.yaml (changed=true)
    vault_kube_kms_deployer_test.go:63: Waiting for Vault deployment to be ready...
    vault_kube_kms_deployer.go:231: Vault deployment: desired=1 ready=0 available=0
    vault_kube_kms_deployer.go:231: Vault deployment: desired=1 ready=0 available=0
    vault_kube_kms_deployer.go:231: Vault deployment: desired=1 ready=0 available=0
    vault_kube_kms_deployer.go:231: Vault deployment: desired=1 ready=0 available=0
    vault_kube_kms_deployer.go:231: Vault deployment: desired=1 ready=0 available=0
    vault_kube_kms_deployer.go:231: Vault deployment: desired=1 ready=0 available=0
    vault_kube_kms_deployer.go:231: Vault deployment: desired=1 ready=0 available=0
    vault_kube_kms_deployer.go:231: Vault deployment: desired=1 ready=1 available=1
    vault_kube_kms_deployer_test.go:63: Reading vault credentials from secret vault-kms-test-20260430-194817/vault-credentials
    vault_kube_kms_deployer_test.go:63: Vault AppRole credentials loaded from secret
    vault_kube_kms_deployer_test.go:63: Vault Enterprise deployed. Service: http://vault.vault-kms-test-20260430-194817.svc:8200
    vault_kube_kms_deployer_test.go:72: Namespace vault-kms-test-20260430-194817 created
    vault_kube_kms_deployer_test.go:79: Deployment ready: 1/1 replicas
    vault_kube_kms_deployer_test.go:92: Vault credentials secret verified
    vault_kube_kms_deployer_test.go:94: Integration test passed!
--- PASS: TestVaultDeployerIntegration (21.53s)
PASS
ok  	github.com/openshift/library-go/test/library/encryption/kms	21.553s

```

```
$ INTEGRATION_TEST=true go test -v -run TestVaultCleanup
=== RUN   TestVaultCleanup
    vault_kube_kms_deployer_test.go:139: Found namespace to cleanup: vault-kms-test-20260430-194343
    vault_kube_kms_deployer_test.go:145: Deleting namespace vault-kms-test-20260430-194343...
    vault_kube_kms_deployer_test.go:155: Verifying namespace deletion...
    vault_kube_kms_deployer_test.go:166: Waiting for namespace deletion... (1/30)
    vault_kube_kms_deployer_test.go:166: Waiting for namespace deletion... (2/30)
    vault_kube_kms_deployer_test.go:166: Waiting for namespace deletion... (3/30)
    vault_kube_kms_deployer_test.go:159: Namespace successfully deleted
    vault_kube_kms_deployer_test.go:160: Cleanup test passed!
--- PASS: TestVaultCleanup (15.22s)
PASS
ok  	github.com/openshift/library-go/test/library/encryption/kms	15.264s

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated Vault-on-Kubernetes deployer for integration testing: deploys Vault, handles license input, waits for readiness, initializes and unseals Vault, configures transit KMS and AppRole auth, stores credentials, and provides cleanup and getters.
* **Tests**
  * Added unit and integration tests covering configuration/defaults, manifest templating, license scenarios, deployment modes, AppRole credential handling with masked logging, deployment/validation, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->