### PR TITLE
pkg/operator/encryption/kms/health: define cobra flag interface

### DIFF
--- a/pkg/operator/encryption/kms/health/cmd.go
+++ b/pkg/operator/encryption/kms/health/cmd.go
@@ -1,0 +1,110 @@
+package health
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog/v2"
+)
+
+// kmsSocketPattern matches the socket path each co-located KMSv2 plugin is
+// mounted at, e.g. unix:///var/run/kmsplugin/kms-1.sock.
+var kmsSocketPattern = regexp.MustCompile(`^unix:///var/run/kmsplugin/kms-\d+\.sock$`)
+
+// options' flag-bound fields are exported so the struct can be logged as a
+// whole via klog.InfoS, which JSON-marshals its values.
+type options struct {
+	KMSSockets   []string
+	Interval     time.Duration
+	ReadTimeout  time.Duration
+	WriteTimeout time.Duration
+	NodeName     string
+	Kubeconfig   string
+
+	newOperatorClient func(*rest.Config) (v1helpers.OperatorClient, error)
+}
+
+func NewCommand(ctx context.Context, newOperatorClient func(*rest.Config) (v1helpers.OperatorClient, error)) *cobra.Command {
+	o := &options{
+		newOperatorClient: newOperatorClient,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "kms-health-reporter",
+		Short: "Observes co-located KMSv2 plugins and publishes status as an OperatorCondition.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.validate(); err != nil {
+				return err
+			}
+			return o.run()
+		},
+	}
+	o.addFlags(cmd.Flags())
+	return cmd
+}
+
+func (o *options) addFlags(fs *pflag.FlagSet) {
+	fs.StringSliceVar(&o.KMSSockets, "kms-sockets", nil, "KMS plugin endpoints in unix:// URI format (e.g. unix:///var/run/kmsplugin/kms-1.sock)")
+	fs.DurationVar(&o.Interval, "interval", 30*time.Second, "cadence between probe+emit cycles")
+	fs.DurationVar(&o.ReadTimeout, "read-timeout", 5*time.Second, "deadline for each Status RPC")
+	fs.DurationVar(&o.WriteTimeout, "write-timeout", 10*time.Second, "deadline for each condition update")
+	fs.StringVar(&o.NodeName, "node-name", "", "node name recorded in the condition used to help to identify the origin")
+	fs.StringVar(&o.Kubeconfig, "kubeconfig", "", "path to a kubeconfig; empty uses in-cluster config")
+}
+
+func (o *options) validate() error {
+	if len(o.KMSSockets) == 0 {
+		return fmt.Errorf("--kms-sockets is required, at least one")
+	}
+	for _, s := range o.KMSSockets {
+		if !kmsSocketPattern.MatchString(s) {
+			return fmt.Errorf("--kms-sockets entry %q must match %s", s, kmsSocketPattern)
+		}
+	}
+
+	if o.Interval <= 0 {
+		return fmt.Errorf("--interval must be positive")
+	}
+	if o.ReadTimeout <= 0 {
+		return fmt.Errorf("--read-timeout must be positive")
+	}
+	if o.WriteTimeout <= 0 {
+		return fmt.Errorf("--write-timeout must be positive")
+	}
+	if o.NodeName == "" {
+		return fmt.Errorf("--node-name is required")
+	}
+
+	return nil
+}
+
+func (o *options) run() error {
+	cfg, err := buildRESTConfig(o.Kubeconfig)
+	if err != nil {
+		return fmt.Errorf("build rest config: %w", err)
+	}
+
+	if _, err := o.newOperatorClient(cfg); err != nil {
+		return fmt.Errorf("build operator client: %w", err)
+	}
+
+	klog.InfoS("kms-health-reporter starting", "config", o)
+
+	return nil
+}
+
+func buildRESTConfig(kubeconfig string) (*rest.Config, error) {
+	if kubeconfig != "" {
+		return clientcmd.BuildConfigFromFlags("", kubeconfig)
+	}
+	return rest.InClusterConfig()
+}

