### PR TITLE
CNTRLPLANE-3237: Carry ConfigMap data from API to plugin lifecycle

### DIFF
--- a/pkg/operator/apiserver/controllerset/apiservercontrollerset.go
+++ b/pkg/operator/apiserver/controllerset/apiservercontrollerset.go
@@ -363,6 +363,7 @@ func (cs *APIServerControllerSet) WithEncryptionControllers(
 	deployer statemachine.Deployer,
 	migrator migrators.Migrator,
 	secretsClient corev1.SecretsGetter,
+	configMapClient corev1.ConfigMapsGetter,
 	apiServerClient configv1client.APIServerInterface,
 	apiServerInformer configv1informers.APIServerInformer,
 	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
@@ -381,6 +382,7 @@ func (cs *APIServerControllerSet) WithEncryptionControllers(
 		apiServerInformer:          apiServerInformer,
 		kubeInformersForNamespaces: kubeInformersForNamespaces,
 		secretsClient:              secretsClient,
+		configMapClient:            configMapClient,
 		resourceSyncer:             resourceSyncer,
 	}
 
@@ -484,6 +486,7 @@ type encryptionControllerBuilder struct {
 	deployer                   statemachine.Deployer
 	migrator                   migrators.Migrator
 	secretsClient              corev1.SecretsGetter
+	configMapClient            corev1.ConfigMapsGetter
 	apiServerClient            configv1client.APIServerInterface
 	apiServerInformer          configv1informers.APIServerInformer
 	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces
@@ -508,6 +511,7 @@ func (e *encryptionControllerBuilder) build() []controllerWrapper {
 		e.apiServerInformer,
 		e.kubeInformersForNamespaces,
 		e.secretsClient,
+		e.configMapClient,
 		e.eventRecorder,
 		e.resourceSyncer,
 	)

--- a/pkg/operator/encryption/controllers.go
+++ b/pkg/operator/encryption/controllers.go
@@ -34,6 +34,7 @@ func NewControllers(
 	apiServerInformer configv1informers.APIServerInformer,
 	kubeInformersForNamespaces operatorv1helpers.KubeInformersForNamespaces,
 	secretsClient corev1.SecretsGetter,
+	configMapClient corev1.ConfigMapsGetter,
 	eventRecorder events.Recorder,
 	resourceSyncer *resourcesynccontroller.ResourceSyncController,
 ) (Controllers, error) {
@@ -71,6 +72,7 @@ func NewControllers(
 			apiServerInformer,
 			kubeInformersForNamespaces,
 			secretsClient,
+			configMapClient,
 			encryptionSecretSelector,
 			eventRecorder,
 		),

--- a/pkg/operator/encryption/controllers/key_controller.go
+++ b/pkg/operator/encryption/controllers/key_controller.go
@@ -121,7 +121,7 @@ func NewKeyController(
 			apiServerInformer.Informer(),
 			operatorClient.Informer(),
 			kubeInformersForNamespaces.InformersFor("openshift-config-managed").Core().V1().Secrets().Informer(),
-			// TODO: add informer for openshift-config namespace to watch referenced Secrets for KMS plugin secret data changes
+			// TODO: add informers for openshift-config namespace to watch referenced Secrets and ConfigMaps for KMS plugin data changes
 			deployer,
 		).ToController(
 		c.controllerInstanceName,
@@ -304,6 +304,24 @@ func (c *keyController) generateKeySecret(ctx context.Context, keyID uint64, cur
 				}
 			}
 		}
+
+		if cmName, expectedKeys, err := referencedConfigMapName(apiServerEncryption.KMS); err != nil {
+			return nil, err
+		} else if len(cmName) > 0 {
+			refCM, err := c.configMapClient.ConfigMaps(openshiftConfigNS).Get(ctx, cmName, metav1.GetOptions{})
+			if err != nil {
+				return nil, fmt.Errorf("failed to get configmap %s in %s: %w", cmName, openshiftConfigNS, err)
+			}
+			for _, key := range expectedKeys {
+				v, ok := refCM.Data[key]
+				if !ok {
+					return nil, fmt.Errorf("configmap %s in %s is missing required key %q", cmName, openshiftConfigNS, key)
+				}
+				if err := ks.KMS.PluginConfigMapData.Set(cmName, key, []byte(v)); err != nil {
+					return nil, err
+				}
+			}
+		}
 	}
 	return secrets.FromKeyState(c.instanceName, ks)
 }
@@ -420,6 +438,21 @@ func referencedSecretName(plugin configv1.KMSPluginConfig) (string, []string, er
 		default:
 			return "", nil, fmt.Errorf("unsupported Vault authentication type %q", plugin.Vault.Authentication.Type)
 		}
