### PR TITLE
NO-JIRA: Fix data race in InMemoryRecorder

### DIFF
--- a/pkg/operator/events/recorder_in_memory.go
+++ b/pkg/operator/events/recorder_in_memory.go
@@ -42,6 +42,8 @@ func NewInMemoryRecorder(sourceComponent string, clock clock.PassiveClock) InMem
 }
 
 func (r *inMemoryEventRecorder) ComponentName() string {
+	r.Lock()
+	defer r.Unlock()
 	return r.source
 }
 
@@ -55,6 +57,8 @@ func (r *inMemoryEventRecorder) ForComponent(component string) Recorder {
 }
 
 func (r *inMemoryEventRecorder) WithContext(ctx context.Context) Recorder {
+	r.Lock()
+	defer r.Unlock()
 	r.ctx = ctx
 	return r
 }
@@ -65,7 +69,9 @@ func (r *inMemoryEventRecorder) WithComponentSuffix(suffix string) Recorder {
 
 // Events returns list of recorded events
 func (r *inMemoryEventRecorder) Events() []*corev1.Event {
-	return r.events
+	r.Lock()
+	defer r.Unlock()
+	return append([]*corev1.Event(nil), r.events...)
 }
 
 func (r *inMemoryEventRecorder) Event(reason, message string) {


### PR DESCRIPTION
Events() reads the events slice, ComponentName() reads source,
and WithContext() writes ctx — all without holding the embedded
mutex that Event()/Warning()/ForComponent() use. Add locking to
all three for consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed race conditions in the in-memory event recorder: reads are now concurrency-safe and return independent snapshots so callers can't observe or modify internal event storage during concurrent operations.
  * Protected component/context metadata accesses from concurrent reads/writes.
  * Improves stability under concurrent workloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->