### PR TITLE
CNTRLPLANE-3226: kms: validate Vault AppRole authentication secret name

### DIFF
--- a/pkg/operator/encryption/kms/pluginlifecycle/vault.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/vault.go
@@ -13,6 +13,9 @@ import (
 // It assumes the input data has been already been validated.
 func newVaultSidecarProvider(name, keyID, udsPath string, vaultConfig configv1.VaultKMSPluginConfig, creds *credentialResolver) (*vault, error) {
 	secretName := vaultConfig.Authentication.AppRole.Secret.Name
+	if secretName == "" {
+		return nil, fmt.Errorf("vault AppRole authentication secret name cannot be empty")
+	}
 
 	roleID, err := creds.Value(secretName, "role-id")
 	if err != nil {

--- a/pkg/operator/encryption/kms/pluginlifecycle/vault_test.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/vault_test.go
@@ -31,6 +31,7 @@ func TestVaultSidecarProvider_BuildSidecarContainer(t *testing.T) {
 		udsPath            string
 		inputContainers    []corev1.Container
 		expectedContainers []corev1.Container
+		expectErr          string
 	}{
 		{
 			name: "builds container with correct args",
@@ -178,6 +179,20 @@ func TestVaultSidecarProvider_BuildSidecarContainer(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "empty secret name",
+			vaultConfig: configv1.VaultKMSPluginConfig{
+				Authentication: configv1.VaultAuthentication{
+					AppRole: configv1.VaultAppRoleAuthentication{
+						Secret: configv1.VaultSecretReference{Name: ""},
+					},
+				},
+			},
+			containerName: "kms-plugin",
+			keyID:         "555",
+			udsPath:       "unix:///var/run/kmsplugin/kms-555.sock",
+			expectErr:     "vault AppRole authentication secret name cannot be empty",
+		},
 	}
 
 	for _, tt := range tests {
@@ -195,6 +210,10 @@ func TestVaultSidecarProvider_BuildSidecarContainer(t *testing.T) {
 			}
 
 			provider, err := newVaultSidecarProvider(tt.containerName, tt.keyID, tt.udsPath, tt.vaultConfig, creds)
+			if tt.expectErr != "" {
+				require.EqualError(t, err, tt.expectErr)
+				return
+			}
 			require.NoError(t, err)
 
 			container, err := provider.BuildSidecarContainer()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added validation for Vault AppRole authentication to require a secret name, providing a clearer error message when configuration is incomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->