### PR TITLE
CNTRLPLANE-3236: kms: set required field in container sidecar

### DIFF
--- a/pkg/operator/encryption/kms/pluginlifecycle/sidecar_test.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/sidecar_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/encryption/kms"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	apiserverv1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
@@ -148,9 +149,17 @@ func TestAddKMSPluginSidecarToPodSpec(t *testing.T) {
 						VolumeMounts: []corev1.VolumeMount{socketMount},
 					},
 					{
-						Name:         "vault-kms-plugin-555",
-						Image:        "quay.io/test/vault:v1",
-						Args:         sidecarArgs,
+						Name:                     "vault-kms-plugin-555",
+						Image:                    "quay.io/test/vault:v1",
+						Args:                     sidecarArgs,
+						ImagePullPolicy:          corev1.PullIfNotPresent,
+						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("50Mi"),
+								corev1.ResourceCPU:    resource.MustParse("5m"),
+							},
+						},
 						VolumeMounts: []corev1.VolumeMount{socketMount},
 					},
 				},
@@ -185,6 +194,14 @@ func TestAddKMSPluginSidecarToPodSpec(t *testing.T) {
 							"-vault-namespace=other-namespace",
 							"-transit-mount=transit2",
 						},
+						ImagePullPolicy:          corev1.PullIfNotPresent,
+						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("50Mi"),
+								corev1.ResourceCPU:    resource.MustParse("5m"),
+							},
+						},
 						VolumeMounts: []corev1.VolumeMount{socketMount},
 					},
 					{
@@ -198,6 +215,14 @@ func TestAddKMSPluginSidecarToPodSpec(t *testing.T) {
 							"-approle-secret-id-path=/var/run/secrets/vault-kms/secret-id-555",
 							"-vault-namespace=my-namespace",
 							"-transit-mount=transit",
+						},
+						ImagePullPolicy:          corev1.PullIfNotPresent,
+						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("50Mi"),
+								corev1.ResourceCPU:    resource.MustParse("5m"),
+							},
 						},
 						VolumeMounts: []corev1.VolumeMount{socketMount},
 					},
@@ -397,9 +422,17 @@ func TestAddKMSPluginSidecarToPodSpec(t *testing.T) {
 						VolumeMounts: []corev1.VolumeMount{socketMount},
 					},
 					{
-						Name:         "vault-kms-plugin-555",
-						Image:        "quay.io/test/vault:v1",
-						Args:         sidecarArgs,
+						Name:                     "vault-kms-plugin-555",
+						Image:                    "quay.io/test/vault:v1",
+						Args:                     sidecarArgs,
+						ImagePullPolicy:          corev1.PullIfNotPresent,
+						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("50Mi"),
+								corev1.ResourceCPU:    resource.MustParse("5m"),
+							},
+						},
 						VolumeMounts: []corev1.VolumeMount{socketMount},
 					},
 				},

--- a/pkg/operator/encryption/kms/pluginlifecycle/vault.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/vault.go
@@ -5,6 +5,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 // newVaultSidecarProvider creates a Vault sidecar provider from the given KMS plugin configuration.
@@ -54,8 +55,19 @@ func (v *vault) BuildSidecarContainer() (corev1.Container, error) {
 	}
 
 	return corev1.Container{
-		Name:  v.Name(),
-		Image: v.config.KMSPluginImage,
-		Args:  args,
+		Name:                     v.Name(),
+		Image:                    v.config.KMSPluginImage,
+		Args:                     args,
+		ImagePullPolicy:          corev1.PullIfNotPresent,
+		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+		// TODO(bertinatto): the plugin sidecar needs to be measure under heavy load to figure out good defaults.
+		// For now follow what most sidecars in the kube-apiserver pod do. xref:
+		// https://github.com/openshift/cluster-kube-apiserver-operator/commit/e15a19cd2474c8b60ce17ac16dd8f422c729847a
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("50Mi"),
+				corev1.ResourceCPU:    resource.MustParse("5m"),
+			},
+		},
 	}, nil
 }

--- a/pkg/operator/encryption/kms/pluginlifecycle/vault_test.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/vault_test.go
@@ -6,6 +6,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func TestVaultSidecarProvider_BuildSidecarContainer(t *testing.T) {
@@ -48,6 +49,14 @@ func TestVaultSidecarProvider_BuildSidecarContainer(t *testing.T) {
 							"-approle-secret-id-path=/var/run/secrets/vault-kms/secret-id-555",
 							"-vault-namespace=my-namespace",
 							"-transit-mount=transit",
+						},
+						ImagePullPolicy:          corev1.PullIfNotPresent,
+						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("50Mi"),
+								corev1.ResourceCPU:    resource.MustParse("5m"),
+							},
 						},
 					},
 				},
@@ -94,6 +103,14 @@ func TestVaultSidecarProvider_BuildSidecarContainer(t *testing.T) {
 							"-vault-namespace=my-namespace",
 							"-transit-mount=transit",
 						},
+						ImagePullPolicy:          corev1.PullIfNotPresent,
+						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("50Mi"),
+								corev1.ResourceCPU:    resource.MustParse("5m"),
+							},
+						},
 					},
 				},
 			},
@@ -128,6 +145,14 @@ func TestVaultSidecarProvider_BuildSidecarContainer(t *testing.T) {
 							// These are not added
 							// "-vault-namespace=",
 							// "-transit-mount=",
+						},
+						ImagePullPolicy:          corev1.PullIfNotPresent,
+						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("50Mi"),
+								corev1.ResourceCPU:    resource.MustParse("5m"),
+							},
 						},
 					},
 				},


### PR DESCRIPTION
OpenShift CI expects these fields to be set. We have a few monitor tests that assert that.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Vault KMS sidecar now sets container policies and default resource requests to improve reliability (pull policy, termination message behavior, CPU/memory requests).
* **Tests**
  * Updated tests to validate the new sidecar container policies and resource request defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->