### PR TITLE
NO-JIRA: EnforcesSecuritySettings deprecates SecureTLSConfig

### DIFF
--- a/pkg/crypto/crypto.go
+++ b/pkg/crypto/crypto.go
@@ -309,7 +309,14 @@ func DefaultCiphers() []uint16 {
 }
 
 // SecureTLSConfig enforces the default minimum security settings for the cluster.
+// Deprecated: use EnforcesSecuritySettings instead.
 func SecureTLSConfig(config *tls.Config) *tls.Config {
+	EnforcesSecuritySettings(config)
+	return config
+}
+
+// EnforcesSecuritySettings enforces the default minimum security settings for the cluster on the given TLS config.
+func EnforcesSecuritySettings(config *tls.Config) {
 	if config.MinVersion == 0 {
 		config.MinVersion = DefaultTLSVersion()
 	}
@@ -318,7 +325,6 @@ func SecureTLSConfig(config *tls.Config) *tls.Config {
 	if len(config.CipherSuites) == 0 {
 		config.CipherSuites = DefaultCiphers()
 	}
-	return config
 }
 
 // OpenSSLToIANACipherSuites maps input OpenSSL Cipher Suite names to their

--- a/pkg/crypto/crypto.go
+++ b/pkg/crypto/crypto.go
@@ -321,7 +321,6 @@ func EnforcesSecuritySettings(config *tls.Config) {
 		config.MinVersion = DefaultTLSVersion()
 	}
 
-	config.PreferServerCipherSuites = true
 	if len(config.CipherSuites) == 0 {
 		config.CipherSuites = DefaultCiphers()
 	}


### PR DESCRIPTION
EnforcesSecuritySettings deprecates SecureTLSConfig

The returned value of `SecureTLSConfig` seems redundant, and it is not clear from its description how to use the function: `SecureTLSConfig(config)` or `config:=SecureTLSConfig(config)` (they are equivalent with the current implementation). The intention of the returned value is not explained either in the commit https://github.com/openshift/library-go/commit/699695d1217317b048d53dc99b1a6b4edcc27e67 where it was introduced.

This pull makes it clear by introducing a new function `EnforcesSecuritySettings` whose name comes from the description. I believe I should not modify the signature of any existing functions to avoid breaking changes.

Do not modify tls.Config's PreferServerCipherSuites

With [go1.25.0](https://pkg.go.dev/crypto/tls@go1.25.0), `PreferServerCipherSuites` has no effect.

```
    // PreferServerCipherSuites is a legacy field and has no effect.
	//
	// It used to control whether the server would follow the client's or the
	// server's preference. Servers now select the best mutually supported
	// cipher suite based on logic that takes into account inferred client
	// hardware, server hardware, and security.
	//
	// Deprecated: PreferServerCipherSuites is ignored.
	PreferServerCipherSuites bool
```

lib-go uses Go 1.25.0 at the comment.

https://github.com/openshift/library-go/blob/c7d432293c132035eb34b61c409b37f756ed2e6e/go.mod#L3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured TLS security configuration logic with a new function for enforcing security settings.
  * Deprecated existing TLS configuration function; migration to the new function recommended.
  * Removed server cipher suite preference setting from TLS configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->