### PR TITLE
NO-JIRA: Keep equality during roundtrips of EncryptionConfiguration

### DIFF
--- a/pkg/operator/encryption/encryptiondata/config.go
+++ b/pkg/operator/encryption/encryptiondata/config.go
@@ -8,6 +8,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
 	"k8s.io/klog/v2"
@@ -76,7 +77,10 @@ func FromEncryptionState(encryptionState map[schema.GroupResource]state.GroupRes
 	})
 
 	return &Config{
-		Encryption: &apiserverconfigv1.EncryptionConfiguration{Resources: resourceConfigs},
+		Encryption: &apiserverconfigv1.EncryptionConfiguration{
+			TypeMeta:  metav1.TypeMeta{Kind: "EncryptionConfiguration", APIVersion: "apiserver.config.k8s.io/v1"},
+			Resources: resourceConfigs,
+		},
 		KMSPlugins: kmsPlugins,
 	}, nil
 }

--- a/pkg/operator/encryption/encryptiondata/config_test.go
+++ b/pkg/operator/encryption/encryptiondata/config_test.go
@@ -13,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
 
@@ -697,6 +698,34 @@ func keyToKMSConfiguration(key *corev1.Secret, resource string) *apiserverconfig
 		Timeout: &metav1.Duration{
 			Duration: 10 * time.Second,
 		},
+	}
+}
+
+func TestFromEncryptionStateMatchesFromSecretTypeMeta(t *testing.T) {
+	keySecret := encryptiontesting.CreateEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 1, []byte("61def964fb967f5d7c44a2af8dab6865"))
+	ks, err := secrets.ToKeyState(keySecret)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fromState, err := encryptiondata.FromEncryptionState(map[schema.GroupResource]state.GroupResourceState{
+		{Resource: "secrets"}: {WriteKey: ks, ReadKeys: []state.KeyState{ks}},
+	})
+	if err != nil {
+		t.Fatalf("FromEncryptionState error: %v", err)
+	}
+
+	secret, err := encryptiondata.ToSecret("openshift-config-managed", "encryption-config", fromState)
+	if err != nil {
+		t.Fatalf("ToSecret error: %v", err)
+	}
+	fromSecret, err := encryptiondata.FromSecret(secret)
+	if err != nil {
+		t.Fatalf("FromSecret error: %v", err)
+	}
+
+	if !equality.Semantic.DeepEqual(fromState.Encryption, fromSecret.Encryption) {
+		t.Errorf("FromEncryptionState and FromSecret produced different Encryption:\nfromState:  %#v\nfromSecret: %#v", fromState.Encryption, fromSecret.Encryption)
 	}
 }
 

--- a/pkg/operator/encryption/statemachine/transition_test.go
+++ b/pkg/operator/encryption/statemachine/transition_test.go
@@ -48,7 +48,6 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 				return
 			}
 			expected := expected.DeepCopy()
