### PR TITLE
Added new test case for update image scenario

### DIFF
--- a/test/library/encryption/helpers.go
+++ b/test/library/encryption/helpers.go
@@ -403,6 +403,34 @@ func WaitForPodImagePullBackOff(ctx context.Context, t testing.TB, kubeClient ku
 	require.NoError(t, err, "timed out waiting for pod to enter ImagePullBackOff in namespace %s", namespace)
 }
 
+// WaitForPodContainerCondition polls pods until at least one pod satisfies the given condition.
+// keyName is the current encryption key secret name, passed to match so callers can
+// correlate pod container names with the active key (e.g. vault-kms-plugin-42).
+func WaitForPodContainerCondition(ctx context.Context, t testing.TB, kubeClient kubernetes.Interface, namespace, labelSelector, keyName string, match func(pod corev1.Pod, keyName string) bool) {
+	t.Helper()
+	t.Logf("Waiting up to %s for a pod in %s (selector=%s, key=%s) to satisfy condition",
+		waitPollTimeout, namespace, labelSelector, keyName)
+	err := wait.PollUntilContextTimeout(ctx, waitPollInterval, waitPollTimeout, true, func(ctx context.Context) (bool, error) {
+		pods, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+		if err != nil {
+			t.Logf("Error listing pods: %v", err)
+			return false, nil
+		}
+		if len(pods.Items) == 0 {
+			t.Logf("No pods found yet in %s", namespace)
+			return false, nil
+		}
+		for _, pod := range pods.Items {
+			if match(pod, keyName) {
+				return true, nil
+			}
+		}
+		t.Logf("No pod yet satisfies condition")
+		return false, nil
+	})
+	require.NoError(t, err, "timed out waiting for a pod in %s to satisfy condition", namespace)
+}
+
 // WaitForCurrentKeyMigrated waits until the current (latest) encryption key has completed
 // migration for all target group resources. It fails if the key changes unexpectedly
 // (i.e. a different key than prevKeyMeta appears).

--- a/test/library/encryption/scenarios.go
+++ b/test/library/encryption/scenarios.go
@@ -353,3 +353,66 @@ func TestKMSInvalidEncryptionRecovery(ctx context.Context, t testing.TB, scenari
 		}
 	}
 }
+
+// KMSInPlaceUpdateScenario tests that updating an in-place KMS config field
+// (e.g. kmsPluginImage) takes effect without creating a new encryption key.
+// The caller supplies Provider (initial valid config) and UpdatedProvider (same config
+// with one in-place field changed).
+type KMSInPlaceUpdateScenario struct {
+	BasicScenario
+	Provider        EncryptionProvider
+	UpdatedProvider EncryptionProvider
+	// WaitForPropagation is called after the in-place update to verify the change
+	// took effect. Receives the current encryption key so callers can match pod
+	// container names to the active key. Same pattern as WaitForStuck in
+	// KMSInvalidEncryptionRecoveryScenario.
+	WaitForPropagation func(ctx context.Context, t testing.TB, keyMeta EncryptionKeyMeta)
+}
+
+// TestKMSInPlaceUpdate validates in-place KMS config field updates:
+//  1. Apply valid provider and verify migration
+//  2. Update in-place field and verify no new encryption key is created
+//  3. WaitForPropagation — caller verifies the change took effect
+func TestKMSInPlaceUpdate(ctx context.Context, t testing.TB, scenario KMSInPlaceUpdateScenario) {
+	e := NewE(t, PrintEventsOnFailure(scenario.OperatorNamespace))
+	clientSet := GetClients(e)
+
+	require.NotNil(t, scenario.Provider.Setup, "Provider.Setup must not be nil")
+	require.NotNil(t, scenario.UpdatedProvider.Setup, "UpdatedProvider.Setup must not be nil")
+	require.NotNil(t, scenario.WaitForPropagation, "WaitForPropagation must not be nil")
+	require.Equal(t, configv1.EncryptionTypeKMS, scenario.Provider.Type, "Provider must use KMS encryption type")
+	require.Equal(t, configv1.EncryptionTypeKMS, scenario.UpdatedProvider.Type, "UpdatedProvider must use KMS encryption type")
+
+	steps := []testStep{
+		{name: "ApplyValidProviderAndVerifyMigration", testFunc: func(t testing.TB) {
+			SetAndWaitForEncryptionType(ctx, t, scenario.Provider, scenario.TargetGRs,
+				scenario.Namespace, scenario.LabelSelector)
+			scenario.AssertFunc(t, clientSet, scenario.Provider.Type,
+				scenario.Namespace, scenario.LabelSelector)
+		}},
+		{name: "UpdateInPlaceField", testFunc: func(t testing.TB) {
+			keyMeta, err := GetLastKeyMeta(t, clientSet.Kube,
+				scenario.Namespace, scenario.LabelSelector)
+			require.NoError(t, err)
+			scenario.UpdatedProvider.Setup(ctx, t)
+			ApplyEncryption(ctx, t, scenario.UpdatedProvider.APIServerEncryption)
+			WaitForNoNewEncryptionKey(t, clientSet.Kube, keyMeta,
+				scenario.Namespace, scenario.LabelSelector)
+		}},
+		{name: "WaitForPropagation", testFunc: func(t testing.TB) {
+			keyMeta, err := GetLastKeyMeta(t, clientSet.Kube,
+				scenario.Namespace, scenario.LabelSelector)
+			require.NoError(t, err)
+			scenario.WaitForPropagation(ctx, t, keyMeta)
+		}},
+	}
+
+	for _, step := range steps {
+		t.Logf("=== STEP: %s ===", step.name)
+		step.testFunc(e)
+		if t.Failed() {
+			t.Errorf("stopping the test as %q step failed", step.name)
+			return
+		}
+	}
+}


### PR DESCRIPTION
Added new test case for update image scenario

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end scenario that verifies an in-place KMS configuration update does not create a new encryption key and validates propagation of the change.
  * Added a test helper that waits for at least one matching API server pod and ensures all matching pods satisfy a caller-defined container condition for more reliable rollout verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->