### PR TITLE
NO-JIRA: Create Vault Secret for fake Vault setup

### DIFF
--- a/test/library/encryption/kms/vault.go
+++ b/test/library/encryption/kms/vault.go
@@ -42,6 +42,11 @@ var DefaultVaultEncryptionProvider = library.EncryptionProvider{
 	Setup:               ensureDefaultVaultAppRoleSecret,
 }
 
+var DefaultFakeVaultEncryptionProvider = library.EncryptionProvider{
+	APIServerEncryption: DefaultFakeKMSPluginConfig,
+	Setup:               ensureDefaultVaultAppRoleSecret,
+}
+
 // DefaultVaultKMSPluginConfig is the standard Vault KMS encryption config
 // used by CI e2e tests.
 var DefaultVaultKMSPluginConfig = configv1.APIServerEncryption{
@@ -65,18 +70,21 @@ var DefaultVaultKMSPluginConfig = configv1.APIServerEncryption{
 }
 
 // DefaultFakeKMSPluginConfig is a fake Vault KMS configuration used by unit tests.
-var DefaultFakeKMSPluginConfig = configv1.KMSPluginConfig{
-	Type: configv1.VaultKMSProvider,
-	Vault: configv1.VaultKMSPluginConfig{
-		KMSPluginImage: WellKnownUpstreamMockKMSPluginImage,
-		VaultAddress:   "https://vault.example.com",
-		Authentication: configv1.VaultAuthentication{
-			Type: configv1.VaultAuthenticationTypeAppRole,
-			AppRole: configv1.VaultAppRoleAuthentication{
-				Secret: configv1.VaultSecretReference{Name: "vault-approle-secret"},
+var DefaultFakeKMSPluginConfig = configv1.APIServerEncryption{
+	Type: configv1.EncryptionTypeKMS,
+	KMS: configv1.KMSPluginConfig{
+		Type: configv1.VaultKMSProvider,
+		Vault: configv1.VaultKMSPluginConfig{
+			KMSPluginImage: WellKnownUpstreamMockKMSPluginImage,
+			VaultAddress:   "https://vault.example.com",
+			Authentication: configv1.VaultAuthentication{
+				Type: configv1.VaultAuthenticationTypeAppRole,
+				AppRole: configv1.VaultAppRoleAuthentication{
+					Secret: configv1.VaultSecretReference{Name: defaultVaultAppRoleSecretName},
+				},
 			},
+			TransitKey: "test-transit-key",
 		},
-		TransitKey: "test-transit-key",
 	},
 }
 


### PR DESCRIPTION
This PR configures fake Vault plugin to create the referenced secret. Otherwise, https://github.com/openshift/library-go/pull/2212 degrades the cluster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure for encryption provider configuration with improved constant usage and reduced hardcoding in vault-based encryption setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->