### PR TITLE
CNTRLPLANE-3364: added vault key rotation func

### DIFF
--- a/test/library/encryption/kms/vault.go
+++ b/test/library/encryption/kms/vault.go
@@ -1,7 +1,13 @@
 package kms
 
 import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -17,6 +23,7 @@ import (
 
 const (
 	defaultVaultNamespace         = "vault-kms"
+	defaultVaultPodName           = "vault-0"
 	defaultVaultCredentialsSecret = "vault-credentials"
 	defaultVaultAppRoleSecretName = "vault-approle-secret"
 	defaultVaultKMSPluginImage    = "quay.io/openshifttest/mock-kms-plugin@sha256:03bb07a2c08b509653c4c70217a06a4b389c10b4d87922f50ee5eac82db5e140"
@@ -25,6 +32,7 @@ const (
 	defaultVaultTransitMount      = "transit"
 	defaultVaultTransitKey        = "kms-key"
 	defaultAppRoleTargetNamespace = "openshift-config"
+	vaultCommandTimeout           = 30 * time.Second
 )
 
 // DefaultVaultEncryptionProvider is a ready-to-use Vault KMS EncryptionProvider for e2e tests.
@@ -98,4 +106,64 @@ func ensureDefaultVaultAppRoleSecret(t testing.TB) {
 	_, changed, err := resourceapply.ApplySecret(ctx, cs.Kube.CoreV1(), recorder, required)
 	require.NoError(t, err, "failed to apply AppRole secret")
 	t.Logf("Applied AppRole secret %s in %s (changed=%v)", defaultVaultAppRoleSecretName, defaultAppRoleTargetNamespace, changed)
+}
+
+// RotateVaultTransitKey rotates the Vault transit encryption key. All old key versions are retained.
+// Reference: https://developer.hashicorp.com/vault/api-docs/secret/transit#rotate-key
+// Steps:
+// 1. Get initial key version
+// 2. Execute 'vault write -f transit/keys/<key-name>/rotate' via oc exec
+// 3. Get new key version and validate it increased
+func RotateVaultTransitKey(t testing.TB) {
+	t.Helper()
+	ctx := t.Context()
+
+	initialVersion := getCurrentKeyVersion(ctx, t)
+	rotateKey(ctx, t)
+	newVersion := getCurrentKeyVersion(ctx, t)
+
+	require.Greater(t, newVersion, initialVersion, "rotation failed: version did not increase (before=%d, after=%d)", initialVersion, newVersion)
+}
+
+// rotateKey executes the vault key rotation command
+func rotateKey(ctx context.Context, t testing.TB) {
+	t.Helper()
+	commandCtx, cancel := context.WithTimeout(ctx, vaultCommandTimeout)
+	defer cancel()
+
+	// Command: vault write -f transit/keys/<key-name>/rotate
+	// Reference: https://developer.hashicorp.com/vault/api-docs/secret/transit#rotate-key
+	cmd := exec.CommandContext(commandCtx, "oc", "exec", defaultVaultPodName, "-n", defaultVaultNamespace, "--",
+		"vault", "write", "-f", fmt.Sprintf("transit/keys/%s/rotate", defaultVaultTransitKey))
+
+	t.Logf("Executing: %s", cmd.String())
+	output, err := cmd.Output()
+	if ee, ok := err.(*exec.ExitError); ok {
+		require.NoError(t, err, "vault key rotation failed, stderr: %s", string(ee.Stderr))
+	}
+	require.NoError(t, err, "vault key rotation failed")
+	t.Logf("Command output: %s", string(output))
+}
+
+// getCurrentKeyVersion retrieves the current (latest) key version
+func getCurrentKeyVersion(ctx context.Context, t testing.TB) int {
+	t.Helper()
+	commandCtx, cancel := context.WithTimeout(ctx, vaultCommandTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(commandCtx, "oc", "exec", defaultVaultPodName, "-n", defaultVaultNamespace, "--",
+		"vault", "read", "-field=latest_version", fmt.Sprintf("transit/keys/%s", defaultVaultTransitKey))
+
+	t.Logf("Executing: %s", cmd.String())
+	output, err := cmd.Output()
+	if ee, ok := err.(*exec.ExitError); ok {
+		require.NoError(t, err, "failed to read key version, stderr: %s", string(ee.Stderr))
+	}
+	require.NoError(t, err, "failed to read key version")
+	t.Logf("Command output: %s", string(output))
+
+	version, err := strconv.Atoi(strings.TrimSpace(string(output)))
+	require.NoError(t, err, "failed to parse key version from output: %q", string(output))
+
+	return version
 }


### PR DESCRIPTION
Added the vault kms key rotation function.
Currently two functions are defined : 
first one only rotates the key - vault creates multiple versions after rotation;  keeping the min_decryption_version same.
second one rotates the key and also updates the min_decryption_version field to the latest version resulting in only 1 key available at at time for decryption. 

Let me know your thoughts if both functions are needed.

edit : Removed the second one.
Only one function has been added for key rotation. No other parameters changed. 


Please find the test execution log.
```
$ INTEGRATION_TEST=true go test -v -count=1 .
=== RUN   TestVaultKeyRotationIntegration
    vault_key_rotation_test.go:259: Vault is running and configured correctly
    vault_key_rotation_test.go:47: Getting initial key information...
    vault_key_rotation_test.go:48: Executing: /usr/local/sbin/oc exec vault-0 -n vault-kms -- vault read -format=json transit/keys/kms-key
    vault_key_rotation_test.go:48: Command output: {
          "request_id": "71ea8d00-0549-ec6c-1365-acce08603087",
          "lease_id": "",
          "lease_duration": 0,
          "renewable": false,
          "data": {
            "allow_plaintext_backup": false,
            "auto_rotate_period": 0,
            "deletion_allowed": false,
            "derived": false,
            "exportable": false,
            "imported_key": false,
            "keys": {
              "1": 1779189310
            },
            "latest_version": 1,
            "min_available_version": 0,
            "min_decryption_version": 1,
            "min_encryption_version": 0,
            "name": "kms-key",
            "supports_decryption": true,
            "supports_derivation": true,
            "supports_encryption": true,
            "supports_signing": false,
            "type": "aes256-gcm96"
          },
          "warnings": null,
          "mount_type": "transit"
        }
    vault_key_rotation_test.go:58: Test 1: Rotating key (all old keys retained)...
    vault_key_rotation_test.go:59: Executing: /usr/local/sbin/oc exec vault-0 -n vault-kms -- vault read -field=latest_version transit/keys/kms-key
    vault_key_rotation_test.go:59: Command output: 1
    vault_key_rotation_test.go:59: Executing: /usr/local/sbin/oc exec vault-0 -n vault-kms -- vault write -f transit/keys/kms-key/rotate
    vault_key_rotation_test.go:59: Command output: Key                       Value
        ---                       -----
        allow_plaintext_backup    false
        auto_rotate_period        0s
        deletion_allowed          false
        derived                   false
        exportable                false
        imported_key              false
        keys                      map[1:1779189310 2:1779189330]
        latest_version            2
        min_available_version     0
        min_decryption_version    1
        min_encryption_version    0
        name                      kms-key
        supports_decryption       true
        supports_derivation       true
        supports_encryption       true
        supports_signing          false
        type                      aes256-gcm96
    vault_key_rotation_test.go:59: Executing: /usr/local/sbin/oc exec vault-0 -n vault-kms -- vault read -field=latest_version transit/keys/kms-key
    vault_key_rotation_test.go:59: Command output: 2
    vault_key_rotation_test.go:60: Key rotated successfully
    vault_key_rotation_test.go:63: Test 2: Verifying old keys are retained...
    vault_key_rotation_test.go:64: Executing: /usr/local/sbin/oc exec vault-0 -n vault-kms -- vault read -format=json transit/keys/kms-key
    vault_key_rotation_test.go:64: Command output: {
          "request_id": "66099cc6-f7c9-b7e7-069f-8c89c75092f6",
          "lease_id": "",
          "lease_duration": 0,
          "renewable": false,
          "data": {
            "allow_plaintext_backup": false,
            "auto_rotate_period": 0,
            "deletion_allowed": false,
            "derived": false,
            "exportable": false,
            "imported_key": false,
            "keys": {
              "1": 1779189310,
              "2": 1779189330
            },
            "latest_version": 2,
            "min_available_version": 0,
            "min_decryption_version": 1,
            "min_encryption_version": 0,
            "name": "kms-key",
            "supports_decryption": true,
            "supports_derivation": true,
            "supports_encryption": true,
            "supports_signing": false,
            "type": "aes256-gcm96"
          },
          "warnings": null,
          "mount_type": "transit"
        }
    vault_key_rotation_test.go:82: All tests passed successfully!
--- PASS: TestVaultKeyRotationIntegration (12.48s)
=== RUN   TestVaultKeyRotationWithEncryptionDecryption
    vault_key_rotation_test.go:259: Vault is running and configured correctly
    vault_key_rotation_test.go:114: Executing: /usr/local/sbin/oc exec vault-0 -n vault-kms -- vault read -format=json transit/keys/kms-key
    vault_key_rotation_test.go:114: Command output: {
          "request_id": "a460397f-bdec-7b60-897d-1cec76b6d44f",
          "lease_id": "",
          "lease_duration": 0,
          "renewable": false,
          "data": {
            "allow_plaintext_backup": false,
            "auto_rotate_period": 0,
            "deletion_allowed": false,
            "derived": false,
            "exportable": false,
            "imported_key": false,
            "keys": {
              "1": 1779189310,
              "2": 1779189330
            },
            "latest_version": 2,
            "min_available_version": 0,
            "min_decryption_version": 1,
            "min_encryption_version": 0,
            "name": "kms-key",
            "supports_decryption": true,
            "supports_derivation": true,
            "supports_encryption": true,
            "supports_signing": false,
            "type": "aes256-gcm96"
          },
          "warnings": null,
          "mount_type": "transit"
        }
    vault_key_rotation_test.go:122: 
        --- Step 1: Encrypt data with current key ---
    vault_key_rotation_test.go:279: Executing: /usr/local/sbin/oc exec vault-0 -n vault-kms -- vault write -format=json transit/encrypt/kms-key plaintext=bXktZGF0YWJhc2UtcGFzc3dvcmQtMTIzNDU= key_version=2
    vault_key_rotation_test.go:284: Output: {
          "request_id": "068dd93f-f977-d6f9-ade1-e41d525b7ff0",
          "lease_id": "",
          "lease_duration": 0,
          "renewable": false,
          "data": {
            "ciphertext": "vault:v2:DMW2DAk74HbTkNIiWXcJThO3f0DZSRxUmpbNvl/r7GyxaD30318jJWscqhYFCi2XoPHllQRY",
            "key_version": 2
          },
          "warnings": null,
          "mount_type": "transit"
        }
    vault_key_rotation_test.go:128: Encrypted: my-database-password-12345
    vault_key_rotation_test.go:131: 
        --- Step 2: Verify decryption of data encrypted with current key ---
    vault_key_rotation_test.go:311: Executing: /usr/local/sbin/oc exec vault-0 -n vault-kms -- vault write -format=json transit/decrypt/kms-key ciphertext=vault:v2:DMW2DAk74HbTkNIiWXcJThO3f0DZSRxUmpbNvl/r7GyxaD30318jJWscqhYFCi2XoPHllQRY
    vault_key_rotation_test.go:316: Output: {
          "request_id": "9691ed6a-b173-14fe-41ce-b7fceef8fe15",
          "lease_id": "",
          "lease_duration": 0,
          "renewable": false,
          "data": {
            "plaintext": "bXktZGF0YWJhc2UtcGFzc3dvcmQtMTIzNDU="
          },
          "warnings": null,
          "mount_type": "transit"
        }
    vault_key_rotation_test.go:139: ✅ Successfully decrypted: my-database-password-12345
    vault_key_rotation_test.go:142: 
        --- Step 3: Perform key rotation ---
    vault_key_rotation_test.go:143: Executing: /usr/local/sbin/oc exec vault-0 -n vault-kms -- vault read -field=latest_version transit/keys/kms-key
    vault_key_rotation_test.go:143: Command output: 2
    vault_key_rotation_test.go:143: Executing: /usr/local/sbin/oc exec vault-0 -n vault-kms -- vault write -f transit/keys/kms-key/rotate
    vault_key_rotation_test.go:143: Command output: Key                       Value
        ---                       -----
        allow_plaintext_backup    false
        auto_rotate_period        0s
        deletion_allowed          false
        derived                   false
        exportable                false
        imported_key              false
        keys                      map[1:1779189310 2:1779189330 3:1779189346]
        latest_version            3
        min_available_version     0
        min_decryption_version    1
        min_encryption_version    0
        name                      kms-key
        supports_decryption       true
        supports_derivation       true
        supports_encryption       true
        supports_signing          false
        type                      aes256-gcm96
    vault_key_rotation_test.go:143: Executing: /usr/local/sbin/oc exec vault-0 -n vault-kms -- vault read -field=latest_version transit/keys/kms-key
    vault_key_rotation_test.go:143: Command output: 3
    vault_key_rotation_test.go:146: Executing: /usr/local/sbin/oc exec vault-0 -n vault-kms -- vault read -format=json transit/keys/kms-key
    vault_key_rotation_test.go:146: Command output: {
          "request_id": "060d3c1b-f595-0ae9-65cf-2d73e896542a",
          "lease_id": "",
          "lease_duration": 0,
          "renewable": false,
          "data": {
            "allow_plaintext_backup": false,
            "auto_rotate_period": 0,
            "deletion_allowed": false,
            "derived": false,
            "exportable": false,
            "imported_key": false,
            "keys": {
              "1": 1779189310,
              "2": 1779189330,
              "3": 1779189346
            },
            "latest_version": 3,
            "min_available_version": 0,
            "min_decryption_version": 1,
            "min_encryption_version": 0,
            "name": "kms-key",
            "supports_decryption": true,
            "supports_derivation": true,
            "supports_encryption": true,
            "supports_signing": false,
            "type": "aes256-gcm96"
          },
          "warnings": null,
          "mount_type": "transit"
        }
    vault_key_rotation_test.go:152: ✅ Key rotation complete
    vault_key_rotation_test.go:155: 
        --- Step 4: Verify data encrypted with OLD key still decrypts ---
    vault_key_rotation_test.go:311: Executing: /usr/local/sbin/oc exec vault-0 -n vault-kms -- vault write -format=json transit/decrypt/kms-key ciphertext=vault:v2:DMW2DAk74HbTkNIiWXcJThO3f0DZSRxUmpbNvl/r7GyxaD30318jJWscqhYFCi2XoPHllQRY
    vault_key_rotation_test.go:316: Output: {
          "request_id": "138c9703-a930-5357-3b41-dc4deb97b323",
          "lease_id": "",
          "lease_duration": 0,
          "renewable": false,
          "data": {
            "plaintext": "bXktZGF0YWJhc2UtcGFzc3dvcmQtMTIzNDU="
          },
          "warnings": null,
          "mount_type": "transit"
        }
    vault_key_rotation_test.go:163: ✅ Successfully decrypted old data: my-database-password-12345
    vault_key_rotation_test.go:164: ✅ Old key still works after rotation!
    vault_key_rotation_test.go:167: 
        --- Step 5: Encrypt NEW data with current key ---
    vault_key_rotation_test.go:279: Executing: /usr/local/sbin/oc exec vault-0 -n vault-kms -- vault write -format=json transit/encrypt/kms-key plaintext=bXktYXBpLXRva2VuLTY3ODkw
    vault_key_rotation_test.go:284: Output: {
          "request_id": "34552db3-beb9-67b2-a456-05ef026e5aa0",
          "lease_id": "",
          "lease_duration": 0,
          "renewable": false,
          "data": {
            "ciphertext": "vault:v3:6xftRhGENkRmkiUl0ffN8+h7+jiCGx+YqslhYsa68GPfYbuZnL78ZNQ0QJxqUA==",
            "key_version": 3
          },
          "warnings": null,
          "mount_type": "transit"
        }
    vault_key_rotation_test.go:173: Encrypted: my-api-token-67890
    vault_key_rotation_test.go:311: Executing: /usr/local/sbin/oc exec vault-0 -n vault-kms -- vault write -format=json transit/decrypt/kms-key ciphertext=vault:v3:6xftRhGENkRmkiUl0ffN8+h7+jiCGx+YqslhYsa68GPfYbuZnL78ZNQ0QJxqUA==
    vault_key_rotation_test.go:316: Output: {
          "request_id": "b57608e1-756d-774d-b6ad-0f76d5747ebd",
          "lease_id": "",
          "lease_duration": 0,
          "renewable": false,
          "data": {
            "plaintext": "bXktYXBpLXRva2VuLTY3ODkw"
          },
          "warnings": null,
          "mount_type": "transit"
        }
    vault_key_rotation_test.go:183: ✅ Successfully decrypted new data: my-api-token-67890
    vault_key_rotation_test.go:186: 
        --- Step 6: Verify all key versions are retained ---
    vault_key_rotation_test.go:187: Executing: /usr/local/sbin/oc exec vault-0 -n vault-kms -- vault read -format=json transit/keys/kms-key
    vault_key_rotation_test.go:187: Command output: {
          "request_id": "fc480fed-fd1a-d4f2-fbe4-e84b8aa75cbf",
          "lease_id": "",
          "lease_duration": 0,
          "renewable": false,
          "data": {
            "allow_plaintext_backup": false,
            "auto_rotate_period": 0,
            "deletion_allowed": false,
            "derived": false,
            "exportable": false,
            "imported_key": false,
            "keys": {
              "1": 1779189310,
              "2": 1779189330,
              "3": 1779189346
            },
            "latest_version": 3,
            "min_available_version": 0,
            "min_decryption_version": 1,
            "min_encryption_version": 0,
            "name": "kms-key",
            "supports_decryption": true,
            "supports_derivation": true,
            "supports_encryption": true,
            "supports_signing": false,
            "type": "aes256-gcm96"
          },
          "warnings": null,
          "mount_type": "transit"
        }
    vault_key_rotation_test.go:196: 
        === TEST SUMMARY ===
    vault_key_rotation_test.go:197: ✅ Key rotation preserves access to all old encrypted data
    vault_key_rotation_test.go:198: ✅ All key versions are retained after rotation
    vault_key_rotation_test.go:199: ✅ Both old and new data remain accessible
--- PASS: TestVaultKeyRotationWithEncryptionDecryption (23.84s)
PASS
ok  	github.com/openshift/library-go/test/library/encryption/kms	36.350s


```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added test utilities to trigger Vault key rotations and verify the key version increases.
  * Added ability to read Vault key metadata for validation during tests.
  * Support for default and customizable Vault target settings to simplify testing across environments; improved error reporting with captured command output on failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->