### PR TITLE
CNTRLPLANE-3237: Unexport Entries in KMSSecretData

### DIFF
--- a/pkg/operator/encryption/controllers/state_controller_test.go
+++ b/pkg/operator/encryption/controllers/state_controller_test.go
@@ -1263,7 +1263,7 @@ func validateSecretWithEncryptionConfig(actualSecret *corev1.Secret, expectedEnc
 		return fmt.Errorf("failed to verfy the encryption config, due to %v", err)
 	}
 
-	cmpOpt := cmp.AllowUnexported(encryptiondata.KMSPluginsSecretData{})
+	cmpOpt := cmp.AllowUnexported(encryptiondata.KMSPluginsSecretData{}, state.KMSSecretData{})
 	if !cmp.Equal(expectedEncryptionCfg, actualEncryptionCfg, cmpOpt) {
 		return fmt.Errorf("%s", cmp.Diff(expectedEncryptionCfg, actualEncryptionCfg, cmpOpt))
 	}

--- a/pkg/operator/encryption/encryptiondata/config.go
+++ b/pkg/operator/encryption/encryptiondata/config.go
@@ -122,7 +122,7 @@ func FromEncryptionState(encryptionState map[schema.GroupResource]state.GroupRes
 			}
 			if key.HasKMSSecretData() {
 				if existing, exists := kmsPluginsSecretData.Get(key.Key.Name); exists {
-					if !equality.Semantic.DeepEqual(existing, key.KMS.PluginSecretData) {
+					if !equality.Semantic.DeepEqual(existing.FlatEntries(), key.KMS.PluginSecretData.FlatEntries()) {
 						return nil, fmt.Errorf("KMS secret data mismatch for keyID %s: secret data from different resources must be identical", key.Key.Name)
 					}
 				} else {

--- a/pkg/operator/encryption/encryptiondata/config_test.go
+++ b/pkg/operator/encryption/encryptiondata/config_test.go
@@ -815,13 +815,12 @@ func TestFromEncryptionStateKMSSecretDataValidation(t *testing.T) {
 						KMS: &state.KMSState{
 							Encryption: &apiserverconfigv1.KMSConfiguration{APIVersion: "v2", Name: "1", Endpoint: "unix:///var/run/kmsplugin/kms-1.sock"},
 							Plugin:     encryptiontesting.DefaultKMSPluginConfig,
-							PluginSecretData: state.KMSSecretData{
-								Entries: map[string]map[string][]byte{
-									"vault-approle-secret": {
-										"role-id":   []byte("test-role-id"),
-										"secret-id": []byte("test-secret-id"),
-									},
-								}},
+							PluginSecretData: func() state.KMSSecretData {
+								var sd state.KMSSecretData
+								sd.Set("vault-approle-secret", "role-id", []byte("test-role-id"))
+								sd.Set("vault-approle-secret", "secret-id", []byte("test-secret-id"))
+								return sd
+							}(),
 						},
 					}},
 				},
@@ -832,13 +831,12 @@ func TestFromEncryptionStateKMSSecretDataValidation(t *testing.T) {
 						KMS: &state.KMSState{
 							Encryption: &apiserverconfigv1.KMSConfiguration{APIVersion: "v2", Name: "1", Endpoint: "unix:///var/run/kmsplugin/kms-1.sock"},
 							Plugin:     encryptiontesting.DefaultKMSPluginConfig,
-							PluginSecretData: state.KMSSecretData{
-								Entries: map[string]map[string][]byte{
-									"vault-approle-secret": {
-										"role-id":   []byte("test-role-id"),
-										"secret-id": []byte("test-secret-id"),
-									},
-								}},
+							PluginSecretData: func() state.KMSSecretData {
+								var sd state.KMSSecretData
+								sd.Set("vault-approle-secret", "role-id", []byte("test-role-id"))
+								sd.Set("vault-approle-secret", "secret-id", []byte("test-secret-id"))
+								return sd
+							}(),
 						},
 					}},
 				},
@@ -860,12 +858,11 @@ func TestFromEncryptionStateKMSSecretDataValidation(t *testing.T) {
 						KMS: &state.KMSState{
 							Encryption: &apiserverconfigv1.KMSConfiguration{APIVersion: "v2", Name: "1", Endpoint: "unix:///var/run/kmsplugin/kms-1.sock"},
 							Plugin:     encryptiontesting.DefaultKMSPluginConfig,
-							PluginSecretData: state.KMSSecretData{
-								Entries: map[string]map[string][]byte{
-									"vault-approle-secret": {
-										"role-id": []byte("role-id-a"),
-									},
-								}},
+							PluginSecretData: func() state.KMSSecretData {
+								var sd state.KMSSecretData
+								sd.Set("vault-approle-secret", "role-id", []byte("role-id-a"))
+								return sd
+							}(),
 						},
 					}},
 				},
