### PR TITLE
CNTRLPLANE-3237: Introduce getter for KMS SecretData

### DIFF
--- a/pkg/operator/encryption/controllers/state_controller_test.go
+++ b/pkg/operator/encryption/controllers/state_controller_test.go
@@ -1263,8 +1263,9 @@ func validateSecretWithEncryptionConfig(actualSecret *corev1.Secret, expectedEnc
 		return fmt.Errorf("failed to verfy the encryption config, due to %v", err)
 	}
 
-	if !cmp.Equal(expectedEncryptionCfg, actualEncryptionCfg) {
-		return fmt.Errorf("%s", cmp.Diff(expectedEncryptionCfg, actualEncryptionCfg))
+	cmpOpt := cmp.AllowUnexported(encryptiondata.KMSPluginsSecretData{})
+	if !cmp.Equal(expectedEncryptionCfg, actualEncryptionCfg, cmpOpt) {
+		return fmt.Errorf("%s", cmp.Diff(expectedEncryptionCfg, actualEncryptionCfg, cmpOpt))
 	}
 
 	// rewrite the payload and compare the rest

--- a/pkg/operator/encryption/encryptiondata/config.go
+++ b/pkg/operator/encryption/encryptiondata/config.go
@@ -39,7 +39,17 @@ type Config struct {
 // KMSPluginsSecretData maps keyID to secret data carried from Key Secrets into
 // the encryption-config Secret. Structure: keyID → secretName → dataKey → value.
 type KMSPluginsSecretData struct {
-	ByKeyID map[string]state.KMSSecretData
+	byKeyID map[string]state.KMSSecretData
+}
+
+// Get returns the KMSSecretData for the given keyID and true if it exists,
+// or a zero value and false otherwise. It is safe to call on a nil map.
+func (d *KMSPluginsSecretData) Get(keyID string) (state.KMSSecretData, bool) {
+	if d.byKeyID == nil {
+		return state.KMSSecretData{}, false
+	}
+	sd, ok := d.byKeyID[keyID]
+	return sd, ok
 }
 
 // SetFromRawKey stores a value for the given keyID, splitting rawKey
@@ -48,25 +58,25 @@ func (d *KMSPluginsSecretData) SetFromRawKey(keyID, rawKey string, value []byte)
 	if len(keyID) == 0 {
 		return fmt.Errorf("keyID must not be empty")
 	}
-	if d.ByKeyID == nil {
-		d.ByKeyID = map[string]state.KMSSecretData{}
+	if d.byKeyID == nil {
+		d.byKeyID = map[string]state.KMSSecretData{}
 	}
-	sd := d.ByKeyID[keyID]
+	sd := d.byKeyID[keyID]
 	if err := sd.SetFromRawKey(rawKey, value); err != nil {
 		return err
 	}
-	d.ByKeyID[keyID] = sd
+	d.byKeyID[keyID] = sd
 	return nil
 }
 
 // FlatEntriesByKeyID returns the stored data as a map of keyID to flat entries,
 // where each flat entry is keyed by "secretName_dataKey".
 func (d *KMSPluginsSecretData) FlatEntriesByKeyID() map[string]map[string][]byte {
-	if d.ByKeyID == nil {
+	if d.byKeyID == nil {
 		return nil
 	}
 	result := map[string]map[string][]byte{}
-	for keyID, sd := range d.ByKeyID {
+	for keyID, sd := range d.byKeyID {
 		if flat := sd.FlatEntries(); flat != nil {
 			result[keyID] = flat
 		}
@@ -111,7 +121,7 @@ func FromEncryptionState(encryptionState map[schema.GroupResource]state.GroupRes
 				}
 			}
 			if key.HasKMSSecretData() {
-				if existing, exists := kmsPluginsSecretData.ByKeyID[key.Key.Name]; exists {
+				if existing, exists := kmsPluginsSecretData.Get(key.Key.Name); exists {
 					if !equality.Semantic.DeepEqual(existing, key.KMS.PluginSecretData) {
 						return nil, fmt.Errorf("KMS secret data mismatch for keyID %s: secret data from different resources must be identical", key.Key.Name)
 					}

--- a/pkg/operator/encryption/encryptiondata/config_test.go
+++ b/pkg/operator/encryption/encryptiondata/config_test.go
@@ -843,14 +843,12 @@ func TestFromEncryptionStateKMSSecretDataValidation(t *testing.T) {
 					}},
 				},
 			},
-			expectedData: encryptiondata.KMSPluginsSecretData{ByKeyID: map[string]state.KMSSecretData{
-				"1": {Entries: map[string]map[string][]byte{
-					"vault-approle-secret": {
-						"role-id":   []byte("test-role-id"),
-						"secret-id": []byte("test-secret-id"),
-					},
-				}},
-			}},
+			expectedData: func() encryptiondata.KMSPluginsSecretData {
+				var sd encryptiondata.KMSPluginsSecretData
+				sd.SetFromRawKey("1", "vault-approle-secret_role-id", []byte("test-role-id"))
+				sd.SetFromRawKey("1", "vault-approle-secret_secret-id", []byte("test-secret-id"))
+				return sd
+			}(),
 		},
 		{
 			name: "mismatched secret data across resources",
@@ -922,8 +920,9 @@ func TestFromEncryptionStateKMSSecretDataValidation(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if !cmp.Equal(tt.expectedData, cfg.KMSPluginsSecretData) {
-				t.Fatalf("unexpected secret data: %s", cmp.Diff(tt.expectedData, cfg.KMSPluginsSecretData))
+			cmpOpt := cmp.AllowUnexported(encryptiondata.KMSPluginsSecretData{})
+			if !cmp.Equal(tt.expectedData, cfg.KMSPluginsSecretData, cmpOpt) {
+				t.Fatalf("unexpected secret data: %s", cmp.Diff(tt.expectedData, cfg.KMSPluginsSecretData, cmpOpt))
 			}
 		})
 	}
@@ -1007,14 +1006,12 @@ func TestSecretRoundtrip(t *testing.T) {
 				KMSPlugins: map[string]configv1.KMSPluginConfig{
 					"1": encryptiontesting.DefaultKMSPluginConfig,
 				},
-				KMSPluginsSecretData: encryptiondata.KMSPluginsSecretData{ByKeyID: map[string]state.KMSSecretData{
-					"1": {Entries: map[string]map[string][]byte{
-						"vault-approle-secret": {
-							"role-id":   []byte("test-role-id"),
-							"secret-id": []byte("test-secret-id"),
-						},
-					}},
-				}},
+				KMSPluginsSecretData: func() encryptiondata.KMSPluginsSecretData {
+					var sd encryptiondata.KMSPluginsSecretData
+					sd.SetFromRawKey("1", "vault-approle-secret_role-id", []byte("test-role-id"))
+					sd.SetFromRawKey("1", "vault-approle-secret_secret-id", []byte("test-secret-id"))
+					return sd
+				}(),
 			},
 		},
 		{
@@ -1050,20 +1047,14 @@ func TestSecretRoundtrip(t *testing.T) {
 					"1": encryptiontesting.DefaultKMSPluginConfig,
 					"2": encryptiontesting.DefaultKMSPluginConfig,
 				},
-				KMSPluginsSecretData: encryptiondata.KMSPluginsSecretData{ByKeyID: map[string]state.KMSSecretData{
-					"1": {Entries: map[string]map[string][]byte{
-						"vault-approle-secret": {
-							"role-id":   []byte("role-id-1"),
-							"secret-id": []byte("secret-id-1"),
-						},
-					}},
-					"2": {Entries: map[string]map[string][]byte{
-						"vault-approle-secret": {
-							"role-id":   []byte("role-id-2"),
-							"secret-id": []byte("secret-id-2"),
-						},
-					}},
-				}},
+				KMSPluginsSecretData: func() encryptiondata.KMSPluginsSecretData {
+					var sd encryptiondata.KMSPluginsSecretData
+					sd.SetFromRawKey("1", "vault-approle-secret_role-id", []byte("role-id-1"))
+					sd.SetFromRawKey("1", "vault-approle-secret_secret-id", []byte("secret-id-1"))
+					sd.SetFromRawKey("2", "vault-approle-secret_role-id", []byte("role-id-2"))
+					sd.SetFromRawKey("2", "vault-approle-secret_secret-id", []byte("secret-id-2"))
+					return sd
+				}(),
 			},
 		},
 		{
@@ -1113,8 +1104,9 @@ func TestSecretRoundtrip(t *testing.T) {
 			if err != nil {
 				t.Fatalf("FromSecret() error: %v", err)
 			}
-			if !cmp.Equal(tt.cfg, got) {
-				t.Errorf("roundtrip mismatch:\n%s", cmp.Diff(tt.cfg, got))
+			cmpOpt := cmp.AllowUnexported(encryptiondata.KMSPluginsSecretData{})
+			if !cmp.Equal(tt.cfg, got, cmpOpt) {
+				t.Errorf("roundtrip mismatch:\n%s", cmp.Diff(tt.cfg, got, cmpOpt))
 			}
 		})
 	}
@@ -1149,14 +1141,12 @@ func TestToSecretSecretDataEdgeCases(t *testing.T) {
 		},
 		{
 			name: "valid secret data produces correct data keys",
-			secretData: encryptiondata.KMSPluginsSecretData{ByKeyID: map[string]state.KMSSecretData{
-				"1": {Entries: map[string]map[string][]byte{
-					"vault-approle-secret": {
-						"role-id":   []byte("test-role-id"),
-						"secret-id": []byte("test-secret-id"),
-					},
-				}},
-			}},
+			secretData: func() encryptiondata.KMSPluginsSecretData {
+				var sd encryptiondata.KMSPluginsSecretData
+				sd.SetFromRawKey("1", "vault-approle-secret_role-id", []byte("test-role-id"))
+				sd.SetFromRawKey("1", "vault-approle-secret_secret-id", []byte("test-secret-id"))
+				return sd
+			}(),
 			expectedDataKeys: map[string][]byte{
 				"kms-plugin-secret-vault-approle-secret_role-id-1":   []byte("test-role-id"),
 				"kms-plugin-secret-vault-approle-secret_secret-id-1": []byte("test-secret-id"),
@@ -1164,16 +1154,12 @@ func TestToSecretSecretDataEdgeCases(t *testing.T) {
 		},
 		{
 			name: "multiple secrets within same keyID",
-			secretData: encryptiondata.KMSPluginsSecretData{ByKeyID: map[string]state.KMSSecretData{
-				"1": {Entries: map[string]map[string][]byte{
-					"secret-a": {
-						"key-1": []byte("val-a1"),
-					},
-					"secret-b": {
-						"key-2": []byte("val-b2"),
-					},
-				}},
-			}},
+			secretData: func() encryptiondata.KMSPluginsSecretData {
+				var sd encryptiondata.KMSPluginsSecretData
+				sd.SetFromRawKey("1", "secret-a_key-1", []byte("val-a1"))
+				sd.SetFromRawKey("1", "secret-b_key-2", []byte("val-b2"))
+				return sd
+			}(),
 			expectedDataKeys: map[string][]byte{
 				"kms-plugin-secret-secret-a_key-1-1": []byte("val-a1"),
 				"kms-plugin-secret-secret-b_key-2-1": []byte("val-b2"),
@@ -1247,14 +1233,12 @@ func TestFromSecretSecretData(t *testing.T) {
 				"kms-plugin-secret-vault-approle-secret_role-id-1":   []byte("test-role-id"),
 				"kms-plugin-secret-vault-approle-secret_secret-id-1": []byte("test-secret-id"),
 			},
-			expectedData: encryptiondata.KMSPluginsSecretData{ByKeyID: map[string]state.KMSSecretData{
-				"1": {Entries: map[string]map[string][]byte{
-					"vault-approle-secret": {
-						"role-id":   []byte("test-role-id"),
-						"secret-id": []byte("test-secret-id"),
-					},
-				}},
-			}},
+			expectedData: func() encryptiondata.KMSPluginsSecretData {
+				var sd encryptiondata.KMSPluginsSecretData
+				sd.SetFromRawKey("1", "vault-approle-secret_role-id", []byte("test-role-id"))
+				sd.SetFromRawKey("1", "vault-approle-secret_secret-id", []byte("test-secret-id"))
+				return sd
+			}(),
 		},
 		{
 			name:      "no secret data keys",
@@ -1274,20 +1258,14 @@ func TestFromSecretSecretData(t *testing.T) {
 				"kms-plugin-secret-vault-approle-secret_role-id-2":   []byte("role-id-2"),
 				"kms-plugin-secret-vault-approle-secret_secret-id-2": []byte("secret-id-2"),
 			},
-			expectedData: encryptiondata.KMSPluginsSecretData{ByKeyID: map[string]state.KMSSecretData{
-				"1": {Entries: map[string]map[string][]byte{
-					"vault-approle-secret": {
-						"role-id":   []byte("role-id-1"),
-						"secret-id": []byte("secret-id-1"),
-					},
-				}},
-				"2": {Entries: map[string]map[string][]byte{
-					"vault-approle-secret": {
-						"role-id":   []byte("role-id-2"),
-						"secret-id": []byte("secret-id-2"),
-					},
-				}},
-			}},
+			expectedData: func() encryptiondata.KMSPluginsSecretData {
+				var sd encryptiondata.KMSPluginsSecretData
+				sd.SetFromRawKey("1", "vault-approle-secret_role-id", []byte("role-id-1"))
+				sd.SetFromRawKey("1", "vault-approle-secret_secret-id", []byte("secret-id-1"))
+				sd.SetFromRawKey("2", "vault-approle-secret_role-id", []byte("role-id-2"))
+				sd.SetFromRawKey("2", "vault-approle-secret_secret-id", []byte("secret-id-2"))
+				return sd
+			}(),
 		},
 	}
 
@@ -1302,8 +1280,9 @@ func TestFromSecretSecretData(t *testing.T) {
 			if err != nil {
 				t.Fatalf("FromSecret() error: %v", err)
 			}
-			if !cmp.Equal(tt.expectedData, cfg.KMSPluginsSecretData) {
-				t.Fatalf("unexpected secret data: %s", cmp.Diff(tt.expectedData, cfg.KMSPluginsSecretData))
+			cmpOpt := cmp.AllowUnexported(encryptiondata.KMSPluginsSecretData{})
+			if !cmp.Equal(tt.expectedData, cfg.KMSPluginsSecretData, cmpOpt) {
+				t.Fatalf("unexpected secret data: %s", cmp.Diff(tt.expectedData, cfg.KMSPluginsSecretData, cmpOpt))
 			}
 		})
 	}

--- a/pkg/operator/encryption/state/types.go
+++ b/pkg/operator/encryption/state/types.go
@@ -82,6 +82,23 @@ type KMSSecretData struct {
 	Entries map[string]map[string][]byte
 }
 
+// Get returns the value for the given secretName and dataKey. It returns false if
+// secretName or dataKey is empty, if Entries is nil, or if the key does not exist.
+func (d *KMSSecretData) Get(secretName, dataKey string) ([]byte, bool) {
+	if len(secretName) == 0 || len(dataKey) == 0 {
+		return nil, false
+	}
+	if d.Entries == nil {
+		return nil, false
+	}
+	secretEntries, ok := d.Entries[secretName]
+	if !ok {
+		return nil, false
+	}
+	value, ok := secretEntries[dataKey]
+	return value, ok
+}
+
 func (d *KMSSecretData) Set(secretName, dataKey string, value []byte) error {
 	if len(secretName) == 0 || len(dataKey) == 0 || len(value) == 0 {
 		return fmt.Errorf("secretName, dataKey, and value must not be empty")

--- a/test/e2e-encryption/encryption_test.go
+++ b/test/e2e-encryption/encryption_test.go
@@ -324,15 +324,15 @@ func TestEncryptionIntegration(tt *testing.T) {
 		}
 
 		for keyID := range expectedKeyIDs {
-			perKeyData, ok := cfg.KMSPluginsSecretData.ByKeyID[keyID]
+			perKeyData, ok := cfg.KMSPluginsSecretData.Get(keyID)
 			require.True(t, ok, "expected secret data for keyID %s in encryption-config secret", keyID)
-			require.NotEmpty(t, perKeyData.Entries, "expected non-empty secret data for keyID %s", keyID)
 
-			// Verify actual values match the source secret
-			vaultData, ok := perKeyData.Entries["vault-approle-secret"]
-			require.True(t, ok, "expected vault-approle-secret data for keyID %s", keyID)
-			require.Equal(t, "test-role-id", string(vaultData["role-id"]), "role-id secret data mismatch for keyID %s", keyID)
-			require.Equal(t, "test-secret-id", string(vaultData["secret-id"]), "secret-id secret data mismatch for keyID %s", keyID)
+			roleID, ok := perKeyData.Get("vault-approle-secret", "role-id")
+			require.True(t, ok, "expected vault-approle-secret/role-id data for keyID %s", keyID)
+			require.Equal(t, "test-role-id", string(roleID), "role-id secret data mismatch for keyID %s", keyID)
+			secretID, ok := perKeyData.Get("vault-approle-secret", "secret-id")
+			require.True(t, ok, "expected vault-approle-secret/secret-id data for keyID %s", keyID)
+			require.Equal(t, "test-secret-id", string(secretID), "secret-id secret data mismatch for keyID %s", keyID)
 
 			// Verify Key Secret also carries the secret data
 			keySecret, err := kubeClient.CoreV1().Secrets("openshift-config-managed").Get(ctx, fmt.Sprintf("encryption-key-%s-%s", component, keyID), metav1.GetOptions{})


### PR DESCRIPTION
This PR introduces getter functionality, so that plugin lifecycle can safely query data in https://github.com/openshift/library-go/pull/2252

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal architecture for KMS secret data handling with enhanced accessor patterns for better encapsulation.
  * Strengthened encryption validation testing to ensure robust secret configuration verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->