### PR TITLE
get vault Service ClusterIP

### DIFF
--- a/test/library/encryption/kms/vault.go
+++ b/test/library/encryption/kms/vault.go
@@ -3,6 +3,7 @@ package kms
 import (
 	"context"
 	"fmt"
+	"net"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -35,11 +36,18 @@ const (
 	vaultCommandTimeout           = 30 * time.Second
 )
 
-// DefaultVaultEncryptionProvider is a ready-to-use Vault KMS EncryptionProvider for e2e tests.
-// It bundles the default config with the AppRole secret setup.
-var DefaultVaultEncryptionProvider = library.EncryptionProvider{
-	APIServerEncryption: DefaultVaultKMSPluginConfig,
-	Setup:               ensureDefaultVaultAppRoleSecret,
+// DefaultVaultEncryptionProvider returns a ready-to-use Vault KMS EncryptionProvider for e2e tests.
+// It resolves the Vault Service ClusterIP at call time to avoid DNS resolution issues,
+// and bundles the AppRole secret setup.
+func DefaultVaultEncryptionProvider(ctx context.Context, t testing.TB) library.EncryptionProvider {
+	cfg := DefaultVaultKMSPluginConfig
+	// Use the Service ClusterIP instead of DNS name because kube-apiserver pods
+	// cannot resolve cluster-local Service names (they use host network DNS).
+	cfg.KMS.Vault.VaultAddress = getVaultServiceAddress(ctx, t)
+	return library.EncryptionProvider{
+		APIServerEncryption: cfg,
+		Setup:               ensureDefaultVaultAppRoleSecret,
+	}
 }
 
 var DefaultFakeVaultEncryptionProvider = library.EncryptionProvider{
@@ -173,4 +181,30 @@ func getCurrentKeyVersion(ctx context.Context, t testing.TB) int {
 	require.NoError(t, err, "failed to parse key version from output: %q", string(output))
 
 	return version
+}
+
+// getVaultServiceAddress returns the Vault address using the Service's ClusterIP
+// instead of the DNS name, reading the port and scheme from the Service spec.
+func getVaultServiceAddress(ctx context.Context, t testing.TB) string {
+	t.Helper()
+	cs := library.GetClients(t)
+
+	svc, err := cs.Kube.CoreV1().Services(defaultVaultNamespace).Get(ctx, "vault", metav1.GetOptions{})
+	require.NoError(t, err, "failed to get vault Service in namespace %s", defaultVaultNamespace)
+	require.NotEmpty(t, svc.Spec.ClusterIP, "vault Service has no ClusterIP")
+	require.NotEmpty(t, svc.Spec.Ports, "vault Service has no ports")
+
+	// The Vault Helm chart names the client port "https" (8200).
+	var port *corev1.ServicePort
+	for i := range svc.Spec.Ports {
+		if svc.Spec.Ports[i].Name == "https" {
+			port = &svc.Spec.Ports[i]
+			break
+		}
+	}
+	require.NotNil(t, port, "vault Service has no port named \"https\"")
+
+	addr := fmt.Sprintf("https://%s", net.JoinHostPort(svc.Spec.ClusterIP, strconv.Itoa(int(port.Port))))
+	t.Logf("Resolved Vault Service address: %s", addr)
+	return addr
 }


### PR DESCRIPTION
get vault Service ClusterIP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved encryption test setup to dynamically resolve the Vault service address from the cluster, requiring a reachable service IP and port and deriving protocol from port naming when applicable.
  * Test Vault configuration is populated at invocation time so each run uses current runtime values.
  * Existing AppRole secret wiring for tests is preserved to maintain prior authentication behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->