### PR TITLE
CNTRLPLANE-3237: Add utility function to dedup KMS providers

### DIFF
--- a/pkg/operator/encryption/encryptiondata/secret.go
+++ b/pkg/operator/encryption/encryptiondata/secret.go
@@ -2,9 +2,13 @@ package encryptiondata
 
 import (
 	"fmt"
+	"sort"
+	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
 
 	configv1 "github.com/openshift/api/config/v1"
 
@@ -97,4 +101,47 @@ func ToSecret(ns, name string, secretData *Config) (*corev1.Secret, error) {
 	}
 
 	return s, nil
+}
+
+// ExtractUniqueAndSortedKMSConfigurations collects deduplicated KMS providers from the
+// EncryptionConfiguration, strips the resource suffix from each Name, and returns them
+// sorted by keyID descending. Duplicate keyIDs with mismatched config (ignoring Name) error out.
+func ExtractUniqueAndSortedKMSConfigurations(secretData *Config) ([]*apiserverconfigv1.KMSConfiguration, error) {
+	if !secretData.HasEncryptionConfiguration() {
+		return nil, fmt.Errorf("encryption configuration is required")
+	}
+	byKeyID := map[string]*apiserverconfigv1.KMSConfiguration{}
+	for _, resource := range secretData.Encryption.Resources {
+		for _, provider := range resource.Providers {
+			if provider.KMS == nil {
+				continue
+			}
+			keyID, err := getKeyIDFromPluginName(provider.KMS.Name)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse key ID from plugin name %q: %w", provider.KMS.Name, err)
+			}
+			if _, err := strconv.ParseUint(keyID, 10, 64); err != nil {
+				return nil, fmt.Errorf("key ID %q is not a valid integer: %w", keyID, err)
+			}
+			kmsCopy := provider.KMS.DeepCopy()
+			kmsCopy.Name = keyID
+			if existing, exists := byKeyID[keyID]; exists {
+				if !equality.Semantic.DeepEqual(existing, kmsCopy) {
+					return nil, fmt.Errorf("KMS configuration mismatch for keyID %s: configs from different resources must be identical", keyID)
+				}
+			}
+			byKeyID[keyID] = kmsCopy
+		}
+	}
+
+	result := make([]*apiserverconfigv1.KMSConfiguration, 0, len(byKeyID))
+	for _, v := range byKeyID {
+		result = append(result, v)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		iKeyID, _ := strconv.ParseUint(result[i].Name, 10, 64)
+		jKeyID, _ := strconv.ParseUint(result[j].Name, 10, 64)
+		return iKeyID > jKeyID
+	})
+	return result, nil
 }

