### PR TITLE
CNTRLPLANE-3237: operator/encryption: add FlatEntry and FormatKMSSecretDataKey helpers for secret data keys

### DIFF
--- a/pkg/operator/encryption/encryptiondata/secret.go
+++ b/pkg/operator/encryption/encryptiondata/secret.go
@@ -91,7 +91,7 @@ func FromSecret(encryptionConfigSecret *corev1.Secret) (*Config, error) {
 	// which is then split on "_" to recover secretName and dataKey.
 	var kmsPluginsSecretData KMSPluginsSecretData
 	for key, value := range encryptionConfigSecret.Data {
-		keyID, rawKey, found, err := parseSecretDataKey(key)
+		keyID, rawKey, found, err := parseKMSSecretDataKey(key)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse secret data key %s: %w", key, err)
 		}
@@ -151,8 +151,8 @@ func ToSecret(ns, name string, secretData *Config) (*corev1.Secret, error) {
 	// Each entry from FlatEntries() (e.g. "app-role_role-id") is combined with the keyID
 	// (e.g. "1") to produce "kms-plugin-secret-app-role_role-id-1".
 	for keyID, flatEntries := range secretData.KMSPluginsSecretData.FlatEntriesByKeyID() {
-		for flatKey, value := range flatEntries {
-			s.Data[encryptionConfigSecretDataPrefix+flatKey+"-"+keyID] = value
+		for rawKey, value := range flatEntries {
+			s.Data[FormatKMSSecretDataKey(rawKey, keyID)] = value
 		}
 	}
 
@@ -202,7 +202,19 @@ func ExtractUniqueAndSortedKMSConfigurations(secretData *Config) ([]*apiserverco
 	return result, nil
 }
 
-func parseSecretDataKey(dataKey string) (keyID, rawKey string, found bool, err error) {
+// FormatKMSSecretDataKey returns the data key used in the encryption-config Secret
+// for a KMS plugin secret entry: "kms-plugin-secret-{rawKey}-{keyID}",
+// where rawKey is the combined "secretName_dataKey" from KMSSecretData.FlatEntry.
+//
+// Note:
+//
+// It does not validate inputs. The callers are expected to use KMSSecretData.Set,
+// which rejects empty values and underscores in secretName.
+func FormatKMSSecretDataKey(rawKey, keyID string) string {
+	return fmt.Sprintf("%s%s-%s", encryptionConfigSecretDataPrefix, rawKey, keyID)
+}
+
+func parseKMSSecretDataKey(dataKey string) (keyID, rawKey string, found bool, err error) {
 	rest, found := strings.CutPrefix(dataKey, encryptionConfigSecretDataPrefix)
 	if !found {
 		return "", "", false, nil

--- a/pkg/operator/encryption/encryptiondata/secret_test.go
+++ b/pkg/operator/encryption/encryptiondata/secret_test.go
@@ -421,7 +421,7 @@ func TestParseSecretDataKey(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			keyID, rawKey, found, err := parseSecretDataKey(tt.dataKey)
+			keyID, rawKey, found, err := parseKMSSecretDataKey(tt.dataKey)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")

--- a/pkg/operator/encryption/state/types.go
+++ b/pkg/operator/encryption/state/types.go
@@ -126,6 +126,16 @@ func (d *KMSSecretData) SetFromRawKey(rawKey string, value []byte) error {
 	return d.Set(parts[0], parts[1], value)
 }
 
+// FlatEntry returns the combined key "secretName_dataKey" used in flat representations.
+//
+// Note:
+//
+// It does not validate inputs. The callers are expected to use Set,
+// which rejects empty values and underscores in secretName.
+func (d *KMSSecretData) FlatEntry(secretName, dataKey string) string {
+	return secretName + secretDataKeySeparator + dataKey
+}
+
 // FlatEntries returns the stored data as a flat map keyed by "secretName_dataKey".
 // "_" separates secretName from dataKey because "_" is forbidden in
 // Kubernetes secret names, making the split unambiguous.
@@ -136,7 +146,7 @@ func (d *KMSSecretData) FlatEntries() map[string][]byte {
 	result := map[string][]byte{}
 	for secretName, keys := range d.entries {
 		for dataKey, value := range keys {
-			result[secretName+secretDataKeySeparator+dataKey] = value
+			result[d.FlatEntry(secretName, dataKey)] = value
 		}
 	}
 	return result


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved KMS plugin secret data key parsing and formatting to enhance internal code structure and maintainability.
  * Introduced new helper utilities for consistent key formatting and flat entry generation in encryption data handling.

* **Tests**
  * Updated encryption key parsing test coverage to reflect internal improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->