### PR TITLE
OCPBUGS-85367: controllercmd,certsyncpod: add UserAgentSuffix to distinguish clients

### DIFF
--- a/pkg/controller/controllercmd/builder.go
+++ b/pkg/controller/controllercmd/builder.go
@@ -3,11 +3,12 @@ package controllercmd
 import (
 	"context"
 	"fmt"
-	"k8s.io/utils/clock"
 	"os"
 	"strings"
 	"sync"
 	"time"
+
+	"k8s.io/utils/clock"
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
@@ -106,6 +107,10 @@ type ControllerBuilder struct {
 	enableHTTP2 bool
 
 	skipInClusterAuthLookup bool
+
+	// userAgentSuffix is appended to the default UserAgent string on REST
+	// clients created by this builder. Set via WithUserAgentSuffix.
+	userAgentSuffix string
 }
 
 type TopologyDetector interface {
@@ -251,6 +256,13 @@ func (b *ControllerBuilder) WithEventRecorderOptions(options record.CorrelatorOp
 	return b
 }
 
+// WithUserAgentSuffix appends the given suffix to the default UserAgent on REST
+// clients created by this builder, making requests distinguishable by component.
+func (b *ControllerBuilder) WithUserAgentSuffix(suffix string) *ControllerBuilder {
+	b.userAgentSuffix = suffix
+	return b
+}
+
 // WithComponentOwnerReference overrides controller reference resolution for event recording
 func (b *ControllerBuilder) WithComponentOwnerReference(reference *corev1.ObjectReference) *ControllerBuilder {
 	b.componentOwnerReference = reference
@@ -262,6 +274,10 @@ func (b *ControllerBuilder) Run(ctx context.Context, config *unstructured.Unstru
 	clientConfig, err := b.getClientConfig()
 	if err != nil {
 		return err
+	}
+
+	if len(b.userAgentSuffix) > 0 {
+		rest.AddUserAgent(clientConfig, b.userAgentSuffix)
 	}
 
 	if b.fileObserver != nil {

--- a/pkg/controller/controllercmd/builder_test.go
+++ b/pkg/controller/controllercmd/builder_test.go
@@ -8,9 +8,12 @@ import (
 	"testing"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/utils/clock"
+
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/library-go/pkg/operator/events/eventstesting"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestControllerBuilder_getOnStartedLeadingFunc(t *testing.T) {
@@ -243,6 +246,47 @@ func TestInfraStatusTopologyLeaderElection(t *testing.T) {
 			leConfig := topologyLeaderElection(tc.topology, tc.original)
 			if !reflect.DeepEqual(tc.expected, leConfig) {
 				t.Errorf("expected %#v, got %#v", tc.expected, leConfig)
+			}
+		})
+	}
+}
+
+func TestWithUserAgentSuffix(t *testing.T) {
+	tests := []struct {
+		name                string
+		withUserAgentSuffix string
+		wantSuffix          string
+	}{
+		{
+			name:                "suffix is appended to default user agent",
+			withUserAgentSuffix: "cert-recovery",
+			wantSuffix:          "/cert-recovery",
+		},
+		{
+			name:                "no suffix leaves user agent empty for default handling",
+			withUserAgentSuffix: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := NewController("test-component", nil, clock.RealClock{}).
+				WithUserAgentSuffix(tt.withUserAgentSuffix)
+
+			cfg := &rest.Config{}
+			if len(b.userAgentSuffix) > 0 {
+				rest.AddUserAgent(cfg, b.userAgentSuffix)
+			}
+
+			if tt.withUserAgentSuffix == "" {
+				if cfg.UserAgent != "" {
+					t.Errorf("expected empty UserAgent, got %q", cfg.UserAgent)
+				}
+				return
+			}
+
+			if !strings.HasSuffix(cfg.UserAgent, tt.wantSuffix) {
+				t.Errorf("expected UserAgent to end with %q, but UserAgent is %q", tt.wantSuffix, cfg.UserAgent)
 			}
 		})
 	}

--- a/pkg/controller/controllercmd/cmd.go
+++ b/pkg/controller/controllercmd/cmd.go
@@ -82,6 +82,10 @@ type ControllerCommandConfig struct {
 	ComponentOwnerReference *corev1.ObjectReference
 	healthChecks            []healthz.HealthChecker
 	eventRecorderOptions    record.CorrelatorOptions
+
+	// UserAgentSuffix is appended to the default UserAgent on REST clients,
+	// making requests from this component distinguishable.
+	UserAgentSuffix string
 }
 
 // NewControllerConfig returns a new ControllerCommandConfig which can be used to wire up all the boiler plate of a controller
@@ -341,7 +345,8 @@ func (c *ControllerCommandConfig) StartController(ctx context.Context) error {
 		WithHealthChecks(c.healthChecks...).
 		WithEventRecorderOptions(c.eventRecorderOptions).
 		WithRestartOnChange(exitOnChangeReactorCh, startingFileContent, observedFiles...).
-		WithComponentOwnerReference(c.ComponentOwnerReference)
+		WithComponentOwnerReference(c.ComponentOwnerReference).
+		WithUserAgentSuffix(c.UserAgentSuffix)
 
 	if !c.DisableServing {
 		builder = builder.WithServer(config.ServingInfo, config.Authentication, config.Authorization)

--- a/pkg/operator/staticpod/certsyncpod/certsync_cmd.go
+++ b/pkg/operator/staticpod/certsyncpod/certsync_cmd.go
@@ -2,9 +2,10 @@ package certsyncpod
 
 import (
 	"context"
-	"k8s.io/utils/clock"
 	"os"
 	"time"
+
+	"k8s.io/utils/clock"
 
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
@@ -118,6 +119,8 @@ func (o *CertSyncControllerOptions) Complete() error {
 	if err != nil {
 		return err
 	}
+
+	rest.AddUserAgent(kubeConfig, "cert-syncer")
 
 	if len(o.Namespace) == 0 && len(os.Getenv("POD_NAMESPACE")) > 0 {
 		o.Namespace = os.Getenv("POD_NAMESPACE")


### PR DESCRIPTION
Add `WithUserAgentSuffix` to `ControllerBuilder` and expose `UserAgentSuffix` on `ControllerCommandConfig` so that static pod sidecar controllers using localhost can be identified by the kube-apiserver's pre-readiness request filter.

The `cert-syncer`, which does not use `controllercmd`, sets its suffix directly in `Complete()`.

---

Note that this does not generate super pretty `UserAgent` strings. When you run the test, you get something like

```
___TestWithUserAgentSuffix_in_github_com_openshift_library_go_pkg_controller_controllercmd.test/v0.0.0 (linux/amd64) kubernetes/$Format/cert-recovery
```

So to check for a particular component, you need to do `HasPrefix("cluster-kube-controller-manager-operator") && HasSuffix(/cert-syncer), for example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Controllers now support a configurable REST client User-Agent suffix, which is appended to outgoing requests for clearer identification.

* **Tests**
  * Added coverage to verify the User-Agent suffix behavior, including the “empty suffix” and “appended suffix” cases.

* **Documentation / Chores**
  * Reorganized import ordering where applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->