### PR TITLE
SPLAT-2651: Changed Node struct to not be pointer in CPIConfig

### DIFF
--- a/pkg/cloudprovider/vsphere/config_test.go
+++ b/pkg/cloudprovider/vsphere/config_test.go
@@ -179,3 +179,48 @@ func TestINIConfigConversion(t *testing.T) {
 		})
 	}
 }
+
+func TestEmptyNodesOmittedInYAML(t *testing.T) {
+	g := gmg.NewWithT(t)
+
+	// Create a config with an empty Nodes struct
+	config := &CPIConfig{
+		CommonConfig: CommonConfig{
+			Global: Global{
+				User:     "testuser",
+				Password: "testpass",
+			},
+		},
+		Nodes: Nodes{}, // Empty struct, should be omitted
+	}
+
+	yamlOutput, err := MarshalConfig(config)
+	g.Expect(err).ToNot(gmg.HaveOccurred())
+
+	// Verify that "nodes:" does not appear in the output
+	g.Expect(yamlOutput).ToNot(gmg.ContainSubstring("nodes:"))
+}
+
+func TestNodesWithValuesIncludedInYAML(t *testing.T) {
+	g := gmg.NewWithT(t)
+
+	// Create a config with a populated Nodes struct
+	config := &CPIConfig{
+		CommonConfig: CommonConfig{
+			Global: Global{
+				User:     "testuser",
+				Password: "testpass",
+			},
+		},
+		Nodes: Nodes{
+			InternalNetworkSubnetCIDR: "192.168.1.0/24",
+		},
+	}
+
+	yamlOutput, err := MarshalConfig(config)
+	g.Expect(err).ToNot(gmg.HaveOccurred())
+
+	// Verify that "nodes:" DOES appear when the struct has values
+	g.Expect(yamlOutput).To(gmg.ContainSubstring("nodes:"))
+	g.Expect(yamlOutput).To(gmg.ContainSubstring("internalNetworkSubnetCidr: 192.168.1.0/24"))
+}

--- a/pkg/cloudprovider/vsphere/ini.go
+++ b/pkg/cloudprovider/vsphere/ini.go
@@ -219,7 +219,7 @@ func (iniConfig *cpiConfigINI) createConfig() (*CPIConfig, error) {
 		iniConfig.Nodes.ExternalVMNetworkName != "" ||
 		iniConfig.Nodes.ExcludeInternalNetworkSubnetCIDR != "" ||
 		iniConfig.Nodes.ExcludeExternalNetworkSubnetCIDR != "" {
-		cfg.Nodes = &Nodes{
+		cfg.Nodes = Nodes{
 			InternalNetworkSubnetCIDR:        iniConfig.Nodes.InternalNetworkSubnetCIDR,
 			ExternalNetworkSubnetCIDR:        iniConfig.Nodes.ExternalNetworkSubnetCIDR,
 			InternalVMNetworkName:            iniConfig.Nodes.InternalVMNetworkName,

--- a/pkg/cloudprovider/vsphere/yaml.go
+++ b/pkg/cloudprovider/vsphere/yaml.go
@@ -140,7 +140,7 @@ type Nodes struct {
 // CPIConfig is the YAML representation of vsphere-cloud-provider config
 type CPIConfig struct {
 	CommonConfig `json:",inline"`
-	Nodes        *Nodes `json:"nodes,omitempty"`
+	Nodes        Nodes `json:"nodes,omitzero"`
 }
 
 // readCPIConfigYAML parses vSphere cloud config file and stores it into CPIConfig


### PR DESCRIPTION
[SPLAT-2651](https://redhat.atlassian.net/browse/SPLAT-2651)

### Changes
- Changed Node struct to not be a pointer in the CPIConfig for vSphere

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests for YAML serialization of the Nodes configuration, ensuring empty Nodes are omitted and populated Nodes include the expected network CIDR.

* **Refactor**
  * Adjusted configuration handling so empty Nodes are omitted from serialized output and populated Nodes render correctly, improving consistency of saved/loaded config.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->