### PR TITLE
OCPBUGS-86504: fix IsOperatorManaged ignoring Unmanaged state

### DIFF
--- a/pkg/operator/management/management_state.go
+++ b/pkg/operator/management/management_state.go
@@ -62,7 +62,7 @@ func IsOperatorUnknownState(state v1.ManagementState) bool {
 
 // IsOperatorManaged indicates whether the operator management state allows the control loop to proceed and manage the operand.
 func IsOperatorManaged(state v1.ManagementState) bool {
-	if IsOperatorAlwaysManaged() || IsOperatorNotRemovable() {
+	if IsOperatorAlwaysManaged() {
 		return true
 	}
 	switch state {


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-86504

`IsOperatorManaged()` returned true unconditionally when IsOperatorNotRemovable() was true, causing static resources controllers to always sync even with managementState: Unmanaged. 

This affected payload operators (e.g. CSI drivers) that call  SetOperatorNotRemovable() — setting a ClusterCSIDriver to Unmanaged had no effect on reconciliation.

The two flags are orthogonal: an operator that can't be removed should still stop reconciling when set to Unmanaged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved operator management state handling to correctly process always-managed operators through the control loop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->