### PR TITLE
CNTRLPLANE-3238: test/kms: add reusable Vault KMS helpers and KMSTestProvider abstraction

### DIFF
--- a/test/library/encryption/helpers.go
+++ b/test/library/encryption/helpers.go
@@ -36,9 +36,9 @@ var (
 	waitPollTimeout       = 69*time.Minute + 10*time.Minute
 	defaultEncryptionMode = string(configv1.EncryptionTypeIdentity)
 
-	SupportedStaticEncryptionProviders = []configv1.APIServerEncryption{
-		{Type: configv1.EncryptionTypeAESGCM},
-		{Type: configv1.EncryptionTypeAESCBC},
+	SupportedStaticEncryptionProviders = []EncryptionProvider{
+		{APIServerEncryption: configv1.APIServerEncryption{Type: configv1.EncryptionTypeAESGCM}},
+		{APIServerEncryption: configv1.APIServerEncryption{Type: configv1.EncryptionTypeAESCBC}},
 	}
 )
 
@@ -56,8 +56,9 @@ type EncryptionKeyMeta struct {
 
 type UpdateUnsupportedConfigFunc func(raw []byte) error
 
-func SetAndWaitForEncryptionType(t testing.TB, provider configv1.APIServerEncryption, defaultTargetGRs []schema.GroupResource, namespace, labelSelector string) ClientSet {
+func SetAndWaitForEncryptionType(t testing.TB, provider EncryptionProvider, defaultTargetGRs []schema.GroupResource, namespace, labelSelector string) ClientSet {
 	t.Helper()
+
 	t.Logf("Starting encryption e2e test for %q mode", provider.Type)
 
 	clientSet := GetClients(t)
@@ -66,10 +67,13 @@ func SetAndWaitForEncryptionType(t testing.TB, provider configv1.APIServerEncryp
 
 	apiServer, err := clientSet.ApiServerConfig.Get(context.TODO(), "cluster", metav1.GetOptions{})
 	require.NoError(t, err)
-	needsUpdate := !equality.Semantic.DeepEqual(apiServer.Spec.Encryption, provider)
+	needsUpdate := !equality.Semantic.DeepEqual(apiServer.Spec.Encryption, provider.APIServerEncryption)
 	if needsUpdate {
-		t.Logf("Updating encryption configuration for APIServer from %#v to %#v", apiServer.Spec.Encryption, provider)
-		apiServer.Spec.Encryption = provider
+		if provider.Setup != nil {
+			provider.Setup(t)
+		}
+		t.Logf("Updating encryption configuration for APIServer from %#v to %#v", apiServer.Spec.Encryption, provider.APIServerEncryption)
+		apiServer.Spec.Encryption = provider.APIServerEncryption
 		_, err = clientSet.ApiServerConfig.Update(context.TODO(), apiServer, metav1.UpdateOptions{})
 		require.NoError(t, err)
 	} else {

--- a/test/library/encryption/kms/vault.go
+++ b/test/library/encryption/kms/vault.go
@@ -1,11 +1,62 @@
 package kms
 
 import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/clock"
+
 	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	library "github.com/openshift/library-go/test/library/encryption"
 )
 
-// DefaultFakeKMSPluginConfig is a fake Vault KMS configuration used by tests.
-// The values are not real and are likely to change as the KMS integration evolves.
+const (
+	defaultVaultNamespace         = "vault-kms"
+	defaultVaultCredentialsSecret = "vault-credentials"
+	defaultVaultAppRoleSecretName = "vault-approle-secret"
+	defaultVaultKMSPluginImage    = "quay.io/openshifttest/mock-kms-plugin@sha256:03bb07a2c08b509653c4c70217a06a4b389c10b4d87922f50ee5eac82db5e140"
+	defaultVaultAddress           = "https://vault.vault-kms.svc:8200"
+	defaultVaultEnterpriseNS      = "admin"
+	defaultVaultTransitMount      = "transit"
+	defaultVaultTransitKey        = "kms-key"
+	defaultAppRoleTargetNamespace = "openshift-config"
+)
+
+// DefaultVaultEncryptionProvider is a ready-to-use Vault KMS EncryptionProvider for e2e tests.
+// It bundles the default config with the AppRole secret setup.
+var DefaultVaultEncryptionProvider = library.EncryptionProvider{
+	APIServerEncryption: DefaultVaultKMSPluginConfig,
+	Setup:               ensureDefaultVaultAppRoleSecret,
+}
+
+// DefaultVaultKMSPluginConfig is the standard Vault KMS encryption config
+// used by CI e2e tests.
+var DefaultVaultKMSPluginConfig = configv1.APIServerEncryption{
+	Type: configv1.EncryptionTypeKMS,
+	KMS: configv1.KMSPluginConfig{
+		Type: configv1.VaultKMSProvider,
+		Vault: configv1.VaultKMSPluginConfig{
+			KMSPluginImage: defaultVaultKMSPluginImage,
+			VaultAddress:   defaultVaultAddress,
+			VaultNamespace: defaultVaultEnterpriseNS,
+			TransitMount:   defaultVaultTransitMount,
+			TransitKey:     defaultVaultTransitKey,
+			Authentication: configv1.VaultAuthentication{
+				Type: configv1.VaultAuthenticationTypeAppRole,
+				AppRole: configv1.VaultAppRoleAuthentication{
+					Secret: configv1.VaultSecretReference{Name: defaultVaultAppRoleSecretName},
+				},
+			},
+		},
+	},
+}
+
+// DefaultFakeKMSPluginConfig is a fake Vault KMS configuration used by unit tests.
 var DefaultFakeKMSPluginConfig = configv1.KMSPluginConfig{
 	Type: configv1.VaultKMSProvider,
 	Vault: configv1.VaultKMSPluginConfig{
@@ -19,4 +70,32 @@ var DefaultFakeKMSPluginConfig = configv1.KMSPluginConfig{
 		},
 		TransitKey: "test-transit-key",
 	},
+}
+
+// ensureDefaultVaultAppRoleSecret reads credentials from the vault-credentials secret
+// (created by a CI step) and applies the AppRole secret in openshift-config
+// using the default configuration constants.
+func ensureDefaultVaultAppRoleSecret(t testing.TB) {
+	t.Helper()
+	ctx := t.Context()
+	cs := library.GetClients(t)
+
+	creds, err := cs.Kube.CoreV1().Secrets(defaultVaultNamespace).Get(ctx, defaultVaultCredentialsSecret, metav1.GetOptions{})
+	require.NoError(t, err, "failed to read %s/%s secret (was the vault-install CI step run?)", defaultVaultNamespace, defaultVaultCredentialsSecret)
+
+	required := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultVaultAppRoleSecretName,
+			Namespace: defaultAppRoleTargetNamespace,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"roleID":   creds.Data["role-id"],
+			"secretID": creds.Data["secret-id"],
+		},
+	}
+	recorder := events.NewInMemoryRecorder("vault-approle-secret-setup", clock.RealClock{})
+	_, changed, err := resourceapply.ApplySecret(ctx, cs.Kube.CoreV1(), recorder, required)
+	require.NoError(t, err, "failed to apply AppRole secret")
+	t.Logf("Applied AppRole secret %s in %s (changed=%v)", defaultVaultAppRoleSecretName, defaultAppRoleTargetNamespace, changed)
 }

--- a/test/library/encryption/perf_scenarios.go
+++ b/test/library/encryption/perf_scenarios.go
@@ -19,7 +19,7 @@ type PerfScenario struct {
 	AssertMigrationTime   func(t testing.TB, migrationTime time.Duration)
 	// DBLoaderWorker is the number of workers that will execute DBLoaderFunc
 	DBLoaderWorkers    int
-	EncryptionProvider configv1.APIServerEncryption
+	EncryptionProvider EncryptionProvider
 }
 
 func TestPerfEncryption(t *testing.T, scenario PerfScenario) {

--- a/test/library/encryption/scenarios.go
+++ b/test/library/encryption/scenarios.go
@@ -25,19 +25,27 @@ type BasicScenario struct {
 	AssertFunc                      func(t testing.TB, clientSet ClientSet, expectedMode configv1.EncryptionType, namespace, labelSelector string)
 }
 
+// EncryptionProvider pairs an encryption config with an optional setup function
+// that ensures prerequisites (secrets, credentials, infrastructure) are in place.
+type EncryptionProvider struct {
+	configv1.APIServerEncryption
+	// Setup is called once before the provider is first used. May be nil.
+	Setup func(t testing.TB)
+}
+
 func TestEncryptionTypeIdentity(t testing.TB, scenario BasicScenario) {
 	e := NewE(t, PrintEventsOnFailure(scenario.OperatorNamespace))
-	clientSet := SetAndWaitForEncryptionType(e, configv1.APIServerEncryption{Type: configv1.EncryptionTypeIdentity}, scenario.TargetGRs, scenario.Namespace, scenario.LabelSelector)
+	clientSet := SetAndWaitForEncryptionType(e, EncryptionProvider{APIServerEncryption: configv1.APIServerEncryption{Type: configv1.EncryptionTypeIdentity}}, scenario.TargetGRs, scenario.Namespace, scenario.LabelSelector)
 	scenario.AssertFunc(e, clientSet, configv1.EncryptionTypeIdentity, scenario.Namespace, scenario.LabelSelector)
 }
 
 func TestEncryptionTypeUnset(t testing.TB, scenario BasicScenario) {
 	e := NewE(t, PrintEventsOnFailure(scenario.OperatorNamespace))
-	clientSet := SetAndWaitForEncryptionType(e, configv1.APIServerEncryption{}, scenario.TargetGRs, scenario.Namespace, scenario.LabelSelector)
+	clientSet := SetAndWaitForEncryptionType(e, EncryptionProvider{}, scenario.TargetGRs, scenario.Namespace, scenario.LabelSelector)
 	scenario.AssertFunc(e, clientSet, configv1.EncryptionTypeIdentity, scenario.Namespace, scenario.LabelSelector)
 }
 
-func resolveProvider(t testing.TB, defaultType configv1.EncryptionType, providers []configv1.APIServerEncryption) configv1.APIServerEncryption {
+func resolveProvider(t testing.TB, defaultType configv1.EncryptionType, providers []EncryptionProvider) EncryptionProvider {
 	t.Helper()
 	if len(providers) > 1 {
 		t.Fatalf("expected at most one provider, got %d", len(providers))
@@ -45,10 +53,10 @@ func resolveProvider(t testing.TB, defaultType configv1.EncryptionType, provider
 	if len(providers) == 1 {
 		return providers[0]
 	}
-	return configv1.APIServerEncryption{Type: defaultType}
+	return EncryptionProvider{APIServerEncryption: configv1.APIServerEncryption{Type: defaultType}}
 }
 
-func TestEncryptionTypeAESCBC(t testing.TB, scenario BasicScenario, providers ...configv1.APIServerEncryption) {
+func TestEncryptionTypeAESCBC(t testing.TB, scenario BasicScenario, providers ...EncryptionProvider) {
 	provider := resolveProvider(t, configv1.EncryptionTypeAESCBC, providers)
 	e := NewE(t, PrintEventsOnFailure(scenario.OperatorNamespace))
 	clientSet := SetAndWaitForEncryptionType(e, provider, scenario.TargetGRs, scenario.Namespace, scenario.LabelSelector)
@@ -56,7 +64,7 @@ func TestEncryptionTypeAESCBC(t testing.TB, scenario BasicScenario, providers ..
 	AssertEncryptionConfig(e, clientSet, scenario.EncryptionConfigSecretName, scenario.EncryptionConfigSecretNamespace, scenario.TargetGRs)
 }
 
-func TestEncryptionTypeAESGCM(t testing.TB, scenario BasicScenario, providers ...configv1.APIServerEncryption) {
+func TestEncryptionTypeAESGCM(t testing.TB, scenario BasicScenario, providers ...EncryptionProvider) {
 	provider := resolveProvider(t, configv1.EncryptionTypeAESGCM, providers)
 	e := NewE(t, PrintEventsOnFailure(scenario.OperatorNamespace))
 	clientSet := SetAndWaitForEncryptionType(e, provider, scenario.TargetGRs, scenario.Namespace, scenario.LabelSelector)
@@ -64,7 +72,7 @@ func TestEncryptionTypeAESGCM(t testing.TB, scenario BasicScenario, providers ..
 	AssertEncryptionConfig(e, clientSet, scenario.EncryptionConfigSecretName, scenario.EncryptionConfigSecretNamespace, scenario.TargetGRs)
 }
 
-func TestEncryptionTypeKMS(t testing.TB, scenario BasicScenario, providers ...configv1.APIServerEncryption) {
+func TestEncryptionTypeKMS(t testing.TB, scenario BasicScenario, providers ...EncryptionProvider) {
 	provider := resolveProvider(t, configv1.EncryptionTypeKMS, providers)
 	e := NewE(t, PrintEventsOnFailure(scenario.OperatorNamespace))
 	clientSet := SetAndWaitForEncryptionType(e, provider, scenario.TargetGRs, scenario.Namespace, scenario.LabelSelector)
@@ -72,7 +80,7 @@ func TestEncryptionTypeKMS(t testing.TB, scenario BasicScenario, providers ...co
 	AssertEncryptionConfig(e, clientSet, scenario.EncryptionConfigSecretName, scenario.EncryptionConfigSecretNamespace, scenario.TargetGRs)
 }
 
-func TestEncryptionType(t testing.TB, scenario BasicScenario, provider configv1.APIServerEncryption) {
+func TestEncryptionType(t testing.TB, scenario BasicScenario, provider EncryptionProvider) {
 	switch provider.Type {
 	case configv1.EncryptionTypeAESCBC:
 		TestEncryptionTypeAESCBC(t, scenario, provider)
@@ -94,7 +102,7 @@ type OnOffScenario struct {
 	AssertResourceNotEncryptedFunc func(t testing.TB, clientSet ClientSet, resource runtime.Object)
 	ResourceFunc                   func(t testing.TB, namespace string) runtime.Object
 	ResourceName                   string
-	EncryptionProvider             configv1.APIServerEncryption
+	EncryptionProvider             EncryptionProvider
 }
 
 type testStep struct {
@@ -155,13 +163,13 @@ type ProvidersMigrationScenario struct {
 	// EncryptionProviders is the list of encryption providers to migrate through.
 	// The test will migrate through each provider in order, then always end by
 	// switching to identity (off) to verify the resource is re-written unencrypted.
-	EncryptionProviders []configv1.APIServerEncryption
+	EncryptionProviders []EncryptionProvider
 }
 
 // ShuffleEncryptionProviders returns a new slice with the providers in random order,
 // leaving the original slice unchanged. Use this to test different migration orderings.
-func ShuffleEncryptionProviders(providers []configv1.APIServerEncryption) []configv1.APIServerEncryption {
-	shuffled := make([]configv1.APIServerEncryption, len(providers))
+func ShuffleEncryptionProviders(providers []EncryptionProvider) []EncryptionProvider {
+	shuffled := make([]EncryptionProvider, len(providers))
 	copy(shuffled, providers)
 	mathrand.Shuffle(len(shuffled), func(i, j int) {
 		shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
@@ -232,7 +240,7 @@ type RotationScenario struct {
 	CreateResourceFunc    func(t testing.TB, clientSet ClientSet, namespace string) runtime.Object
 	GetRawResourceFunc    func(t testing.TB, clientSet ClientSet, namespace string) string
 	UnsupportedConfigFunc UpdateUnsupportedConfigFunc
-	EncryptionProvider    configv1.APIServerEncryption
+	EncryptionProvider    EncryptionProvider
 }
 
 // TestEncryptionRotation first encrypts data with aescbc key


### PR DESCRIPTION
Move the Vault KMS encryption config and AppRole secret setup from cluster-kube-apiserver-operator into library-go so any operator can reuse them.

Add KMSTestProvider type that pairs an encryption config with its setup function, enabling the same test cases to run against multiple KMS provider without duplicating test logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced Vault KMS encryption tests with Enterprise namespace support and AppRole authentication credentials setup
  * Updated encryption provider configuration structure with wrapper type supporting optional per-provider setup hooks
  * Reorganized supported static encryption providers list for encryption test scenario handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->