### PR TITLE
CNTRLPLANE-3237: operator/encryption: make FlatEntry validate that the entry exists

### DIFF
--- a/pkg/operator/encryption/state/types.go
+++ b/pkg/operator/encryption/state/types.go
@@ -126,13 +126,16 @@ func (d *KMSSecretData) SetFromRawKey(rawKey string, value []byte) error {
 	return d.Set(parts[0], parts[1], value)
 }
 
-// FlatEntry returns the combined key "secretName_dataKey" used in flat representations.
-//
-// Note:
-//
-// It does not validate inputs. The callers are expected to use Set,
-// which rejects empty values and underscores in secretName.
-func (d *KMSSecretData) FlatEntry(secretName, dataKey string) string {
+// FlatEntry returns the combined key "secretName_dataKey" for a stored entry.
+// It returns false if the entry does not exist.
+func (d *KMSSecretData) FlatEntry(secretName, dataKey string) (string, bool) {
+	if _, ok := d.Get(secretName, dataKey); !ok {
+		return "", false
+	}
+	return d.flatEntry(secretName, dataKey), true
+}
+
+func (d *KMSSecretData) flatEntry(secretName, dataKey string) string {
 	return secretName + secretDataKeySeparator + dataKey
 }
 
@@ -146,7 +149,7 @@ func (d *KMSSecretData) FlatEntries() map[string][]byte {
 	result := map[string][]byte{}
 	for secretName, keys := range d.entries {
 		for dataKey, value := range keys {
-			result[d.FlatEntry(secretName, dataKey)] = value
+			result[d.flatEntry(secretName, dataKey)] = value
 		}
 	}
 	return result


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation in encryption key management systems to properly verify existence of secret entries before processing, improving reliability when handling encrypted data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->