### PR TITLE
CNTRLPLANE-3236: kms: skip TLS verification

### DIFF
--- a/pkg/operator/encryption/kms/pluginlifecycle/sidecar_test.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/sidecar_test.go
@@ -114,6 +114,7 @@ func TestAddKMSPluginSidecarToPodSpec(t *testing.T) {
 		"-approle-role-id=dummy-role-id-555",
 		"-approle-secret-id-path=/var/run/secrets/vault-kms/secret-id-555",
 		"-vault-namespace=my-namespace",
+		"-tls-skip-verify",
 	}
 
 	socketMount := corev1.VolumeMount{
@@ -198,6 +199,7 @@ func TestAddKMSPluginSidecarToPodSpec(t *testing.T) {
 							"-approle-role-id=dummy-role-id-777",
 							"-approle-secret-id-path=/var/run/secrets/vault-kms/secret-id-777",
 							"-vault-namespace=other-namespace",
+							"-tls-skip-verify",
 						},
 						ImagePullPolicy:          corev1.PullIfNotPresent,
 						RestartPolicy:            ptr.To(corev1.ContainerRestartPolicyAlways),
@@ -221,6 +223,7 @@ func TestAddKMSPluginSidecarToPodSpec(t *testing.T) {
 							"-approle-role-id=dummy-role-id-555",
 							"-approle-secret-id-path=/var/run/secrets/vault-kms/secret-id-555",
 							"-vault-namespace=my-namespace",
+							"-tls-skip-verify",
 						},
 						ImagePullPolicy:          corev1.PullIfNotPresent,
 						RestartPolicy:            ptr.To(corev1.ContainerRestartPolicyAlways),

--- a/pkg/operator/encryption/kms/pluginlifecycle/vault.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/vault.go
@@ -52,6 +52,10 @@ func (v *vault) BuildSidecarContainer() (corev1.Container, error) {
 		args = append(args, fmt.Sprintf("-vault-namespace=%s", v.config.VaultNamespace))
 	}
 
+	// TODO(bertinatto): this is a temporary workaround until the ca bundle is wired into the
+	// encryption config secret. This should be removed before shipping the KMS feature.
+	args = append(args, "-tls-skip-verify")
+
 	return corev1.Container{
 		Name:            v.Name(),
 		Image:           v.config.KMSPluginImage,

--- a/pkg/operator/encryption/kms/pluginlifecycle/vault_test.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/vault_test.go
@@ -49,6 +49,7 @@ func TestVaultSidecarProvider_BuildSidecarContainer(t *testing.T) {
 						"-approle-role-id=dummy-role-id-555",
 						"-approle-secret-id-path=/var/run/secrets/vault-kms/secret-id-555",
 						"-vault-namespace=my-namespace",
+						"-tls-skip-verify",
 					},
 					ImagePullPolicy:          corev1.PullIfNotPresent,
 					RestartPolicy:            ptr.To(corev1.ContainerRestartPolicyAlways),
@@ -99,6 +100,7 @@ func TestVaultSidecarProvider_BuildSidecarContainer(t *testing.T) {
 						"-approle-role-id=dummy-role-id-555",
 						"-approle-secret-id-path=/var/run/secrets/vault-kms/secret-id-555",
 						"-vault-namespace=my-namespace",
+						"-tls-skip-verify",
 					},
 					ImagePullPolicy:          corev1.PullIfNotPresent,
 					RestartPolicy:            ptr.To(corev1.ContainerRestartPolicyAlways),
@@ -139,6 +141,7 @@ func TestVaultSidecarProvider_BuildSidecarContainer(t *testing.T) {
 						"-transit-key=my-key",
 						"-approle-role-id=dummy-role-id-999",
 						"-approle-secret-id-path=/var/run/secrets/vault-kms/secret-id-999",
+						"-tls-skip-verify",
 						// These are not added
 						// "-vault-namespace=",
 					},


### PR DESCRIPTION
This is a temporary workaround so that we are able to test KMS in our CI.

This should be removed once the CA bundle is wired into the encryption configuration secret.

/assign @p0lyn0mial @ardaguclu @tjungblu @gangwgr 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a temporary `-tls-skip-verify` flag to the Vault KMS plugin sidecar to address TLS certificate verification issues. This is a workaround until proper CA bundle integration is implemented in the encryption configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->