### PR TITLE
 CNTRLPLANE-3236: add initial bits for plugin lifecycle

### DIFF
--- a/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
@@ -1,0 +1,161 @@
+package pluginlifecycle
+
+import (
+	"context"
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/klog/v2"
+)
+
+// sidecarProvider abstracts the construction of a KMS plugin sidecar container for a specific provider (e.g. Vault).
+type sidecarProvider interface {
+	// Name returns the identifier used to name the sidecar container and locate its volume mounts.
+	Name() string
+	// BuildSidecarContainer returns a fully configured sidecar container ready to be injected into the API server pod
+	BuildSidecarContainer() (corev1.Container, error)
+}
+
+// newSidecarProvider creates a provider-specific SidecarProvider for the given keyID, UDS endpoint, and plugin configuration.
+func newSidecarProvider(keyID string, udsPath string, pluginConfig configv1.KMSPluginConfig) (sidecarProvider, error) {
+	switch pluginConfig.Type {
+	case configv1.VaultKMSProvider:
+		return newVaultSidecarProvider("vault-kms-plugin", keyID, udsPath, pluginConfig)
+	default:
+		return nil, fmt.Errorf("unsupported KMS plugin configuration")
+	}
+}
+
+// AddKMSPluginSidecarToPodSpec discovers KMS plugins from the encryption-config secret and injects a sidecar container for each one into the pod spec.
+// It uses an uncached client to avoid injecting sidecars based on a stale encryption configuration.
+func AddKMSPluginSidecarToPodSpec(ctx context.Context, podSpec *corev1.PodSpec, containerName string, encryptionConfigNamespace string, encryptionConfigSecretName string, secretClient corev1client.SecretsGetter) error {
+	if podSpec == nil {
+		return fmt.Errorf("pod spec cannot be nil")
+	}
+
+	if containerName == "" {
+		return fmt.Errorf("container name cannot be empty")
+	}
+
+	encryptionConfigurationSecret, err := secretClient.Secrets(encryptionConfigNamespace).Get(ctx, encryptionConfigSecretName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		klog.V(4).Infof("skipping KMS sidecar injection: %s/%s secret not found", encryptionConfigNamespace, encryptionConfigSecretName)
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get %s/%s secret: %w", encryptionConfigNamespace, encryptionConfigSecretName, err)
+	}
+
+	encryptionConfig, err := encryptiondata.FromSecret(encryptionConfigurationSecret)
+	if err != nil {
+		return fmt.Errorf("failed to extract encryption config from %s/%s secret: %w", encryptionConfigNamespace, encryptionConfigSecretName, err)
+	}
+
+	kmsConfigurations, err := encryptiondata.ExtractUniqueAndSortedKMSConfigurations(encryptionConfig)
+	if err != nil {
+		return fmt.Errorf("failed to get KMS configurations: %w", err)
+	}
+	if len(kmsConfigurations) == 0 {
+		klog.V(4).Infof("skipping KMS sidecar injection: no KMS plugins found in EncryptionConfiguration")
+		return nil
+	}
+
+	klog.V(4).Infof("injecting %d KMS sidecar(s)", len(kmsConfigurations))
+
+	for _, kmsConfiguration := range kmsConfigurations {
+		// ExtractUniqueAndSortedKMSConfigurations function rewrites the .Name field to include only the key ID
+		keyID := kmsConfiguration.Name
+		udsPath := kmsConfiguration.Endpoint
+
+		pluginConfig, ok := encryptionConfig.KMSPlugins[keyID]
+		if !ok {
+			return fmt.Errorf("missing plugin config for keyID %s", keyID)
+		}
+
+		sidecarProvider, err := newSidecarProvider(keyID, udsPath, pluginConfig)
+		if err != nil {
+			return fmt.Errorf("failed to create a sidecar provider for keyID %s: %w", keyID, err)
+		}
+
+		if err := appendSidecarContainer(podSpec, sidecarProvider); err != nil {
+			return err
+		}
+
+		if err := ensureSocketVolumeMount(podSpec, sidecarProvider.Name()); err != nil {
+			return err
+		}
+	}
+
+	if err := ensureSocketVolumeMount(podSpec, containerName); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func appendSidecarContainer(podSpec *corev1.PodSpec, provider sidecarProvider) error {
+	container, err := provider.BuildSidecarContainer()
+	if err != nil {
+		return fmt.Errorf("failed to build sidecar container: %w", err)
+	}
+
+	podSpec.Containers = append(podSpec.Containers, container)
+	return nil
+}
+
+func ensureSocketVolumeMount(podSpec *corev1.PodSpec, containerName string) error {
+	containerIndex := -1
+	for i, container := range podSpec.Containers {
+		if container.Name == containerName {
+			containerIndex = i
+			break
+		}
+	}
+
+	if containerIndex < 0 {
+		return fmt.Errorf("container %s not found", containerName)
+	}
+
+	container := &podSpec.Containers[containerIndex]
+	foundMount := false
+	for _, m := range container.VolumeMounts {
+		if m.Name == "kms-plugin-socket" {
+			foundMount = true
+			break
+		}
+	}
+	if !foundMount {
+		container.VolumeMounts = append(container.VolumeMounts,
+			corev1.VolumeMount{
+				Name:      "kms-plugin-socket",
+				MountPath: "/var/run/kmsplugin",
+			},
+		)
+	}
+
+	// The volume mount in the container requires a volume in the podSpec
+	ensureSocketVolume(podSpec)
+	return nil
+}
+
+func ensureSocketVolume(podSpec *corev1.PodSpec) {
+	for _, volume := range podSpec.Volumes {
+		if volume.Name == "kms-plugin-socket" {
+			return
+		}
+	}
+
+	podSpec.Volumes = append(podSpec.Volumes,
+		corev1.Volume{
+			Name: "kms-plugin-socket",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+	)
+}

--- a/pkg/operator/encryption/kms/pluginlifecycle/sidecar_test.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/sidecar_test.go
@@ -1,0 +1,333 @@
+package pluginlifecycle
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/library-go/pkg/operator/encryption/encoding"
+	"github.com/openshift/library-go/pkg/operator/encryption/kms"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	apiserverv1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
+	fake "k8s.io/client-go/kubernetes/fake"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+func TestInjectIntoPodSpec(t *testing.T) {
+	secretClient := func(secrets ...*corev1.Secret) corev1client.SecretsGetter {
+		objs := make([]runtime.Object, len(secrets))
+		for i, s := range secrets {
+			objs[i] = s
+		}
+		return fake.NewSimpleClientset(objs...).CoreV1()
+	}
+
+	vaultConfig := &configv1.KMSPluginConfig{
+		Type: configv1.VaultKMSProvider,
+		Vault: configv1.VaultKMSPluginConfig{
+			KMSPluginImage: "quay.io/test/vault:v1",
+			VaultAddress:   "https://vault.example.com:8200",
+			VaultNamespace: "my-namespace",
+			TransitKey:     "my-key",
+			TransitMount:   "transit",
+			Authentication: configv1.VaultAuthentication{
+				Type: configv1.VaultAuthenticationTypeAppRole,
+				AppRole: configv1.VaultAppRoleAuthentication{
+					Secret: configv1.VaultSecretReference{Name: "vault-kms-credentials"},
+				},
+			},
+		},
+	}
+	pluginConfigBytes, err := encoding.EncodeKMSPluginConfig(*vaultConfig)
+	require.NoError(t, err)
+
+	pluginConfigKey, err := kms.ToPluginConfigSecretDataKeyFor("555")
+	require.NoError(t, err)
+
+	encryptionConfig := &apiserverv1.EncryptionConfiguration{
+		Resources: []apiserverv1.ResourceConfiguration{
+			{
+				Resources: []string{"secrets"},
+				Providers: []apiserverv1.ProviderConfiguration{
+					{
+						KMS: &apiserverv1.KMSConfiguration{
+							APIVersion: "v2",
+							Name:       "555_secrets",
+							Endpoint:   "unix:///var/run/kmsplugin/kms-555.sock",
+						},
+					},
+				},
+			},
+		},
+	}
+	encryptionConfigBytes, err := encoding.EncodeEncryptionConfiguration(encryptionConfig)
+	require.NoError(t, err)
+
+	encryptionConfigSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "encryption-config",
+			Namespace: "openshift-kube-apiserver",
+		},
+		Data: map[string][]byte{
+			"encryption-config": encryptionConfigBytes,
+			pluginConfigKey:     pluginConfigBytes,
+		},
+	}
+
+	sidecarArgs := []string{
+		"-approle-secret-id-path=/var/run/secrets/vault-kms/secret-id-555",
+		"-listen-address=unix:///var/run/kmsplugin/kms-555.sock",
+		"-vault-address=https://vault.example.com:8200",
+		"-vault-namespace=my-namespace",
+		"-transit-mount=transit",
+		"-transit-key=my-key",
+	}
+
+	socketMount := corev1.VolumeMount{
+		Name:      "kms-plugin-socket",
+		MountPath: "/var/run/kmsplugin",
+	}
+	socketVolume := corev1.Volume{
+		Name: "kms-plugin-socket",
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	}
+	resourceDirVolume := corev1.Volume{
+		Name: "resource-dir",
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: "/etc/kubernetes/static-pod-resources",
+			},
+		},
+	}
+
+	tests := []struct {
+		name            string
+		actualPodSpec   *corev1.PodSpec
+		expectedPodSpec *corev1.PodSpec
+		secretClient    corev1client.SecretsGetter
+		wantErr         string
+	}{
+		{
+			name: "single provider: sidecar and volumes injected",
+			actualPodSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "kube-apiserver"},
+				},
+				Volumes: []corev1.Volume{resourceDirVolume},
+			},
+			expectedPodSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:         "kube-apiserver",
+						VolumeMounts: []corev1.VolumeMount{socketMount},
+					},
+					{
+						Name:         "vault-kms-plugin-555",
+						Image:        "quay.io/test/vault:v1",
+						Args:         sidecarArgs,
+						VolumeMounts: []corev1.VolumeMount{socketMount},
+					},
+				},
+				Volumes: []corev1.Volume{resourceDirVolume, socketVolume},
+			},
+			secretClient: secretClient(encryptionConfigSecret),
+		},
+		{
+			name: "two providers during migration: both sidecars injected in keyID order",
+			actualPodSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "kube-apiserver"},
+				},
+				Volumes: []corev1.Volume{resourceDirVolume},
+			},
+			expectedPodSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:         "kube-apiserver",
+						VolumeMounts: []corev1.VolumeMount{socketMount},
+					},
+					{
+						Name:  "vault-kms-plugin-777",
+						Image: "quay.io/test/vault:v2",
+						Args: []string{
+							"-approle-secret-id-path=/var/run/secrets/vault-kms/secret-id-777",
+							"-listen-address=unix:///var/run/kmsplugin/kms-777.sock",
+							"-vault-address=https://vault2.example.com:8200",
+							"-vault-namespace=other-namespace",
+							"-transit-mount=transit2",
+							"-transit-key=other-key",
+						},
+						VolumeMounts: []corev1.VolumeMount{socketMount},
+					},
+					{
+						Name:  "vault-kms-plugin-555",
+						Image: "quay.io/test/vault:v1",
+						Args: []string{
+							"-approle-secret-id-path=/var/run/secrets/vault-kms/secret-id-555",
+							"-listen-address=unix:///var/run/kmsplugin/kms-555.sock",
+							"-vault-address=https://vault.example.com:8200",
+							"-vault-namespace=my-namespace",
+							"-transit-mount=transit",
+							"-transit-key=my-key",
+						},
+						VolumeMounts: []corev1.VolumeMount{socketMount},
+					},
+				},
+				Volumes: []corev1.Volume{resourceDirVolume, socketVolume},
+			},
+			secretClient: func() corev1client.SecretsGetter {
+				vaultConfig2 := &configv1.KMSPluginConfig{
+					Type: configv1.VaultKMSProvider,
+					Vault: configv1.VaultKMSPluginConfig{
+						KMSPluginImage: "quay.io/test/vault:v2",
+						VaultAddress:   "https://vault2.example.com:8200",
+						VaultNamespace: "other-namespace",
+						TransitKey:     "other-key",
+						TransitMount:   "transit2",
+					},
+				}
+				pluginConfig2Bytes, err := encoding.EncodeKMSPluginConfig(*vaultConfig2)
+				require.NoError(t, err)
+
+				pluginConfigKey2, err := kms.ToPluginConfigSecretDataKeyFor("777")
+				require.NoError(t, err)
+
+				multiEncConfig := &apiserverv1.EncryptionConfiguration{
+					Resources: []apiserverv1.ResourceConfiguration{
+						{
+							Resources: []string{"secrets"},
+							Providers: []apiserverv1.ProviderConfiguration{
+								{
+									KMS: &apiserverv1.KMSConfiguration{
+										APIVersion: "v2",
+										Name:       "555_secrets",
+										Endpoint:   "unix:///var/run/kmsplugin/kms-555.sock",
+									},
+								},
+								{
+									KMS: &apiserverv1.KMSConfiguration{
+										APIVersion: "v2",
+										Name:       "777_secrets",
+										Endpoint:   "unix:///var/run/kmsplugin/kms-777.sock",
+									},
+								},
+							},
+						},
+					},
+				}
+				multiEncConfigBytes, err := encoding.EncodeEncryptionConfiguration(multiEncConfig)
+				require.NoError(t, err)
+
+				return secretClient(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "encryption-config",
+						Namespace: "openshift-kube-apiserver",
+					},
+					Data: map[string][]byte{
+						"encryption-config": multiEncConfigBytes,
+						pluginConfigKey:     pluginConfigBytes,
+						pluginConfigKey2:    pluginConfig2Bytes,
+					},
+				})
+			}(),
+		},
+		{
+			name:          "nil pod spec",
+			actualPodSpec: nil,
+			secretClient:  secretClient(encryptionConfigSecret),
+			wantErr:       "pod spec cannot be nil",
+		},
+		{
+			name: "missing encryption-config secret: pod spec unchanged",
+			actualPodSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "kube-apiserver"},
+				},
+			},
+			expectedPodSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "kube-apiserver"},
+				},
+			},
+			secretClient: secretClient(),
+		},
+		{
+			name: "missing encryption-config key in secret: pod spec unchanged",
+			actualPodSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "kube-apiserver"},
+				},
+			},
+			secretClient: secretClient(&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "encryption-config",
+					Namespace: "openshift-kube-apiserver",
+				},
+				Data: map[string][]byte{"other-key": []byte("data")},
+			}),
+			wantErr: "encryption configuration is required",
+		},
+		{
+			name: "no KMS plugin in EncryptionConfiguration: pod spec unchanged",
+			actualPodSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "kube-apiserver"},
+				},
+			},
+			expectedPodSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "kube-apiserver"},
+				},
+			},
+			secretClient: func() corev1client.SecretsGetter {
+				noKMSConfig := &apiserverv1.EncryptionConfiguration{
+					Resources: []apiserverv1.ResourceConfiguration{
+						{
+							Resources: []string{"secrets"},
+							Providers: []apiserverv1.ProviderConfiguration{
+								{AESCBC: &apiserverv1.AESConfiguration{}},
+							},
+						},
+					},
+				}
+				noKMSBytes, err := encoding.EncodeEncryptionConfiguration(noKMSConfig)
+				require.NoError(t, err)
+				return secretClient(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "encryption-config",
+						Namespace: "openshift-kube-apiserver",
+					},
+					Data: map[string][]byte{"encryption-config": noKMSBytes},
+				})
+			}(),
+		},
+		{
+			name: "missing API server container",
+			actualPodSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "other-container"},
+				},
+			},
+			secretClient: secretClient(encryptionConfigSecret),
+			wantErr:      fmt.Sprintf("container %s not found", "kube-apiserver"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := AddKMSPluginSidecarToPodSpec(context.Background(), tt.actualPodSpec, "kube-apiserver", "openshift-kube-apiserver", "encryption-config", tt.secretClient)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedPodSpec, tt.actualPodSpec)
+		})
+	}
+}