--- a/pkg/operator/encryption/kms/health/cmd_test.go
+++ b/pkg/operator/encryption/kms/health/cmd_test.go
@@ -1,0 +1,116 @@
+package health
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// validOptions returns an options value that passes validate. Each test case
+// mutates a single field so the failure under test is unambiguous.
+func validOptions() *options {
+	return &options{
+		KMSSockets:   []string{"unix:///var/run/kmsplugin/kms-1.sock"},
+		Interval:     30 * time.Second,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 10 * time.Second,
+		NodeName:     "node-1",
+	}
+}
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*options)
+		wantErr bool
+	}{
+		{
+			name:   "valid",
+			mutate: func(*options) {},
+		},
+		{
+			name:    "no sockets",
+			mutate:  func(o *options) { o.KMSSockets = nil },
+			wantErr: true,
+		},
+		{
+			name:    "empty socket entry",
+			mutate:  func(o *options) { o.KMSSockets = []string{""} },
+			wantErr: true,
+		},
+		{
+			name:   "multiple valid sockets",
+			mutate: func(o *options) { o.KMSSockets = append(o.KMSSockets, "unix:///var/run/kmsplugin/kms-2.sock") },
+		},
+		{
+			name:    "socket missing unix scheme",
+			mutate:  func(o *options) { o.KMSSockets = []string{"/var/run/kmsplugin/kms-1.sock"} },
+			wantErr: true,
+		},
+		{
+			name:    "socket scheme without path",
+			mutate:  func(o *options) { o.KMSSockets = []string{"unix://"} },
+			wantErr: true,
+		},
+		{
+			name:    "socket wrong directory",
+			mutate:  func(o *options) { o.KMSSockets = []string{"unix:///tmp/kms-1.sock"} },
+			wantErr: true,
+		},
+		{
+			name:    "socket non-numeric index",
+			mutate:  func(o *options) { o.KMSSockets = []string{"unix:///var/run/kmsplugin/kms-x.sock"} },
+			wantErr: true,
+		},
+		{
+			name:    "socket missing .sock suffix",
+			mutate:  func(o *options) { o.KMSSockets = []string{"unix:///var/run/kmsplugin/kms-1"} },
+			wantErr: true,
+		},
+		{
+			name:    "socket with surrounding whitespace",
+			mutate:  func(o *options) { o.KMSSockets = []string{" unix:///var/run/kmsplugin/kms-1.sock "} },
+			wantErr: true,
+		},
+		{
+			name:    "interval zero",
+			mutate:  func(o *options) { o.Interval = 0 },
+			wantErr: true,
+		},
+		{
+			name:    "interval negative",
+			mutate:  func(o *options) { o.Interval = -time.Second },
+			wantErr: true,
+		},
+		{
+			name:    "read timeout zero",
+			mutate:  func(o *options) { o.ReadTimeout = 0 },
+			wantErr: true,
+		},
+		{
+			name:    "write timeout zero",
+			mutate:  func(o *options) { o.WriteTimeout = 0 },
+			wantErr: true,
+		},
+		{
+			name:    "node name empty",
+			mutate:  func(o *options) { o.NodeName = "" },
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			o := validOptions()
+			tc.mutate(o)
+
+			err := o.validate()
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Defines the cobra/pflag command interface for the kms-health-monitor
sidecar.

## Why

I was told to split up the PR https://github.com/openshift/library-go/pull/2161

## Notes

Used for ref https://github.com/ardaguclu/library-go/blob/21d59d1efa2b372350d178aa0696ecdc8b3a6380/pkg/operator/encryption/kms/health/cmd.go

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI tool for KMS health reporting with configurable KMS socket targets, probe interval, per-RPC read/write timeouts, node identification, and kubeconfig/in‑cluster selection; validates inputs and logs startup parameters.
* **Tests**
  * Added unit tests covering socket URI formats, multiple-socket acceptance, timing parameter validation, and node-name requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->