### PR TITLE
CNTRLPLANE-3513: prepare rotation test for KMS

### DIFF
--- a/test/library/encryption/helpers.go
+++ b/test/library/encryption/helpers.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
@@ -55,6 +56,32 @@ type EncryptionKeyMeta struct {
 }
 
 type UpdateUnsupportedConfigFunc func(raw []byte) error
+
+// ForceRotationFunc triggers a key rotation in a provider-specific way.
+// Static encryption (AES-CBC/AES-GCM) sets encryption.reason in unsupported config;
+// KMS rotates the external KMS key (for example Vault transit).
+type ForceRotationFunc func(t testing.TB, ctx context.Context)
+
+// WaitForRotationCompleteFunc waits until re-migration after rotation has finished.
+// Static encryption waits for the next encryption key secret to be migrated;
+// KMS waits for a new finished entry in KeyRotationStatus, created by the rotation controller.
+type WaitForRotationCompleteFunc func(t testing.TB, clientSet ClientSet, prevKeyMeta EncryptionKeyMeta, scenario BasicScenario)
+
+// StaticEncryptionForceRotation returns a ForceRotationFunc that mints a new key via encryption.reason.
+func StaticEncryptionForceRotation(updateUnsupportedConfig UpdateUnsupportedConfigFunc) ForceRotationFunc {
+	return func(t testing.TB, _ context.Context) {
+		t.Helper()
+		require.NoError(t, ForceKeyRotation(t, updateUnsupportedConfig, fmt.Sprintf("test-key-rotation-%s", rand.String(4))))
+	}
+}
+
+// WaitForNextEncryptionKeyRotation waits until a new encryption key secret is fully migrated.
+func WaitForNextEncryptionKeyRotation() WaitForRotationCompleteFunc {
+	return func(t testing.TB, clientSet ClientSet, prevKeyMeta EncryptionKeyMeta, scenario BasicScenario) {
+		t.Helper()
+		WaitForNextMigratedKey(t, clientSet.Kube, prevKeyMeta, scenario.TargetGRs, scenario.Namespace, scenario.LabelSelector)
+	}
+}
 
 func SetAndWaitForEncryptionType(ctx context.Context, t testing.TB, provider EncryptionProvider, defaultTargetGRs []schema.GroupResource, namespace, labelSelector string) ClientSet {
 	t.Helper()

--- a/test/library/encryption/kms/vault.go
+++ b/test/library/encryption/kms/vault.go
@@ -116,13 +116,17 @@ func ensureDefaultVaultAppRoleSecret(ctx context.Context, t testing.TB) {
 	t.Logf("Applied AppRole secret %s in %s (changed=%v)", defaultVaultAppRoleSecretName, defaultAppRoleTargetNamespace, changed)
 }
 
+func ForceVaultKeyRotation() library.ForceRotationFunc {
+	return RotateVaultTransitKey
+}
+
 // RotateVaultTransitKey rotates the Vault transit encryption key. All old key versions are retained.
 // Reference: https://developer.hashicorp.com/vault/api-docs/secret/transit#rotate-key
 // Steps:
 // 1. Get initial key version
 // 2. Execute 'vault write -f transit/keys/<key-name>/rotate' via oc exec
 // 3. Get new key version and validate it increased
-func RotateVaultTransitKey(ctx context.Context, t testing.TB) {
+func RotateVaultTransitKey(t testing.TB, ctx context.Context) {
 	t.Helper()
 
 	initialVersion := getCurrentKeyVersion(ctx, t)

--- a/test/library/encryption/scenarios.go
+++ b/test/library/encryption/scenarios.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/rand"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -238,14 +237,15 @@ func TestEncryptionProvidersMigration(ctx context.Context, t testing.TB, scenari
 
 type RotationScenario struct {
 	BasicScenario
-	CreateResourceFunc    func(t testing.TB, clientSet ClientSet, namespace string) runtime.Object
-	GetRawResourceFunc    func(t testing.TB, clientSet ClientSet, namespace string) string
-	UnsupportedConfigFunc UpdateUnsupportedConfigFunc
-	EncryptionProvider    EncryptionProvider
+	CreateResourceFunc          func(t testing.TB, clientSet ClientSet, namespace string) runtime.Object
+	GetRawResourceFunc          func(t testing.TB, clientSet ClientSet, namespace string) string
+	EncryptionProvider          EncryptionProvider
+	ForceRotationFunc           ForceRotationFunc
+	WaitForRotationCompleteFunc WaitForRotationCompleteFunc
 }
 
-// TestEncryptionRotation first encrypts data with aescbc key
-// then it forces a key rotation by setting the "encyrption.Reason" in the operator's configuration file
+// TestEncryptionRotation encrypts data, forces a provider-specific key rotation, waits for
+// re-migration to complete, and verifies the resource was re-encrypted with different content.
 func TestEncryptionRotation(ctx context.Context, t testing.TB, scenario RotationScenario) {
 	// test data
 	ns := scenario.Namespace
@@ -254,7 +254,7 @@ func TestEncryptionRotation(ctx context.Context, t testing.TB, scenario Rotation
 	// step 1: create the desired resource
 	e := NewE(t)
 	clientSet := GetClients(e)
-	scenario.CreateResourceFunc(e, GetClients(e), ns)
+	scenario.CreateResourceFunc(e, clientSet, ns)
 
 	// step 2: run provided encryption scenario
 	TestEncryptionType(ctx, t, scenario.BasicScenario, scenario.EncryptionProvider)
@@ -265,14 +265,18 @@ func TestEncryptionRotation(ctx context.Context, t testing.TB, scenario Rotation
 	// step 4: force key rotation and wait for migration to complete
 	lastMigratedKeyMeta, err := GetLastKeyMeta(t, clientSet.Kube, ns, labelSelector)
 	require.NoError(e, err)
-	require.NoError(e, ForceKeyRotation(e, scenario.UnsupportedConfigFunc, fmt.Sprintf("test-key-rotation-%s", rand.String(4))))
-	WaitForNextMigratedKey(e, clientSet.Kube, lastMigratedKeyMeta, scenario.TargetGRs, ns, labelSelector)
+	t.Logf("Forcing key rotation for %q encryption", scenario.EncryptionProvider.Type)
+	scenario.ForceRotationFunc(e, ctx)
+
+	t.Logf("Waiting for rotation migration to complete")
+	scenario.WaitForRotationCompleteFunc(e, clientSet, lastMigratedKeyMeta, scenario.BasicScenario)
+
 	scenario.AssertFunc(e, clientSet, scenario.EncryptionProvider.Type, ns, labelSelector)
 
 	// step 5: verify if the provided resource was encrypted with a different key (step 2 vs step 4)
 	rawEncryptedResourceWithKey2 := scenario.GetRawResourceFunc(e, clientSet, ns)
 	if rawEncryptedResourceWithKey1 == rawEncryptedResourceWithKey2 {
-		t.Errorf("expected the resource to has a different content after a key rotation,\ncontentBeforeRotation %s\ncontentAfterRotation %s", rawEncryptedResourceWithKey1, rawEncryptedResourceWithKey2)
+		t.Errorf("expected the resource to have different content after a key rotation,\ncontentBeforeRotation %s\ncontentAfterRotation %s", rawEncryptedResourceWithKey1, rawEncryptedResourceWithKey2)
 	}
 
 	// TODO: assert conditions - operator and encryption migration controller must report status as active not progressing, and not failing for all scenarios


### PR DESCRIPTION
This extracts the force rotation and waiting for new key aspect out of the current rotation test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added modular test helpers and callbacks for triggering and awaiting encryption key rotations; rotation scenarios updated to use these hooks.
  * Improves reliability and flexibility across different key-management backends.
  * No end-user visible changes; internal testing only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->