### PR TITLE
CNTRLPLANE-3236: kms: plugin sidecar should be an init container

### DIFF
--- a/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
@@ -102,14 +102,17 @@ func AddKMSPluginSidecarToPodSpec(ctx context.Context, podSpec *corev1.PodSpec, 
 			return err
 		}
 
-		if err := ensureSocketVolumeMount(podSpec, sidecarProvider.Name()); err != nil {
+		if err := ensureSocketVolumeMountInContainer(podSpec.InitContainers, sidecarProvider.Name()); err != nil {
 			return err
 		}
 	}
 
-	if err := ensureSocketVolumeMount(podSpec, containerName); err != nil {
+	if err := ensureSocketVolumeMountInContainer(podSpec.Containers, containerName); err != nil {
 		return err
 	}
+
+	// The volume mount in the kube-apiserver and KMS plugin containers requires a volume in the podSpec
+	ensureSocketVolume(podSpec)
 
 	return nil
 }
@@ -120,20 +123,20 @@ func ensureSidecarContainer(podSpec *corev1.PodSpec, provider sidecarProvider) e
 		return fmt.Errorf("failed to build sidecar container: %w", err)
 	}
 
-	for i, container := range podSpec.Containers {
+	for i, container := range podSpec.InitContainers {
 		if container.Name == sidecar.Name {
-			podSpec.Containers[i] = sidecar
+			podSpec.InitContainers[i] = sidecar
 			return nil
 		}
 	}
 
-	podSpec.Containers = append(podSpec.Containers, sidecar)
+	podSpec.InitContainers = append(podSpec.InitContainers, sidecar)
 	return nil
 }
 
