### PR TITLE
CNTRLPLANE-3237: use runtime.Encode/Decode with registered types

### DIFF
--- a/pkg/operator/encryption/controllers/key_controller_test.go
+++ b/pkg/operator/encryption/controllers/key_controller_test.go
@@ -3,7 +3,6 @@ package controllers
 import (
 	"context"
 	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
@@ -28,6 +27,7 @@ import (
 
 	"github.com/openshift/library-go/pkg/controller/factory"
 	encryptiondeployer "github.com/openshift/library-go/pkg/operator/encryption/deployer"
+	"github.com/openshift/library-go/pkg/operator/encryption/encoding"
 	encryptiondatatesting "github.com/openshift/library-go/pkg/operator/encryption/encryptiondata/testing"
 	encryptiontesting "github.com/openshift/library-go/pkg/operator/encryption/testing"
 	"github.com/openshift/library-go/pkg/operator/events"
@@ -372,15 +372,24 @@ func TestKeyController(t *testing.T) {
 						if len(kmsConfigData) == 0 {
 							ts.Error("expected kms-encryption-config data to be present")
 						}
-						if string(kmsConfigData) != `{"apiVersion":"v2","name":"1","endpoint":"unix:///var/run/kmsplugin/kms-1.sock","timeout":"10s"}` {
+						expectedEncCfg, err := encoding.EncodeKMSConfiguration(&apiserverconfigv1.KMSConfiguration{
+							APIVersion: "v2",
+							Name:       "1",
+							Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
+							Timeout:    &metav1.Duration{Duration: 10 * time.Second},
+						})
+						if err != nil {
+							ts.Fatalf("failed to encode KMS encryption config: %v", err)
+						}
+						if string(kmsConfigData) != string(expectedEncCfg) {
 							ts.Errorf("unexpected kms-encryption-config: %s", kmsConfigData)
 						}
 
 						// Verify KMS provider config content
 						kmsProviderConfigData := actualSecret.Data["encryption.apiserver.operator.openshift.io-kms-provider-config"]
-						expectedProviderConfig, err := json.Marshal(dummyKMSConfig)
+						expectedProviderConfig, err := encoding.EncodeKMSConfig(dummyKMSConfig)
 						if err != nil {
-							ts.Fatalf("failed to marshal expected provider config: %v", err)
+							ts.Fatalf("failed to encode KMS config: %v", err)
 						}
 						if string(kmsProviderConfigData) != string(expectedProviderConfig) {
 							ts.Errorf("unexpected kms-provider-config: %s", kmsProviderConfigData)
@@ -441,15 +450,24 @@ func TestKeyController(t *testing.T) {
 
 						// Verify KMS config is in data field
 						kmsConfigData := actualSecret.Data["encryption.apiserver.operator.openshift.io-kms-encryption-config"]
-						if string(kmsConfigData) != `{"apiVersion":"v2","name":"6","endpoint":"unix:///var/run/kmsplugin/kms-6.sock","timeout":"10s"}` {
+						expectedEncCfg, err := encoding.EncodeKMSConfiguration(&apiserverconfigv1.KMSConfiguration{
+							APIVersion: "v2",
+							Name:       "6",
+							Endpoint:   "unix:///var/run/kmsplugin/kms-6.sock",
+							Timeout:    &metav1.Duration{Duration: 10 * time.Second},
+						})
+						if err != nil {
+							ts.Fatalf("failed to encode KMS encryption config: %v", err)
+						}
+						if string(kmsConfigData) != string(expectedEncCfg) {
 							ts.Errorf("unexpected kms-encryption-config: %s", kmsConfigData)
 						}
 
 						// Verify KMS provider config content
 						kmsProviderConfigData := actualSecret.Data["encryption.apiserver.operator.openshift.io-kms-provider-config"]
-						expectedProviderConfig, err := json.Marshal(dummyKMSConfig)
+						expectedProviderConfig, err := encoding.EncodeKMSConfig(dummyKMSConfig)
 						if err != nil {
-							ts.Fatalf("failed to marshal expected provider config: %v", err)
+							ts.Fatalf("failed to encode KMS config: %v", err)
 						}
 						if string(kmsProviderConfigData) != string(expectedProviderConfig) {
 							ts.Errorf("unexpected kms-provider-config: %s", kmsProviderConfigData)
@@ -526,15 +544,24 @@ func TestKeyController(t *testing.T) {
 
 						// Verify KMS config is in data field
 						kmsConfigData := actualSecret.Data["encryption.apiserver.operator.openshift.io-kms-encryption-config"]
-						if string(kmsConfigData) != `{"apiVersion":"v2","name":"6","endpoint":"unix:///var/run/kmsplugin/kms-6.sock","timeout":"10s"}` {
+						expectedEncCfg, err := encoding.EncodeKMSConfiguration(&apiserverconfigv1.KMSConfiguration{
+							APIVersion: "v2",
+							Name:       "6",
+							Endpoint:   "unix:///var/run/kmsplugin/kms-6.sock",
+							Timeout:    &metav1.Duration{Duration: 10 * time.Second},
+						})
+						if err != nil {
+							ts.Fatalf("failed to encode KMS encryption config: %v", err)
+						}
+						if string(kmsConfigData) != string(expectedEncCfg) {
 							ts.Errorf("unexpected kms-encryption-config: %s", kmsConfigData)
 						}
 
 						// Verify KMS provider config content
 						kmsProviderConfigData := actualSecret.Data["encryption.apiserver.operator.openshift.io-kms-provider-config"]
-						expectedProviderConfig, err := json.Marshal(dummyKMSConfig)
+						expectedProviderConfig, err := encoding.EncodeKMSConfig(dummyKMSConfig)
 						if err != nil {
-							ts.Fatalf("failed to marshal expected provider config: %v", err)
+							ts.Fatalf("failed to encode KMS config: %v", err)
 						}
 						if string(kmsProviderConfigData) != string(expectedProviderConfig) {
 							ts.Errorf("unexpected kms-provider-config: %s", kmsProviderConfigData)

--- a/pkg/operator/encryption/controllers/state_controller_test.go
+++ b/pkg/operator/encryption/controllers/state_controller_test.go
@@ -699,13 +699,13 @@ func TestStateController(t *testing.T) {
 				}(),
 			},
 			expectedActions: []string{"list:pods:kms", "get:secrets:kms"},
-			expectedError:   fmt.Errorf("invalid encryption config kms/encryption-config-1: yaml: control characters are not allowed"),
+			expectedError:   fmt.Errorf("invalid encryption config kms/encryption-config-1: failed to decode EncryptionConfiguration: yaml: control characters are not allowed"),
 			validateOperatorClientFunc: func(ts *testing.T, operatorClient v1helpers.OperatorClient) {
 				expectedCondition := operatorv1.OperatorCondition{
 					Type:    "EncryptionStateControllerDegraded",
 					Status:  "True",
 					Reason:  "Error",
-					Message: "invalid encryption config kms/encryption-config-1: yaml: control characters are not allowed",
+					Message: "invalid encryption config kms/encryption-config-1: failed to decode EncryptionConfiguration: yaml: control characters are not allowed",
 				}
 				encryptiontesting.ValidateOperatorClientConditions(ts, operatorClient, []operatorv1.OperatorCondition{expectedCondition})
 			},

--- a/pkg/operator/encryption/encoding/encoding.go
+++ b/pkg/operator/encryption/encoding/encoding.go
@@ -1,0 +1,108 @@
+package encoding
+
+import (
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
+)
+
+var (
+	scheme = runtime.NewScheme()
+	codecs = serializer.NewCodecFactory(scheme)
+)
+
+func init() {
+	utilruntime.Must(configv1.AddToScheme(scheme))
+	utilruntime.Must(apiserverconfigv1.AddToScheme(scheme))
+}
+
+// EncodeEncryptionConfiguration serializes an EncryptionConfiguration to its serialized representation.
+func EncodeEncryptionConfiguration(encryptionConfiguration *apiserverconfigv1.EncryptionConfiguration) ([]byte, error) {
+	if encryptionConfiguration == nil {
+		return nil, fmt.Errorf("EncryptionConfiguration object cannot be nil")
+	}
+	encoder := codecs.LegacyCodec(apiserverconfigv1.SchemeGroupVersion)
+	encryptionConfigurationData, err := runtime.Encode(encoder, encryptionConfiguration)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode EncryptionConfiguration: %w", err)
+	}
+	return encryptionConfigurationData, nil
+}
+
+// DecodeEncryptionConfiguration extracts an EncryptionConfiguration object from its serialized representation.
+func DecodeEncryptionConfiguration(data []byte) (*apiserverconfigv1.EncryptionConfiguration, error) {
+	encryptionConfiguration := &apiserverconfigv1.EncryptionConfiguration{}
+	err := runtime.DecodeInto(codecs.UniversalDecoder(apiserverconfigv1.SchemeGroupVersion), data, encryptionConfiguration)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode EncryptionConfiguration: %w", err)
+	}
+	return encryptionConfiguration, nil
+}
+
+// EncodeKMSConfiguration serializes a KMSConfiguration into an EncryptionConfiguration wrapper.
+// We use an EncryptionConfiguration as an envelope type because KMSConfiguration is not a runtime.Object.
+func EncodeKMSConfiguration(encryption *apiserverconfigv1.KMSConfiguration) ([]byte, error) {
+	if encryption == nil {
+		return nil, fmt.Errorf("KMSConfiguration object cannot be nil")
+	}
+	encryptionConfiguration := &apiserverconfigv1.EncryptionConfiguration{
+		Resources: []apiserverconfigv1.ResourceConfiguration{
+			{
+				Providers: []apiserverconfigv1.ProviderConfiguration{
+					{KMS: encryption},
+				},
+			},
+		},
+	}
+	return EncodeEncryptionConfiguration(encryptionConfiguration)
+}
+
+// DecodeKMSConfiguration extracts a KMSConfiguration from its serialized EncryptionConfiguration wrapper.
+// We use an EncryptionConfiguration as an envelope type because KMSConfiguration is not a runtime.Object.
+func DecodeKMSConfiguration(data []byte) (*apiserverconfigv1.KMSConfiguration, error) {
+	encryptionConfiguration, err := DecodeEncryptionConfiguration(data)
+	if err != nil {
+		return nil, err
+	}
+	// This should never happen, unless the object was not serialized with EncodeKMSConfiguration
+	if len(encryptionConfiguration.Resources) != 1 || len(encryptionConfiguration.Resources[0].Providers) != 1 {
+		return nil, fmt.Errorf("invalid KMS encryption config")
+	}
+	return encryptionConfiguration.Resources[0].Providers[0].KMS, nil
+}
+
+// EncodeKMSConfig serializes a configv1.KMSConfig into a configv1.APIServer wrapper.
+// We use a configv1.APIServer as an envelope type because configv1.KMSConfig is not a runtime.Object.
+func EncodeKMSConfig(kmsConfig *configv1.KMSConfig) ([]byte, error) {
+	if kmsConfig == nil {
+		return nil, fmt.Errorf("KMSConfig object cannot be nil")
+	}
+	apiServerObj := &configv1.APIServer{
+		Spec: configv1.APIServerSpec{
+			Encryption: configv1.APIServerEncryption{
+				KMS: kmsConfig,
+			},
+		},
+	}
+	encoder := codecs.LegacyCodec(configv1.SchemeGroupVersion)
+	providerData, err := runtime.Encode(encoder, apiServerObj)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode KMS provider config: %w", err)
+	}
+	return providerData, nil
+}
+
+// DecodeKMSConfig extracts a configv1.KMSConfig object from its serialized configv1.APIServer wrapper.
+// We use a configv1.APIServer as an envelope type because KMSConfig is not a runtime.Object.
+func DecodeKMSConfig(data []byte) (*configv1.KMSConfig, error) {
+	apiServer := &configv1.APIServer{}
+	err := runtime.DecodeInto(codecs.UniversalDecoder(configv1.SchemeGroupVersion), data, apiServer)
+	if err != nil {
+		return nil, err
+	}
+	return apiServer.Spec.Encryption.KMS, nil
+}

--- a/pkg/operator/encryption/encryptiondata/secret.go
+++ b/pkg/operator/encryption/encryptiondata/secret.go
@@ -5,22 +5,10 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
 
+	"github.com/openshift/library-go/pkg/operator/encryption/encoding"
 	"github.com/openshift/library-go/pkg/operator/encryption/state"
 )
-
-var (
-	apiserverScheme = runtime.NewScheme()
-	apiserverCodecs = serializer.NewCodecFactory(apiserverScheme)
-)
-
-func init() {
-	utilruntime.Must(apiserverconfigv1.AddToScheme(apiserverScheme))
-}
 
 // EncryptionConfSecretName is the name of the final encryption config secret that is revisioned per apiserver rollout.
 const EncryptionConfSecretName = "encryption-config"
@@ -33,16 +21,9 @@ func FromSecret(encryptionConfigSecret *corev1.Secret) (*Config, error) {
 	if !ok {
 		return nil, nil
 	}
-
-	decoder := apiserverCodecs.UniversalDecoder(apiserverconfigv1.SchemeGroupVersion)
-	encryptionConfigObj, err := runtime.Decode(decoder, data)
+	encryptionConfig, err := encoding.DecodeEncryptionConfiguration(data)
 	if err != nil {
 		return nil, err
-	}
-
-	encryptionConfig, ok := encryptionConfigObj.(*apiserverconfigv1.EncryptionConfiguration)
-	if !ok {
-		return nil, fmt.Errorf("unexpected wrong type %T", encryptionConfigObj)
 	}
 	return &Config{Encryption: encryptionConfig}, nil
 }
@@ -52,8 +33,7 @@ func ToSecret(ns, name string, secretData *Config) (*corev1.Secret, error) {
 		return nil, fmt.Errorf("secret %s/%s has no encryption config", ns, name)
 	}
 
-	encoder := apiserverCodecs.LegacyCodec(apiserverconfigv1.SchemeGroupVersion)
-	rawEncryptionCfg, err := runtime.Encode(encoder, secretData.Encryption)
+	rawEncryptionCfg, err := encoding.EncodeEncryptionConfiguration(secretData.Encryption)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode the encryption config: %v", err)
 	}

--- a/pkg/operator/encryption/secrets/secrets.go
+++ b/pkg/operator/encryption/secrets/secrets.go
@@ -8,13 +8,13 @@ import (
 	"strconv"
 	"time"
 
-	configv1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 
+	"github.com/openshift/library-go/pkg/operator/encryption/encoding"
 	"github.com/openshift/library-go/pkg/operator/encryption/state"
 )
 
@@ -66,8 +66,8 @@ func ToKeyState(s *corev1.Secret) (state.KeyState, error) {
 	case state.KMS:
 		key.KMSConfig = &state.KMSConfig{}
 		if v, ok := s.Data[EncryptionSecretKMSEncryptionConfig]; ok && len(v) > 0 {
-			kmsConfiguration := &apiserverconfigv1.KMSConfiguration{}
-			if err := json.Unmarshal(v, kmsConfiguration); err != nil {
+			kmsConfiguration, err := encoding.DecodeKMSConfiguration(v)
+			if err != nil {
 				return state.KeyState{}, fmt.Errorf("secret %s/%s has invalid %s data: %w", s.Namespace, s.Name, EncryptionSecretKMSEncryptionConfig, err)
 			}
 			key.KMSConfig.Encryption = kmsConfiguration
@@ -77,11 +77,11 @@ func ToKeyState(s *corev1.Secret) (state.KeyState, error) {
 			return state.KeyState{}, fmt.Errorf("%s can not be empty, when mode is KMS", EncryptionSecretKMSEncryptionConfig)
 		}
 		if v, ok := s.Data[EncryptionSecretKMSProviderConfig]; ok && len(v) > 0 {
-			providerConfig := &configv1.KMSConfig{}
-			if err := json.Unmarshal(v, providerConfig); err != nil {
+			kmsConfig, err := encoding.DecodeKMSConfig(v)
+			if err != nil {
 				return state.KeyState{}, fmt.Errorf("secret %s/%s has invalid %s data: %w", s.Namespace, s.Name, EncryptionSecretKMSProviderConfig, err)
 			}
-			key.KMSConfig.Provider = providerConfig
+			key.KMSConfig.Provider = kmsConfig
 		} else {
 			// encryption.apiserver.operator.openshift.io-kms-provider-config data field is required for KMS
 			// encryption mode.
@@ -144,19 +144,19 @@ func FromKeyState(component string, ks state.KeyState) (*corev1.Secret, error) {
 	}
 
 	if ks.HasKMSEncryption() {
-		kmsEncCfgJSON, err := json.Marshal(ks.KMSConfig.Encryption)
+		encryptionConfigurationData, err := encoding.EncodeKMSConfiguration(ks.KMSConfig.Encryption)
 		if err != nil {
-			return nil, fmt.Errorf("failed to marshal KMS encryption config: %w", err)
+			return nil, err
 		}
-		s.Data[EncryptionSecretKMSEncryptionConfig] = kmsEncCfgJSON
+		s.Data[EncryptionSecretKMSEncryptionConfig] = encryptionConfigurationData
 	}
 
 	if ks.HasKMSProvider() {
-		providerJSON, err := json.Marshal(ks.KMSConfig.Provider)
+		providerData, err := encoding.EncodeKMSConfig(ks.KMSConfig.Provider)
 		if err != nil {
-			return nil, fmt.Errorf("failed to marshal KMS provider config: %w", err)
+			return nil, err
 		}
-		s.Data[EncryptionSecretKMSProviderConfig] = providerJSON
+		s.Data[EncryptionSecretKMSProviderConfig] = providerData
 	}
 
 	return s, nil

--- a/pkg/operator/encryption/secrets/secrets.go
+++ b/pkg/operator/encryption/secrets/secrets.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"time"
 
-	v1 "github.com/openshift/api/config/v1"
+	configv1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -77,7 +77,7 @@ func ToKeyState(s *corev1.Secret) (state.KeyState, error) {
 			return state.KeyState{}, fmt.Errorf("%s can not be empty, when mode is KMS", EncryptionSecretKMSEncryptionConfig)
 		}
 		if v, ok := s.Data[EncryptionSecretKMSProviderConfig]; ok && len(v) > 0 {
-			providerConfig := &v1.KMSConfig{}
+			providerConfig := &configv1.KMSConfig{}
 			if err := json.Unmarshal(v, providerConfig); err != nil {
 				return state.KeyState{}, fmt.Errorf("secret %s/%s has invalid %s data: %w", s.Namespace, s.Name, EncryptionSecretKMSProviderConfig, err)
 			}

--- a/pkg/operator/encryption/secrets/secrets_test.go
+++ b/pkg/operator/encryption/secrets/secrets_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	v1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
 	"k8s.io/utils/diff"
@@ -129,6 +130,7 @@ func TestRoundtrip(t *testing.T) {
 						APIVersion: "v2",
 						Name:       "1",
 						Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
+						Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 					},
 					Provider: &configv1.KMSConfig{},
 				},
@@ -159,6 +161,7 @@ func TestRoundtrip(t *testing.T) {
 						APIVersion: "v2",
 						Name:       "2",
 						Endpoint:   "unix:///var/run/kmsplugin/kms-2.sock",
+						Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 					},
 					Provider: &configv1.KMSConfig{},
 				},

--- a/pkg/operator/encryption/testing/helpers.go
+++ b/pkg/operator/encryption/testing/helpers.go
@@ -16,6 +16,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/library-go/pkg/operator/encryption/encoding"
 	"github.com/openshift/library-go/pkg/operator/encryption/secrets"
 	"github.com/openshift/library-go/pkg/operator/encryption/state"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
@@ -106,10 +107,16 @@ func CreateEncryptionKeySecretWithKMSConfig(targetNS string, grs []schema.GroupR
 		Endpoint:   fmt.Sprintf("unix:///var/run/kmsplugin/kms-%d.sock", keyID),
 		Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 	}
-	kmsConfigJSON, _ := json.Marshal(kmsConfig)
-	secret.Data[encryptionSecretKMSEncryptionConfigForTest] = kmsConfigJSON
-	providerConfigJSON, _ := json.Marshal(&configv1.KMSConfig{})
-	secret.Data[encryptionSecretKMSProviderConfigForTest] = providerConfigJSON
+	encData, err := encoding.EncodeKMSConfiguration(kmsConfig)
+	if err != nil {
+		panic(fmt.Sprintf("failed to encode KMS encryption config: %v", err))
+	}
+	secret.Data[encryptionSecretKMSEncryptionConfigForTest] = encData
+	provData, err := encoding.EncodeKMSConfig(&configv1.KMSConfig{})
+	if err != nil {
+		panic(fmt.Sprintf("failed to encode KMS provider config: %v", err))
+	}
+	secret.Data[encryptionSecretKMSProviderConfigForTest] = provData
 	return secret
 }
 

--- a/test/e2e-encryption/encryption_test.go
+++ b/test/e2e-encryption/encryption_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
+	v1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -38,6 +38,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/encryption"
 	"github.com/openshift/library-go/pkg/operator/encryption/controllers"
 	"github.com/openshift/library-go/pkg/operator/encryption/controllers/migrators"
+	"github.com/openshift/library-go/pkg/operator/encryption/encoding"
 	"github.com/openshift/library-go/pkg/operator/encryption/secrets"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/genericoperatorclient"
@@ -431,8 +432,8 @@ func TestEncryptionIntegration(tt *testing.T) {
 	require.NoError(t, err)
 	kmsProviderConfigData := kmsKeySecret.Data[secrets.EncryptionSecretKMSProviderConfig]
 	require.NotEmpty(t, kmsProviderConfigData, "expected kms-provider-config data to be present in key secret")
-	var providerConfig configv1.KMSConfig
-	require.NoError(t, json.Unmarshal(kmsProviderConfigData, &providerConfig))
+	providerConfig, err := encoding.DecodeKMSConfig(kmsProviderConfigData)
+	require.NoError(t, err)
 	require.Equal(t, configv1.VaultKMSProvider, providerConfig.Type)
 	require.Equal(t, "https://vault.example.com", providerConfig.Vault.VaultAddress)
 	require.Equal(t, "test-transit-key", providerConfig.Vault.TransitKey)


### PR DESCRIPTION
Encode `apiserverconfigv1.KMSConfiguration` inside an `apiserverconfigv1.EncryptionConfiguration` envelope and `configv1.KMSConfig` inside an `configv1.APIServer` envelope.

 This allows for proper use of `runtime.{Encode|Decode}` with registered types instead of raw JSON.

Proof: https://github.com/openshift/cluster-kube-apiserver-operator/pull/2133

```
$ oc get -n openshift-config-managed secrets/encryption-key-openshift-kube-apiserver-1 -o json | jq -r '.data."encryption.apiserver.operator.openshift.io-kms-encryption-config"' | base64 -d | jq
{
  "kind": "EncryptionConfiguration",
  "apiVersion": "apiserver.config.k8s.io/v1",
  "resources": [
    {
      "resources": null,
      "providers": [
        {
          "kms": {
            "apiVersion": "v2",
            "name": "1",
            "endpoint": "unix:///var/run/kmsplugin/kms-1.sock",
            "timeout": "10s"
          }
        }
      ]
    }
  ]
}

$ oc get -n openshift-config-managed secrets/encryption-key-openshift-kube-apiserver-1 -o json | jq -r '.data."encryption.apiserver.operator.openshift.io-kms-provider-config"' | base64 -d | jq
{
  "kind": "APIServer",
  "apiVersion": "config.openshift.io/v1",
  "metadata": {},
  "spec": {
    "servingCerts": {},
    "clientCA": {
      "name": ""
    },
    "encryption": {
      "kms": {
        "type": "Vault",
        "vault": {
          "kmsPluginImage": "quay.io/bertinatto/vault@sha256:33599dd6eee61dcf9a60138759fafda3d88593a3c2072585156882c6b5bd3fa5",
          "vaultAddress": "https://vault.example.com:8200",
          "authentication": {
            "type": "AppRole",
            "appRole": {
              "secret": {
                "name": "vault-approle-secret"
              }
            }
          },
          "transitKey": "my-transit-key"
        }
      }
    },
    "audit": {}
  },
  "status": {}
}
```
/assign @ardaguclu @p0lyn0mial @benluddy 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * KMS/encryption serialization switched to new encoding helpers for more robust, API-compliant handling and clearer encode/decode error messages.

* **Tests**
  * Tests updated to use the new encoding flow, include explicit KMS timeouts, and fail loudly on encoding errors to surface issues earlier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->