--- a/pkg/operator/encryption/kms/pluginlifecycle/vault.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/vault.go
@@ -1,0 +1,50 @@
+package pluginlifecycle
+
+import (
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// newVaultSidecarProvider creates a Vault sidecar provider from the given KMS plugin configuration.
+func newVaultSidecarProvider(name, keyID, udsPath string, pluginConfig configv1.KMSPluginConfig) (*vault, error) {
+	return &vault{
+		name:    name,
+		keyID:   keyID,
+		udsPath: udsPath,
+		config:  &pluginConfig.Vault,
+	}, nil
+}
+
+// vault implements SidecarProvider for HashiCorp Vault KMS.
+type vault struct {
+	name    string
+	keyID   string
+	udsPath string
+	config  *configv1.VaultKMSPluginConfig
+}
+
+// Name returns the sidecar name appended by the key id.
+func (v *vault) Name() string {
+	return fmt.Sprintf("%s-%s", v.name, v.keyID)
+}
+
+// BuildSidecarContainer returns a container spec for the Vault KMS plugin sidecar
+// configured with the Vault address, namespace, transit mount, and transit key.
+func (v *vault) BuildSidecarContainer() (corev1.Container, error) {
+	return corev1.Container{
+		Name:  v.Name(),
+		Image: v.config.KMSPluginImage,
+		Args: []string{
+			// TODO(bertinatto): this path is a placeholder for the mock plugin. This path doesn't exist. It will need to be validated
+			// once we support the actual Vault plugin. It'll likely be different for KASO vs. aggregated API server operators.
+			fmt.Sprintf("-approle-secret-id-path=/var/run/secrets/vault-kms/secret-id-%s", v.keyID),
+			fmt.Sprintf("-listen-address=%s", v.udsPath),
+			fmt.Sprintf("-vault-address=%s", v.config.VaultAddress),
+			fmt.Sprintf("-vault-namespace=%s", v.config.VaultNamespace),
+			fmt.Sprintf("-transit-mount=%s", v.config.TransitMount),
+			fmt.Sprintf("-transit-key=%s", v.config.TransitKey),
+		},
+	}, nil
+}

--- a/pkg/operator/encryption/kms/pluginlifecycle/vault_test.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/vault_test.go
@@ -1,0 +1,147 @@
+package pluginlifecycle
+
+import (
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestVaultSidecarProvider_BuildSidecarContainer(t *testing.T) {
+	tests := []struct {
+		name            string
+		pluginConfig    configv1.KMSPluginConfig
+		containerName   string
+		keyID           string
+		udsPath         string
+		inputPodSpec    *corev1.PodSpec
+		expectedPodSpec *corev1.PodSpec
+		wantErr         string
+	}{
+		{
+			name: "builds container with correct args",
+			pluginConfig: configv1.KMSPluginConfig{
+				Type: configv1.VaultKMSProvider,
+				Vault: configv1.VaultKMSPluginConfig{
+					KMSPluginImage: "quay.io/test/vault:v2",
+					VaultAddress:   "https://vault.example.com:8200",
+					VaultNamespace: "my-namespace",
+					TransitKey:     "my-key",
+					TransitMount:   "transit",
+				},
+			},
+			containerName: "kms-plugin",
+			keyID:         "555",
+			udsPath:       "unix:///var/run/kmsplugin/kms-555.sock",
+			inputPodSpec:  &corev1.PodSpec{},
+			expectedPodSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "kms-plugin-555",
+						Image: "quay.io/test/vault:v2",
+						Args: []string{
+							"-approle-secret-id-path=/var/run/secrets/vault-kms/secret-id-555",
+							"-listen-address=unix:///var/run/kmsplugin/kms-555.sock",
+							"-vault-address=https://vault.example.com:8200",
+							"-vault-namespace=my-namespace",
+							"-transit-mount=transit",
+							"-transit-key=my-key",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "appends to existing containers",
+			pluginConfig: configv1.KMSPluginConfig{
+				Type: configv1.VaultKMSProvider,
+				Vault: configv1.VaultKMSPluginConfig{
+					KMSPluginImage: "quay.io/test/vault:v2",
+					VaultAddress:   "https://vault.example.com:8200",
+					VaultNamespace: "my-namespace",
+					TransitKey:     "my-key",
+					TransitMount:   "transit",
+				},
+			},
+			containerName: "kms-plugin",
+			keyID:         "555",
+			udsPath:       "unix:///var/run/kmsplugin/kms-555.sock",
+			inputPodSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "kube-apiserver",
+						Image: "registry.k8s.io/kube-apiserver:v1.30.0",
+					},
+				},
+			},
+			expectedPodSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "kube-apiserver",
+						Image: "registry.k8s.io/kube-apiserver:v1.30.0",
+					},
+					{
+						Name:  "kms-plugin-555",
+						Image: "quay.io/test/vault:v2",
+						Args: []string{
+							"-approle-secret-id-path=/var/run/secrets/vault-kms/secret-id-555",
+							"-listen-address=unix:///var/run/kmsplugin/kms-555.sock",
+							"-vault-address=https://vault.example.com:8200",
+							"-vault-namespace=my-namespace",
+							"-transit-mount=transit",
+							"-transit-key=my-key",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "empty optional fields",
+			pluginConfig: configv1.KMSPluginConfig{
+				Type: configv1.VaultKMSProvider,
+				Vault: configv1.VaultKMSPluginConfig{
+					KMSPluginImage: "quay.io/test/vault:v2",
+					VaultAddress:   "https://vault.example.com:8200",
+				},
+			},
+			containerName: "kms-plugin",
+			keyID:         "999",
+			udsPath:       "unix:///var/run/kmsplugin/kms.sock",
+			inputPodSpec:  &corev1.PodSpec{},
+			expectedPodSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "kms-plugin-999",
+						Image: "quay.io/test/vault:v2",
+						Args: []string{
+							"-approle-secret-id-path=/var/run/secrets/vault-kms/secret-id-999",
+							"-listen-address=unix:///var/run/kmsplugin/kms.sock",
+							"-vault-address=https://vault.example.com:8200",
+							"-vault-namespace=",
+							"-transit-mount=",
+							"-transit-key=",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider, err := newVaultSidecarProvider(tt.containerName, tt.keyID, tt.udsPath, tt.pluginConfig)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+
+			container, err := provider.BuildSidecarContainer()
+			require.NoError(t, err)
+
+			tt.inputPodSpec.Containers = append(tt.inputPodSpec.Containers, container)
+			require.Equal(t, tt.expectedPodSpec, tt.inputPodSpec)
+		})
+	}
+}


### PR DESCRIPTION
/assign @ardaguclu 

Proof: https://github.com/openshift/cluster-kube-apiserver-operator/pull/2146

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * KMS support: automatic detection and decoding of active KMS endpoint and plugin config from encryption secrets, Vault KMS sidecar provider, and automatic injection of the KMS sidecar plus socket and resource mounts into API server pods.

* **Tests**
  * Added unit tests covering endpoint/key parsing, plugin-config decoding, Vault sidecar container construction, and sidecar injection success and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->