@@ -876,12 +873,11 @@ func TestFromEncryptionStateKMSSecretDataValidation(t *testing.T) {
 						KMS: &state.KMSState{
 							Encryption: &apiserverconfigv1.KMSConfiguration{APIVersion: "v2", Name: "1", Endpoint: "unix:///var/run/kmsplugin/kms-1.sock"},
 							Plugin:     encryptiontesting.DefaultKMSPluginConfig,
-							PluginSecretData: state.KMSSecretData{
-								Entries: map[string]map[string][]byte{
-									"vault-approle-secret": {
-										"role-id": []byte("role-id-b"),
-									},
-								}},
+							PluginSecretData: func() state.KMSSecretData {
+								var sd state.KMSSecretData
+								sd.Set("vault-approle-secret", "role-id", []byte("role-id-b"))
+								return sd
+							}(),
 						},
 					}},
 				},
@@ -920,7 +916,7 @@ func TestFromEncryptionStateKMSSecretDataValidation(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			cmpOpt := cmp.AllowUnexported(encryptiondata.KMSPluginsSecretData{})
+			cmpOpt := cmp.AllowUnexported(encryptiondata.KMSPluginsSecretData{}, state.KMSSecretData{})
 			if !cmp.Equal(tt.expectedData, cfg.KMSPluginsSecretData, cmpOpt) {
 				t.Fatalf("unexpected secret data: %s", cmp.Diff(tt.expectedData, cfg.KMSPluginsSecretData, cmpOpt))
 			}
@@ -1104,7 +1100,7 @@ func TestSecretRoundtrip(t *testing.T) {
 			if err != nil {
 				t.Fatalf("FromSecret() error: %v", err)
 			}
-			cmpOpt := cmp.AllowUnexported(encryptiondata.KMSPluginsSecretData{})
+			cmpOpt := cmp.AllowUnexported(encryptiondata.KMSPluginsSecretData{}, state.KMSSecretData{})
 			if !cmp.Equal(tt.cfg, got, cmpOpt) {
 				t.Errorf("roundtrip mismatch:\n%s", cmp.Diff(tt.cfg, got, cmpOpt))
 			}
@@ -1280,7 +1276,7 @@ func TestFromSecretSecretData(t *testing.T) {
 			if err != nil {
 				t.Fatalf("FromSecret() error: %v", err)
 			}
-			cmpOpt := cmp.AllowUnexported(encryptiondata.KMSPluginsSecretData{})
+			cmpOpt := cmp.AllowUnexported(encryptiondata.KMSPluginsSecretData{}, state.KMSSecretData{})
 			if !cmp.Equal(tt.expectedData, cfg.KMSPluginsSecretData, cmpOpt) {
 				t.Fatalf("unexpected secret data: %s", cmp.Diff(tt.expectedData, cfg.KMSPluginsSecretData, cmpOpt))
 			}

--- a/pkg/operator/encryption/secrets/secrets_test.go
+++ b/pkg/operator/encryption/secrets/secrets_test.go
@@ -200,12 +200,12 @@ func TestRoundtrip(t *testing.T) {
 						Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 					},
 					Plugin: defaultKMSPluginConfig,
-					PluginSecretData: state.KMSSecretData{Entries: map[string]map[string][]byte{
-						"vault-approle-secret": {
-							"role-id":   []byte("test-role-id"),
-							"secret-id": []byte("test-secret-id"),
-						},
-					}},
+					PluginSecretData: func() state.KMSSecretData {
+						var sd state.KMSSecretData
+						sd.Set("vault-approle-secret", "role-id", []byte("test-role-id"))
+						sd.Set("vault-approle-secret", "secret-id", []byte("test-secret-id"))
+						return sd
+					}(),
 				},
 				Migrated: state.MigrationState{
 					Timestamp: now,

--- a/pkg/operator/encryption/state/types.go
+++ b/pkg/operator/encryption/state/types.go
@@ -61,7 +61,7 @@ func (k *KeyState) HasKMSPlugin() bool {
 }
 
 func (k *KeyState) HasKMSSecretData() bool {
-	return k != nil && k.KMS != nil && len(k.KMS.PluginSecretData.Entries) > 0
+	return k != nil && k.KMS != nil && len(k.KMS.PluginSecretData.entries) > 0
 }
 
 // KMSState stores all KMS encryption mode related configurations
@@ -77,9 +77,9 @@ type KMSState struct {
 }
 
 // KMSSecretData stores data key-value pairs fetched from referenced secrets.
-// Entries maps secret names to their data key-value pairs.
+// entries maps secret names to their data key-value pairs.
 type KMSSecretData struct {
-	Entries map[string]map[string][]byte
+	entries map[string]map[string][]byte
 }
 
 // Get returns the value for the given secretName and dataKey. It returns false if
@@ -88,10 +88,10 @@ func (d *KMSSecretData) Get(secretName, dataKey string) ([]byte, bool) {
 	if len(secretName) == 0 || len(dataKey) == 0 {
 		return nil, false
 	}
-	if d.Entries == nil {
+	if d.entries == nil {
 		return nil, false
 	}
-	secretEntries, ok := d.Entries[secretName]
+	secretEntries, ok := d.entries[secretName]
 	if !ok {
 		return nil, false
 	}
@@ -106,13 +106,13 @@ func (d *KMSSecretData) Set(secretName, dataKey string, value []byte) error {
 	if strings.Contains(secretName, "_") {
 		return fmt.Errorf("secret name %q must not contain underscores", secretName)
 	}
-	if d.Entries == nil {
-		d.Entries = map[string]map[string][]byte{}
+	if d.entries == nil {
+		d.entries = map[string]map[string][]byte{}
 	}
-	if d.Entries[secretName] == nil {
-		d.Entries[secretName] = map[string][]byte{}
+	if d.entries[secretName] == nil {
+		d.entries[secretName] = map[string][]byte{}
 	}
-	d.Entries[secretName][dataKey] = value
+	d.entries[secretName][dataKey] = value
 	return nil
 }
 
@@ -130,11 +130,11 @@ func (d *KMSSecretData) SetFromRawKey(rawKey string, value []byte) error {
 // "_" separates secretName from dataKey because "_" is forbidden in
 // Kubernetes secret names, making the split unambiguous.
 func (d *KMSSecretData) FlatEntries() map[string][]byte {
-	if d.Entries == nil {
+	if d.entries == nil {
 		return nil
 	}
 	result := map[string][]byte{}
-	for secretName, keys := range d.Entries {
+	for secretName, keys := range d.entries {
 		for dataKey, value := range keys {
 			result[secretName+secretDataKeySeparator+dataKey] = value
 		}

--- a/pkg/operator/encryption/state/types_test.go
+++ b/pkg/operator/encryption/state/types_test.go
@@ -20,7 +20,7 @@ func TestKMSSecretDataSet(t *testing.T) {
 			secretName: "vault-approle-secret",
 			dataKey:    "role-id",
 			value:      []byte("test-role-id"),
-			expected: KMSSecretData{Entries: map[string]map[string][]byte{
+			expected: KMSSecretData{entries: map[string]map[string][]byte{
 				"vault-approle-secret": {"role-id": []byte("test-role-id")},
 			}},
 		},
@@ -85,7 +85,7 @@ func TestKMSSecretDataSet(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if diff := cmp.Diff(tt.expected, d); diff != "" {
+			if diff := cmp.Diff(tt.expected, d, cmp.AllowUnexported(KMSSecretData{})); diff != "" {
 				t.Errorf("unexpected result (-want +got):\n%s", diff)
 			}
 		})
@@ -104,7 +104,7 @@ func TestKMSSecretDataSetFromRawKey(t *testing.T) {
 			name:   "valid raw key",
 			rawKey: "vault-approle-secret_role-id",
 			value:  []byte("test-role-id"),
-			expected: KMSSecretData{Entries: map[string]map[string][]byte{
+			expected: KMSSecretData{entries: map[string]map[string][]byte{
 				"vault-approle-secret": {"role-id": []byte("test-role-id")},
 			}},
 		},
@@ -118,7 +118,7 @@ func TestKMSSecretDataSetFromRawKey(t *testing.T) {
 			name:   "multiple underscores splits on first only",
 			rawKey: "vault_approle_secret_role-id",
 			value:  []byte("v"),
-			expected: KMSSecretData{Entries: map[string]map[string][]byte{
+			expected: KMSSecretData{entries: map[string]map[string][]byte{
 				"vault": {"approle_secret_role-id": []byte("v")},
 			}},
 		},
@@ -149,7 +149,7 @@ func TestKMSSecretDataSetFromRawKey(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if diff := cmp.Diff(tt.expected, d); diff != "" {
+			if diff := cmp.Diff(tt.expected, d, cmp.AllowUnexported(KMSSecretData{})); diff != "" {
 				t.Errorf("unexpected result (-want +got):\n%s", diff)
 			}
 		})
@@ -157,7 +157,7 @@ func TestKMSSecretDataSetFromRawKey(t *testing.T) {
 }
 
 func TestKMSSecretDataFlatEntries(t *testing.T) {
-	d := KMSSecretData{Entries: map[string]map[string][]byte{
+	d := KMSSecretData{entries: map[string]map[string][]byte{
 		"vault-approle-secret": {
 			"role-id":   []byte("test-role-id"),
 			"secret-id": []byte("test-secret-id"),
@@ -169,7 +169,7 @@ func TestKMSSecretDataFlatEntries(t *testing.T) {
 		"vault-approle-secret_secret-id": []byte("test-secret-id"),
 	}
 
-	if diff := cmp.Diff(expected, d.FlatEntries()); diff != "" {
+	if diff := cmp.Diff(expected, d.FlatEntries(), cmp.AllowUnexported(KMSSecretData{})); diff != "" {
 		t.Errorf("unexpected result (-want +got):\n%s", diff)
 	}
 


### PR DESCRIPTION
This PR applies the changes requested in https://github.com/openshift/library-go/pull/2260 as followup PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal refactoring of KMS encryption secret data handling to improve code encapsulation and maintainability. Encryption configuration validation and secret data management continue to function as expected with no changes to user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->