### PR TITLE
NO-JIRA: Rename to KMSReferenceData and KMSPluginsReferenceData

### DIFF
--- a/pkg/operator/encryption/controllers/state_controller_test.go
+++ b/pkg/operator/encryption/controllers/state_controller_test.go
@@ -1263,7 +1263,7 @@ func validateSecretWithEncryptionConfig(actualSecret *corev1.Secret, expectedEnc
 		return fmt.Errorf("failed to verfy the encryption config, due to %v", err)
 	}
 
-	cmpOpt := cmp.AllowUnexported(encryptiondata.KMSPluginsSecretData{}, state.KMSSecretData{})
+	cmpOpt := cmp.AllowUnexported(encryptiondata.KMSPluginsReferenceData{}, state.KMSReferenceData{})
 	if !cmp.Equal(expectedEncryptionCfg, actualEncryptionCfg, cmpOpt) {
 		return fmt.Errorf("%s", cmp.Diff(expectedEncryptionCfg, actualEncryptionCfg, cmpOpt))
 	}

--- a/pkg/operator/encryption/encryptiondata/config.go
+++ b/pkg/operator/encryption/encryptiondata/config.go
@@ -32,34 +32,34 @@ type Config struct {
 	KMSPlugins map[string]configv1.KMSPluginConfig
 	// KMSPluginsSecretData maps keyID to secret data carried from
 	// Key Secrets into the encryption-config Secret.
-	// Structure: keyID → secretName → dataKey → value.
-	KMSPluginsSecretData KMSPluginsSecretData
+	// Structure: keyID → referenceName → dataKey → value.
+	KMSPluginsSecretData KMSPluginsReferenceData
 }
 
