### PR TITLE
CNTRLPLANE-3361: kms: accept VaultKMSPluginConfig directly in newVaultSidecarProvider

### DIFF
--- a/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
@@ -27,7 +27,7 @@ type sidecarProvider interface {
 func newSidecarProvider(keyID string, udsPath string, pluginConfig configv1.KMSPluginConfig) (sidecarProvider, error) {
 	switch pluginConfig.Type {
 	case configv1.VaultKMSProvider:
-		return newVaultSidecarProvider("vault-kms-plugin", keyID, udsPath, pluginConfig)
+		return newVaultSidecarProvider("vault-kms-plugin", keyID, udsPath, pluginConfig.Vault)
 	default:
 		return nil, fmt.Errorf("unsupported KMS plugin configuration")
 	}

--- a/pkg/operator/encryption/kms/pluginlifecycle/vault.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/vault.go
@@ -10,12 +10,12 @@ import (
 )
 
 // newVaultSidecarProvider creates a Vault sidecar provider from the given KMS plugin configuration.
-func newVaultSidecarProvider(name, keyID, udsPath string, pluginConfig configv1.KMSPluginConfig) (*vault, error) {
+func newVaultSidecarProvider(name, keyID, udsPath string, vaultConfig configv1.VaultKMSPluginConfig) (*vault, error) {
 	return &vault{
 		name:    name,
 		keyID:   keyID,
 		udsPath: udsPath,
-		config:  &pluginConfig.Vault,
+		config:  vaultConfig,
 	}, nil
 }
 
@@ -24,7 +24,7 @@ type vault struct {
 	name    string
 	keyID   string
 	udsPath string
-	config  *configv1.VaultKMSPluginConfig
+	config  configv1.VaultKMSPluginConfig
 }
 
 // Name returns the sidecar name appended by the key id.

--- a/pkg/operator/encryption/kms/pluginlifecycle/vault_test.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/vault_test.go
@@ -13,7 +13,7 @@ import (
 func TestVaultSidecarProvider_BuildSidecarContainer(t *testing.T) {
 	tests := []struct {
 		name               string
-		pluginConfig       configv1.KMSPluginConfig
+		vaultConfig        configv1.VaultKMSPluginConfig
 		containerName      string
 		keyID              string
 		udsPath            string
@@ -23,15 +23,12 @@ func TestVaultSidecarProvider_BuildSidecarContainer(t *testing.T) {
 	}{
 		{
 			name: "builds container with correct args",
-			pluginConfig: configv1.KMSPluginConfig{
-				Type: configv1.VaultKMSProvider,
-				Vault: configv1.VaultKMSPluginConfig{
-					KMSPluginImage: "quay.io/test/vault:v2",
-					VaultAddress:   "https://vault.example.com:8200",
-					VaultNamespace: "my-namespace",
-					TransitKey:     "my-key",
-					TransitMount:   "transit",
-				},
+			vaultConfig: configv1.VaultKMSPluginConfig{
+				KMSPluginImage: "quay.io/test/vault:v2",
+				VaultAddress:   "https://vault.example.com:8200",
+				VaultNamespace: "my-namespace",
+				TransitKey:     "my-key",
+				TransitMount:   "transit",
 			},
 			containerName:   "kms-plugin",
 			keyID:           "555",
@@ -64,15 +61,12 @@ func TestVaultSidecarProvider_BuildSidecarContainer(t *testing.T) {
 		},
 		{
 			name: "appends to existing containers",
-			pluginConfig: configv1.KMSPluginConfig{
-				Type: configv1.VaultKMSProvider,
-				Vault: configv1.VaultKMSPluginConfig{
-					KMSPluginImage: "quay.io/test/vault:v2",
-					VaultAddress:   "https://vault.example.com:8200",
-					VaultNamespace: "my-namespace",
-					TransitKey:     "my-key",
-					TransitMount:   "transit",
-				},
+			vaultConfig: configv1.VaultKMSPluginConfig{
+				KMSPluginImage: "quay.io/test/vault:v2",
+				VaultAddress:   "https://vault.example.com:8200",
+				VaultNamespace: "my-namespace",
+				TransitKey:     "my-key",
+				TransitMount:   "transit",
 			},
 			containerName: "kms-plugin",
 			keyID:         "555",
@@ -114,15 +108,12 @@ func TestVaultSidecarProvider_BuildSidecarContainer(t *testing.T) {
 		},
 		{
 			name: "empty optional fields",
-			pluginConfig: configv1.KMSPluginConfig{
-				Type: configv1.VaultKMSProvider,
-				Vault: configv1.VaultKMSPluginConfig{
-					KMSPluginImage: "quay.io/test/vault:v2",
-					VaultAddress:   "https://vault.example.com:8200",
-					TransitKey:     "my-key",
-					TransitMount:   "transit",
-					VaultNamespace: "",
-				},
+			vaultConfig: configv1.VaultKMSPluginConfig{
+				KMSPluginImage: "quay.io/test/vault:v2",
+				VaultAddress:   "https://vault.example.com:8200",
+				TransitKey:     "my-key",
+				TransitMount:   "transit",
+				VaultNamespace: "",
 			},
 			containerName:   "kms-plugin",
 			keyID:           "999",
@@ -158,7 +149,7 @@ func TestVaultSidecarProvider_BuildSidecarContainer(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			provider, err := newVaultSidecarProvider(tt.containerName, tt.keyID, tt.udsPath, tt.pluginConfig)
+			provider, err := newVaultSidecarProvider(tt.containerName, tt.keyID, tt.udsPath, tt.vaultConfig)
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
 				return


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal structure of KMS encryption plugin configuration handling by simplifying how Vault-specific configuration is passed through the plugin lifecycle, reducing unnecessary object nesting and improving overall code clarity, maintainability, and efficiency.

* **Tests**
  * Comprehensive test updates to validate the refactored configuration handling patterns and behavior across multiple scenarios and use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->