### PR TITLE
NO-JIRA: Set required KMSConfig in e2e tests for KMS mode

### DIFF
--- a/test/library/encryption/helpers.go
+++ b/test/library/encryption/helpers.go
@@ -24,6 +24,7 @@ import (
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 
 	"github.com/openshift/library-go/test/library"
+	"github.com/openshift/library-go/test/library/encryption/kms"
 )
 
 var (
@@ -66,6 +67,7 @@ func SetAndWaitForEncryptionType(t testing.TB, encryptionType configv1.Encryptio
 	if needsUpdate {
 		t.Logf("Updating encryption type in the config file for APIServer to %q", encryptionType)
 		apiServer.Spec.Encryption.Type = encryptionType
+		apiServer.Spec.Encryption.KMS = defaultTestKMSConfig(encryptionType)
 		_, err = clientSet.ApiServerConfig.Update(context.TODO(), apiServer, metav1.UpdateOptions{})
 		require.NoError(t, err)
 	} else {
@@ -336,5 +338,25 @@ func setUpTearDown(namespace string) func(testing.TB, bool) {
 				t.Logf("Last seen: %-15v Type: %-10v Reason: %-40v Source: %-55v Message: %v", now.Sub(ev.LastTimestamp.Time), ev.Type, ev.Reason, ev.Source.Component, ev.Message)
 			}
 		}
+	}
+}
+
+func defaultTestKMSConfig(encryptionType configv1.EncryptionType) *configv1.KMSConfig {
+	if encryptionType != configv1.EncryptionTypeKMS {
+		return nil
+	}
+	return &configv1.KMSConfig{
+		Type: configv1.VaultKMSProvider,
+		Vault: configv1.VaultKMSConfig{
+			KMSPluginImage: kms.WellKnownUpstreamMockKMSPluginImage,
+			VaultAddress:   "https://vault.example.com",
+			Authentication: configv1.VaultAuthentication{
+				Type: configv1.VaultAuthenticationTypeAppRole,
+				AppRole: configv1.VaultAppRoleAuthentication{
+					Secret: configv1.VaultSecretReference{Name: "vault-approle-secret"},
+				},
+			},
+			TransitKey: "test-transit-key",
+		},
 	}
 }


### PR DESCRIPTION
After the API changes have merged for KMS, KMSConfig can not be nil when encryption mode is set to KMS. This PR fixes this to enable e2e tests again.

Currently apart from the Image field (which points to mock KMS plugin), all the fields are dummy. But we'll have to update them with the correct values, once we onboard Vault enterprise in our CI. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved encryption test infrastructure to better simulate KMS configurations across encryption modes.

---

Note: Internal testing improvements only; no user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->