-// KMSPluginsSecretData maps keyID to secret data carried from Key Secrets into
-// the encryption-config Secret. Structure: keyID → secretName → dataKey → value.
-type KMSPluginsSecretData struct {
-	byKeyID map[string]state.KMSSecretData
+// KMSPluginsReferenceData maps keyID to reference data carried from Key Secrets into
+// the encryption-config Secret. Structure: keyID → referenceName → dataKey → value.
+type KMSPluginsReferenceData struct {
+	byKeyID map[string]state.KMSReferenceData
 }
 
-// Get returns the KMSSecretData for the given keyID and true if it exists,
+// Get returns the KMSReferenceData for the given keyID and true if it exists,
 // or a zero value and false otherwise. It is safe to call on a nil map.
-func (d *KMSPluginsSecretData) Get(keyID string) (state.KMSSecretData, bool) {
+func (d *KMSPluginsReferenceData) Get(keyID string) (state.KMSReferenceData, bool) {
 	if d.byKeyID == nil {
-		return state.KMSSecretData{}, false
+		return state.KMSReferenceData{}, false
 	}
 	sd, ok := d.byKeyID[keyID]
 	return sd, ok
 }
 
 // SetFromRawKey stores a value for the given keyID, splitting rawKey
-// on "_" into secretName and dataKey.
-func (d *KMSPluginsSecretData) SetFromRawKey(keyID, rawKey string, value []byte) error {
+// on "_" into referenceName and dataKey.
+func (d *KMSPluginsReferenceData) SetFromRawKey(keyID, rawKey string, value []byte) error {
 	if len(keyID) == 0 {
 		return fmt.Errorf("keyID must not be empty")
 	}
 	if d.byKeyID == nil {
-		d.byKeyID = map[string]state.KMSSecretData{}
+		d.byKeyID = map[string]state.KMSReferenceData{}
 	}
 	sd := d.byKeyID[keyID]
 	if err := sd.SetFromRawKey(rawKey, value); err != nil {
@@ -70,8 +70,8 @@ func (d *KMSPluginsSecretData) SetFromRawKey(keyID, rawKey string, value []byte)
 }
 
 // FlatEntriesByKeyID returns the stored data as a map of keyID to flat entries,
-// where each flat entry is keyed by "secretName_dataKey".
-func (d *KMSPluginsSecretData) FlatEntriesByKeyID() map[string]map[string][]byte {
+// where each flat entry is keyed by "referenceName_dataKey".
+func (d *KMSPluginsReferenceData) FlatEntriesByKeyID() map[string]map[string][]byte {
 	if d.byKeyID == nil {
 		return nil
 	}
@@ -92,7 +92,7 @@ func (c *Config) HasEncryptionConfiguration() bool {
 func FromEncryptionState(encryptionState map[schema.GroupResource]state.GroupResourceState) (*Config, error) {
 	resourceConfigs := make([]apiserverconfigv1.ResourceConfiguration, 0, len(encryptionState))
 	var kmsPlugins map[string]configv1.KMSPluginConfig
-	var kmsPluginsSecretData KMSPluginsSecretData
+	var kmsPluginsSecretData KMSPluginsReferenceData
 
 	for gr, grKeys := range encryptionState {
 		resourceConfigs = append(resourceConfigs, apiserverconfigv1.ResourceConfiguration{

--- a/pkg/operator/encryption/encryptiondata/config_test.go
+++ b/pkg/operator/encryption/encryptiondata/config_test.go
@@ -803,7 +803,7 @@ func TestFromEncryptionStateKMSSecretDataValidation(t *testing.T) {
 		name            string
 		encryptionState map[schema.GroupResource]state.GroupResourceState
 		expectedErr     string
-		expectedData    encryptiondata.KMSPluginsSecretData
+		expectedData    encryptiondata.KMSPluginsReferenceData
 	}{
 		{
 			name: "matching secret data across resources",
@@ -815,8 +815,8 @@ func TestFromEncryptionStateKMSSecretDataValidation(t *testing.T) {
 						KMS: &state.KMSState{
 							Encryption: &apiserverconfigv1.KMSConfiguration{APIVersion: "v2", Name: "1", Endpoint: "unix:///var/run/kmsplugin/kms-1.sock"},
 							Plugin:     encryptiontesting.DefaultKMSPluginConfig,
-							PluginSecretData: func() state.KMSSecretData {
-								var sd state.KMSSecretData
+							PluginSecretData: func() state.KMSReferenceData {
+								var sd state.KMSReferenceData
 								sd.Set("vault-approle-secret", "role-id", []byte("test-role-id"))
 								sd.Set("vault-approle-secret", "secret-id", []byte("test-secret-id"))
 								return sd
@@ -831,8 +831,8 @@ func TestFromEncryptionStateKMSSecretDataValidation(t *testing.T) {
 						KMS: &state.KMSState{
 							Encryption: &apiserverconfigv1.KMSConfiguration{APIVersion: "v2", Name: "1", Endpoint: "unix:///var/run/kmsplugin/kms-1.sock"},
 							Plugin:     encryptiontesting.DefaultKMSPluginConfig,
-							PluginSecretData: func() state.KMSSecretData {
-								var sd state.KMSSecretData
+							PluginSecretData: func() state.KMSReferenceData {
+								var sd state.KMSReferenceData
 								sd.Set("vault-approle-secret", "role-id", []byte("test-role-id"))
 								sd.Set("vault-approle-secret", "secret-id", []byte("test-secret-id"))
 								return sd
@@ -841,8 +841,8 @@ func TestFromEncryptionStateKMSSecretDataValidation(t *testing.T) {
 					}},
 				},
 			},
-			expectedData: func() encryptiondata.KMSPluginsSecretData {
-				var sd encryptiondata.KMSPluginsSecretData
+			expectedData: func() encryptiondata.KMSPluginsReferenceData {
+				var sd encryptiondata.KMSPluginsReferenceData
 				sd.SetFromRawKey("1", "vault-approle-secret_role-id", []byte("test-role-id"))
 				sd.SetFromRawKey("1", "vault-approle-secret_secret-id", []byte("test-secret-id"))
 				return sd
@@ -858,8 +858,8 @@ func TestFromEncryptionStateKMSSecretDataValidation(t *testing.T) {
 						KMS: &state.KMSState{
 							Encryption: &apiserverconfigv1.KMSConfiguration{APIVersion: "v2", Name: "1", Endpoint: "unix:///var/run/kmsplugin/kms-1.sock"},
 							Plugin:     encryptiontesting.DefaultKMSPluginConfig,
-							PluginSecretData: func() state.KMSSecretData {
-								var sd state.KMSSecretData
+							PluginSecretData: func() state.KMSReferenceData {
+								var sd state.KMSReferenceData
 								sd.Set("vault-approle-secret", "role-id", []byte("role-id-a"))
 								return sd
 							}(),
@@ -873,8 +873,8 @@ func TestFromEncryptionStateKMSSecretDataValidation(t *testing.T) {
 						KMS: &state.KMSState{
 							Encryption: &apiserverconfigv1.KMSConfiguration{APIVersion: "v2", Name: "1", Endpoint: "unix:///var/run/kmsplugin/kms-1.sock"},
 							Plugin:     encryptiontesting.DefaultKMSPluginConfig,
-							PluginSecretData: func() state.KMSSecretData {
-								var sd state.KMSSecretData
+							PluginSecretData: func() state.KMSReferenceData {
+								var sd state.KMSReferenceData
 								sd.Set("vault-approle-secret", "role-id", []byte("role-id-b"))
 								return sd
 							}(),
@@ -916,7 +916,7 @@ func TestFromEncryptionStateKMSSecretDataValidation(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			cmpOpt := cmp.AllowUnexported(encryptiondata.KMSPluginsSecretData{}, state.KMSSecretData{})
+			cmpOpt := cmp.AllowUnexported(encryptiondata.KMSPluginsReferenceData{}, state.KMSReferenceData{})
 			if !cmp.Equal(tt.expectedData, cfg.KMSPluginsSecretData, cmpOpt) {
 				t.Fatalf("unexpected secret data: %s", cmp.Diff(tt.expectedData, cfg.KMSPluginsSecretData, cmpOpt))
 			}
@@ -1002,8 +1002,8 @@ func TestSecretRoundtrip(t *testing.T) {
 				KMSPlugins: map[string]configv1.KMSPluginConfig{
 					"1": encryptiontesting.DefaultKMSPluginConfig,
 				},
-				KMSPluginsSecretData: func() encryptiondata.KMSPluginsSecretData {
-					var sd encryptiondata.KMSPluginsSecretData
+				KMSPluginsSecretData: func() encryptiondata.KMSPluginsReferenceData {
+					var sd encryptiondata.KMSPluginsReferenceData
 					sd.SetFromRawKey("1", "vault-approle-secret_role-id", []byte("test-role-id"))
 					sd.SetFromRawKey("1", "vault-approle-secret_secret-id", []byte("test-secret-id"))
 					return sd
@@ -1043,8 +1043,8 @@ func TestSecretRoundtrip(t *testing.T) {
 					"1": encryptiontesting.DefaultKMSPluginConfig,
 					"2": encryptiontesting.DefaultKMSPluginConfig,
 				},
-				KMSPluginsSecretData: func() encryptiondata.KMSPluginsSecretData {
-					var sd encryptiondata.KMSPluginsSecretData
+				KMSPluginsSecretData: func() encryptiondata.KMSPluginsReferenceData {
+					var sd encryptiondata.KMSPluginsReferenceData
 					sd.SetFromRawKey("1", "vault-approle-secret_role-id", []byte("role-id-1"))
 					sd.SetFromRawKey("1", "vault-approle-secret_secret-id", []byte("secret-id-1"))
 					sd.SetFromRawKey("2", "vault-approle-secret_role-id", []byte("role-id-2"))
@@ -1100,7 +1100,7 @@ func TestSecretRoundtrip(t *testing.T) {
 			if err != nil {
 				t.Fatalf("FromSecret() error: %v", err)
 			}
-			cmpOpt := cmp.AllowUnexported(encryptiondata.KMSPluginsSecretData{}, state.KMSSecretData{})
+			cmpOpt := cmp.AllowUnexported(encryptiondata.KMSPluginsReferenceData{}, state.KMSReferenceData{})
 			if !cmp.Equal(tt.cfg, got, cmpOpt) {
 				t.Errorf("roundtrip mismatch:\n%s", cmp.Diff(tt.cfg, got, cmpOpt))
 			}
@@ -1127,18 +1127,18 @@ func TestToSecretSecretDataEdgeCases(t *testing.T) {
 
 	tests := []struct {
 		name             string
-		secretData       encryptiondata.KMSPluginsSecretData
+		secretData       encryptiondata.KMSPluginsReferenceData
 		wantErr          bool
 		expectedDataKeys map[string][]byte
 	}{
 		{
 			name:       "empty secret data produces no extra keys",
-			secretData: encryptiondata.KMSPluginsSecretData{},
+			secretData: encryptiondata.KMSPluginsReferenceData{},
 		},
 		{
 			name: "valid secret data produces correct data keys",
-			secretData: func() encryptiondata.KMSPluginsSecretData {
-				var sd encryptiondata.KMSPluginsSecretData
+			secretData: func() encryptiondata.KMSPluginsReferenceData {
+				var sd encryptiondata.KMSPluginsReferenceData
 				sd.SetFromRawKey("1", "vault-approle-secret_role-id", []byte("test-role-id"))
 				sd.SetFromRawKey("1", "vault-approle-secret_secret-id", []byte("test-secret-id"))
 				return sd
@@ -1150,8 +1150,8 @@ func TestToSecretSecretDataEdgeCases(t *testing.T) {
 		},
 		{
 			name: "multiple secrets within same keyID",
-			secretData: func() encryptiondata.KMSPluginsSecretData {
-				var sd encryptiondata.KMSPluginsSecretData
+			secretData: func() encryptiondata.KMSPluginsReferenceData {
+				var sd encryptiondata.KMSPluginsReferenceData
 				sd.SetFromRawKey("1", "secret-a_key-1", []byte("val-a1"))
 				sd.SetFromRawKey("1", "secret-b_key-2", []byte("val-b2"))
 				return sd
@@ -1221,7 +1221,7 @@ func TestFromSecretSecretData(t *testing.T) {
 	tests := []struct {
 		name         string
 		extraData    map[string][]byte
-		expectedData encryptiondata.KMSPluginsSecretData
+		expectedData encryptiondata.KMSPluginsReferenceData
 	}{
 		{
 			name: "secret data keys are parsed correctly",
@@ -1229,8 +1229,8 @@ func TestFromSecretSecretData(t *testing.T) {
 				"kms-plugin-secret-vault-approle-secret_role-id-1":   []byte("test-role-id"),
 				"kms-plugin-secret-vault-approle-secret_secret-id-1": []byte("test-secret-id"),
 			},
-			expectedData: func() encryptiondata.KMSPluginsSecretData {
-				var sd encryptiondata.KMSPluginsSecretData
+			expectedData: func() encryptiondata.KMSPluginsReferenceData {
+				var sd encryptiondata.KMSPluginsReferenceData
 				sd.SetFromRawKey("1", "vault-approle-secret_role-id", []byte("test-role-id"))
 				sd.SetFromRawKey("1", "vault-approle-secret_secret-id", []byte("test-secret-id"))
 				return sd
@@ -1254,8 +1254,8 @@ func TestFromSecretSecretData(t *testing.T) {
 				"kms-plugin-secret-vault-approle-secret_role-id-2":   []byte("role-id-2"),
 				"kms-plugin-secret-vault-approle-secret_secret-id-2": []byte("secret-id-2"),
 			},
-			expectedData: func() encryptiondata.KMSPluginsSecretData {
-				var sd encryptiondata.KMSPluginsSecretData
+			expectedData: func() encryptiondata.KMSPluginsReferenceData {
+				var sd encryptiondata.KMSPluginsReferenceData
 				sd.SetFromRawKey("1", "vault-approle-secret_role-id", []byte("role-id-1"))
 				sd.SetFromRawKey("1", "vault-approle-secret_secret-id", []byte("secret-id-1"))
 				sd.SetFromRawKey("2", "vault-approle-secret_role-id", []byte("role-id-2"))
@@ -1276,7 +1276,7 @@ func TestFromSecretSecretData(t *testing.T) {
 			if err != nil {
 				t.Fatalf("FromSecret() error: %v", err)
 			}
-			cmpOpt := cmp.AllowUnexported(encryptiondata.KMSPluginsSecretData{}, state.KMSSecretData{})
+			cmpOpt := cmp.AllowUnexported(encryptiondata.KMSPluginsReferenceData{}, state.KMSReferenceData{})
 			if !cmp.Equal(tt.expectedData, cfg.KMSPluginsSecretData, cmpOpt) {
 				t.Fatalf("unexpected secret data: %s", cmp.Diff(tt.expectedData, cfg.KMSPluginsSecretData, cmpOpt))
 			}

--- a/pkg/operator/encryption/encryptiondata/secret.go
+++ b/pkg/operator/encryption/encryptiondata/secret.go
@@ -89,7 +89,7 @@ func FromSecret(encryptionConfigSecret *corev1.Secret) (*Config, error) {
 	// (e.g. "kms-plugin-secret-app-role_role-id-1"). keyIDFromSecretDataKey
 	// returns the keyID (e.g. "1") and the combined key (e.g. "app-role_role-id"),
 	// which is then split on "_" to recover secretName and dataKey.
-	var kmsPluginsSecretData KMSPluginsSecretData
+	var kmsPluginsSecretData KMSPluginsReferenceData
 	for key, value := range encryptionConfigSecret.Data {
 		keyID, rawKey, found, err := parseKMSSecretDataKey(key)
 		if err != nil {

--- a/pkg/operator/encryption/secrets/secrets_test.go
+++ b/pkg/operator/encryption/secrets/secrets_test.go
@@ -200,8 +200,8 @@ func TestRoundtrip(t *testing.T) {
 						Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 					},
 					Plugin: defaultKMSPluginConfig,
-					PluginSecretData: func() state.KMSSecretData {
-						var sd state.KMSSecretData
+					PluginSecretData: func() state.KMSReferenceData {
+						var sd state.KMSReferenceData
 						sd.Set("vault-approle-secret", "role-id", []byte("test-role-id"))
 						sd.Set("vault-approle-secret", "secret-id", []byte("test-secret-id"))
 						return sd

--- a/pkg/operator/encryption/state/types.go
+++ b/pkg/operator/encryption/state/types.go
@@ -18,10 +18,10 @@ const (
 Altering of the encryption secrets will render you cluster inaccessible.
 Catastrophic data loss can occur from the most minor changes.`
 
-	// secretDataKeySeparator separates the secret name from the data key.
+	// referenceDataKeySeparator separates the reference name from the data key.
 	// Underscore is used because it is forbidden in Kubernetes secret/configmap
 	// names, preventing collisions.
-	secretDataKeySeparator = "_"
+	referenceDataKeySeparator = "_"
 )
 
 // GroupResourceState represents, for a single group resource, the write and read keys in a
@@ -73,25 +73,25 @@ type KMSState struct {
 	Plugin configv1.KMSPluginConfig
 
 	// PluginSecretData stores data key-value pairs fetched from referenced secrets.
-	PluginSecretData KMSSecretData
+	PluginSecretData KMSReferenceData
 }
 
-// KMSSecretData stores data key-value pairs fetched from referenced secrets.
-// entries maps secret names to their data key-value pairs.
-type KMSSecretData struct {
+// KMSReferenceData stores data key-value pairs fetched from referenced secrets or configmaps.
+// entries maps reference names (secret or configmap) to their data key-value pairs.
+type KMSReferenceData struct {
 	entries map[string]map[string][]byte
 }
 
-// Get returns the value for the given secretName and dataKey. It returns false if
-// secretName or dataKey is empty, if Entries is nil, or if the key does not exist.
-func (d *KMSSecretData) Get(secretName, dataKey string) ([]byte, bool) {
-	if len(secretName) == 0 || len(dataKey) == 0 {
+// Get returns the value for the given referenceName and dataKey. It returns false if
+// referenceName or dataKey is empty, if Entries is nil, or if the key does not exist.
+func (d *KMSReferenceData) Get(referenceName, dataKey string) ([]byte, bool) {
+	if len(referenceName) == 0 || len(dataKey) == 0 {
 		return nil, false
 	}
 	if d.entries == nil {
 		return nil, false
 	}
-	secretEntries, ok := d.entries[secretName]
+	secretEntries, ok := d.entries[referenceName]
 	if !ok {
 		return nil, false
 	}
@@ -99,50 +99,54 @@ func (d *KMSSecretData) Get(secretName, dataKey string) ([]byte, bool) {
 	return value, ok
 }
 
-func (d *KMSSecretData) Set(secretName, dataKey string, value []byte) error {
-	if len(secretName) == 0 || len(dataKey) == 0 || len(value) == 0 {
-		return fmt.Errorf("secretName, dataKey, and value must not be empty")
+func (d *KMSReferenceData) Set(referenceName, dataKey string, value []byte) error {
+	if len(referenceName) == 0 || len(dataKey) == 0 || len(value) == 0 {
+		return fmt.Errorf("referenceName, dataKey, and value must not be empty")
 	}
-	if strings.Contains(secretName, "_") {
-		return fmt.Errorf("secret name %q must not contain underscores", secretName)
+	if strings.Contains(referenceName, "_") {
+		return fmt.Errorf("referenceName name %q must not contain underscores", referenceName)
 	}
 	if d.entries == nil {
 		d.entries = map[string]map[string][]byte{}
 	}
-	if d.entries[secretName] == nil {
-		d.entries[secretName] = map[string][]byte{}
+	if d.entries[referenceName] == nil {
+		d.entries[referenceName] = map[string][]byte{}
 	}
-	d.entries[secretName][dataKey] = value
+	d.entries[referenceName][dataKey] = value
 	return nil
 }
 
-// SetFromRawKey splits a combined key of the form "secretName_dataKey"
+// SetFromRawKey splits a combined key of the form "referenceName_dataKey"
 // and stores the value.
-func (d *KMSSecretData) SetFromRawKey(rawKey string, value []byte) error {
-	parts := strings.SplitN(rawKey, secretDataKeySeparator, 2)
+func (d *KMSReferenceData) SetFromRawKey(rawKey string, value []byte) error {
+	parts := strings.SplitN(rawKey, referenceDataKeySeparator, 2)
 	if len(parts) != 2 {
-		return fmt.Errorf("invalid combined key %q: expected format {secretName}%s{dataKey}", rawKey, secretDataKeySeparator)
+		return fmt.Errorf("invalid combined key %q: expected format {referenceName}%s{dataKey}", rawKey, referenceDataKeySeparator)
 	}
 	return d.Set(parts[0], parts[1], value)
 }
 
-// FlatEntry returns the combined key "secretName_dataKey" for a stored entry.
-// It returns false if the entry does not exist.
-func (d *KMSSecretData) FlatEntry(secretName, dataKey string) (string, bool) {
-	if _, ok := d.Get(secretName, dataKey); !ok {
+// FlatEntry returns the combined key "referenceName_dataKey" used in flat representations.
+//
+// Note:
+//
+// It does not validate inputs. The callers are expected to use Set,
+// which rejects empty values and underscores in referenceName.
+func (d *KMSReferenceData) FlatEntry(referenceName, dataKey string) (string, bool) {
+	if _, ok := d.Get(referenceName, dataKey); !ok {
 		return "", false
 	}
-	return d.flatEntry(secretName, dataKey), true
+	return d.flatEntry(referenceName, dataKey), true
 }
 
-func (d *KMSSecretData) flatEntry(secretName, dataKey string) string {
-	return secretName + secretDataKeySeparator + dataKey
+func (d *KMSReferenceData) flatEntry(referenceName, dataKey string) string {
+	return referenceName + referenceDataKeySeparator + dataKey
 }
 
-// FlatEntries returns the stored data as a flat map keyed by "secretName_dataKey".
-// "_" separates secretName from dataKey because "_" is forbidden in
-// Kubernetes secret names, making the split unambiguous.
-func (d *KMSSecretData) FlatEntries() map[string][]byte {
+// FlatEntries returns the stored data as a flat map keyed by "referenceName_dataKey".
+// "_" separates referenceName from dataKey because "_" is forbidden in
+// Kubernetes secret/configmap names, making the split unambiguous.
+func (d *KMSReferenceData) FlatEntries() map[string][]byte {
 	if d.entries == nil {
 		return nil
 	}

--- a/pkg/operator/encryption/state/types_test.go
+++ b/pkg/operator/encryption/state/types_test.go
@@ -6,21 +6,21 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestKMSSecretDataSet(t *testing.T) {
+func TestKMSReferenceDataSet(t *testing.T) {
 	tests := []struct {
 		name       string
 		secretName string
 		dataKey    string
 		value      []byte
 		wantErr    bool
-		expected   KMSSecretData
+		expected   KMSReferenceData
 	}{
 		{
 			name:       "valid set",
 			secretName: "vault-approle-secret",
 			dataKey:    "role-id",
 			value:      []byte("test-role-id"),
-			expected: KMSSecretData{entries: map[string]map[string][]byte{
+			expected: KMSReferenceData{entries: map[string]map[string][]byte{
 				"vault-approle-secret": {"role-id": []byte("test-role-id")},
 			}},
 		},
@@ -74,7 +74,7 @@ func TestKMSSecretDataSet(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var d KMSSecretData
+			var d KMSReferenceData
 			err := d.Set(tt.secretName, tt.dataKey, tt.value)
 			if tt.wantErr {
 				if err == nil {
@@ -85,26 +85,26 @@ func TestKMSSecretDataSet(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if diff := cmp.Diff(tt.expected, d, cmp.AllowUnexported(KMSSecretData{})); diff != "" {
+			if diff := cmp.Diff(tt.expected, d, cmp.AllowUnexported(KMSReferenceData{})); diff != "" {
 				t.Errorf("unexpected result (-want +got):\n%s", diff)
 			}
 		})
 	}
 }
 
-func TestKMSSecretDataSetFromRawKey(t *testing.T) {
+func TestKMSReferenceDataSetFromRawKey(t *testing.T) {
 	tests := []struct {
 		name     string
 		rawKey   string
 		value    []byte
 		wantErr  bool
-		expected KMSSecretData
+		expected KMSReferenceData
 	}{
 		{
 			name:   "valid raw key",
 			rawKey: "vault-approle-secret_role-id",
 			value:  []byte("test-role-id"),
-			expected: KMSSecretData{entries: map[string]map[string][]byte{
+			expected: KMSReferenceData{entries: map[string]map[string][]byte{
 				"vault-approle-secret": {"role-id": []byte("test-role-id")},
 			}},
 		},
@@ -118,7 +118,7 @@ func TestKMSSecretDataSetFromRawKey(t *testing.T) {
 			name:   "multiple underscores splits on first only",
 			rawKey: "vault_approle_secret_role-id",
 			value:  []byte("v"),
-			expected: KMSSecretData{entries: map[string]map[string][]byte{
+			expected: KMSReferenceData{entries: map[string]map[string][]byte{
 				"vault": {"approle_secret_role-id": []byte("v")},
 			}},
 		},
@@ -138,7 +138,7 @@ func TestKMSSecretDataSetFromRawKey(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var d KMSSecretData
+			var d KMSReferenceData
 			err := d.SetFromRawKey(tt.rawKey, tt.value)
 			if tt.wantErr {
 				if err == nil {
@@ -149,15 +149,15 @@ func TestKMSSecretDataSetFromRawKey(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if diff := cmp.Diff(tt.expected, d, cmp.AllowUnexported(KMSSecretData{})); diff != "" {
+			if diff := cmp.Diff(tt.expected, d, cmp.AllowUnexported(KMSReferenceData{})); diff != "" {
 				t.Errorf("unexpected result (-want +got):\n%s", diff)
 			}
 		})
 	}
 }
 
-func TestKMSSecretDataFlatEntries(t *testing.T) {
-	d := KMSSecretData{entries: map[string]map[string][]byte{
+func TestKMSReferenceDataFlatEntries(t *testing.T) {
+	d := KMSReferenceData{entries: map[string]map[string][]byte{
 		"vault-approle-secret": {
 			"role-id":   []byte("test-role-id"),
 			"secret-id": []byte("test-secret-id"),
@@ -169,12 +169,12 @@ func TestKMSSecretDataFlatEntries(t *testing.T) {
 		"vault-approle-secret_secret-id": []byte("test-secret-id"),
 	}
 
-	if diff := cmp.Diff(expected, d.FlatEntries(), cmp.AllowUnexported(KMSSecretData{})); diff != "" {
+	if diff := cmp.Diff(expected, d.FlatEntries(), cmp.AllowUnexported(KMSReferenceData{})); diff != "" {
 		t.Errorf("unexpected result (-want +got):\n%s", diff)
 	}
 
 	// zero value returns nil
-	var empty KMSSecretData
+	var empty KMSReferenceData
 	if empty.FlatEntries() != nil {
 		t.Errorf("expected nil, got %v", empty.FlatEntries())
 	}


### PR DESCRIPTION
As requested in https://github.com/openshift/library-go/pull/2259#discussion_r3349166328

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Migrated the internal representation for KMS plugin secret/reference data to a new reference-oriented format.
* **Tests**
  * Updated tests and comparison helpers to align with the new reference-oriented data structures.

*No public APIs or user-visible behavior changed.*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->