### PR TITLE
NO-JIRA: Error out when there is duplicate kms-plugin-config in encryption-config Secret

### DIFF
--- a/pkg/operator/encryption/encryptiondata/secret.go
+++ b/pkg/operator/encryption/encryptiondata/secret.go
@@ -46,6 +46,9 @@ func FromSecret(encryptionConfigSecret *corev1.Secret) (*Config, error) {
 		if kmsPlugins == nil {
 			kmsPlugins = map[string]configv1.KMSPluginConfig{}
 		}
+		if _, exists := kmsPlugins[keyID]; exists {
+			return nil, fmt.Errorf("duplicate KMS plugin config for keyID %s", keyID)
+		}
 		kmsPlugins[keyID] = pluginConfig
 	}
 


### PR DESCRIPTION
kms-plugin-configs are stored in encryption-config Secret as deduplicated. So theoretically it is not possible to have multiple plugins for same key id. But it is better to add this check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * KMS encryption configuration now validates for duplicate key identifiers and returns a clear error message when duplicates are detected, preventing silent configuration inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->