+	default:
+		return "", nil, fmt.Errorf("unsupported KMS provider type %q", plugin.Type)
+	}
+}
+
+// referencedConfigMapName returns the name of the configmap referenced by the KMS plugin
+// config and the specific data keys to carry from that configmap. Only the listed keys
+// are copied into the Key Secret; any other data in the referenced configmap is ignored.
+func referencedConfigMapName(plugin configv1.KMSPluginConfig) (string, []string, error) {
+	switch plugin.Type {
+	case configv1.VaultKMSProvider:
+		if plugin.Vault.TLS.CABundle.Name == "" {
+			return "", nil, nil
+		}
+		return plugin.Vault.TLS.CABundle.Name, []string{"ca-bundle.crt"}, nil
 	default:
 		return "", nil, fmt.Errorf("unsupported KMS provider type %q", plugin.Type)
 	}

--- a/pkg/operator/encryption/controllers/key_controller.go
+++ b/pkg/operator/encryption/controllers/key_controller.go
@@ -75,6 +75,7 @@ type keyController struct {
 
 	deployer                 statemachine.Deployer
 	secretClient             corev1client.SecretsGetter
+	configMapClient          corev1client.ConfigMapsGetter
 	provider                 Provider
 	preconditionsFulfilledFn preconditionsFulfilled
 
@@ -92,6 +93,7 @@ func NewKeyController(
 	apiServerInformer configv1informers.APIServerInformer,
 	kubeInformersForNamespaces operatorv1helpers.KubeInformersForNamespaces,
 	secretClient corev1client.SecretsGetter,
+	configMapClient corev1client.ConfigMapsGetter,
 	encryptionSecretSelector metav1.ListOptions,
 	eventRecorder events.Recorder,
 ) factory.Controller {
@@ -108,6 +110,7 @@ func NewKeyController(
 		provider:                 provider,
 		preconditionsFulfilledFn: preconditionsFulfilledFn,
 		secretClient:             secretClient,
+		configMapClient:          configMapClient,
 	}
 
 	return factory.New().

--- a/pkg/operator/encryption/controllers/key_controller_test.go
+++ b/pkg/operator/encryption/controllers/key_controller_test.go
@@ -740,6 +740,7 @@ func TestKeyController(t *testing.T) {
 			// note that the informer factory is not used in the test - it's only needed to create the controller
 			kubeInformers := v1helpers.NewKubeInformersForNamespaces(fakeKubeClient, "openshift-config-managed", "openshift-config", scenario.targetNamespace)
 			fakeSecretClient := fakeKubeClient.CoreV1()
+			fakeConfigMapClient := fakeKubeClient.CoreV1()
 			fakePodClient := fakeKubeClient.CoreV1()
 			fakeConfigClient := configv1clientfake.NewSimpleClientset(scenario.apiServerObjects...)
 			fakeApiServerClient := fakeConfigClient.ConfigV1().APIServers()
@@ -751,7 +752,7 @@ func TestKeyController(t *testing.T) {
 			}
 			provider := newTestProvider(scenario.targetGRs)
 
-			target := NewKeyController(scenario.targetNamespace, nil, provider, deployer, alwaysFulfilledPreconditions, fakeOperatorClient, fakeApiServerClient, fakeApiServerInformer, kubeInformers, fakeSecretClient, scenario.encryptionSecretSelector, eventRecorder)
+			target := NewKeyController(scenario.targetNamespace, nil, provider, deployer, alwaysFulfilledPreconditions, fakeOperatorClient, fakeApiServerClient, fakeApiServerInformer, kubeInformers, fakeSecretClient, fakeConfigMapClient, scenario.encryptionSecretSelector, eventRecorder)
 
 			// act
 			err = target.Sync(context.TODO(), factory.NewSyncContext("test", eventRecorder))

--- a/pkg/operator/encryption/controllers/key_controller_test.go
+++ b/pkg/operator/encryption/controllers/key_controller_test.go
@@ -337,10 +337,11 @@ func TestKeyController(t *testing.T) {
 				{Group: "", Resource: "secrets"},
 			},
 			targetNamespace: "kms",
-			expectedActions: []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config", "create:secrets:openshift-config-managed", "create:events:kms"},
+			expectedActions: []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config", "get:configmaps:openshift-config", "create:secrets:openshift-config-managed", "create:events:kms"},
 			initialObjects: []runtime.Object{
 				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
 				encryptiontesting.CreateVaultAppRoleSecret("vault-approle-secret", "test-role-id", "test-secret-id"),
+				encryptiontesting.CreateVaultCABundleConfigMap("vault-ca-bundle", "test-ca-cert"),
 			},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			validateFunc: func(ts *testing.T, actions []clientgotesting.Action, targetNamespace string, targetGRs []schema.GroupResource) {
@@ -391,6 +392,11 @@ func TestKeyController(t *testing.T) {
 							ts.Errorf("expected secret-id secret data to be 'test-secret-id', got %q", secretID)
 						}
 
+						// Verify configmap data is carried
+						if caCert := string(actualSecret.Data["encryption.apiserver.operator.openshift.io-kms-plugin-configmap-vault-ca-bundle_ca-bundle.crt"]); caCert != "test-ca-cert" {
+							ts.Errorf("expected ca-bundle.crt configmap data to be 'test-ca-cert', got %q", caCert)
+						}
+
 						// Verify internal reason
 						if actualSecret.Annotations["encryption.apiserver.operator.openshift.io/internal-reason"] != "secrets-key-does-not-exist" {
 							ts.Errorf("unexpected internal reason: %s", actualSecret.Annotations["encryption.apiserver.operator.openshift.io/internal-reason"])
@@ -429,10 +435,11 @@ func TestKeyController(t *testing.T) {
 				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
 				encryptiontesting.CreateEncryptionKeySecretWithRawKeyWithMode("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 5, []byte("61def964fb967f5d7c44a2af8dab6865"), "aescbc"),
 				encryptiontesting.CreateVaultAppRoleSecret("vault-approle-secret", "test-role-id", "test-secret-id"),
+				encryptiontesting.CreateVaultCABundleConfigMap("vault-ca-bundle", "test-ca-cert"),
 			},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			targetNamespace:  "kms",
-			expectedActions:  []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config", "create:secrets:openshift-config-managed", "create:events:kms"},
+			expectedActions:  []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config", "get:configmaps:openshift-config", "create:secrets:openshift-config-managed", "create:events:kms"},
 			validateFunc: func(ts *testing.T, actions []clientgotesting.Action, targetNamespace string, targetGRs []schema.GroupResource) {
 				wasSecretValidated := false
 				for _, action := range actions {
@@ -524,10 +531,11 @@ func TestKeyController(t *testing.T) {
 				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
 				encryptiontesting.CreateEncryptionKeySecretWithRawKeyWithMode("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 5, []byte("identity-key"), "identity"),
 				encryptiontesting.CreateVaultAppRoleSecret("vault-approle-secret", "test-role-id", "test-secret-id"),
+				encryptiontesting.CreateVaultCABundleConfigMap("vault-ca-bundle", "test-ca-cert"),
 			},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			targetNamespace:  "kms",
-			expectedActions:  []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config", "create:secrets:openshift-config-managed", "create:events:kms"},
+			expectedActions:  []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config", "get:configmaps:openshift-config", "create:secrets:openshift-config-managed", "create:events:kms"},
 			validateFunc: func(ts *testing.T, actions []clientgotesting.Action, targetNamespace string, targetGRs []schema.GroupResource) {
 				wasSecretValidated := false
 				for _, action := range actions {
@@ -642,6 +650,64 @@ func TestKeyController(t *testing.T) {
 				encryptiontesting.ValidateOperatorClientConditions(ts, operatorClient, []operatorv1.OperatorCondition{expectedCondition})
 			},
 			expectedError: errors.New(`failed to create key: secret vault-approle-secret in openshift-config is missing required key "secret-id"`),
+		},
+
+		{
+			name: "degraded when KMS referenced configmap does not exist",
+			targetGRs: []schema.GroupResource{
+				{Group: "", Resource: "secrets"},
+			},
+			targetNamespace: "kms",
+			expectedActions: []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config", "get:configmaps:openshift-config"},
+			initialObjects: []runtime.Object{
+				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
+				encryptiontesting.CreateVaultAppRoleSecret("vault-approle-secret", "test-role-id", "test-secret-id"),
+			},
+			apiServerObjects: []runtime.Object{apiServerWithKMS},
+			validateOperatorClientFunc: func(ts *testing.T, operatorClient v1helpers.OperatorClient) {
+				_, status, _, err := operatorClient.GetOperatorState()
+				if err != nil {
+					ts.Fatal(err)
+				}
+				for _, c := range status.Conditions {
+					if c.Type == "EncryptionKeyControllerDegraded" && c.Status == "True" {
+						if !strings.Contains(c.Message, "failed to get configmap vault-ca-bundle in openshift-config") {
+							ts.Errorf("unexpected degraded message: %s", c.Message)
+						}
+						return
+					}
+				}
+				ts.Fatal("expected EncryptionKeyControllerDegraded condition")
+			},
+			expectedError: fmt.Errorf(`failed to create key: failed to get configmap vault-ca-bundle in openshift-config: configmaps "vault-ca-bundle" not found`),
+		},
+
+		{
+			name: "degraded when KMS referenced configmap is missing a required key",
+			targetGRs: []schema.GroupResource{
+				{Group: "", Resource: "secrets"},
+			},
+			targetNamespace: "kms",
+			expectedActions: []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config", "get:configmaps:openshift-config"},
+			initialObjects: []runtime.Object{
+				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
+				encryptiontesting.CreateVaultAppRoleSecret("vault-approle-secret", "test-role-id", "test-secret-id"),
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: "vault-ca-bundle", Namespace: "openshift-config"},
+					Data:       map[string]string{"wrong-key": "some-data"},
+				},
+			},
+			apiServerObjects: []runtime.Object{apiServerWithKMS},
+			validateOperatorClientFunc: func(ts *testing.T, operatorClient v1helpers.OperatorClient) {
+				expectedCondition := operatorv1.OperatorCondition{
+					Type:    "EncryptionKeyControllerDegraded",
+					Status:  "True",
+					Reason:  "Error",
+					Message: `failed to create key: configmap vault-ca-bundle in openshift-config is missing required key "ca-bundle.crt"`,
+				}
+				encryptiontesting.ValidateOperatorClientConditions(ts, operatorClient, []operatorv1.OperatorCondition{expectedCondition})
+			},
+			expectedError: errors.New(`failed to create key: configmap vault-ca-bundle in openshift-config is missing required key "ca-bundle.crt"`),
 		},
 
 		{
@@ -850,6 +916,75 @@ func TestReferencedSecretName(t *testing.T) {
 			}
 			if name != scenario.expectedName {
 				t.Errorf("expected secret name %q, got %q", scenario.expectedName, name)
+			}
+			if len(dataKeys) != len(scenario.expectedDataKeys) {
+				t.Fatalf("expected %d data keys, got %d", len(scenario.expectedDataKeys), len(dataKeys))
+			}
+			for i, key := range dataKeys {
+				if key != scenario.expectedDataKeys[i] {
+					t.Errorf("expected data key[%d] %q, got %q", i, scenario.expectedDataKeys[i], key)
+				}
+			}
+		})
+	}
+}
+
+func TestReferencedConfigMapName(t *testing.T) {
+	scenarios := []struct {
+		name             string
+		plugin           configv1.KMSPluginConfig
+		expectedName     string
+		expectedDataKeys []string
+		expectedError    bool
+	}{
+		{
+			name: "Vault with TLS CA bundle returns configmap name and keys",
+			plugin: configv1.KMSPluginConfig{
+				Type: configv1.VaultKMSProvider,
+				Vault: configv1.VaultKMSPluginConfig{
+					TLS: configv1.VaultTLSConfig{
+						CABundle: configv1.VaultConfigMapReference{Name: "vault-ca-bundle"},
+					},
+				},
+			},
+			expectedName:     "vault-ca-bundle",
+			expectedDataKeys: []string{"ca-bundle.crt"},
+		},
+		{
+			name: "Vault without TLS CA bundle returns empty",
+			plugin: configv1.KMSPluginConfig{
+				Type:  configv1.VaultKMSProvider,
+				Vault: configv1.VaultKMSPluginConfig{},
+			},
+			expectedName:     "",
+			expectedDataKeys: nil,
+		},
+		{
+			name:          "unknown KMS provider returns error",
+			plugin:        configv1.KMSPluginConfig{Type: "UnknownProvider"},
+			expectedError: true,
+		},
+		{
+			name:          "empty plugin config returns error",
+			plugin:        configv1.KMSPluginConfig{},
+			expectedError: true,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			name, dataKeys, err := referencedConfigMapName(scenario.plugin)
+			if scenario.expectedError {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if name != scenario.expectedName {
+				t.Errorf("expected configmap name %q, got %q", scenario.expectedName, name)
 			}
 			if len(dataKeys) != len(scenario.expectedDataKeys) {
 				t.Fatalf("expected %d data keys, got %d", len(scenario.expectedDataKeys), len(dataKeys))

--- a/pkg/operator/encryption/controllers/state_controller_test.go
+++ b/pkg/operator/encryption/controllers/state_controller_test.go
@@ -1132,6 +1132,9 @@ func TestStateController(t *testing.T) {
 					Vault: configv1.VaultKMSPluginConfig{
 						KMSPluginImage: "registry.example.com/kms-plugin@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
 						VaultAddress:   "https://vault.example.com",
+						TLS: configv1.VaultTLSConfig{
+							CABundle: configv1.VaultConfigMapReference{Name: "vault-ca-bundle"},
+						},
 						Authentication: configv1.VaultAuthentication{
 							Type: configv1.VaultAuthenticationTypeAppRole,
 							AppRole: configv1.VaultAppRoleAuthentication{

--- a/pkg/operator/encryption/encryptiondata/config.go
+++ b/pkg/operator/encryption/encryptiondata/config.go
@@ -34,6 +34,10 @@ type Config struct {
 	// Key Secrets into the encryption-config Secret.
 	// Structure: keyID → referenceName → dataKey → value.
 	KMSPluginsSecretData KMSPluginsReferenceData
+	// KMSPluginsConfigMapData maps keyID to configmap data carried from
+	// Key Secrets into the encryption-config Secret.
+	// Structure: keyID → referenceName → dataKey → value.
+	KMSPluginsConfigMapData KMSPluginsReferenceData
 }
 
 // KMSPluginsReferenceData maps keyID to reference data carried from Key Secrets into
@@ -93,6 +97,7 @@ func FromEncryptionState(encryptionState map[schema.GroupResource]state.GroupRes
 	resourceConfigs := make([]apiserverconfigv1.ResourceConfiguration, 0, len(encryptionState))
 	var kmsPlugins map[string]configv1.KMSPluginConfig
 	var kmsPluginsSecretData KMSPluginsReferenceData
+	var kmsPluginsConfigMapData KMSPluginsReferenceData
 
 	for gr, grKeys := range encryptionState {
 		resourceConfigs = append(resourceConfigs, apiserverconfigv1.ResourceConfiguration{
@@ -133,6 +138,19 @@ func FromEncryptionState(encryptionState map[schema.GroupResource]state.GroupRes
 					}
 				}
 			}
+			if key.HasKMSConfigMapData() {
+				if existing, exists := kmsPluginsConfigMapData.Get(key.Key.Name); exists {
+					if !equality.Semantic.DeepEqual(existing.FlatEntries(), key.KMS.PluginConfigMapData.FlatEntries()) {
+						return nil, fmt.Errorf("KMS configmap data mismatch for keyID %s: configmap data from different resources must be identical", key.Key.Name)
+					}
+				} else {
+					for rawKey, value := range key.KMS.PluginConfigMapData.FlatEntries() {
+						if err := kmsPluginsConfigMapData.SetFromRawKey(key.Key.Name, rawKey, value); err != nil {
+							return nil, fmt.Errorf("failed to copy configmap data for keyID %s: %w", key.Key.Name, err)
+						}
+					}
+				}
+			}
 		}
 	}
 
@@ -142,9 +160,10 @@ func FromEncryptionState(encryptionState map[schema.GroupResource]state.GroupRes
 	})
 
 	return &Config{
-		Encryption:           &apiserverconfigv1.EncryptionConfiguration{Resources: resourceConfigs},
-		KMSPlugins:           kmsPlugins,
-		KMSPluginsSecretData: kmsPluginsSecretData,
+		Encryption:              &apiserverconfigv1.EncryptionConfiguration{Resources: resourceConfigs},
+		KMSPlugins:              kmsPlugins,
+		KMSPluginsSecretData:    kmsPluginsSecretData,
+		KMSPluginsConfigMapData: kmsPluginsConfigMapData,
 	}, nil
 }
 

--- a/pkg/operator/encryption/encryptiondata/secret.go
+++ b/pkg/operator/encryption/encryptiondata/secret.go
@@ -49,6 +49,9 @@ const (
 	// encryptionConfigSecretDataPrefix is the data key prefix for KMS plugin secret
 	// data entries in the encryption-config Secret. Full key: "kms-plugin-secret-{secretName}_{dataKey}-{keyID}".
 	encryptionConfigSecretDataPrefix = "kms-plugin-secret-"
+	// encryptionConfigConfigMapDataPrefix is the data key prefix for KMS plugin configmap
+	// data entries in the encryption-config Secret. Full key: "kms-plugin-configmap-{cmName}_{dataKey}-{keyID}".
+	encryptionConfigConfigMapDataPrefix = "kms-plugin-configmap-"
 )
 
 func FromSecret(encryptionConfigSecret *corev1.Secret) (*Config, error) {
@@ -91,7 +94,7 @@ func FromSecret(encryptionConfigSecret *corev1.Secret) (*Config, error) {
 	// which is then split on "_" to recover secretName and dataKey.
 	var kmsPluginsSecretData KMSPluginsReferenceData
 	for key, value := range encryptionConfigSecret.Data {
-		keyID, rawKey, found, err := parseKMSSecretDataKey(key)
+		keyID, rawKey, found, err := parseKMSReferenceDataKey(key, encryptionConfigSecretDataPrefix)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse secret data key %s: %w", key, err)
 		}
@@ -103,7 +106,23 @@ func FromSecret(encryptionConfigSecret *corev1.Secret) (*Config, error) {
 		}
 	}
 
-	return &Config{Encryption: encryptionConfig, KMSPlugins: kmsPlugins, KMSPluginsSecretData: kmsPluginsSecretData}, nil
+	// Extract configmap data entries from the encryption-config Secret.
+	// Data keys follow the format "kms-plugin-configmap-{cmName}_{dataKey}-{keyID}".
+	var kmsPluginsConfigMapData KMSPluginsReferenceData
+	for key, value := range encryptionConfigSecret.Data {
+		keyID, rawKey, found, err := parseKMSReferenceDataKey(key, encryptionConfigConfigMapDataPrefix)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse configmap data key %s: %w", key, err)
+		}
+		if !found {
+			continue
+		}
+		if err := kmsPluginsConfigMapData.SetFromRawKey(keyID, rawKey, value); err != nil {
+			return nil, fmt.Errorf("failed to set key %s: %w", key, err)
+		}
+	}
+
+	return &Config{Encryption: encryptionConfig, KMSPlugins: kmsPlugins, KMSPluginsSecretData: kmsPluginsSecretData, KMSPluginsConfigMapData: kmsPluginsConfigMapData}, nil
 }
 
 func ToSecret(ns, name string, secretData *Config) (*corev1.Secret, error) {
@@ -153,6 +172,12 @@ func ToSecret(ns, name string, secretData *Config) (*corev1.Secret, error) {
 	for keyID, flatEntries := range secretData.KMSPluginsSecretData.FlatEntriesByKeyID() {
 		for rawKey, value := range flatEntries {
 			s.Data[FormatKMSSecretDataKey(rawKey, keyID)] = value
+		}
+	}
+
+	for keyID, flatEntries := range secretData.KMSPluginsConfigMapData.FlatEntriesByKeyID() {
+		for rawKey, value := range flatEntries {
+			s.Data[formatKMSConfigMapDataKey(rawKey, keyID)] = value
 		}
 	}
 
@@ -214,8 +239,20 @@ func FormatKMSSecretDataKey(rawKey, keyID string) string {
 	return fmt.Sprintf("%s%s-%s", encryptionConfigSecretDataPrefix, rawKey, keyID)
 }
 
-func parseKMSSecretDataKey(dataKey string) (keyID, rawKey string, found bool, err error) {
-	rest, found := strings.CutPrefix(dataKey, encryptionConfigSecretDataPrefix)
+// formatKMSConfigMapDataKey returns the data key used in the encryption-config Secret
+// for a KMS plugin configmap entry: "kms-plugin-configmap-{rawKey}-{keyID}",
+// where rawKey is the combined "configMapName_dataKey" from KMSReferenceData.FlatEntry.
+//
+// Note:
+//
+// It does not validate inputs. The callers are expected to use KMSReferenceData.Set,
+// which rejects empty values and underscores in referenceName.
+func formatKMSConfigMapDataKey(rawKey, keyID string) string {
+	return fmt.Sprintf("%s%s-%s", encryptionConfigConfigMapDataPrefix, rawKey, keyID)
+}
+
+func parseKMSReferenceDataKey(dataKey, prefix string) (keyID, rawKey string, found bool, err error) {
+	rest, found := strings.CutPrefix(dataKey, prefix)
 	if !found {
 		return "", "", false, nil
 	}

--- a/pkg/operator/encryption/encryptiondata/secret_test.go
+++ b/pkg/operator/encryption/encryptiondata/secret_test.go
@@ -421,7 +421,84 @@ func TestParseSecretDataKey(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			keyID, rawKey, found, err := parseKMSSecretDataKey(tt.dataKey)
+			keyID, rawKey, found, err := parseKMSReferenceDataKey(tt.dataKey, encryptionConfigSecretDataPrefix)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if found != tt.wantFound {
+				t.Fatalf("found: got %v, want %v", found, tt.wantFound)
+			}
+			if found {
+				if keyID != tt.wantKeyID {
+					t.Errorf("keyID: got %q, want %q", keyID, tt.wantKeyID)
+				}
+				if rawKey != tt.wantRawKey {
+					t.Errorf("rawKey: got %q, want %q", rawKey, tt.wantRawKey)
+				}
+			}
+		})
+	}
+}
+
+func TestParseConfigMapDataKey(t *testing.T) {
+	tests := []struct {
+		name       string
+		dataKey    string
+		wantKeyID  string
+		wantRawKey string
+		wantFound  bool
+		wantErr    bool
+	}{
+		{
+			name:       "valid key",
+			dataKey:    "kms-plugin-configmap-vault-ca-bundle_ca-bundle.crt-1",
+			wantKeyID:  "1",
+			wantRawKey: "vault-ca-bundle_ca-bundle.crt",
+			wantFound:  true,
+		},
+		{
+			name:       "valid key with large keyID",
+			dataKey:    "kms-plugin-configmap-vault-ca-bundle_ca-bundle.crt-42",
+			wantKeyID:  "42",
+			wantRawKey: "vault-ca-bundle_ca-bundle.crt",
+			wantFound:  true,
+		},
+		{
+			name:    "encryption-config key ignored",
+			dataKey: "encryption-config",
+		},
+		{
+			name:    "secret data key ignored",
+			dataKey: "kms-plugin-secret-vault-approle-secret_role-id-1",
+		},
+		{
+			name:    "empty string",
+			dataKey: "",
+		},
+		{
+			name:    "prefix only",
+			dataKey: "kms-plugin-configmap-",
+		},
+		{
+			name:    "no dash after prefix",
+			dataKey: "kms-plugin-configmap-nodash",
+		},
+		{
+			name:    "non-numeric keyID",
+			dataKey: "kms-plugin-configmap-vault-ca-bundle_ca-bundle.crt-abc",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			keyID, rawKey, found, err := parseKMSReferenceDataKey(tt.dataKey, encryptionConfigConfigMapDataPrefix)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")

--- a/pkg/operator/encryption/secrets/secrets.go
+++ b/pkg/operator/encryption/secrets/secrets.go
@@ -97,6 +97,15 @@ func ToKeyState(s *corev1.Secret) (state.KeyState, error) {
 				return state.KeyState{}, fmt.Errorf("secret %s/%s has malformed secret data key %q: %w", s.Namespace, s.Name, dataKey, err)
 			}
 		}
+		for dataKey, value := range s.Data {
+			rawKey, found := strings.CutPrefix(dataKey, encryptionSecretKMSConfigMapDataPrefix)
+			if !found {
+				continue
+			}
+			if err := key.KMS.PluginConfigMapData.SetFromRawKey(rawKey, value); err != nil {
+				return state.KeyState{}, fmt.Errorf("secret %s/%s has malformed configmap data key %q: %w", s.Namespace, s.Name, dataKey, err)
+			}
+		}
 		key.Mode = keyMode
 	default:
 		return state.KeyState{}, fmt.Errorf("secret %s/%s has invalid mode: %s", s.Namespace, s.Name, keyMode)
@@ -172,6 +181,12 @@ func FromKeyState(component string, ks state.KeyState) (*corev1.Secret, error) {
 	if ks.HasKMSSecretData() {
 		for flatKey, value := range ks.KMS.PluginSecretData.FlatEntries() {
 			s.Data[encryptionSecretKMSSecretDataPrefix+flatKey] = value
+		}
+	}
+
+	if ks.HasKMSConfigMapData() {
+		for flatKey, value := range ks.KMS.PluginConfigMapData.FlatEntries() {
+			s.Data[encryptionSecretKMSConfigMapDataPrefix+flatKey] = value
 		}
 	}
 

--- a/pkg/operator/encryption/secrets/types.go
+++ b/pkg/operator/encryption/secrets/types.go
@@ -62,6 +62,11 @@ const (
 	// fetched from the referenced secret in openshift-config. The full data key is
 	// constructed as prefix + secretName + separator + dataKey.
 	encryptionSecretKMSSecretDataPrefix = "encryption.apiserver.operator.openshift.io-kms-plugin-secret-"
+
+	// encryptionSecretKMSConfigMapDataPrefix is the data field key prefix for configmap data
+	// values fetched from the referenced configmap in openshift-config. The full data key is
+	// constructed as prefix + configMapName + separator + dataKey.
+	encryptionSecretKMSConfigMapDataPrefix = "encryption.apiserver.operator.openshift.io-kms-plugin-configmap-"
 )
 
 // MigratedGroupResources is the data structured stored in the

--- a/pkg/operator/encryption/state/types.go
+++ b/pkg/operator/encryption/state/types.go
@@ -64,6 +64,10 @@ func (k *KeyState) HasKMSSecretData() bool {
 	return k != nil && k.KMS != nil && len(k.KMS.PluginSecretData.entries) > 0
 }
 
+func (k *KeyState) HasKMSConfigMapData() bool {
+	return k != nil && k.KMS != nil && len(k.KMS.PluginConfigMapData.entries) > 0
+}
+
 // KMSState stores all KMS encryption mode related configurations
 type KMSState struct {
 	// Encoded EncryptionConfig that stores the KMS related fields
@@ -74,6 +78,9 @@ type KMSState struct {
 
 	// PluginSecretData stores data key-value pairs fetched from referenced secrets.
 	PluginSecretData KMSReferenceData
+
+	// PluginConfigMapData stores data key-value pairs fetched from referenced configmaps.
+	PluginConfigMapData KMSReferenceData
 }
 
 // KMSReferenceData stores data key-value pairs fetched from referenced secrets or configmaps.

--- a/pkg/operator/encryption/testing/helpers.go
+++ b/pkg/operator/encryption/testing/helpers.go
@@ -109,6 +109,9 @@ var DefaultKMSPluginConfig = configv1.KMSPluginConfig{
 				Secret: configv1.VaultSecretReference{Name: "vault-approle-secret"},
 			},
 		},
+		TLS: configv1.VaultTLSConfig{
+			CABundle: configv1.VaultConfigMapReference{Name: "vault-ca-bundle"},
+		},
 		TransitKey: "test-transit-key",
 	},
 }
@@ -160,6 +163,18 @@ func CreateVaultAppRoleSecret(name, roleID, secretID string) *corev1.Secret {
 			"secret-id": []byte(secretID),
 		},
 		Type: corev1.SecretTypeOpaque,
+	}
+}
+
+func CreateVaultCABundleConfigMap(name, caBundleCrt string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "openshift-config",
+		},
+		Data: map[string]string{
+			"ca-bundle.crt": caBundleCrt,
+		},
 	}
 }
 

--- a/test/e2e-encryption/encryption_test.go
+++ b/test/e2e-encryption/encryption_test.go
@@ -164,6 +164,7 @@ func TestEncryptionIntegration(tt *testing.T) {
 		fakeConfigInformer.Config().V1().APIServers(),
 		kubeInformers,
 		deployer, // secret client wrapping kubeClient with encryption-config revision counting
+		kubeClient.CoreV1(),
 		eventRecorder,
 		nil,
 	)

--- a/test/e2e-encryption/encryption_test.go
+++ b/test/e2e-encryption/encryption_test.go
@@ -306,6 +306,38 @@ func TestEncryptionIntegration(tt *testing.T) {
 		}
 	}
 
+	verifyKMSConfigMapData := func() {
+		t.Helper()
+		encryptionConfigSecret, err := kubeClient.CoreV1().Secrets("openshift-config-managed").Get(ctx, fmt.Sprintf("encryption-config-%s", component), metav1.GetOptions{})
+		require.NoError(t, err)
+		cfg, err := encryptiondata.FromSecret(encryptionConfigSecret)
+		require.NoError(t, err)
+
+		expectedKeyIDs := map[string]bool{}
+		for _, rc := range cfg.Encryption.Resources {
+			for _, p := range rc.Providers {
+				if p.KMS != nil {
+					parts := strings.SplitN(p.KMS.Name, "_", 2)
+					require.Len(t, parts, 2, "unexpected KMS provider name format: %s", p.KMS.Name)
+					expectedKeyIDs[parts[0]] = true
+				}
+			}
+		}
+
+		for keyID := range expectedKeyIDs {
+			perKeyData, ok := cfg.KMSPluginsConfigMapData.Get(keyID)
+			require.True(t, ok, "expected configmap data for keyID %s in encryption-config secret", keyID)
+
+			caCert, ok := perKeyData.Get("vault-ca-bundle", "ca-bundle.crt")
+			require.True(t, ok, "expected vault-ca-bundle/ca-bundle.crt data for keyID %s", keyID)
+			require.Equal(t, "test-ca-cert", string(caCert), "ca-bundle.crt configmap data mismatch for keyID %s", keyID)
+
+			keySecret, err := kubeClient.CoreV1().Secrets("openshift-config-managed").Get(ctx, fmt.Sprintf("encryption-key-%s-%s", component, keyID), metav1.GetOptions{})
+			require.NoError(t, err)
+			require.Equal(t, "test-ca-cert", string(keySecret.Data["encryption.apiserver.operator.openshift.io-kms-plugin-configmap-vault-ca-bundle_ca-bundle.crt"]), "key secret %s ca-bundle.crt configmap data mismatch", keyID)
+		}
+	}
+
 	verifyKMSSecretData := func() {
 		t.Helper()
 		encryptionConfigSecret, err := kubeClient.CoreV1().Secrets("openshift-config-managed").Get(ctx, fmt.Sprintf("encryption-config-%s", component), metav1.GetOptions{})
@@ -502,8 +534,18 @@ func TestEncryptionIntegration(tt *testing.T) {
 	require.NoError(t, err)
 	defer kubeClient.CoreV1().Secrets("openshift-config").Delete(ctx, "vault-approle-secret", metav1.DeleteOptions{})
 
+	t.Logf("Create vault CA bundle configmap")
+	_, err = kubeClient.CoreV1().ConfigMaps("openshift-config").Create(ctx, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "vault-ca-bundle", Namespace: "openshift-config"},
+		Data: map[string]string{
+			"ca-bundle.crt": "test-ca-cert",
+		},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+	defer kubeClient.CoreV1().ConfigMaps("openshift-config").Delete(ctx, "vault-ca-bundle", metav1.DeleteOptions{})
+
 	t.Logf("Switch to KMS")
-	_, err = fakeApiServerClient.Patch(ctx, "cluster", types.MergePatchType, []byte(`{"spec":{"encryption":{"type":"KMS","kms":{"type":"Vault","vault":{"kmsPluginImage":"registry.example.com/kms-plugin@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890","vaultAddress":"https://vault.example.com","authentication":{"type":"AppRole","appRole":{"secret":{"name":"vault-approle-secret"}}},"transitKey":"test-transit-key"}}}}}`), metav1.PatchOptions{})
+	_, err = fakeApiServerClient.Patch(ctx, "cluster", types.MergePatchType, []byte(`{"spec":{"encryption":{"type":"KMS","kms":{"type":"Vault","vault":{"kmsPluginImage":"registry.example.com/kms-plugin@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890","vaultAddress":"https://vault.example.com","tls":{"caBundle":{"name":"vault-ca-bundle"}},"authentication":{"type":"AppRole","appRole":{"secret":{"name":"vault-approle-secret"}}},"transitKey":"test-transit-key"}}}}}`), metav1.PatchOptions{})
 	require.NoError(t, err)
 	waitForKeys(7)
 	kms8 := kmsPluginName("kubeapiservers", "8")
@@ -517,6 +559,7 @@ func TestEncryptionIntegration(tt *testing.T) {
 	waitForConditionStatus("Encrypted", operatorv1.ConditionTrue)
 	verifyKMSPlugins()
 	verifyKMSSecretData()
+	verifyKMSConfigMapData()
 
 	t.Logf("Verify KMS key secret contains provider config")
 	kmsKeySecret, err := kubeClient.CoreV1().Secrets("openshift-config-managed").Get(ctx, fmt.Sprintf("encryption-key-%s-8", component), metav1.GetOptions{})
@@ -541,9 +584,10 @@ func TestEncryptionIntegration(tt *testing.T) {
 	waitForConditionStatus("Encrypted", operatorv1.ConditionTrue)
 	verifyKMSPlugins()
 	verifyKMSSecretData()
+	verifyKMSConfigMapData()
 
 	t.Logf("Switch back to KMS")
-	_, err = fakeApiServerClient.Patch(ctx, "cluster", types.MergePatchType, []byte(`{"spec":{"encryption":{"type":"KMS","kms":{"type":"Vault","vault":{"kmsPluginImage":"registry.example.com/kms-plugin@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890","vaultAddress":"https://vault.example.com","authentication":{"type":"AppRole","appRole":{"secret":{"name":"vault-approle-secret"}}},"transitKey":"test-transit-key"}}}}}`), metav1.PatchOptions{})
+	_, err = fakeApiServerClient.Patch(ctx, "cluster", types.MergePatchType, []byte(`{"spec":{"encryption":{"type":"KMS","kms":{"type":"Vault","vault":{"kmsPluginImage":"registry.example.com/kms-plugin@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890","vaultAddress":"https://vault.example.com","tls":{"caBundle":{"name":"vault-ca-bundle"}},"authentication":{"type":"AppRole","appRole":{"secret":{"name":"vault-approle-secret"}}},"transitKey":"test-transit-key"}}}}}`), metav1.PatchOptions{})
 	require.NoError(t, err)
 	waitForKeys(9)
 	kms10 := kmsPluginName("kubeapiservers", "10")
@@ -557,6 +601,7 @@ func TestEncryptionIntegration(tt *testing.T) {
 	waitForConditionStatus("Encrypted", operatorv1.ConditionTrue)
 	verifyKMSPlugins()
 	verifyKMSSecretData()
+	verifyKMSConfigMapData()
 
 	t.Logf("Rotate KMS key via aescbc (KMS->AESCBC->KMS)")
 	_, err = fakeApiServerClient.Patch(ctx, "cluster", types.MergePatchType, []byte(`{"spec":{"encryption":{"type":"aescbc","kms":null}}}`), metav1.PatchOptions{})
@@ -570,9 +615,10 @@ func TestEncryptionIntegration(tt *testing.T) {
 	waitForConditionStatus("Encrypted", operatorv1.ConditionTrue)
 	verifyKMSPlugins()
 	verifyKMSSecretData()
+	verifyKMSConfigMapData()
 
 	t.Logf("Switch back to KMS after rotation")
-	_, err = fakeApiServerClient.Patch(ctx, "cluster", types.MergePatchType, []byte(`{"spec":{"encryption":{"type":"KMS","kms":{"type":"Vault","vault":{"kmsPluginImage":"registry.example.com/kms-plugin@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890","vaultAddress":"https://vault.example.com","authentication":{"type":"AppRole","appRole":{"secret":{"name":"vault-approle-secret"}}},"transitKey":"test-transit-key"}}}}}`), metav1.PatchOptions{})
+	_, err = fakeApiServerClient.Patch(ctx, "cluster", types.MergePatchType, []byte(`{"spec":{"encryption":{"type":"KMS","kms":{"type":"Vault","vault":{"kmsPluginImage":"registry.example.com/kms-plugin@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890","vaultAddress":"https://vault.example.com","tls":{"caBundle":{"name":"vault-ca-bundle"}},"authentication":{"type":"AppRole","appRole":{"secret":{"name":"vault-approle-secret"}}},"transitKey":"test-transit-key"}}}}}`), metav1.PatchOptions{})
 	require.NoError(t, err)
 	waitForKeys(11)
 	kms12 := kmsPluginName("kubeapiservers", "12")
@@ -586,6 +632,7 @@ func TestEncryptionIntegration(tt *testing.T) {
 	waitForConditionStatus("Encrypted", operatorv1.ConditionTrue)
 	verifyKMSPlugins()
 	verifyKMSSecretData()
+	verifyKMSConfigMapData()
 
 	t.Logf("Delete the encryption-config while in KMS mode")
 	_, err = kubeClient.CoreV1().Secrets("openshift-config-managed").Patch(ctx, fmt.Sprintf("encryption-config-%s", component), types.JSONPatchType, []byte(`[{"op":"remove","path":"/metadata/finalizers"}]`), metav1.PatchOptions{})


### PR DESCRIPTION
This PR embraces the same approach we used https://github.com/openshift/library-go/pull/2212. In order to make the structures reusable, this PR renames KMSSecretData to KMSReferenceData, KMSPluginsSecretData to KMSPluginsReferenceData. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * KMS plugin configuration can reference ConfigMaps (e.g., Vault TLS CA bundles); operator reads those ConfigMaps and includes their data in generated encryption key secrets and encryption-config handling. Missing or malformed ConfigMaps produce degraded conditions.

* **Tests**
  * Expanded unit and end-to-end tests for ConfigMap-backed KMS configs, including missing/invalid ConfigMap scenarios and CA-bundle verification.

* **Chores**
  * Unified reference-data handling so KMS plugin data supports both Secret- and ConfigMap-backed entries and round-trip serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->