### PR TITLE
CNTRLPLANE-3361: kms: update Vault sidecar resource requests per Vault team recommendation

### DIFF
--- a/pkg/operator/encryption/kms/pluginlifecycle/sidecar_test.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/sidecar_test.go
@@ -159,8 +159,8 @@ func TestAddKMSPluginSidecarToPodSpec(t *testing.T) {
 						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
-								corev1.ResourceMemory: resource.MustParse("50Mi"),
-								corev1.ResourceCPU:    resource.MustParse("5m"),
+								corev1.ResourceMemory: resource.MustParse("64Mi"),
+								corev1.ResourceCPU:    resource.MustParse("10m"),
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{socketMount},
@@ -204,8 +204,8 @@ func TestAddKMSPluginSidecarToPodSpec(t *testing.T) {
 						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
-								corev1.ResourceMemory: resource.MustParse("50Mi"),
-								corev1.ResourceCPU:    resource.MustParse("5m"),
+								corev1.ResourceMemory: resource.MustParse("64Mi"),
+								corev1.ResourceCPU:    resource.MustParse("10m"),
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{socketMount},
@@ -227,8 +227,8 @@ func TestAddKMSPluginSidecarToPodSpec(t *testing.T) {
 						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
-								corev1.ResourceMemory: resource.MustParse("50Mi"),
-								corev1.ResourceCPU:    resource.MustParse("5m"),
+								corev1.ResourceMemory: resource.MustParse("64Mi"),
+								corev1.ResourceCPU:    resource.MustParse("10m"),
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{socketMount},
@@ -440,8 +440,8 @@ func TestAddKMSPluginSidecarToPodSpec(t *testing.T) {
 						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
-								corev1.ResourceMemory: resource.MustParse("50Mi"),
-								corev1.ResourceCPU:    resource.MustParse("5m"),
+								corev1.ResourceMemory: resource.MustParse("64Mi"),
+								corev1.ResourceCPU:    resource.MustParse("10m"),
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{socketMount},

--- a/pkg/operator/encryption/kms/pluginlifecycle/vault.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/vault.go
@@ -61,13 +61,12 @@ func (v *vault) BuildSidecarContainer() (corev1.Container, error) {
 		// regular containers and keeps it running for the pod's lifetime.
 		RestartPolicy:            ptr.To(corev1.ContainerRestartPolicyAlways),
 		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
-		// TODO(bertinatto): the plugin sidecar needs to be measure under heavy load to figure out good defaults.
-		// For now follow what most sidecars in the kube-apiserver pod do. xref:
-		// https://github.com/openshift/cluster-kube-apiserver-operator/commit/e15a19cd2474c8b60ce17ac16dd8f422c729847a
+		// Vault team recommendation based on single-node OCP cluster measurements:
+		// ~10 mCPU / 32-64 MiB steady state, memory peaked at ~60 MiB under 400 KEK rotations.
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse("50Mi"),
-				corev1.ResourceCPU:    resource.MustParse("5m"),
+				corev1.ResourceMemory: resource.MustParse("64Mi"),
+				corev1.ResourceCPU:    resource.MustParse("10m"),
 			},
 		},
 	}, nil

--- a/pkg/operator/encryption/kms/pluginlifecycle/vault_test.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/vault_test.go
@@ -55,8 +55,8 @@ func TestVaultSidecarProvider_BuildSidecarContainer(t *testing.T) {
 					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
-							corev1.ResourceMemory: resource.MustParse("50Mi"),
-							corev1.ResourceCPU:    resource.MustParse("5m"),
+							corev1.ResourceMemory: resource.MustParse("64Mi"),
+							corev1.ResourceCPU:    resource.MustParse("10m"),
 						},
 					},
 				},
@@ -105,8 +105,8 @@ func TestVaultSidecarProvider_BuildSidecarContainer(t *testing.T) {
 					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
-							corev1.ResourceMemory: resource.MustParse("50Mi"),
-							corev1.ResourceCPU:    resource.MustParse("5m"),
+							corev1.ResourceMemory: resource.MustParse("64Mi"),
+							corev1.ResourceCPU:    resource.MustParse("10m"),
 						},
 					},
 				},
@@ -147,8 +147,8 @@ func TestVaultSidecarProvider_BuildSidecarContainer(t *testing.T) {
 					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
-							corev1.ResourceMemory: resource.MustParse("50Mi"),
-							corev1.ResourceCPU:    resource.MustParse("5m"),
+							corev1.ResourceMemory: resource.MustParse("64Mi"),
+							corev1.ResourceCPU:    resource.MustParse("10m"),
 						},
 					},
 				},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Vault KMS sidecar container resource requests: CPU increased from 5m to 10m, memory increased from 50Mi to 64Mi.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->