-func ensureSocketVolumeMount(podSpec *corev1.PodSpec, containerName string) error {
+func ensureSocketVolumeMountInContainer(containers []corev1.Container, containerName string) error {
 	containerIndex := -1
-	for i, container := range podSpec.Containers {
+	for i, container := range containers {
 		if container.Name == containerName {
 			containerIndex = i
 			break
@@ -144,8 +147,8 @@ func ensureSocketVolumeMount(podSpec *corev1.PodSpec, containerName string) erro
 		return fmt.Errorf("container %s not found", containerName)
 	}
 
-	container := &podSpec.Containers[containerIndex]
 	foundMount := false
+	container := &containers[containerIndex]
 	for _, m := range container.VolumeMounts {
 		if m.Name == "kms-plugin-socket" {
 			foundMount = true
@@ -160,9 +163,6 @@ func ensureSocketVolumeMount(podSpec *corev1.PodSpec, containerName string) erro
 			},
 		)
 	}
-
-	// The volume mount in the container requires a volume in the podSpec
-	ensureSocketVolume(podSpec)
 	return nil
 }
 

--- a/pkg/operator/encryption/kms/pluginlifecycle/sidecar_test.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/sidecar_test.go
@@ -18,6 +18,7 @@ import (
 	apiserverv1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
 	fake "k8s.io/client-go/kubernetes/fake"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/utils/ptr"
 )
 
 type sidecarTestFixtures struct {
@@ -148,11 +149,14 @@ func TestAddKMSPluginSidecarToPodSpec(t *testing.T) {
 						Name:         "kube-apiserver",
 						VolumeMounts: []corev1.VolumeMount{socketMount},
 					},
+				},
+				InitContainers: []corev1.Container{
 					{
 						Name:                     "vault-kms-plugin-555",
 						Image:                    "quay.io/test/vault:v1",
 						Args:                     sidecarArgs,
 						ImagePullPolicy:          corev1.PullIfNotPresent,
+						RestartPolicy:            ptr.To(corev1.ContainerRestartPolicyAlways),
 						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
@@ -182,6 +186,8 @@ func TestAddKMSPluginSidecarToPodSpec(t *testing.T) {
 						Name:         "kube-apiserver",
 						VolumeMounts: []corev1.VolumeMount{socketMount},
 					},
+				},
+				InitContainers: []corev1.Container{
 					{
 						Name:  "vault-kms-plugin-777",
 						Image: "quay.io/test/vault:v2",
@@ -195,6 +201,7 @@ func TestAddKMSPluginSidecarToPodSpec(t *testing.T) {
 							"-transit-mount=transit2",
 						},
 						ImagePullPolicy:          corev1.PullIfNotPresent,
+						RestartPolicy:            ptr.To(corev1.ContainerRestartPolicyAlways),
 						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
@@ -217,6 +224,7 @@ func TestAddKMSPluginSidecarToPodSpec(t *testing.T) {
 							"-transit-mount=transit",
 						},
 						ImagePullPolicy:          corev1.PullIfNotPresent,
+						RestartPolicy:            ptr.To(corev1.ContainerRestartPolicyAlways),
 						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
@@ -409,6 +417,8 @@ func TestAddKMSPluginSidecarToPodSpec(t *testing.T) {
 						Name:         "kube-apiserver",
 						VolumeMounts: []corev1.VolumeMount{socketMount},
 					},
+				},
+				InitContainers: []corev1.Container{
 					{
 						Name: "vault-kms-plugin-555",
 					},
@@ -421,11 +431,14 @@ func TestAddKMSPluginSidecarToPodSpec(t *testing.T) {
 						Name:         "kube-apiserver",
 						VolumeMounts: []corev1.VolumeMount{socketMount},
 					},
+				},
+				InitContainers: []corev1.Container{
 					{
 						Name:                     "vault-kms-plugin-555",
 						Image:                    "quay.io/test/vault:v1",
 						Args:                     sidecarArgs,
 						ImagePullPolicy:          corev1.PullIfNotPresent,
+						RestartPolicy:            ptr.To(corev1.ContainerRestartPolicyAlways),
 						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{

--- a/pkg/operator/encryption/kms/pluginlifecycle/vault.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/vault.go
@@ -6,6 +6,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/utils/ptr"
 )
 
 // newVaultSidecarProvider creates a Vault sidecar provider from the given KMS plugin configuration.
@@ -55,10 +56,13 @@ func (v *vault) BuildSidecarContainer() (corev1.Container, error) {
 	}
 
 	return corev1.Container{
-		Name:                     v.Name(),
-		Image:                    v.config.KMSPluginImage,
-		Args:                     args,
-		ImagePullPolicy:          corev1.PullIfNotPresent,
+		Name:            v.Name(),
+		Image:           v.config.KMSPluginImage,
+		Args:            args,
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		// We place the container in InitContainers with RestartPolicyAlways so the kubelet starts it before
+		// regular containers and keeps it running for the pod's lifetime.
+		RestartPolicy:            ptr.To(corev1.ContainerRestartPolicyAlways),
 		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 		// TODO(bertinatto): the plugin sidecar needs to be measure under heavy load to figure out good defaults.
 		// For now follow what most sidecars in the kube-apiserver pod do. xref:

--- a/pkg/operator/encryption/kms/pluginlifecycle/vault_test.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/vault_test.go
@@ -7,18 +7,19 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/utils/ptr"
 )
 
 func TestVaultSidecarProvider_BuildSidecarContainer(t *testing.T) {
 	tests := []struct {
-		name            string
-		pluginConfig    configv1.KMSPluginConfig
-		containerName   string
-		keyID           string
-		udsPath         string
-		inputPodSpec    *corev1.PodSpec
-		expectedPodSpec *corev1.PodSpec
-		wantErr         string
+		name               string
+		pluginConfig       configv1.KMSPluginConfig
+		containerName      string
+		keyID              string
+		udsPath            string
+		inputContainers    []corev1.Container
+		expectedContainers []corev1.Container
+		wantErr            string
 	}{
 		{
 			name: "builds container with correct args",
@@ -32,31 +33,30 @@ func TestVaultSidecarProvider_BuildSidecarContainer(t *testing.T) {
 					TransitMount:   "transit",
 				},
 			},
-			containerName: "kms-plugin",
-			keyID:         "555",
-			udsPath:       "unix:///var/run/kmsplugin/kms-555.sock",
-			inputPodSpec:  &corev1.PodSpec{},
-			expectedPodSpec: &corev1.PodSpec{
-				Containers: []corev1.Container{
-					{
-						Name:  "kms-plugin-555",
-						Image: "quay.io/test/vault:v2",
-						Args: []string{
-							"-listen-address=unix:///var/run/kmsplugin/kms-555.sock",
-							"-vault-address=https://vault.example.com:8200",
-							"-transit-key=my-key",
-							"-approle-role-id=dummy-role-id-555",
-							"-approle-secret-id-path=/var/run/secrets/vault-kms/secret-id-555",
-							"-vault-namespace=my-namespace",
-							"-transit-mount=transit",
-						},
-						ImagePullPolicy:          corev1.PullIfNotPresent,
-						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
-						Resources: corev1.ResourceRequirements{
-							Requests: corev1.ResourceList{
-								corev1.ResourceMemory: resource.MustParse("50Mi"),
-								corev1.ResourceCPU:    resource.MustParse("5m"),
-							},
+			containerName:   "kms-plugin",
+			keyID:           "555",
+			udsPath:         "unix:///var/run/kmsplugin/kms-555.sock",
+			inputContainers: nil,
+			expectedContainers: []corev1.Container{
+				{
+					Name:  "kms-plugin-555",
+					Image: "quay.io/test/vault:v2",
+					Args: []string{
+						"-listen-address=unix:///var/run/kmsplugin/kms-555.sock",
+						"-vault-address=https://vault.example.com:8200",
+						"-transit-key=my-key",
+						"-approle-role-id=dummy-role-id-555",
+						"-approle-secret-id-path=/var/run/secrets/vault-kms/secret-id-555",
+						"-vault-namespace=my-namespace",
+						"-transit-mount=transit",
+					},
+					ImagePullPolicy:          corev1.PullIfNotPresent,
+					RestartPolicy:            ptr.To(corev1.ContainerRestartPolicyAlways),
+					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("50Mi"),
+							corev1.ResourceCPU:    resource.MustParse("5m"),
 						},
 					},
 				},
@@ -77,39 +77,36 @@ func TestVaultSidecarProvider_BuildSidecarContainer(t *testing.T) {
 			containerName: "kms-plugin",
 			keyID:         "555",
 			udsPath:       "unix:///var/run/kmsplugin/kms-555.sock",
-			inputPodSpec: &corev1.PodSpec{
-				Containers: []corev1.Container{
-					{
-						Name:  "kube-apiserver",
-						Image: "registry.k8s.io/kube-apiserver:v1.30.0",
-					},
+			inputContainers: []corev1.Container{
+				{
+					Name:  "kube-apiserver",
+					Image: "registry.k8s.io/kube-apiserver:v1.30.0",
 				},
 			},
-			expectedPodSpec: &corev1.PodSpec{
-				Containers: []corev1.Container{
-					{
-						Name:  "kube-apiserver",
-						Image: "registry.k8s.io/kube-apiserver:v1.30.0",
+			expectedContainers: []corev1.Container{
+				{
+					Name:  "kube-apiserver",
+					Image: "registry.k8s.io/kube-apiserver:v1.30.0",
+				},
+				{
+					Name:  "kms-plugin-555",
+					Image: "quay.io/test/vault:v2",
+					Args: []string{
+						"-listen-address=unix:///var/run/kmsplugin/kms-555.sock",
+						"-vault-address=https://vault.example.com:8200",
+						"-transit-key=my-key",
+						"-approle-role-id=dummy-role-id-555",
+						"-approle-secret-id-path=/var/run/secrets/vault-kms/secret-id-555",
+						"-vault-namespace=my-namespace",
+						"-transit-mount=transit",
 					},
-					{
-						Name:  "kms-plugin-555",
-						Image: "quay.io/test/vault:v2",
-						Args: []string{
-							"-listen-address=unix:///var/run/kmsplugin/kms-555.sock",
-							"-vault-address=https://vault.example.com:8200",
-							"-transit-key=my-key",
-							"-approle-role-id=dummy-role-id-555",
-							"-approle-secret-id-path=/var/run/secrets/vault-kms/secret-id-555",
-							"-vault-namespace=my-namespace",
-							"-transit-mount=transit",
-						},
-						ImagePullPolicy:          corev1.PullIfNotPresent,
-						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
-						Resources: corev1.ResourceRequirements{
-							Requests: corev1.ResourceList{
-								corev1.ResourceMemory: resource.MustParse("50Mi"),
-								corev1.ResourceCPU:    resource.MustParse("5m"),
-							},
+					ImagePullPolicy:          corev1.PullIfNotPresent,
+					RestartPolicy:            ptr.To(corev1.ContainerRestartPolicyAlways),
+					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("50Mi"),
+							corev1.ResourceCPU:    resource.MustParse("5m"),
 						},
 					},
 				},
@@ -127,32 +124,31 @@ func TestVaultSidecarProvider_BuildSidecarContainer(t *testing.T) {
 					TransitMount:   "",
 				},
 			},
-			containerName: "kms-plugin",
-			keyID:         "999",
-			udsPath:       "unix:///var/run/kmsplugin/kms.sock",
-			inputPodSpec:  &corev1.PodSpec{},
-			expectedPodSpec: &corev1.PodSpec{
-				Containers: []corev1.Container{
-					{
-						Name:  "kms-plugin-999",
-						Image: "quay.io/test/vault:v2",
-						Args: []string{
-							"-listen-address=unix:///var/run/kmsplugin/kms.sock",
-							"-vault-address=https://vault.example.com:8200",
-							"-transit-key=my-key",
-							"-approle-role-id=dummy-role-id-999",
-							"-approle-secret-id-path=/var/run/secrets/vault-kms/secret-id-999",
-							// These are not added
-							// "-vault-namespace=",
-							// "-transit-mount=",
-						},
-						ImagePullPolicy:          corev1.PullIfNotPresent,
-						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
-						Resources: corev1.ResourceRequirements{
-							Requests: corev1.ResourceList{
-								corev1.ResourceMemory: resource.MustParse("50Mi"),
-								corev1.ResourceCPU:    resource.MustParse("5m"),
-							},
+			containerName:   "kms-plugin",
+			keyID:           "999",
+			udsPath:         "unix:///var/run/kmsplugin/kms.sock",
+			inputContainers: nil,
+			expectedContainers: []corev1.Container{
+				{
+					Name:  "kms-plugin-999",
+					Image: "quay.io/test/vault:v2",
+					Args: []string{
+						"-listen-address=unix:///var/run/kmsplugin/kms.sock",
+						"-vault-address=https://vault.example.com:8200",
+						"-transit-key=my-key",
+						"-approle-role-id=dummy-role-id-999",
+						"-approle-secret-id-path=/var/run/secrets/vault-kms/secret-id-999",
+						// These are not added
+						// "-vault-namespace=",
+						// "-transit-mount=",
+					},
+					ImagePullPolicy:          corev1.PullIfNotPresent,
+					RestartPolicy:            ptr.To(corev1.ContainerRestartPolicyAlways),
+					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("50Mi"),
+							corev1.ResourceCPU:    resource.MustParse("5m"),
 						},
 					},
 				},
@@ -172,8 +168,8 @@ func TestVaultSidecarProvider_BuildSidecarContainer(t *testing.T) {
 			container, err := provider.BuildSidecarContainer()
 			require.NoError(t, err)
 
-			tt.inputPodSpec.Containers = append(tt.inputPodSpec.Containers, container)
-			require.Equal(t, tt.expectedPodSpec, tt.inputPodSpec)
+			tt.inputContainers = append(tt.inputContainers, container)
+			require.Equal(t, tt.expectedContainers, tt.inputContainers)
 		})
 	}
 }


### PR DESCRIPTION
In recent runs of KMS tests I noticed that, upon receiving the termination signal from the kubelet, the KMS plugin sidecar would terminate right away. This caused a problem for the `kube-apiserver` that was still gracefully handling in-flight requests before shutting down, as it still needed the plugin to be running and serving requests via the UDS path.

This patch uses the Sidecar Containers feature [1] from Kubernetes to handle this issue. Now the KMS plugin is an init container with restart policy set to Always. This prevents the plugin from shutting down before kube-apiserver.

[1] https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure KMS plugin socket mount is added to both init and application containers and that the socket volume is created reliably, improving sidecar injection and migration robustness.
  * Sidecar containers now use a RestartPolicy of Always for improved reliability.

* **Tests**
  * Tests updated to assert RestartPolicy and verify correct init-container injection, ordering, and replacement during migrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->