### PR TITLE
PoC: Rotation management in Key Controller

### DIFF
--- a/pkg/operator/encryption/controllers/key_controller.go
+++ b/pkg/operator/encryption/controllers/key_controller.go
@@ -479,6 +479,7 @@ func (c *keyController) clearMigrationAnnotations(ctx context.Context, s *corev1
 	delete(s.Annotations, secrets.EncryptionSecretMigratedTimestamp)
 	delete(s.Annotations, secrets.EncryptionSecretMigratedResources)
 	s.Annotations[secrets.EncryptionSecretMigratedKEKID] = convergedKEKID
+	s.Annotations[secrets.EncryptionSecretRotationNeeded] = ""
 	_, err := c.secretClient.Secrets(s.Namespace).Update(ctx, s, metav1.UpdateOptions{})
 	return err
 }

--- a/pkg/operator/encryption/controllers/key_controller.go
+++ b/pkg/operator/encryption/controllers/key_controller.go
@@ -192,6 +192,7 @@ func (c *keyController) checkAndCreateKeys(ctx context.Context, syncContext fact
 	var (
 		newKeyRequired bool
 		newKeyID       uint64
+		latestKeyID    uint64
 		reasons        []string
 	)
 
@@ -201,7 +202,10 @@ func (c *keyController) checkAndCreateKeys(ctx context.Context, syncContext fact
 
 	var commonReason *string
 	for gr, grKeys := range desiredEncryptionState {
-		latestKeyID, internalReason, needed := needsNewKey(grKeys, currentMode, externalReason, encryptedGRs)
+		grLatestKeyID, internalReason, needed := needsNewKey(grKeys, currentMode, externalReason, encryptedGRs)
+		if latestKeyID < grLatestKeyID {
+			latestKeyID = grLatestKeyID
+		}
 		if !needed {
 			continue
 		}
@@ -213,13 +217,16 @@ func (c *keyController) checkAndCreateKeys(ctx context.Context, syncContext fact
 		}
 
 		newKeyRequired = true
-		nextKeyID := latestKeyID + 1
+		nextKeyID := grLatestKeyID + 1
 		if newKeyID < nextKeyID {
 			newKeyID = nextKeyID
 		}
 		reasons = append(reasons, fmt.Sprintf("%s-%s", gr.Resource, internalReason))
 	}
 	if !newKeyRequired {
+		if currentMode == state.KMS {
+			return c.maybeStartKMSRotation(ctx, syncContext, latestKeyID)
+		}
 		return nil
 	}
 	if commonReason != nil && len(*commonReason) > 0 && len(reasons) > 1 {
@@ -386,7 +393,11 @@ func needsNewKey(grKeys state.GroupResourceState, currentMode state.Mode, extern
 		return 0, "", false
 	}
 
-	// we have not migrated the latest key, do nothing until that is complete
+	// We have not migrated the latest key, do nothing until that is complete.
+	// For KMS mode, KEK rotation is initiated by maybeStartKMSRotation clearing the
+	// migration annotations on the key secret. Once cleared, MigratedFor returns false
+	// here, preventing needsNewKey from requesting a new key and holding off further
+	// action until the migration controller finishes re-migrating all resources.
 	if allMigrated, _, _ := state.MigratedFor(encryptedGRs, latestKey); !allMigrated {
 		return 0, "", false
 	}
@@ -422,6 +433,54 @@ func needsNewKey(grKeys state.GroupResourceState, currentMode state.Mode, extern
 	// we check for encryptionSecretMigratedTimestamp set by migration controller to determine when migration completed
 	// this also generates back pressure for key rotation when migration takes a long time or was recently completed
 	return latestKeyID, "rotation-interval-has-passed", time.Since(latestKey.Migrated.Timestamp) > encryptionSecretMigrationInterval
+}
+
+// maybeStartKMSRotation detects whether the external KMS KEK has rotated and triggers
+// re-migration if needed. It does not create a new key secret — the keyID stays the same,
+// only the wrapping key (KEK) has changed externally.
+//
+// The flow is:
+//  1. Get the converged KEKID from health reports (all healthy nodes must agree)
+//  2. Compare it with the KEKID annotation on the key secret (from the last migration)
+//  3. If different, clear migration annotations to trigger the migration controller
+//
+// Once migration annotations are cleared, needsNewKey's MigratedFor check returns false,
+// which holds off further action until the migration controller finishes re-migrating.
+func (c *keyController) maybeStartKMSRotation(ctx context.Context, syncContext factory.SyncContext, latestKeyID uint64) error {
+	// TODO: In the full implementation, retrieve health reports from operator status
+	// and compute the converged KEKID via ConvergedKEKForKeyID(healthReports, latestKeyID).
+	// All healthy nodes must report the same KEKID for convergence.
+	// For now, this is a placeholder.
+	convergedKEKID := "" // placeholder: would come from health reports
+	if len(convergedKEKID) == 0 {
+		return nil
+	}
+
+	secretName := fmt.Sprintf("encryption-key-%s-%d", c.instanceName, latestKeyID)
+	s, err := c.secretClient.Secrets("openshift-config-managed").Get(ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get key secret %s: %v", secretName, err)
+	}
+
+	currentKEKID := s.Annotations[secrets.EncryptionSecretMigratedKEKID]
+	if currentKEKID == convergedKEKID {
+		return nil
+	}
+
+	if err := c.clearMigrationAnnotations(ctx, s, convergedKEKID); err != nil {
+		return err
+	}
+
+	syncContext.Recorder().Eventf("KMSKEKRotationDetected", "KEK rotation detected for key %d: %s -> %s, migration annotations cleared", latestKeyID, currentKEKID, convergedKEKID)
+	return nil
+}
+
+func (c *keyController) clearMigrationAnnotations(ctx context.Context, s *corev1.Secret, convergedKEKID string) error {
+	delete(s.Annotations, secrets.EncryptionSecretMigratedTimestamp)
+	delete(s.Annotations, secrets.EncryptionSecretMigratedResources)
+	s.Annotations[secrets.EncryptionSecretMigratedKEKID] = convergedKEKID
+	_, err := c.secretClient.Secrets(s.Namespace).Update(ctx, s, metav1.UpdateOptions{})
+	return err
 }
 
 // referencedSecretName returns the name of the secret referenced by the KMS plugin

--- a/pkg/operator/encryption/controllers/migration_controller.go
+++ b/pkg/operator/encryption/controllers/migration_controller.go
@@ -226,6 +226,17 @@ func (c *migrationController) migrateKeysIfNeededAndRevisionStable(ctx context.C
 			continue
 		}
 
+		// If KMS KEK rotation was detected, prune the existing StorageVersionMigration
+		// so EnsureMigration creates a fresh one. Without this, EnsureMigration would
+		// find the old completed migration (same writeKey name) and return immediately
+		// without actually re-encrypting.
+		if grActualKeys.WriteKey.RotationNeeded {
+			if err := c.migrator.PruneMigration(gr); err != nil {
+				errs = append(errs, err)
+				continue
+			}
+		}
+
 		// idem-potent migration start
 		finished, result, when, err := c.migrator.EnsureMigration(gr, grActualKeys.WriteKey.Key.Name)
 		if err == nil && finished && result != nil && time.Since(when) > migrationRetryDuration {
@@ -311,6 +322,7 @@ func setResourceMigrated(gr schema.GroupResource, s *corev1.Secret) (bool, error
 		s.Annotations = map[string]string{}
 	}
 	s.Annotations[secrets.EncryptionSecretMigratedTimestamp] = time.Now().Format(time.RFC3339)
+	delete(s.Annotations, secrets.EncryptionSecretRotationNeeded)
 
 	// update resource list
 	if !alreadyMigrated {

--- a/pkg/operator/encryption/secrets/secrets.go
+++ b/pkg/operator/encryption/secrets/secrets.go
@@ -59,6 +59,9 @@ func ToKeyState(s *corev1.Secret) (state.KeyState, error) {
 	if v, ok := s.Annotations[encryptionSecretExternalReason]; ok && len(v) > 0 {
 		key.ExternalReason = v
 	}
+	if _, ok := s.Annotations[EncryptionSecretRotationNeeded]; ok {
+		key.RotationNeeded = true
+	}
 
 	keyMode := state.Mode(s.Annotations[encryptionSecretMode])
 	switch keyMode {
@@ -148,6 +151,10 @@ func FromKeyState(component string, ks state.KeyState) (*corev1.Secret, error) {
 			EncryptionSecretKeyDataKey: bs,
 		},
 		Type: corev1.SecretTypeOpaque,
+	}
+
+	if ks.RotationNeeded {
+		s.Annotations[EncryptionSecretRotationNeeded] = ""
 	}
 
 	if !ks.Migrated.Timestamp.IsZero() {

--- a/pkg/operator/encryption/secrets/types.go
+++ b/pkg/operator/encryption/secrets/types.go
@@ -68,7 +68,8 @@ const (
 	// constructed as prefix + configMapName + separator + dataKey.
 	encryptionSecretKMSConfigMapDataPrefix = "encryption.apiserver.operator.openshift.io-kms-plugin-configmap-"
 
-	EncryptionSecretMigratedKEKID = "encryption.apiserver.operator.openshift.io/migrated-kek-id"
+	EncryptionSecretMigratedKEKID     = "encryption.apiserver.operator.openshift.io/migrated-kek-id"
+	EncryptionSecretRotationNeeded    = "encryption.apiserver.operator.openshift.io/rotation-needed"
 )
 
 // MigratedGroupResources is the data structured stored in the

--- a/pkg/operator/encryption/secrets/types.go
+++ b/pkg/operator/encryption/secrets/types.go
@@ -67,6 +67,8 @@ const (
 	// values fetched from the referenced configmap in openshift-config. The full data key is
 	// constructed as prefix + configMapName + separator + dataKey.
 	encryptionSecretKMSConfigMapDataPrefix = "encryption.apiserver.operator.openshift.io-kms-plugin-configmap-"
+
+	EncryptionSecretMigratedKEKID = "encryption.apiserver.operator.openshift.io/migrated-kek-id"
 )
 
 // MigratedGroupResources is the data structured stored in the

--- a/pkg/operator/encryption/state/types.go
+++ b/pkg/operator/encryption/state/types.go
@@ -50,6 +50,11 @@ type KeyState struct {
 	ExternalReason string
 	// stores all the KMS encryption mode related configurations
 	KMS *KMSState
+	// RotationNeeded indicates that a KMS KEK rotation has been detected and
+	// re-migration is required. Set by the key controller when the converged
+	// KEKID differs from the last migrated KEKID. The migration controller
+	// removes it after migration completes.
+	RotationNeeded bool
 }
 
 func (k *KeyState) HasKMSEncryption() bool {


### PR DESCRIPTION
This is inspired by https://github.com/openshift/library-go/pull/2286. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Automatic detection of external KMS key rotations now triggers re-migration of encrypted resources.
  * Migration state tracking for encrypted secrets enhanced; a rotation-needed flag is now recorded and cleared when migration completes.
  * Key lifecycle handling improved to coordinate creation/rotation across resources and ensure migrations are retried when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->