### PR TITLE
NO-JIRA: Rename AppRole datakeys to role-id and secret-id

### DIFF
--- a/test/library/encryption/kms/vault.go
+++ b/test/library/encryption/kms/vault.go
@@ -106,8 +106,8 @@ func ensureDefaultVaultAppRoleSecret(ctx context.Context, t testing.TB) {
 		},
 		Type: corev1.SecretTypeOpaque,
 		Data: map[string][]byte{
-			"roleID":   creds.Data["role-id"],
-			"secretID": creds.Data["secret-id"],
+			"role-id":   creds.Data["role-id"],
+			"secret-id": creds.Data["secret-id"],
 		},
 	}
 	recorder := events.NewInMemoryRecorder("vault-approle-secret-setup", clock.RealClock{})


### PR DESCRIPTION
This PR fixes AppRole Secret datakeys to align with https://github.com/openshift/library-go/pull/2212

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated AppRole credential key format in Kubernetes Secrets from camelCase to hyphenated format (`role-id`, `secret-id`). This standardizes the secret data structure for Vault AppRole consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->