### PR TITLE
NO-JIRA: Fix data race in TestControllerScheduled

### DIFF
--- a/pkg/controller/factory/factory_test.go
+++ b/pkg/controller/factory/factory_test.go
@@ -3,10 +3,12 @@ package factory
 import (
 	"context"
 	"fmt"
-	clocktesting "k8s.io/utils/clock/testing"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	clocktesting "k8s.io/utils/clock/testing"
 
 	v1 "k8s.io/api/core/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
@@ -225,43 +227,46 @@ func TestControllerWithInformer2(t *testing.T) {
 func TestControllerScheduled(t *testing.T) {
 	syncCalled := make(chan struct{})
 	controller := New().ResyncSchedule("@every 1s").WithSync(func(ctx context.Context, controllerContext SyncContext) error {
-		syncCalled <- struct{}{}
+		select {
+		case syncCalled <- struct{}{}:
+		case <-ctx.Done():
+		}
 		return nil
 	}).ToController("test", events.NewInMemoryRecorder("fake-controller", clocktesting.NewFakePassiveClock(time.Now())))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	syncCounter := 0
-	var syncMutex sync.Mutex
+	var syncCounter atomic.Int32
+	var wg sync.WaitGroup
 
-	// observe sync calls
-	go func() {
+	wg.Go(func() {
 		for {
 			select {
 			case <-syncCalled:
-				syncMutex.Lock()
-				syncCounter++
-				t.Logf("#%d sync called", syncCounter)
-				syncMutex.Unlock()
+				i := syncCounter.Add(1)
+				t.Logf("#%d sync called", i)
 			case <-ctx.Done():
 				t.Logf("controller finished")
 				return
 			}
 		}
-	}()
+	})
 
-	go controller.Run(ctx, 1)
+	wg.Go(func() {
+		controller.Run(ctx, 1)
+	})
 
 	timeoutCtx, timeoutCtxCancel := context.WithTimeout(ctx, 10*time.Second)
 	defer timeoutCtxCancel()
-	if err := wait.PollImmediateUntil(500*time.Millisecond, func() (done bool, err error) {
-		syncMutex.Lock()
-		defer syncMutex.Unlock()
-		return syncCounter > 3, nil
-	}, timeoutCtx.Done()); err != nil {
+	if err := wait.PollUntilContextCancel(timeoutCtx, 500*time.Millisecond, true, func(ctx context.Context) (done bool, err error) {
+		return syncCounter.Load() >= 3, nil
+	}); err != nil {
 		t.Errorf("failed to observe at least 3 sync calls: %v", err)
 	}
+
+	cancel()
+	wg.Wait()
 }
 
 func TestControllerSyncAfterStart(t *testing.T) {


### PR DESCRIPTION
The observer goroutine could call t.Logf after the test returned,
racing with testing cleanup. Fix by using sync.WaitGroup to ensure
all goroutines finish before the test exits, making the sync callback
cancel-aware to prevent deadlock, using atomic.Int32 for the sync
counter, and replacing deprecated wait.PollImmediateUntil with
wait.PollUntilContextCancel.

```
=================
WARNING: DATA RACE
Read at 0x00c00056a293 by goroutine 133:
  testing.(*common).destination()
      /usr/local/go/src/testing/testing.go:1058 +0x96
  testing.(*common).log()
      /usr/local/go/src/testing/testing.go:1036 +0xbe
  testing.(*common).Logf()
      /usr/local/go/src/testing/testing.go:1200 +0x8e
  github.com/openshift/library-go/pkg/controller/factory.TestControllerScheduled.func2()
      /home/okupka/Projects/tchap/library-go/pkg/controller/factory/factory_test.go:248 +0x1d5

Previous write at 0x00c00056a293 by goroutine 131:
  testing.tRunner.func1()
      /usr/local/go/src/testing/testing.go:2023 +0x904
  runtime.deferreturn()
      /usr/local/go/src/runtime/panic.go:668 +0x5d
  testing.(*T).Run.gowrap1()
      /usr/local/go/src/testing/testing.go:2101 +0x38

Goroutine 133 (running) created at:
  github.com/openshift/library-go/pkg/controller/factory.TestControllerScheduled()
      /home/okupka/Projects/tchap/library-go/pkg/controller/factory/factory_test.go:239 +0x713
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:2036 +0x21c
  testing.(*T).Run.gowrap1()
      /usr/local/go/src/testing/testing.go:2101 +0x38

Goroutine 131 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:2101 +0xb12
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:2585 +0x85
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:2036 +0x21c
  testing.runTests()
      /usr/local/go/src/testing/testing.go:2583 +0x9e9
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:2443 +0xf4b
  main.main()
      _testmain.go:72 +0x164
==================

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved controller test reliability by adding coordinated observation of repeated runs, better cancellation handling, and orderly shutdown to reduce flakiness.
  * Strengthened timing/wait logic to more robustly verify multiple execution cycles.

Note: These are internal testing improvements with no user-visible changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->