--- a/pkg/operator/encryption/encryptiondata/secret_test.go
+++ b/pkg/operator/encryption/encryptiondata/secret_test.go
@@ -1,0 +1,244 @@
+package encryptiondata_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
+
+	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
+)
+
+func TestExtractUniqueAndSortedKMSConfigurations(t *testing.T) {
+	timeout := &metav1.Duration{Duration: 10 * time.Second}
+
+	tests := []struct {
+		name      string
+		cfg       *encryptiondata.Config
+		want      []*apiserverconfigv1.KMSConfiguration
+		wantError bool
+	}{
+		{
+			name:      "nil encryption returns error",
+			cfg:       nil,
+			wantError: true,
+		},
+		{
+			name:      "nil encryption returns error",
+			cfg:       &encryptiondata.Config{},
+			wantError: true,
+		},
+		{
+			name: "empty provider list returns empty slice",
+			cfg: &encryptiondata.Config{
+				Encryption: &apiserverconfigv1.EncryptionConfiguration{
+					Resources: []apiserverconfigv1.ResourceConfiguration{{
+						Resources: []string{"secrets"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{},
+					}},
+				},
+			},
+			want: []*apiserverconfigv1.KMSConfiguration{},
+		},
+		{
+			name: "single resource single KMS provider",
+			cfg: &encryptiondata.Config{
+				Encryption: &apiserverconfigv1.EncryptionConfiguration{
+					Resources: []apiserverconfigv1.ResourceConfiguration{{
+						Resources: []string{"secrets"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{{
+							KMS: &apiserverconfigv1.KMSConfiguration{
+								APIVersion: "v2",
+								Name:       "1_secrets",
+								Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
+								Timeout:    timeout,
+							},
+						}},
+					}},
+				},
+			},
+			want: []*apiserverconfigv1.KMSConfiguration{{
+				APIVersion: "v2",
+				Name:       "1",
+				Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
+				Timeout:    timeout,
+			}},
+		},
+		{
+			name: "same keyID across resources is deduplicated",
+			cfg: &encryptiondata.Config{
+				Encryption: &apiserverconfigv1.EncryptionConfiguration{
+					Resources: []apiserverconfigv1.ResourceConfiguration{
+						{
+							Resources: []string{"secrets"},
+							Providers: []apiserverconfigv1.ProviderConfiguration{{
+								KMS: &apiserverconfigv1.KMSConfiguration{
+									APIVersion: "v2",
+									Name:       "1_secrets",
+									Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
+									Timeout:    timeout,
+								},
+							}},
+						},
+						{
+							Resources: []string{"configmaps"},
+							Providers: []apiserverconfigv1.ProviderConfiguration{{
+								KMS: &apiserverconfigv1.KMSConfiguration{
+									APIVersion: "v2",
+									Name:       "1_configmaps",
+									Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
+									Timeout:    timeout,
+								},
+							}},
+						},
+					},
+				},
+			},
+			want: []*apiserverconfigv1.KMSConfiguration{{
+				APIVersion: "v2",
+				Name:       "1",
+				Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
+				Timeout:    timeout,
+			}},
+		},
+		{
+			name: "multiple keyIDs sorted descending",
+			cfg: &encryptiondata.Config{
+				Encryption: &apiserverconfigv1.EncryptionConfiguration{
+					Resources: []apiserverconfigv1.ResourceConfiguration{{
+						Resources: []string{"secrets"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{
+							{
+								KMS: &apiserverconfigv1.KMSConfiguration{
+									APIVersion: "v2",
+									Name:       "1_secrets",
+									Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
+									Timeout:    timeout,
+								},
+							},
+							{
+								KMS: &apiserverconfigv1.KMSConfiguration{
+									APIVersion: "v2",
+									Name:       "3_secrets",
+									Endpoint:   "unix:///var/run/kmsplugin/kms-3.sock",
+									Timeout:    timeout,
+								},
+							},
+							{
+								KMS: &apiserverconfigv1.KMSConfiguration{
+									APIVersion: "v2",
+									Name:       "2_secrets",
+									Endpoint:   "unix:///var/run/kmsplugin/kms-2.sock",
+									Timeout:    timeout,
+								},
+							},
+						},
+					}},
+				},
+			},
+			want: []*apiserverconfigv1.KMSConfiguration{
+				{APIVersion: "v2", Name: "3", Endpoint: "unix:///var/run/kmsplugin/kms-3.sock", Timeout: timeout},
+				{APIVersion: "v2", Name: "2", Endpoint: "unix:///var/run/kmsplugin/kms-2.sock", Timeout: timeout},
+				{APIVersion: "v2", Name: "1", Endpoint: "unix:///var/run/kmsplugin/kms-1.sock", Timeout: timeout},
+			},
+		},
+		{
+			name: "non-KMS providers are skipped",
+			cfg: &encryptiondata.Config{
+				Encryption: &apiserverconfigv1.EncryptionConfiguration{
+					Resources: []apiserverconfigv1.ResourceConfiguration{{
+						Resources: []string{"secrets"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{
+							{Identity: &apiserverconfigv1.IdentityConfiguration{}},
+							{
+								KMS: &apiserverconfigv1.KMSConfiguration{
+									APIVersion: "v2",
+									Name:       "1_secrets",
+									Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
+									Timeout:    timeout,
+								},
+							},
+							{AESCBC: &apiserverconfigv1.AESConfiguration{Keys: []apiserverconfigv1.Key{{Name: "k", Secret: "s"}}}},
+						},
+					}},
+				},
+			},
+			want: []*apiserverconfigv1.KMSConfiguration{{
+				APIVersion: "v2",
+				Name:       "1",
+				Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
+				Timeout:    timeout,
+			}},
+		},
+		{
+			name: "mismatched duplicate keyID errors",
+			cfg: &encryptiondata.Config{
+				Encryption: &apiserverconfigv1.EncryptionConfiguration{
+					Resources: []apiserverconfigv1.ResourceConfiguration{
+						{
+							Resources: []string{"secrets"},
+							Providers: []apiserverconfigv1.ProviderConfiguration{{
+								KMS: &apiserverconfigv1.KMSConfiguration{
+									APIVersion: "v2",
+									Name:       "1_secrets",
+									Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
+									Timeout:    timeout,
+								},
+							}},
+						},
+						{
+							Resources: []string{"configmaps"},
+							Providers: []apiserverconfigv1.ProviderConfiguration{{
+								KMS: &apiserverconfigv1.KMSConfiguration{
+									APIVersion: "v2",
+									Name:       "1_configmaps",
+									Endpoint:   "unix:///var/run/kmsplugin/kms-DIFFERENT.sock",
+									Timeout:    timeout,
+								},
+							}},
+						},
+					},
+				},
+			},
+			wantError: true,
+		},
+		{
+			name: "invalid plugin name errors",
+			cfg: &encryptiondata.Config{
+				Encryption: &apiserverconfigv1.EncryptionConfiguration{
+					Resources: []apiserverconfigv1.ResourceConfiguration{{
+						Resources: []string{"secrets"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{{
+							KMS: &apiserverconfigv1.KMSConfiguration{
+								APIVersion: "v2",
+								Name:       "no-underscore",
+								Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
+							},
+						}},
+					}},
+				},
+			},
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := encryptiondata.ExtractUniqueAndSortedKMSConfigurations(tt.cfg)
+			if tt.wantError {
+				if err == nil {
+					t.Fatal("expected error but got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("unexpected result (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a utility function to deduplicate the providers from the EncryptionConfiguration. This PR also updates the name of KMSConfiguration to only store the keyID (by discarding the resource name).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved KMS configuration extraction with stronger validation, automatic deduplication of duplicate provider entries, deterministic sorting of configurations, and explicit error reporting for malformed or conflicting entries.

* **Tests**
  * Added comprehensive test coverage for KMS extraction, covering empty inputs, non-KMS providers, deduplication, sorting order, and error conditions for invalid or conflicting configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->