### PR TITLE
NO-JIRA: Configure existed CABundle for Real Vault plugin

### DIFF
--- a/test/library/encryption/kms/vault.go
+++ b/test/library/encryption/kms/vault.go
@@ -27,6 +27,7 @@ const (
 	defaultVaultPodName            = "vault-0"
 	defaultVaultCredentialsSecret  = "vault-credentials"
 	defaultVaultAppRoleSecretName  = "vault-approle-secret"
+	defaultVaultConfigMapName      = "vault-ca-bundle"
 	defaultFAKEVaultKMSPluginImage = "quay.io/openshifttest/mock-kms-plugin@sha256:958a2f8276037468aa47dc2137d3c30dfcd96489455eddb2fe655f8168a57622"
 	defaultVaultKMSPluginImage     = "registry.ci.openshift.org/control-plane-custom-builds/vault-kube-kms@sha256:33599dd6eee61dcf9a60138759fafda3d88593a3c2072585156882c6b5bd3fa5"
 	defaultVaultAddress            = "https://vault.vault-kms.svc:8200"
@@ -73,6 +74,12 @@ var DefaultVaultKMSPluginConfig = configv1.APIServerEncryption{
 				AppRole: configv1.VaultAppRoleAuthentication{
 					Secret: configv1.VaultSecretReference{Name: defaultVaultAppRoleSecretName},
 				},
+			},
+			TLS: configv1.VaultTLSConfig{
+				CABundle: configv1.VaultConfigMapReference{
+					Name: defaultVaultConfigMapName,
+				},
+				ServerName: fmt.Sprintf("vault.%s.svc", defaultVaultNamespace),
 			},
 		},
 	},


### PR DESCRIPTION
Our CI setup extracts and creates [correct ca bundle](https://github.com/openshift/release/blob/f804d662330462cc294022db55a2184c92886473/ci-operator/step-registry/etcd-encryption/vault-install/etcd-encryption-vault-install-commands.sh#L83-L97) with the [server name](https://github.com/openshift/release/blob/f804d662330462cc294022db55a2184c92886473/ci-operator/step-registry/etcd-encryption/vault-install/etcd-encryption-vault-install-commands.sh#L71).

This PR configures API for this configmap to be used by plugin lifecycle. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Vault KMS encryption provider test configuration with default TLS settings including CA bundle and server name configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->