### PR TITLE
CNTRLPLANE-3237: Introduce kms to kms migration

### DIFF
--- a/pkg/operator/encryption/controllers/key_controller.go
+++ b/pkg/operator/encryption/controllers/key_controller.go
@@ -199,9 +199,21 @@ func (c *keyController) checkAndCreateKeys(ctx context.Context, syncContext fact
 	// fills up the state with all resources and set identity write key if write key secrets
 	// are missing.
 
+	var desiredProviderCfg kmsProviderConfig = noopKMSProviderConfig{}
+	if currentMode == state.KMS {
+		var err error
+		desiredProviderCfg, err = newKMSProviderConfig(apiEncryptionConfiguration.KMS)
+		if err != nil {
+			return err
+		}
+	}
+
 	var commonReason *string
 	for gr, grKeys := range desiredEncryptionState {
-		latestKeyID, internalReason, needed := needsNewKey(grKeys, currentMode, externalReason, encryptedGRs)
+		latestKeyID, internalReason, needed, err := needsNewKey(grKeys, currentMode, externalReason, encryptedGRs, desiredProviderCfg)
+		if err != nil {
+			return err
+		}
 		if !needed {
 			continue
 		}
@@ -228,7 +240,7 @@ func (c *keyController) checkAndCreateKeys(ctx context.Context, syncContext fact
 
 	sort.Sort(sort.StringSlice(reasons))
 	internalReason := strings.Join(reasons, ", ")
-	keySecret, err := c.generateKeySecret(ctx, newKeyID, currentMode, apiEncryptionConfiguration, internalReason, externalReason)
+	keySecret, err := c.generateKeySecret(ctx, newKeyID, currentMode, apiEncryptionConfiguration, desiredProviderCfg, internalReason, externalReason)
 	if err != nil {
 		return fmt.Errorf("failed to create key: %v", err)
 	}
@@ -265,7 +277,7 @@ func (c *keyController) validateExistingSecret(ctx context.Context, keySecret *c
 	return nil // we made this key earlier
 }
 
-func (c *keyController) generateKeySecret(ctx context.Context, keyID uint64, currentMode state.Mode, apiServerEncryption configv1.APIServerEncryption, internalReason, externalReason string) (*corev1.Secret, error) {
+func (c *keyController) generateKeySecret(ctx context.Context, keyID uint64, currentMode state.Mode, apiServerEncryption configv1.APIServerEncryption, desiredProviderCfg kmsProviderConfig, internalReason, externalReason string) (*corev1.Secret, error) {
 	bs := crypto.ModeToNewKeyFunc[currentMode]()
 	ks := state.KeyState{
 		Key: apiserverv1.Key{
@@ -287,12 +299,7 @@ func (c *keyController) generateKeySecret(ctx context.Context, keyID uint64, cur
 			Plugin: apiServerEncryption.KMS,
 		}
 
-		providerCfg, err := newKMSProviderConfig(apiServerEncryption.KMS)
-		if err != nil {
-			return nil, err
-		}
-
-		if secretName, expectedKeys, err := providerCfg.referencedSecretName(); err != nil {
+		if secretName, expectedKeys, err := desiredProviderCfg.referencedSecretName(); err != nil {
 			return nil, err
 		} else if len(secretName) > 0 {
 			refSecret, err := c.secretClient.Secrets(openshiftConfigNS).Get(ctx, secretName, metav1.GetOptions{})
@@ -310,7 +317,7 @@ func (c *keyController) generateKeySecret(ctx context.Context, keyID uint64, cur
 			}
 		}
 
-		if cmName, expectedKeys, err := providerCfg.referencedConfigMapName(); err != nil {
+		if cmName, expectedKeys, err := desiredProviderCfg.referencedConfigMapName(); err != nil {
 			return nil, err
 		} else if len(cmName) > 0 {
 			refCM, err := c.configMapClient.ConfigMaps(openshiftConfigNS).Get(ctx, cmName, metav1.GetOptions{})
@@ -363,21 +370,21 @@ func (c *keyController) getCurrentModeReasonAndEncryptionConfig(ctx context.Cont
 
 // needsNewKey checks whether a new key must be created for the given resource. If true, it also returns the latest
 // used key ID and a reason string.
-func needsNewKey(grKeys state.GroupResourceState, currentMode state.Mode, externalReason string, encryptedGRs []schema.GroupResource) (uint64, string, bool) {
+func needsNewKey(grKeys state.GroupResourceState, currentMode state.Mode, externalReason string, encryptedGRs []schema.GroupResource, desiredProviderCfg kmsProviderConfig) (uint64, string, bool, error) {
 	// we always need to have some encryption keys unless we are turned off
 	if len(grKeys.ReadKeys) == 0 {
-		return 0, "key-does-not-exist", currentMode != state.Identity
+		return 0, "key-does-not-exist", currentMode != state.Identity, nil
 	}
 
 	latestKey := grKeys.ReadKeys[0]
 	latestKeyID, ok := state.NameToKeyID(latestKey.Key.Name)
 	if !ok {
-		return latestKeyID, fmt.Sprintf("key-secret-%d-is-invalid", latestKeyID), true
+		return latestKeyID, fmt.Sprintf("key-secret-%d-is-invalid", latestKeyID), true, nil
 	}
 
 	// if latest secret has been deleted, we will never be able to migrate to that key.
 	if !latestKey.Backed {
-		return latestKeyID, fmt.Sprintf("encryption-config-key-%d-not-backed-by-secret", latestKeyID), true
+		return latestKeyID, fmt.Sprintf("encryption-config-key-%d-not-backed-by-secret", latestKeyID), true, nil
 	}
 
 	// check that we have pruned read-keys: the write-keys, plus at most one more backed read-key (potentially some unbacked once before)
@@ -388,45 +395,53 @@ func needsNewKey(grKeys state.GroupResourceState, currentMode state.Mode, extern
 		}
 	}
 	if backedKeys > 2 {
-		return 0, "", false
+		return 0, "", false, nil
 	}
 
 	// we have not migrated the latest key, do nothing until that is complete
 	if allMigrated, _, _ := state.MigratedFor(encryptedGRs, latestKey); !allMigrated {
-		return 0, "", false
+		return 0, "", false, nil
 	}
 
 	// if the most recent secret was encrypted in a mode different than the current mode, we need to generate a new key
 	if latestKey.Mode != currentMode {
-		return latestKeyID, "encryption-mode-changed", true
+		return latestKeyID, "encryption-mode-changed", true, nil
 	}
 
 	// if the most recent secret turned off encryption and we want to keep it that way, do nothing
 	if latestKey.Mode == state.Identity && currentMode == state.Identity {
-		return 0, "", false
+		return 0, "", false, nil
 	}
 
 	if currentMode == state.KMS {
 		// We are here because Encryption Mode is not changed
+		// However, we need to create a new key if migration-triggering fields
+		// in the KMS provider configuration have changed.
+		if latestKey.KMS == nil {
+			return 0, "", false, fmt.Errorf("KMS-mode key %q has nil KMS state, possibly corrupted key secret", latestKey.Key.Name)
+		}
+		same, err := desiredProviderCfg.sameProviderInstance(latestKey.KMS.Plugin)
+		if err != nil {
+			return 0, "", false, fmt.Errorf("failed to check KMS provider instance: %w", err)
+		}
+		if !same {
+			return latestKeyID, "kms-provider-changed", true, nil
+		}
 
-		// For now in Tech Preview v1, we don't support configurational changes. Therefore,
-		// it is pointless comparing the secrets.
-
-		// For KMS mode, we don't do time-based rotation. Therefore, we shortcut here
-		// KMS keys are rotated externally by the KMS system.
-		// Moreover, we don't trigger new key when external reason is changed.
+		// For KMS mode, we don't do time-based rotation. KMS keys are rotated
+		// externally by the KMS provider. Moreover, we don't trigger new key when external reason is changed.
 		// Because it would lead to duplicate providers which is not allowed.
-		return 0, "", false
+		return 0, "", false, nil
 	}
 
 	// if the most recent secret has a different external reason than the current reason, we need to generate a new key
 	if latestKey.ExternalReason != externalReason && len(externalReason) != 0 {
-		return latestKeyID, "external-reason-changed", true
+		return latestKeyID, "external-reason-changed", true, nil
 	}
 
 	// we check for encryptionSecretMigratedTimestamp set by migration controller to determine when migration completed
 	// this also generates back pressure for key rotation when migration takes a long time or was recently completed
-	return latestKeyID, "rotation-interval-has-passed", time.Since(latestKey.Migrated.Timestamp) > encryptionSecretMigrationInterval
+	return latestKeyID, "rotation-interval-has-passed", time.Since(latestKey.Migrated.Timestamp) > encryptionSecretMigrationInterval, nil
 }
 
 // kmsProviderConfig abstracts provider-specific KMS logic so that every
@@ -442,7 +457,26 @@ type kmsProviderConfig interface {
 	// config and the specific data keys to carry from that configmap. Only the listed keys
 	// are copied into the Key Secret; any other data in the referenced configmap is ignored.
 	referencedConfigMapName() (string, []string, error)
+	// sameProviderInstance reports whether latest (stored in the key secret)
+	// and this provider config refer to the same KMS provider instance.
+	// Returns false when migration-triggering fields differ (e.g. VaultAddress, TransitKey).
+	sameProviderInstance(stored configv1.KMSPluginConfig) (bool, error)
 }
+
+// noopKMSProviderConfig is a safe zero-value implementation used for non-KMS modes.
+// All methods return empty/false so callers never need nil checks.
+type noopKMSProviderConfig struct{}
+
+func (noopKMSProviderConfig) referencedSecretName() (string, []string, error) {
+	return "", nil, fmt.Errorf("referencedSecretName called on non-KMS provider")
+}
+func (noopKMSProviderConfig) referencedConfigMapName() (string, []string, error) {
+	return "", nil, fmt.Errorf("referencedConfigMapName called on non-KMS provider")
+}
+func (noopKMSProviderConfig) sameProviderInstance(configv1.KMSPluginConfig) (bool, error) {
+	return false, fmt.Errorf("sameProviderInstance called on non-KMS provider")
+}
+func (noopKMSProviderConfig) sourceConfig() interface{} { return nil }
 
 func newKMSProviderConfig(plugin configv1.KMSPluginConfig) (kmsProviderConfig, error) {
 	switch plugin.Type {
@@ -477,6 +511,30 @@ func (v *vaultProviderConfig) referencedConfigMapName() (string, []string, error
 		return "", nil, nil
 	}
 	return v.vault.TLS.CABundle.Name, []string{"ca-bundle.crt"}, nil
+}
+
+func (v *vaultProviderConfig) sameProviderInstance(stored configv1.KMSPluginConfig) (bool, error) {
+	if stored.Type != configv1.VaultKMSProvider {
+		klog.V(2).Infof("KMS provider instance changed: provider type changed from %q to %q", stored.Type, configv1.VaultKMSProvider)
+		return false, nil
+	}
+	if v.vault.VaultAddress != stored.Vault.VaultAddress {
+		klog.V(2).Infof("KMS provider instance changed: VaultAddress changed from %q to %q", stored.Vault.VaultAddress, v.vault.VaultAddress)
+		return false, nil
+	}
+	if v.vault.VaultNamespace != stored.Vault.VaultNamespace {
+		klog.V(2).Infof("KMS provider instance changed: VaultNamespace changed from %q to %q", stored.Vault.VaultNamespace, v.vault.VaultNamespace)
+		return false, nil
+	}
+	if v.vault.TransitMount != stored.Vault.TransitMount {
+		klog.V(2).Infof("KMS provider instance changed: TransitMount changed from %q to %q", stored.Vault.TransitMount, v.vault.TransitMount)
+		return false, nil
+	}
+	if v.vault.TransitKey != stored.Vault.TransitKey {
+		klog.V(2).Infof("KMS provider instance changed: TransitKey changed from %q to %q", stored.Vault.TransitKey, v.vault.TransitKey)
+		return false, nil
+	}
+	return true, nil
 }
 
 // TODO make this un-settable once set

--- a/pkg/operator/encryption/controllers/key_controller_test.go
+++ b/pkg/operator/encryption/controllers/key_controller_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	clocktesting "k8s.io/utils/clock/testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -768,6 +769,68 @@ func TestKeyController(t *testing.T) {
 				}
 			},
 		},
+
+		{
+			name: "no-op when only KMSPluginImage changes (non-migration field)",
+			targetGRs: []schema.GroupResource{
+				{Group: "", Resource: "secrets"},
+			},
+			initialObjects: []runtime.Object{
+				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
+				encryptiontesting.CreateMigratedEncryptionKeySecretWithKMSPluginConfig("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 5, time.Now()),
+			},
+			apiServerObjects: []runtime.Object{func() runtime.Object {
+				s := simpleAPIServer.DeepCopy()
+				changedConfig := encryptiontesting.DefaultKMSPluginConfig.DeepCopy()
+				changedConfig.Vault.KMSPluginImage = "registry.example.com/kms-plugin@sha256:0000000000000000000000000000000000000000000000000000000000000000"
+				s.Spec.Encryption = configv1.APIServerEncryption{Type: "KMS", KMS: *changedConfig}
+				return s
+			}()},
+			targetNamespace: "kms",
+			expectedActions: []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed"},
+		},
+
+		{
+			name: "no-op when only Authentication changes (non-migration field)",
+			targetGRs: []schema.GroupResource{
+				{Group: "", Resource: "secrets"},
+			},
+			initialObjects: []runtime.Object{
+				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
+				encryptiontesting.CreateMigratedEncryptionKeySecretWithKMSPluginConfig("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 5, time.Now()),
+			},
+			apiServerObjects: []runtime.Object{func() runtime.Object {
+				s := simpleAPIServer.DeepCopy()
+				changedConfig := encryptiontesting.DefaultKMSPluginConfig.DeepCopy()
+				changedConfig.Vault.Authentication.AppRole.Secret.Name = "new-approle-secret"
+				s.Spec.Encryption = configv1.APIServerEncryption{Type: "KMS", KMS: *changedConfig}
+				return s
+			}()},
+			targetNamespace: "kms",
+			expectedActions: []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed"},
+		},
+
+		{
+			name: "no-op when only TLS changes (non-migration field)",
+			targetGRs: []schema.GroupResource{
+				{Group: "", Resource: "secrets"},
+			},
+			initialObjects: []runtime.Object{
+				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
+				encryptiontesting.CreateMigratedEncryptionKeySecretWithKMSPluginConfig("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 5, time.Now()),
+			},
+			apiServerObjects: []runtime.Object{func() runtime.Object {
+				s := simpleAPIServer.DeepCopy()
+				changedConfig := encryptiontesting.DefaultKMSPluginConfig.DeepCopy()
+				changedConfig.Vault.TLS = configv1.VaultTLSConfig{
+					CABundle: configv1.VaultConfigMapReference{Name: "my-ca"},
+				}
+				s.Spec.Encryption = configv1.APIServerEncryption{Type: "KMS", KMS: *changedConfig}
+				return s
+			}()},
+			targetNamespace: "kms",
+			expectedActions: []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed"},
+		},
 	}
 
 	for _, scenario := range scenarios {
@@ -842,6 +905,98 @@ func TestKeyController(t *testing.T) {
 			if scenario.validateOperatorClientFunc != nil {
 				scenario.validateOperatorClientFunc(t, fakeOperatorClient)
 			}
+		})
+	}
+}
+
+func TestKMSMigrationTriggeredFields(t *testing.T) {
+	simpleAPIServer := &configv1.APIServer{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}}
+
+	scenarios := []struct {
+		name   string
+		mutate func(cfg *configv1.KMSPluginConfig)
+	}{
+		{
+			name:   "VaultAddress",
+			mutate: func(cfg *configv1.KMSPluginConfig) { cfg.Vault.VaultAddress = "https://vault-new.example.com" },
+		},
+		{
+			name:   "VaultNamespace",
+			mutate: func(cfg *configv1.KMSPluginConfig) { cfg.Vault.VaultNamespace = "new-namespace" },
+		},
+		{
+			name:   "TransitMount",
+			mutate: func(cfg *configv1.KMSPluginConfig) { cfg.Vault.TransitMount = "new-mount" },
+		},
+		{
+			name:   "TransitKey",
+			mutate: func(cfg *configv1.KMSPluginConfig) { cfg.Vault.TransitKey = "new-transit-key" },
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			changedConfig := encryptiontesting.DefaultKMSPluginConfig.DeepCopy()
+			scenario.mutate(changedConfig)
+
+			apiServerWithChangedKMS := simpleAPIServer.DeepCopy()
+			apiServerWithChangedKMS.Spec.Encryption = configv1.APIServerEncryption{Type: "KMS", KMS: *changedConfig}
+
+			fakeOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(
+				&operatorv1.StaticPodOperatorSpec{
+					OperatorSpec: operatorv1.OperatorSpec{ManagementState: operatorv1.Managed},
+				},
+				&operatorv1.StaticPodOperatorStatus{
+					OperatorStatus: operatorv1.OperatorStatus{
+						Conditions: []operatorv1.OperatorCondition{
+							{Type: "EncryptionKeyControllerDegraded", Status: "False"},
+						},
+					},
+					NodeStatuses: []operatorv1.NodeStatus{{NodeName: "node-1"}},
+				},
+				nil, nil,
+			)
+
+			initialObjects := []runtime.Object{
+				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
+				encryptiontesting.CreateMigratedEncryptionKeySecretWithKMSPluginConfig("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 5, time.Now()),
+				encryptiontesting.CreateVaultAppRoleSecret("vault-approle-secret", "test-role-id", "test-secret-id"),
+				encryptiontesting.CreateVaultCABundleConfigMap("vault-ca-bundle", "test-ca-cert"),
+			}
+
+			fakeKubeClient := fake.NewSimpleClientset(initialObjects...)
+			eventRecorder := events.NewRecorder(fakeKubeClient.CoreV1().Events("kms"), "test-encryptionKeyController", &corev1.ObjectReference{}, clocktesting.NewFakePassiveClock(time.Now()))
+			kubeInformers := v1helpers.NewKubeInformersForNamespaces(fakeKubeClient, "openshift-config-managed", "openshift-config", "kms")
+			fakeSecretClient := fakeKubeClient.CoreV1()
+			fakeConfigMapClient := fakeKubeClient.CoreV1()
+			fakePodClient := fakeKubeClient.CoreV1()
+			fakeConfigClient := configv1clientfake.NewSimpleClientset(apiServerWithChangedKMS)
+			fakeApiServerClient := fakeConfigClient.ConfigV1().APIServers()
+			fakeApiServerInformer := configv1informers.NewSharedInformerFactory(fakeConfigClient, time.Minute).Config().V1().APIServers()
+
+			deployer, err := encryptiondeployer.NewRevisionLabelPodDeployer("revision", "kms", kubeInformers, fakePodClient, fakeSecretClient, encryptiondeployer.StaticPodNodeProvider{OperatorClient: fakeOperatorClient})
+			require.NoError(t, err)
+
+			provider := newTestProvider([]schema.GroupResource{{Group: "", Resource: "secrets"}})
+			target := NewKeyController("kms", nil, provider, deployer, alwaysFulfilledPreconditions, fakeOperatorClient, fakeApiServerClient, fakeApiServerInformer, kubeInformers, fakeSecretClient, fakeConfigMapClient, metav1.ListOptions{}, eventRecorder)
+
+			err = target.Sync(context.TODO(), factory.NewSyncContext("test", eventRecorder))
+			require.NoError(t, err)
+
+			expectedActions := []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config", "get:configmaps:openshift-config", "create:secrets:openshift-config-managed", "create:events:kms"}
+			require.NoError(t, encryptiontesting.ValidateActionsVerbs(fakeKubeClient.Actions(), expectedActions))
+
+			for _, action := range fakeKubeClient.Actions() {
+				if action.Matches("create", "secrets") {
+					createAction := action.(clientgotesting.CreateAction)
+					actualSecret := createAction.GetObject().(*corev1.Secret)
+					require.Equal(t, "KMS", actualSecret.Annotations["encryption.apiserver.operator.openshift.io/mode"])
+					require.Equal(t, "secrets-kms-provider-changed", actualSecret.Annotations["encryption.apiserver.operator.openshift.io/internal-reason"])
+					require.Equal(t, "encryption-key-kms-6", actualSecret.Name)
+					return
+				}
+			}
+			t.Fatal("expected a new key secret to be created")
 		})
 	}
 }
@@ -1137,6 +1292,121 @@ func TestGetCurrentModeReasonAndEncryptionConfig(t *testing.T) {
 			if currentMode == "KMS" && encryption.KMS == (configv1.KMSPluginConfig{}) {
 				t.Errorf("expected non-empty KMS config when mode is KMS")
 			}
+		})
+	}
+}
+
+func TestSameProviderInstance(t *testing.T) {
+	baseConfig := &configv1.KMSPluginConfig{
+		Type: configv1.VaultKMSProvider,
+		Vault: configv1.VaultKMSPluginConfig{
+			KMSPluginImage: "registry.example.com/kms-plugin@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+			VaultAddress:   "https://vault.example.com",
+			VaultNamespace: "ns1",
+			TransitMount:   "transit",
+			TransitKey:     "my-key",
+			Authentication: configv1.VaultAuthentication{
+				Type: configv1.VaultAuthenticationTypeAppRole,
+				AppRole: configv1.VaultAppRoleAuthentication{
+					Secret: configv1.VaultSecretReference{Name: "vault-approle-secret"},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		latest   *configv1.KMSPluginConfig
+		current  *configv1.KMSPluginConfig
+		expected bool
+	}{
+		{
+			name:     "identical configs",
+			latest:   baseConfig.DeepCopy(),
+			current:  baseConfig.DeepCopy(),
+			expected: true,
+		},
+		{
+			name:   "different VaultAddress",
+			latest: baseConfig.DeepCopy(),
+			current: func() *configv1.KMSPluginConfig {
+				c := baseConfig.DeepCopy()
+				c.Vault.VaultAddress = "https://vault-new.example.com"
+				return c
+			}(),
+			expected: false,
+		},
+		{
+			name:   "different VaultNamespace",
+			latest: baseConfig.DeepCopy(),
+			current: func() *configv1.KMSPluginConfig {
+				c := baseConfig.DeepCopy()
+				c.Vault.VaultNamespace = "ns2"
+				return c
+			}(),
+			expected: false,
+		},
+		{
+			name:   "different TransitKey",
+			latest: baseConfig.DeepCopy(),
+			current: func() *configv1.KMSPluginConfig {
+				c := baseConfig.DeepCopy()
+				c.Vault.TransitKey = "new-key"
+				return c
+			}(),
+			expected: false,
+		},
+		{
+			name:   "different TransitMount",
+			latest: baseConfig.DeepCopy(),
+			current: func() *configv1.KMSPluginConfig {
+				c := baseConfig.DeepCopy()
+				c.Vault.TransitMount = "custom-transit"
+				return c
+			}(),
+			expected: false,
+		},
+		{
+			name:   "different KMSPluginImage only",
+			latest: baseConfig.DeepCopy(),
+			current: func() *configv1.KMSPluginConfig {
+				c := baseConfig.DeepCopy()
+				c.Vault.KMSPluginImage = "registry.example.com/kms-plugin@sha256:0000000000000000000000000000000000000000000000000000000000000000"
+				return c
+			}(),
+			expected: true,
+		},
+		{
+			name:   "different TLS only",
+			latest: baseConfig.DeepCopy(),
+			current: func() *configv1.KMSPluginConfig {
+				c := baseConfig.DeepCopy()
+				c.Vault.TLS = configv1.VaultTLSConfig{
+					CABundle: configv1.VaultConfigMapReference{Name: "my-ca"},
+				}
+				return c
+			}(),
+			expected: true,
+		},
+		{
+			name:   "different Authentication only",
+			latest: baseConfig.DeepCopy(),
+			current: func() *configv1.KMSPluginConfig {
+				c := baseConfig.DeepCopy()
+				c.Vault.Authentication.AppRole.Secret.Name = "new-secret"
+				return c
+			}(),
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			providerCfg, err := newKMSProviderConfig(*tt.current)
+			require.NoError(t, err)
+			got, err := providerCfg.sameProviderInstance(*tt.latest)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, got)
 		})
 	}
 }

--- a/test/e2e-encryption/encryption_test.go
+++ b/test/e2e-encryption/encryption_test.go
@@ -634,33 +634,64 @@ func TestEncryptionIntegration(tt *testing.T) {
 	verifyKMSSecretData()
 	verifyKMSConfigMapData()
 
+	t.Logf("KMS-to-KMS migration: change VaultAddress")
+	_, err = fakeApiServerClient.Patch(ctx, "cluster", types.MergePatchType, []byte(`{"spec":{"encryption":{"kms":{"vault":{"vaultAddress":"https://vault-new.example.com"}}}}}`), metav1.PatchOptions{})
+	require.NoError(t, err)
+	waitForKeys(12)
+	kms13 := kmsPluginName("kubeapiservers", "13")
+	kms13Sched := kmsPluginName("kubeschedulers", "13")
+	waitForConfigs(
+		fmt.Sprintf("kubeapiservers.operator.openshift.io=kms:%s,kms:%s,aescbc:11,identity;kubeschedulers.operator.openshift.io=kms:%s,kms:%s,aescbc:11,identity", kms12, kms13, kms12Sched, kms13Sched),
+		fmt.Sprintf("kubeapiservers.operator.openshift.io=kms:%s,kms:%s,aescbc:11,identity;kubeschedulers.operator.openshift.io=kms:%s,kms:%s,aescbc:11,identity", kms13, kms12, kms13Sched, kms12Sched),
+		fmt.Sprintf("kubeapiservers.operator.openshift.io=kms:%s,kms:%s,identity;kubeschedulers.operator.openshift.io=kms:%s,kms:%s,identity", kms13, kms12, kms13Sched, kms12Sched),
+	)
+	waitForMigration("13")
+	waitForConditionStatus("Encrypted", operatorv1.ConditionTrue)
+
+	t.Logf("Verify KMS-to-KMS migration key secret contains updated plugin config")
+	kmsKeySecret13, err := kubeClient.CoreV1().Secrets("openshift-config-managed").Get(ctx, fmt.Sprintf("encryption-key-%s-13", component), metav1.GetOptions{})
+	require.NoError(t, err)
+	kmsPluginConfigData13 := kmsKeySecret13.Data["encryption.apiserver.operator.openshift.io-kms-plugin-config"]
+	require.NotEmpty(t, kmsPluginConfigData13)
+	pluginConfig13, err := encoding.DecodeKMSPluginConfig(kmsPluginConfigData13)
+	require.NoError(t, err)
+	require.Equal(t, "https://vault-new.example.com", pluginConfig13.Vault.VaultAddress)
+	require.Equal(t, "test-transit-key", pluginConfig13.Vault.TransitKey)
+
+	t.Logf("KMS non-migration change: only KMSPluginImage changes (no new key expected)")
+	_, err = fakeApiServerClient.Patch(ctx, "cluster", types.MergePatchType, []byte(`{"spec":{"encryption":{"type":"KMS","kms":{"type":"Vault","vault":{"kmsPluginImage":"registry.example.com/kms-plugin@sha256:0000000000000000000000000000000000000000000000000000000000000000","vaultAddress":"https://vault-new.example.com","authentication":{"type":"AppRole","appRole":{"secret":{"name":"vault-approle-secret"}}},"transitKey":"test-transit-key"}}}}}`), metav1.PatchOptions{})
+	require.NoError(t, err)
+	time.Sleep(5 * time.Second)
+	waitForKeys(12)
+	waitForConditionStatus("Encrypted", operatorv1.ConditionTrue)
+
 	t.Logf("Delete the encryption-config while in KMS mode")
 	_, err = kubeClient.CoreV1().Secrets("openshift-config-managed").Patch(ctx, fmt.Sprintf("encryption-config-%s", component), types.JSONPatchType, []byte(`[{"op":"remove","path":"/metadata/finalizers"}]`), metav1.PatchOptions{})
 	require.NoError(t, err)
 	err = kubeClient.CoreV1().Secrets("openshift-config-managed").Delete(ctx, fmt.Sprintf("encryption-config-%s", component), metav1.DeleteOptions{})
 	require.NoError(t, err)
 	waitForConfigs(
-		fmt.Sprintf("kubeapiservers.operator.openshift.io=kms:%s,aescbc:11,identity;kubeschedulers.operator.openshift.io=kms:%s,aescbc:11,identity", kms12, kms12Sched),
+		fmt.Sprintf("kubeapiservers.operator.openshift.io=kms:%s,kms:%s,identity;kubeschedulers.operator.openshift.io=kms:%s,kms:%s,identity", kms13, kms12, kms13Sched, kms12Sched),
 	)
 	waitForConditionStatus("Encrypted", operatorv1.ConditionTrue)
 
 	t.Logf("Delete the operand config while in KMS mode")
 	deployer.DeleteOperandConfig()
 	waitForConfigs(
-		// kms12 is migrated and hence only one needed, but we rotate through identity
-		fmt.Sprintf("kubeapiservers.operator.openshift.io=identity,kms:%s,aescbc:11;kubeschedulers.operator.openshift.io=identity,kms:%s,aescbc:11", kms12, kms12Sched),
-		// kms12 is migrated, plus one backed key (11)
-		fmt.Sprintf("kubeapiservers.operator.openshift.io=kms:%s,aescbc:11,identity;kubeschedulers.operator.openshift.io=kms:%s,aescbc:11,identity", kms12, kms12Sched),
+		// kms13 is migrated and hence only one needed, but we rotate through identity
+		fmt.Sprintf("kubeapiservers.operator.openshift.io=identity,kms:%s,kms:%s;kubeschedulers.operator.openshift.io=identity,kms:%s,kms:%s", kms13, kms12, kms13Sched, kms12Sched),
+		// kms13 is migrated, plus one backed key (12)
+		fmt.Sprintf("kubeapiservers.operator.openshift.io=kms:%s,kms:%s,identity;kubeschedulers.operator.openshift.io=kms:%s,kms:%s,identity", kms13, kms12, kms13Sched, kms12Sched),
 	)
 	waitForConditionStatus("Encrypted", operatorv1.ConditionTrue)
 
 	t.Logf("Switch to identity from KMS")
 	_, err = fakeApiServerClient.Patch(ctx, "cluster", types.MergePatchType, []byte(`{"spec":{"encryption":{"type":"identity","kms":null}}}`), metav1.PatchOptions{})
 	require.NoError(t, err)
-	waitForKeys(12)
+	waitForKeys(13)
 	waitForConfigs(
-		fmt.Sprintf("kubeapiservers.operator.openshift.io=kms:%s,aescbc:11,identity,aesgcm:13;kubeschedulers.operator.openshift.io=kms:%s,aescbc:11,identity,aesgcm:13", kms12, kms12Sched),
-		fmt.Sprintf("kubeapiservers.operator.openshift.io=identity,kms:%s,aescbc:11,aesgcm:13;kubeschedulers.operator.openshift.io=identity,kms:%s,aescbc:11,aesgcm:13", kms12, kms12Sched),
+		fmt.Sprintf("kubeapiservers.operator.openshift.io=kms:%s,kms:%s,identity,aesgcm:14;kubeschedulers.operator.openshift.io=kms:%s,kms:%s,identity,aesgcm:14", kms13, kms12, kms13Sched, kms12Sched),
+		fmt.Sprintf("kubeapiservers.operator.openshift.io=identity,kms:%s,kms:%s,aesgcm:14;kubeschedulers.operator.openshift.io=identity,kms:%s,kms:%s,aesgcm:14", kms13, kms12, kms13Sched, kms12Sched),
 	)
 	waitForConditionStatus("Encrypted", operatorv1.ConditionFalse)
 }


### PR DESCRIPTION
This PR introduces KMS to KMS migration described in https://github.com/openshift/enhancements/blob/master/enhancements/kube-apiserver/kms-encryption-foundations.md. KMS to KMS migration is triggered only when predefined set of fields are updated. 

This PR paves the way for pre-flight checker. So that preflight-checker can be integrated to key controller.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-key KMS provider configurations are tracked and stored alongside encryption keys, improving KMS→KMS migration accuracy and cross-secret consistency.

* **Bug Fixes / Behavior**
  * Controller now detects meaningful KMS provider changes (e.g., address, namespace, transit settings) and triggers key rollover; innocuous config changes no longer cause rotations.

* **Tests**
  * Expanded unit and e2e coverage for provider-change detection, migration flows, no-op scenarios, and per-key consistency checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->