### PR TITLE
CNTRLPLANE-3237: Complete transition to plugin term from provider in KMS

### DIFF
--- a/pkg/operator/encryption/encryptiondata/config.go
+++ b/pkg/operator/encryption/encryptiondata/config.go
@@ -152,9 +152,9 @@ func ToEncryptionState(secretData *Config, keySecrets []*corev1.Secret) (map[sch
 
 			case provider.KMS != nil:
 				// Name and Secret must match to find our backed Secret
-				keyID, err := getKeyIDFromProviderName(provider.KMS.Name)
+				keyID, err := getKeyIDFromPluginName(provider.KMS.Name)
 				if err != nil {
-					klog.Warningf("resource: %s provider index: %d: Skipping invalid provider name %s: %v", resourceConfig.Resources[0], i, provider.KMS.Name, err)
+					klog.Warningf("resource: %s provider index: %d: Skipping invalid plugin name %s: %v", resourceConfig.Resources[0], i, provider.KMS.Name, err)
 					continue // should never happen
 				}
 				ks = state.KeyState{
@@ -257,7 +257,7 @@ func stateToProviders(resource string, desired state.GroupResourceState) []apise
 			}
 			// In order to preserve the uniqueness, we should insert resource name
 			kmsCopy := key.KMS.Encryption.DeepCopy()
-			kmsCopy.Name = createKMSProviderName(key.Key.Name, resource)
+			kmsCopy.Name = createKMSPluginName(key.Key.Name, resource)
 			provider := apiserverconfigv1.ProviderConfiguration{
 				KMS: kmsCopy,
 			}
@@ -281,19 +281,19 @@ func stateToProviders(resource string, desired state.GroupResourceState) []apise
 	return providers
 }
 
-func createKMSProviderName(keyID, resource string) string {
-	// Ideally we should have used keyID simply in kms provider name.
+func createKMSPluginName(keyID, resource string) string {
+	// Ideally we should have used keyID simply in kms plugin name.
 	// However, this is an upstream constraint that every provider name must be unique.
-	// To maintain uniqueness while still allowing access to the keyID, we generate provider name in this format.
+	// To maintain uniqueness while still allowing access to the keyID, we generate plugin name in this format.
 	return fmt.Sprintf("%s_%s", keyID, resource)
 }
 
-func getKeyIDFromProviderName(providerName string) (string, error) {
+func getKeyIDFromPluginName(pluginName string) (string, error) {
 	// We just need to obtain the keyID to find our backed secret
 	// e.g. "1_secrets"
-	parsed := strings.SplitN(providerName, "_", 2)
+	parsed := strings.SplitN(pluginName, "_", 2)
 	if len(parsed) != 2 {
-		return "", fmt.Errorf("invalid provider name %q: expected format keyID_resourceName", providerName)
+		return "", fmt.Errorf("invalid plugin name %q: expected format keyID_resourceName", pluginName)
 	}
 	return parsed[0], nil
 }

--- a/test/e2e-encryption/encryption_test.go
+++ b/test/e2e-encryption/encryption_test.go
@@ -456,8 +456,8 @@ func TestEncryptionIntegration(tt *testing.T) {
 	_, err = fakeApiServerClient.Patch(ctx, "cluster", types.MergePatchType, []byte(`{"spec":{"encryption":{"type":"KMS","kms":{"type":"Vault","vault":{"kmsPluginImage":"registry.example.com/kms-plugin@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890","vaultAddress":"https://vault.example.com","authentication":{"type":"AppRole","appRole":{"secret":{"name":"vault-approle-secret"}}},"transitKey":"test-transit-key"}}}}}`), metav1.PatchOptions{})
 	require.NoError(t, err)
 	waitForKeys(7)
-	kms8 := kmsProviderName("kubeapiservers", "8")
-	kms8Sched := kmsProviderName("kubeschedulers", "8")
+	kms8 := kmsPluginName("kubeapiservers", "8")
+	kms8Sched := kmsPluginName("kubeschedulers", "8")
 	waitForConfigs(
 		fmt.Sprintf("kubeapiservers.operator.openshift.io=aescbc:7,kms:%s,aescbc:5,identity;kubeschedulers.operator.openshift.io=aescbc:7,kms:%s,aescbc:5,identity", kms8, kms8Sched),
 		fmt.Sprintf("kubeapiservers.operator.openshift.io=kms:%s,aescbc:7,aescbc:5,identity;kubeschedulers.operator.openshift.io=kms:%s,aescbc:7,aescbc:5,identity", kms8, kms8Sched),
@@ -494,8 +494,8 @@ func TestEncryptionIntegration(tt *testing.T) {
 	_, err = fakeApiServerClient.Patch(ctx, "cluster", types.MergePatchType, []byte(`{"spec":{"encryption":{"type":"KMS","kms":{"type":"Vault","vault":{"kmsPluginImage":"registry.example.com/kms-plugin@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890","vaultAddress":"https://vault.example.com","authentication":{"type":"AppRole","appRole":{"secret":{"name":"vault-approle-secret"}}},"transitKey":"test-transit-key"}}}}}`), metav1.PatchOptions{})
 	require.NoError(t, err)
 	waitForKeys(9)
-	kms10 := kmsProviderName("kubeapiservers", "10")
-	kms10Sched := kmsProviderName("kubeschedulers", "10")
+	kms10 := kmsPluginName("kubeapiservers", "10")
+	kms10Sched := kmsPluginName("kubeschedulers", "10")
 	waitForConfigs(
 		fmt.Sprintf("kubeapiservers.operator.openshift.io=aescbc:9,kms:%s,kms:%s,identity;kubeschedulers.operator.openshift.io=aescbc:9,kms:%s,kms:%s,identity", kms10, kms8, kms10Sched, kms8Sched),
 		fmt.Sprintf("kubeapiservers.operator.openshift.io=kms:%s,aescbc:9,kms:%s,identity;kubeschedulers.operator.openshift.io=kms:%s,aescbc:9,kms:%s,identity", kms10, kms8, kms10Sched, kms8Sched),
@@ -521,8 +521,8 @@ func TestEncryptionIntegration(tt *testing.T) {
 	_, err = fakeApiServerClient.Patch(ctx, "cluster", types.MergePatchType, []byte(`{"spec":{"encryption":{"type":"KMS","kms":{"type":"Vault","vault":{"kmsPluginImage":"registry.example.com/kms-plugin@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890","vaultAddress":"https://vault.example.com","authentication":{"type":"AppRole","appRole":{"secret":{"name":"vault-approle-secret"}}},"transitKey":"test-transit-key"}}}}}`), metav1.PatchOptions{})
 	require.NoError(t, err)
 	waitForKeys(11)
-	kms12 := kmsProviderName("kubeapiservers", "12")
-	kms12Sched := kmsProviderName("kubeschedulers", "12")
+	kms12 := kmsPluginName("kubeapiservers", "12")
+	kms12Sched := kmsPluginName("kubeschedulers", "12")
 	waitForConfigs(
 		fmt.Sprintf("kubeapiservers.operator.openshift.io=aescbc:11,kms:%s,kms:%s,identity;kubeschedulers.operator.openshift.io=aescbc:11,kms:%s,kms:%s,identity", kms12, kms10, kms12Sched, kms10Sched),
 		fmt.Sprintf("kubeapiservers.operator.openshift.io=kms:%s,aescbc:11,kms:%s,identity;kubeschedulers.operator.openshift.io=kms:%s,aescbc:11,kms:%s,identity", kms12, kms10, kms12Sched, kms10Sched),
@@ -873,6 +873,6 @@ func (p *provider) ShouldRunEncryptionControllers() (bool, error) {
 }
 
 // Format: {keyID}_{resource}
-func kmsProviderName(resource, keyID string) string {
+func kmsPluginName(resource, keyID string) string {
 	return fmt.Sprintf("%s_%s", keyID, resource)
 }


### PR DESCRIPTION
This PR completes the transition from the usage of term provider to plugin in KMS context as requested https://github.com/openshift/library-go/pull/2208#discussion_r3210824792

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the KMS configuration naming convention used when converting between config and state to a unified "plugin" style for consistent key identifier handling.

* **Tests**
  * Updated encryption end-to-end tests to validate the new KMS plugin naming format during mode changes and rotations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->