-			expected.TypeMeta = metav1.TypeMeta{}
 			secretData, err := encryptiondata.FromEncryptionState(state)
 			if err != nil {
 				ts.Fatalf("unexpected error from FromEncryptionState: %v", err)
@@ -81,6 +80,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 				[]schema.GroupResource{{Group: "", Resource: "configmaps"}, {Group: "", Resource: "secrets"}},
 			},
 			equalsConfig(&apiserverconfigv1.EncryptionConfiguration{
+				TypeMeta: metav1.TypeMeta{Kind: "EncryptionConfiguration", APIVersion: "apiserver.config.k8s.io/v1"},
 				Resources: []apiserverconfigv1.ResourceConfiguration{
 					{
 						Resources: []string{"configmaps"},
@@ -111,6 +111,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 			"config exists with write keys, no secrets => nothing done, config unchanged",
 			args{
 				toSecretData(&apiserverconfigv1.EncryptionConfiguration{
+					TypeMeta: metav1.TypeMeta{Kind: "EncryptionConfiguration", APIVersion: "apiserver.config.k8s.io/v1"},
 					Resources: []apiserverconfigv1.ResourceConfiguration{{
 						Resources: []string{"configmaps"},
 						Providers: []apiserverconfigv1.ProviderConfiguration{{
@@ -142,6 +143,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 				[]schema.GroupResource{{Group: "", Resource: "configmaps"}, {Group: "", Resource: "secrets"}},
 			},
 			equalsConfig(&apiserverconfigv1.EncryptionConfiguration{
+				TypeMeta: metav1.TypeMeta{Kind: "EncryptionConfiguration", APIVersion: "apiserver.config.k8s.io/v1"},
 				Resources: []apiserverconfigv1.ResourceConfiguration{{
 					Resources: []string{"configmaps"},
 					Providers: []apiserverconfigv1.ProviderConfiguration{{
@@ -172,6 +174,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 			"config exists with only one resource => 2nd resource is added",
 			args{
 				toSecretData(&apiserverconfigv1.EncryptionConfiguration{
+					TypeMeta: metav1.TypeMeta{Kind: "EncryptionConfiguration", APIVersion: "apiserver.config.k8s.io/v1"},
 					Resources: []apiserverconfigv1.ResourceConfiguration{{
 						Resources: []string{"configmaps"},
 						Providers: []apiserverconfigv1.ProviderConfiguration{{
@@ -193,6 +196,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 				[]schema.GroupResource{{Group: "", Resource: "configmaps"}, {Group: "", Resource: "secrets"}},
 			},
 			equalsConfig(&apiserverconfigv1.EncryptionConfiguration{
+				TypeMeta: metav1.TypeMeta{Kind: "EncryptionConfiguration", APIVersion: "apiserver.config.k8s.io/v1"},
 				Resources: []apiserverconfigv1.ResourceConfiguration{
 					{
 						Resources: []string{"configmaps"},
@@ -227,6 +231,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 			"config exists with two resources, GRs reduced => only one resource stays",
 			args{
 				toSecretData(&apiserverconfigv1.EncryptionConfiguration{
+					TypeMeta: metav1.TypeMeta{Kind: "EncryptionConfiguration", APIVersion: "apiserver.config.k8s.io/v1"},
 					Resources: []apiserverconfigv1.ResourceConfiguration{{
 						Resources: []string{"configmaps"},
 						Providers: []apiserverconfigv1.ProviderConfiguration{{
@@ -260,6 +265,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 				[]schema.GroupResource{{Group: "", Resource: "configmaps"}},
 			},
 			equalsConfig(&apiserverconfigv1.EncryptionConfiguration{
+				TypeMeta: metav1.TypeMeta{Kind: "EncryptionConfiguration", APIVersion: "apiserver.config.k8s.io/v1"},
 				Resources: []apiserverconfigv1.ResourceConfiguration{
 					{
 						Resources: []string{"configmaps"},
@@ -288,6 +294,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 				[]schema.GroupResource{{Group: "", Resource: "configmaps"}, {Group: "", Resource: "secrets"}},
 			},
 			equalsConfig(&apiserverconfigv1.EncryptionConfiguration{
+				TypeMeta: metav1.TypeMeta{Kind: "EncryptionConfiguration", APIVersion: "apiserver.config.k8s.io/v1"},
 				Resources: []apiserverconfigv1.ResourceConfiguration{
 					{
 						Resources: []string{"configmaps"},
@@ -332,6 +339,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 				[]schema.GroupResource{{Group: "", Resource: "configmaps"}, {Group: "", Resource: "secrets"}},
 			},
 			equalsConfig(&apiserverconfigv1.EncryptionConfiguration{
+				TypeMeta: metav1.TypeMeta{Kind: "EncryptionConfiguration", APIVersion: "apiserver.config.k8s.io/v1"},
 				Resources: []apiserverconfigv1.ResourceConfiguration{
 					{
 						Resources: []string{"configmaps"},
@@ -409,6 +417,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 			"config exists, write key secret is missing => no-op",
 			args{
 				toSecretData(&apiserverconfigv1.EncryptionConfiguration{
+					TypeMeta: metav1.TypeMeta{Kind: "EncryptionConfiguration", APIVersion: "apiserver.config.k8s.io/v1"},
 					Resources: []apiserverconfigv1.ResourceConfiguration{
 						{
 							Resources: []string{"configmaps"},
@@ -476,6 +485,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 				[]schema.GroupResource{{Group: "", Resource: "configmaps"}, {Group: "", Resource: "secrets"}},
 			},
 			equalsConfig(&apiserverconfigv1.EncryptionConfiguration{
+				TypeMeta: metav1.TypeMeta{Kind: "EncryptionConfiguration", APIVersion: "apiserver.config.k8s.io/v1"},
 				// 4 is becoming new write key, not 5!
 				Resources: []apiserverconfigv1.ResourceConfiguration{
 					{
@@ -554,6 +564,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 			"config exists without identity => identity is appended",
 			args{
 				toSecretData(&apiserverconfigv1.EncryptionConfiguration{
+					TypeMeta: metav1.TypeMeta{Kind: "EncryptionConfiguration", APIVersion: "apiserver.config.k8s.io/v1"},
 					Resources: []apiserverconfigv1.ResourceConfiguration{
 						{
 							Resources: []string{"configmaps"},
@@ -585,6 +596,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 				[]schema.GroupResource{{Group: "", Resource: "configmaps"}, {Group: "", Resource: "secrets"}},
 			},
 			equalsConfig(&apiserverconfigv1.EncryptionConfiguration{
+				TypeMeta: metav1.TypeMeta{Kind: "EncryptionConfiguration", APIVersion: "apiserver.config.k8s.io/v1"},
 				Resources: []apiserverconfigv1.ResourceConfiguration{
 					{
 						Resources: []string{"configmaps"},
@@ -619,6 +631,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 			"config exists, new key secret => new key added as read key",
 			args{
 				toSecretData(&apiserverconfigv1.EncryptionConfiguration{
+					TypeMeta: metav1.TypeMeta{Kind: "EncryptionConfiguration", APIVersion: "apiserver.config.k8s.io/v1"},
 					Resources: []apiserverconfigv1.ResourceConfiguration{{
 						Resources: []string{"configmaps"},
 						Providers: []apiserverconfigv1.ProviderConfiguration{{
@@ -653,6 +666,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 				[]schema.GroupResource{{Group: "", Resource: "configmaps"}, {Group: "", Resource: "secrets"}},
 			},
 			equalsConfig(&apiserverconfigv1.EncryptionConfiguration{
+				TypeMeta: metav1.TypeMeta{Kind: "EncryptionConfiguration", APIVersion: "apiserver.config.k8s.io/v1"},
 				Resources: []apiserverconfigv1.ResourceConfiguration{
 					{
 						Resources: []string{"configmaps"},
@@ -701,6 +715,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 			"config exists, read keys are consistent => new write key is set",
 			args{
 				toSecretData(&apiserverconfigv1.EncryptionConfiguration{
+					TypeMeta: metav1.TypeMeta{Kind: "EncryptionConfiguration", APIVersion: "apiserver.config.k8s.io/v1"},
 					Resources: []apiserverconfigv1.ResourceConfiguration{{
 						Resources: []string{"configmaps"},
 						Providers: []apiserverconfigv1.ProviderConfiguration{{
@@ -749,6 +764,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 				[]schema.GroupResource{{Group: "", Resource: "configmaps"}, {Group: "", Resource: "secrets"}},
 			},
 			equalsConfig(&apiserverconfigv1.EncryptionConfiguration{
+				TypeMeta: metav1.TypeMeta{Kind: "EncryptionConfiguration", APIVersion: "apiserver.config.k8s.io/v1"},
 				Resources: []apiserverconfigv1.ResourceConfiguration{
 					{
 						Resources: []string{"configmaps"},
@@ -797,6 +813,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 			"config exists, read+write keys are consistent, not migrated => nothing changes",
 			args{
 				toSecretData(&apiserverconfigv1.EncryptionConfiguration{
+					TypeMeta: metav1.TypeMeta{Kind: "EncryptionConfiguration", APIVersion: "apiserver.config.k8s.io/v1"},
 					Resources: []apiserverconfigv1.ResourceConfiguration{{
 						Resources: []string{"configmaps"},
 						Providers: []apiserverconfigv1.ProviderConfiguration{{
@@ -845,6 +862,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 				[]schema.GroupResource{{Group: "", Resource: "configmaps"}, {Group: "", Resource: "secrets"}},
 			},
 			equalsConfig(&apiserverconfigv1.EncryptionConfiguration{
+				TypeMeta: metav1.TypeMeta{Kind: "EncryptionConfiguration", APIVersion: "apiserver.config.k8s.io/v1"},
 				Resources: []apiserverconfigv1.ResourceConfiguration{
 					{
 						Resources: []string{"configmaps"},
@@ -893,6 +911,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 			"config exists, read+write keys are consistent, migrated => old read-keys are pruned from config",
 			args{
 				toSecretData(&apiserverconfigv1.EncryptionConfiguration{
+					TypeMeta: metav1.TypeMeta{Kind: "EncryptionConfiguration", APIVersion: "apiserver.config.k8s.io/v1"},
 					Resources: []apiserverconfigv1.ResourceConfiguration{{
 						Resources: []string{"configmaps"},
 						Providers: []apiserverconfigv1.ProviderConfiguration{{
@@ -956,6 +975,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 				[]schema.GroupResource{{Group: "", Resource: "configmaps"}, {Group: "", Resource: "secrets"}},
 			},
 			equalsConfig(&apiserverconfigv1.EncryptionConfiguration{
+				TypeMeta: metav1.TypeMeta{Kind: "EncryptionConfiguration", APIVersion: "apiserver.config.k8s.io/v1"},
 				Resources: []apiserverconfigv1.ResourceConfiguration{
 					{
 						Resources: []string{"configmaps"},
@@ -1011,6 +1031,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 				[]schema.GroupResource{{Group: "", Resource: "secrets"}},
 			},
 			equalsConfig(&apiserverconfigv1.EncryptionConfiguration{
+				TypeMeta: metav1.TypeMeta{Kind: "EncryptionConfiguration", APIVersion: "apiserver.config.k8s.io/v1"},
 				Resources: []apiserverconfigv1.ResourceConfiguration{
 					{
 						Resources: []string{"secrets"},
@@ -1031,6 +1052,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 			"config exists with AESCBC, KMS secret added => KMS added as read key (migration scenario)",
 			args{
 				toSecretData(&apiserverconfigv1.EncryptionConfiguration{
+					TypeMeta: metav1.TypeMeta{Kind: "EncryptionConfiguration", APIVersion: "apiserver.config.k8s.io/v1"},
 					Resources: []apiserverconfigv1.ResourceConfiguration{{
 						Resources: []string{"secrets"},
 						Providers: []apiserverconfigv1.ProviderConfiguration{{
@@ -1053,6 +1075,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 				[]schema.GroupResource{{Group: "", Resource: "secrets"}},
 			},
 			equalsConfig(&apiserverconfigv1.EncryptionConfiguration{
+				TypeMeta: metav1.TypeMeta{Kind: "EncryptionConfiguration", APIVersion: "apiserver.config.k8s.io/v1"},
 				Resources: []apiserverconfigv1.ResourceConfiguration{
 					{
 						Resources: []string{"secrets"},
@@ -1081,6 +1104,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 			"config exists with KMS, read keys are consistent => new write key is set",
 			args{
 				toSecretData(&apiserverconfigv1.EncryptionConfiguration{
+					TypeMeta: metav1.TypeMeta{Kind: "EncryptionConfiguration", APIVersion: "apiserver.config.k8s.io/v1"},
 					Resources: []apiserverconfigv1.ResourceConfiguration{{
 						Resources: []string{"secrets"},
 						Providers: []apiserverconfigv1.ProviderConfiguration{{
@@ -1110,6 +1134,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 				[]schema.GroupResource{{Group: "", Resource: "secrets"}},
 			},
 			equalsConfig(&apiserverconfigv1.EncryptionConfiguration{
+				TypeMeta: metav1.TypeMeta{Kind: "EncryptionConfiguration", APIVersion: "apiserver.config.k8s.io/v1"},
 				Resources: []apiserverconfigv1.ResourceConfiguration{
 					{
 						Resources: []string{"secrets"},
@@ -1138,6 +1163,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 			"config exists with KMS, read+write keys consistent, not migrated => nothing changes",
 			args{
 				toSecretData(&apiserverconfigv1.EncryptionConfiguration{
+					TypeMeta: metav1.TypeMeta{Kind: "EncryptionConfiguration", APIVersion: "apiserver.config.k8s.io/v1"},
 					Resources: []apiserverconfigv1.ResourceConfiguration{{
 						Resources: []string{"secrets"},
 						Providers: []apiserverconfigv1.ProviderConfiguration{{
@@ -1167,6 +1193,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 				[]schema.GroupResource{{Group: "", Resource: "secrets"}},
 			},
 			equalsConfig(&apiserverconfigv1.EncryptionConfiguration{
+				TypeMeta: metav1.TypeMeta{Kind: "EncryptionConfiguration", APIVersion: "apiserver.config.k8s.io/v1"},
 				Resources: []apiserverconfigv1.ResourceConfiguration{{
 					Resources: []string{"secrets"},
 					Providers: []apiserverconfigv1.ProviderConfiguration{{
@@ -1193,6 +1220,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 			"KMS has converged after migrating from AESCBC => nothing changes",
 			args{
 				toSecretData(&apiserverconfigv1.EncryptionConfiguration{
+					TypeMeta: metav1.TypeMeta{Kind: "EncryptionConfiguration", APIVersion: "apiserver.config.k8s.io/v1"},
 					Resources: []apiserverconfigv1.ResourceConfiguration{{
 						Resources: []string{"secrets"},
 						Providers: []apiserverconfigv1.ProviderConfiguration{{
@@ -1222,6 +1250,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 				[]schema.GroupResource{{Group: "", Resource: "secrets"}},
 			},
 			equalsConfig(&apiserverconfigv1.EncryptionConfiguration{
+				TypeMeta: metav1.TypeMeta{Kind: "EncryptionConfiguration", APIVersion: "apiserver.config.k8s.io/v1"},
 				Resources: []apiserverconfigv1.ResourceConfiguration{{
 					Resources: []string{"secrets"},
 					Providers: []apiserverconfigv1.ProviderConfiguration{{
@@ -1248,6 +1277,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 			"AESCBC has converged after migrating back from KMS => nothing changes",
 			args{
 				toSecretData(&apiserverconfigv1.EncryptionConfiguration{
+					TypeMeta: metav1.TypeMeta{Kind: "EncryptionConfiguration", APIVersion: "apiserver.config.k8s.io/v1"},
 					Resources: []apiserverconfigv1.ResourceConfiguration{{
 						Resources: []string{"secrets"},
 						Providers: []apiserverconfigv1.ProviderConfiguration{{
@@ -1277,6 +1307,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 				[]schema.GroupResource{{Group: "", Resource: "secrets"}},
 			},
 			equalsConfig(&apiserverconfigv1.EncryptionConfiguration{
+				TypeMeta: metav1.TypeMeta{Kind: "EncryptionConfiguration", APIVersion: "apiserver.config.k8s.io/v1"},
 				Resources: []apiserverconfigv1.ResourceConfiguration{{
 					Resources: []string{"secrets"},
 					Providers: []apiserverconfigv1.ProviderConfiguration{{


### PR DESCRIPTION
Since Encryption of Config struct is not set TypeMeta, it won't be equal to the EncryptionConfiguration returned from encryption-config Secret. This does not create a bug, because we do all comparisons against `Encryption.Resources` not `Encryption`.

However, conceptually this is not right. After the roundtrips, we must have same data. Therefore, this PR adds TypeMeta to EncryptionConfiguration resources to keep it consistent as well as a test demonstrating the issue (test fails without the patch).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve resource metadata (kind and API version) when converting encryption configurations and state so settings remain intact across round-trip conversions and comparisons.

* **Tests**
  * Added and updated tests to validate round-trip conversion and ensure expected configurations now include and match the preserved resource metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->