### PR TITLE
Review

### DIFF
--- a/test/library/encryption/helpers.go
+++ b/test/library/encryption/helpers.go
@@ -109,13 +109,13 @@ func WaitForEncryptionKeyBasedOn(t testing.TB, kubeClient kubernetes.Interface, 
 	}
 
 	if prevKeyMeta.Mode == encryptionMode {
-		waitForNoNewEncryptionKey(t, kubeClient, prevKeyMeta, namespace, labelSelector)
+		WaitForNoNewEncryptionKey(t, kubeClient, prevKeyMeta, namespace, labelSelector)
 		return
 	}
 	WaitForNextMigratedKey(t, kubeClient, prevKeyMeta, defaultTargetGRs, namespace, labelSelector)
 }
 
-func waitForNoNewEncryptionKey(t testing.TB, kubeClient kubernetes.Interface, prevKeyMeta EncryptionKeyMeta, namespace, labelSelector string) {
+func WaitForNoNewEncryptionKey(t testing.TB, kubeClient kubernetes.Interface, prevKeyMeta EncryptionKeyMeta, namespace, labelSelector string) {
 	t.Helper()
 	// given that the happy path scenario needs ~30 min
 	// waiting 5 min to see if a new key hasn't been created seems to be enough.
@@ -317,6 +317,30 @@ func determineNextEncryptionKeyName(prevKeyName, labelSelector string) (string, 
 
 	// no encryption key - the first one will look like the following
 	return fmt.Sprintf("encryption-key-%s-1", ret[1]), nil
+}
+
+// WaitForPodImagePullBackOff polls pods in the given namespace until at least one pod
+// has a container stuck in ImagePullBackOff or ErrImagePull.
+func WaitForPodImagePullBackOff(ctx context.Context, t testing.TB, kubeClient kubernetes.Interface, namespace, labelSelector string, timeout time.Duration) {
+	t.Helper()
+	t.Logf("Waiting up to %s for a pod in %s (selector=%s) to enter ImagePullBackOff", timeout, namespace, labelSelector)
+	err := wait.PollUntilContextTimeout(ctx, waitPollInterval, timeout, true, func(ctx context.Context) (bool, error) {
+		pods, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+		if err != nil {
+			t.Logf("Error listing pods: %v", err)
+			return false, nil
+		}
+		for _, pod := range pods.Items {
+			for _, cs := range append(pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses...) {
+				if cs.State.Waiting != nil && (cs.State.Waiting.Reason == "ImagePullBackOff" || cs.State.Waiting.Reason == "ErrImagePull") {
+					t.Logf("Pod %s container %s is in %s", pod.Name, cs.Name, cs.State.Waiting.Reason)
+					return true, nil
+				}
+			}
+		}
+		return false, nil
+	})
+	require.NoError(t, err, "timed out waiting for pod to enter ImagePullBackOff in namespace %s", namespace)
 }
 
 func setUpTearDown(namespace string) func(testing.TB, bool) {

--- a/test/library/encryption/scenarios.go
+++ b/test/library/encryption/scenarios.go
@@ -8,10 +8,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/rand"
-
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/rand"
 
 	configv1 "github.com/openshift/api/config/v1"
 )
@@ -276,4 +276,65 @@ func TestEncryptionRotation(ctx context.Context, t testing.TB, scenario Rotation
 	}
 
 	// TODO: assert conditions - operator and encryption migration controller must report status as active not progressing, and not failing for all scenarios
+}
+
+// ApplyEncryption applies the given encryption config to apiserver/cluster
+// without waiting for completion.
+func ApplyEncryption(ctx context.Context, t testing.TB, encryption configv1.APIServerEncryption) {
+	t.Helper()
+	cs := GetClients(t)
+	apiServer, err := cs.ApiServerConfig.Get(ctx, "cluster", metav1.GetOptions{})
+	require.NoError(t, err)
+	apiServer.Spec.Encryption = encryption
+	_, err = cs.ApiServerConfig.Update(ctx, apiServer, metav1.UpdateOptions{})
+	require.NoError(t, err)
+	t.Logf("Applied encryption config (type=%s)", encryption.Type)
+}
+
+type InvalidKMSRecoveryScenario struct {
+	BasicScenario
+	InvalidKMSProvider EncryptionProvider
+	ValidKMSProvider   EncryptionProvider
+	WaitForStuck       func(ctx context.Context, t testing.TB)
+}
+
+// TestInvalidKMSRecovery validates recovery from an invalid KMS plugin image:
+//  1. Apply KMS with invalid image — pods stuck in ImagePullBackOff, revisions stuck
+//  2. Switch to AESCBC — verify no new encryption key is created (revisions stuck)
+//  3. Apply valid KMS config — verify recovery and successful encryption
+func TestInvalidKMSRecovery(ctx context.Context, t testing.TB, scenario InvalidKMSRecoveryScenario) {
+	e := NewE(t, PrintEventsOnFailure(scenario.OperatorNamespace))
+	clientSet := GetClients(e)
+
+	steps := []testStep{
+		{name: "ApplyInvalidKMSConfig", testFunc: func(t testing.TB) {
+			if scenario.InvalidKMSProvider.Setup != nil {
+				scenario.InvalidKMSProvider.Setup(ctx, t)
+			}
+			ApplyEncryption(ctx, t, scenario.InvalidKMSProvider.APIServerEncryption)
+		}},
+		{name: "WaitForStuck", testFunc: func(t testing.TB) {
+			scenario.WaitForStuck(ctx, t)
+		}},
+		{name: "SwitchToAESCBCAndVerifyNoNewKey", testFunc: func(t testing.TB) {
+			prevKeyMeta, err := GetLastKeyMeta(t, clientSet.Kube,
+				scenario.Namespace, scenario.LabelSelector)
+			require.NoError(t, err)
+			ApplyEncryption(ctx, t, configv1.APIServerEncryption{Type: configv1.EncryptionTypeAESCBC})
+			WaitForNoNewEncryptionKey(t, clientSet.Kube, prevKeyMeta,
+				scenario.Namespace, scenario.LabelSelector)
+		}},
+		{name: "ApplyValidKMSAndVerifyRecovery", testFunc: func(t testing.TB) {
+			TestEncryptionTypeKMS(ctx, t, scenario.BasicScenario, scenario.ValidKMSProvider)
+		}},
+	}
+
+	for _, step := range steps {
+		t.Logf("=== STEP: %s ===", step.name)
+		step.testFunc(e)
+		if t.Failed() {
+			t.Errorf("stopping the test as %q step failed", step.name)
+			return
+		}
+	}
 }


### PR DESCRIPTION
Reviewed version of https://github.com/openshift/library-go/pull/2249/

Caller will use like this;

```go
 encryption.TestInvalidKMSRecovery(ctx, t, encryption.InvalidKMSRecoveryScenario{
      BasicScenario:      basicScenario, 
      InvalidKMSProvider: invalidProvider,
      ValidKMSProvider:   validProvider,
      WaitForStuck: func(ctx context.Context, t testing.TB) {
          encryption.WaitForPodImagePullBackOff(ctx, t, kubeClient, ns, selector, 10*time.Minute)
      },
  })

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced encryption testing infrastructure with improved helper functions and additional test scenarios for validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->