### PR TITLE
test/kms: replace t.Context() with context.Background() for Ginkgo compatibility

### DIFF
--- a/test/library/encryption/helpers.go
+++ b/test/library/encryption/helpers.go
@@ -58,6 +58,7 @@ type UpdateUnsupportedConfigFunc func(raw []byte) error
 
 func SetAndWaitForEncryptionType(t testing.TB, provider EncryptionProvider, defaultTargetGRs []schema.GroupResource, namespace, labelSelector string) ClientSet {
 	t.Helper()
+	ctx := context.TODO()
 
 	t.Logf("Starting encryption e2e test for %q mode", provider.Type)
 
@@ -65,16 +66,16 @@ func SetAndWaitForEncryptionType(t testing.TB, provider EncryptionProvider, defa
 	lastMigratedKeyMeta, err := GetLastKeyMeta(t, clientSet.Kube, namespace, labelSelector)
 	require.NoError(t, err)
 
-	apiServer, err := clientSet.ApiServerConfig.Get(context.TODO(), "cluster", metav1.GetOptions{})
+	apiServer, err := clientSet.ApiServerConfig.Get(ctx, "cluster", metav1.GetOptions{})
 	require.NoError(t, err)
 	needsUpdate := !equality.Semantic.DeepEqual(apiServer.Spec.Encryption, provider.APIServerEncryption)
 	if needsUpdate {
 		if provider.Setup != nil {
-			provider.Setup(t)
+			provider.Setup(ctx, t)
 		}
 		t.Logf("Updating encryption configuration for APIServer from %#v to %#v", apiServer.Spec.Encryption, provider.APIServerEncryption)
 		apiServer.Spec.Encryption = provider.APIServerEncryption
-		_, err = clientSet.ApiServerConfig.Update(context.TODO(), apiServer, metav1.UpdateOptions{})
+		_, err = clientSet.ApiServerConfig.Update(ctx, apiServer, metav1.UpdateOptions{})
 		require.NoError(t, err)
 	} else {
 		t.Logf("APIServer is already configured to use %q mode", provider.Type)

--- a/test/library/encryption/kms/vault.go
+++ b/test/library/encryption/kms/vault.go
@@ -85,7 +85,7 @@ var DefaultFakeKMSPluginConfig = configv1.KMSPluginConfig{
 // using the default configuration constants.
 func ensureDefaultVaultAppRoleSecret(t testing.TB) {
 	t.Helper()
-	ctx := t.Context()
+	ctx := context.Background()
 	cs := library.GetClients(t)
 
 	creds, err := cs.Kube.CoreV1().Secrets(defaultVaultNamespace).Get(ctx, defaultVaultCredentialsSecret, metav1.GetOptions{})
@@ -116,7 +116,7 @@ func ensureDefaultVaultAppRoleSecret(t testing.TB) {
 // 3. Get new key version and validate it increased
 func RotateVaultTransitKey(t testing.TB) {
 	t.Helper()
-	ctx := t.Context()
+	ctx := context.Background()
 
 	initialVersion := getCurrentKeyVersion(ctx, t)
 	rotateKey(ctx, t)

--- a/test/library/encryption/kms/vault.go
+++ b/test/library/encryption/kms/vault.go
@@ -83,9 +83,8 @@ var DefaultFakeKMSPluginConfig = configv1.KMSPluginConfig{
 // ensureDefaultVaultAppRoleSecret reads credentials from the vault-credentials secret
 // (created by a CI step) and applies the AppRole secret in openshift-config
 // using the default configuration constants.
-func ensureDefaultVaultAppRoleSecret(t testing.TB) {
+func ensureDefaultVaultAppRoleSecret(ctx context.Context, t testing.TB) {
 	t.Helper()
-	ctx := context.Background()
 	cs := library.GetClients(t)
 
 	creds, err := cs.Kube.CoreV1().Secrets(defaultVaultNamespace).Get(ctx, defaultVaultCredentialsSecret, metav1.GetOptions{})
@@ -114,9 +113,8 @@ func ensureDefaultVaultAppRoleSecret(t testing.TB) {
 // 1. Get initial key version
 // 2. Execute 'vault write -f transit/keys/<key-name>/rotate' via oc exec
 // 3. Get new key version and validate it increased
-func RotateVaultTransitKey(t testing.TB) {
+func RotateVaultTransitKey(ctx context.Context, t testing.TB) {
 	t.Helper()
-	ctx := context.Background()
 
 	initialVersion := getCurrentKeyVersion(ctx, t)
 	rotateKey(ctx, t)

--- a/test/library/encryption/scenarios.go
+++ b/test/library/encryption/scenarios.go
@@ -1,6 +1,7 @@
 package encryption
 
 import (
+	"context"
 	"fmt"
 	mathrand "math/rand/v2"
 	"strings"
@@ -30,7 +31,9 @@ type BasicScenario struct {
 type EncryptionProvider struct {
 	configv1.APIServerEncryption
 	// Setup is called once before the provider is first used. May be nil.
-	Setup func(t testing.TB)
+	// Context is accepted as an explicit argument because testing.TB.Context()
+	// is not supported by all implementations (e.g. Ginkgo's GinkgoTBWrapper).
+	Setup func(ctx context.Context, t testing.TB)
 }
 
 func TestEncryptionTypeIdentity(t testing.TB, scenario BasicScenario) {


### PR DESCRIPTION
test/kms: replace t.Context() with context.Background() for Ginkgo compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved context handling in encryption tests so Vault and Kubernetes operations use an explicit context for secret and key actions.
  * Updated encryption provider setup hooks to accept and receive explicit context parameters, improving control and isolation during test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->