### PR TITLE
operator/encryption: add migration generation counter for KMS key re-migration

### DIFF
--- a/pkg/operator/encryption/controllers/key_controller.go
+++ b/pkg/operator/encryption/controllers/key_controller.go
@@ -365,8 +365,8 @@ func needsNewKey(grKeys state.GroupResourceState, currentMode state.Mode, extern
 		return 0, "", false
 	}
 
-	// we have not migrated the latest key, do nothing until that is complete
-	if allMigrated, _, _ := state.MigratedFor(encryptedGRs, latestKey); !allMigrated {
+	// we have not migrated the latest key (or re-migration is in progress), do nothing until that is complete
+	if allMigrated, _, needsRemigration, _ := state.MigratedFor(encryptedGRs, latestKey); !allMigrated || needsRemigration {
 		return 0, "", false
 	}
 

--- a/pkg/operator/encryption/controllers/migration_controller.go
+++ b/pkg/operator/encryption/controllers/migration_controller.go
@@ -216,25 +216,35 @@ func (c *migrationController) migrateKeysIfNeededAndRevisionStable(ctx context.C
 	// using a write key that another API server has not observed
 	// this could lead to etcd storing data that not all API servers can decrypt
 	var errs []error
+	remigrationPending := false
 	for _, gr := range grs {
 		grActualKeys := currentState[gr]
 		if !grActualKeys.HasWriteKey() {
 			continue // no write key to migrate to
 		}
 
-		if alreadyMigrated, _, _ := state.MigratedFor([]schema.GroupResource{gr}, grActualKeys.WriteKey); alreadyMigrated {
+		alreadyMigrated, _, needsRemigration, _ := state.MigratedFor([]schema.GroupResource{gr}, grActualKeys.WriteKey)
+		if alreadyMigrated && !needsRemigration {
 			continue
+		}
+		if needsRemigration {
+			remigrationPending = true
+		}
+
+		writeKeyForMigrator := grActualKeys.WriteKey.Key.Name
+		if grActualKeys.WriteKey.MigrationGeneration > 0 {
+			writeKeyForMigrator = fmt.Sprintf("%s-%d", writeKeyForMigrator, grActualKeys.WriteKey.MigrationGeneration)
 		}
 
 		// idem-potent migration start
-		finished, result, when, err := c.migrator.EnsureMigration(gr, grActualKeys.WriteKey.Key.Name)
+		finished, result, when, err := c.migrator.EnsureMigration(gr, writeKeyForMigrator)
 		if err == nil && finished && result != nil && time.Since(when) > migrationRetryDuration {
 			// last migration error is far enough ago. Prune and retry.
 			if err := c.migrator.PruneMigration(gr); err != nil {
 				errs = append(errs, err)
 				continue
 			}
-			finished, result, when, err = c.migrator.EnsureMigration(gr, grActualKeys.WriteKey.Key.Name)
+			finished, result, when, err = c.migrator.EnsureMigration(gr, writeKeyForMigrator)
 
 		}
 		if err != nil {
@@ -283,7 +293,44 @@ func (c *migrationController) migrateKeysIfNeededAndRevisionStable(ctx context.C
 		}
 	}
 
+	if remigrationPending && len(migratingResources) == 0 && len(errs) == 0 {
+		if err := c.updateMigratedGeneration(ctx, syncContext, currentState, grs); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
 	return migratingResources, errors.NewAggregate(errs)
+}
+
+// updateMigratedGeneration sets the migrated-generation annotation on the write key
+// secret to match the migration-generation, indicating that all resources have been
+// successfully re-migrated for the current generation.
+func (c *migrationController) updateMigratedGeneration(ctx context.Context, syncContext factory.SyncContext, currentState map[schema.GroupResource]state.GroupResourceState, grs []schema.GroupResource) error {
+	if len(grs) == 0 {
+		return nil
+	}
+	writeKey := currentState[grs[0]].WriteKey
+	writeKeySecret, err := secrets.FromKeyState(c.instanceName, writeKey)
+	if err != nil {
+		return err
+	}
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		s, err := c.secretClient.Secrets(writeKeySecret.Namespace).Get(ctx, writeKeySecret.Name, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to get key secret %s/%s: %v", writeKeySecret.Namespace, writeKeySecret.Name, err)
+		}
+		requestedGen := s.Annotations[secrets.EncryptionSecretMigrationGeneration]
+		if s.Annotations[secrets.EncryptionSecretMigratedGeneration] == requestedGen {
+			return nil
+		}
+		if s.Annotations == nil {
+			s.Annotations = map[string]string{}
+		}
+		s.Annotations[secrets.EncryptionSecretMigratedGeneration] = requestedGen
+		_, updateErr := c.secretClient.Secrets(s.Namespace).Update(ctx, s, metav1.UpdateOptions{})
+		resourcehelper.ReportUpdateEvent(syncContext.Recorder(), s, updateErr)
+		return updateErr
+	})
 }
 
 func setResourceMigrated(gr schema.GroupResource, s *corev1.Secret) (bool, error) {
@@ -303,8 +350,13 @@ func setResourceMigrated(gr schema.GroupResource, s *corev1.Secret) (bool, error
 		}
 	}
 
+	// During re-migration (generation mismatch), always refresh the timestamp
+	// even if the resource is already in the migrated list.
+	generationMismatch := s.Annotations[secrets.EncryptionSecretMigrationGeneration] != s.Annotations[secrets.EncryptionSecretMigratedGeneration] &&
+		len(s.Annotations[secrets.EncryptionSecretMigrationGeneration]) > 0
+
 	// update timestamp, if missing or first migration of gr
-	if _, found := s.Annotations[secrets.EncryptionSecretMigratedTimestamp]; found && alreadyMigrated {
+	if _, found := s.Annotations[secrets.EncryptionSecretMigratedTimestamp]; found && alreadyMigrated && !generationMismatch {
 		return false, nil
 	}
 	if s.Annotations == nil {

--- a/pkg/operator/encryption/secrets/secrets.go
+++ b/pkg/operator/encryption/secrets/secrets.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/klog/v2"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -51,6 +53,23 @@ func ToKeyState(s *corev1.Secret) (state.KeyState, error) {
 			return state.KeyState{}, fmt.Errorf("secret %s/%s has invalid %s annotation: %v", s.Namespace, s.Name, EncryptionSecretMigratedResources, err)
 		}
 		key.Migrated.Resources = migrated.Resources
+	}
+
+	if v, ok := s.Annotations[EncryptionSecretMigrationGeneration]; ok && len(v) > 0 {
+		gen, err := strconv.ParseUint(v, 10, 64)
+		if err != nil {
+			klog.V(4).Infof("secret %s/%s has invalid %s annotation %q, defaulting to 0", s.Namespace, s.Name, EncryptionSecretMigrationGeneration, v)
+		} else {
+			key.MigrationGeneration = uint(gen)
+		}
+	}
+	if v, ok := s.Annotations[EncryptionSecretMigratedGeneration]; ok && len(v) > 0 {
+		gen, err := strconv.ParseUint(v, 10, 64)
+		if err != nil {
+			klog.V(4).Infof("secret %s/%s has invalid %s annotation %q, defaulting to 0", s.Namespace, s.Name, EncryptionSecretMigratedGeneration, v)
+		} else {
+			key.Migrated.Generation = uint(gen)
+		}
 	}
 
 	if v, ok := s.Annotations[encryptionSecretInternalReason]; ok && len(v) > 0 {
@@ -151,6 +170,13 @@ func FromKeyState(component string, ks state.KeyState) (*corev1.Secret, error) {
 			return nil, err
 		}
 		s.Annotations[EncryptionSecretMigratedResources] = string(bs)
+	}
+
+	if ks.MigrationGeneration > 0 {
+		s.Annotations[EncryptionSecretMigrationGeneration] = strconv.FormatUint(uint64(ks.MigrationGeneration), 10)
+	}
+	if ks.Migrated.Generation > 0 {
+		s.Annotations[EncryptionSecretMigratedGeneration] = strconv.FormatUint(uint64(ks.Migrated.Generation), 10)
 	}
 
 	if ks.HasKMSEncryption() {

--- a/pkg/operator/encryption/secrets/secrets_test.go
+++ b/pkg/operator/encryption/secrets/secrets_test.go
@@ -217,6 +217,26 @@ func TestRoundtrip(t *testing.T) {
 				ExternalReason: "external",
 			},
 		},
+		{
+			name:      "aescbc with migration generation",
+			component: "kms",
+			ks: state.KeyState{
+				Key: v1.Key{
+					Name:   "5",
+					Secret: base64.StdEncoding.EncodeToString([]byte("abcdef")),
+				},
+				Backed: true,
+				Mode:   "aescbc",
+				Migrated: state.MigrationState{
+					Timestamp:  now,
+					Resources: []schema.GroupResource{
+						{Resource: "secrets"},
+					},
+					Generation: 2,
+				},
+				MigrationGeneration: 3,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/operator/encryption/secrets/types.go
+++ b/pkg/operator/encryption/secrets/types.go
@@ -41,6 +41,17 @@ const (
 	// determine if a new key should be created even if encryptionSecretMigrationInterval has not been reached.
 	encryptionSecretExternalReason = "encryption.apiserver.operator.openshift.io/external-reason"
 
+	// EncryptionSecretMigrationGeneration is the requested migration generation.
+	// When this value exceeds EncryptionSecretMigratedGeneration, re-migration is
+	// needed (e.g. after a remote KMS key rotation where the local secret stays the
+	// same but all data must be re-encrypted).
+	EncryptionSecretMigrationGeneration = "encryption.apiserver.operator.openshift.io/migration-generation"
+
+	// EncryptionSecretMigratedGeneration is the generation for which migration was
+	// last completed. Set by the migration controller after all resources have been
+	// successfully re-migrated for a given migration generation.
+	EncryptionSecretMigratedGeneration = "encryption.apiserver.operator.openshift.io/migrated-generation"
+
 	// In the data field of the secret API object, this (map) key is used to hold the actual encryption key
 	// (i.e. for AES-CBC mode the value associated with this map key is 32 bytes of random noise).
 	EncryptionSecretKeyDataKey = "encryption.apiserver.operator.openshift.io-key"

--- a/pkg/operator/encryption/state/helpers.go
+++ b/pkg/operator/encryption/state/helpers.go
@@ -11,7 +11,10 @@ import (
 
 // MigratedFor returns whether all given resources are marked as migrated in the given key.
 // It returns missing GRs and a reason if that's not the case.
-func MigratedFor(grs []schema.GroupResource, km KeyState) (ok bool, missing []schema.GroupResource, reason string) {
+// needsRemigration is true when all GRs have been migrated but the key's
+// MigrationGeneration exceeds its MigratedGeneration, indicating that
+// re-migration is required (e.g. after a remote KMS key rotation).
+func MigratedFor(grs []schema.GroupResource, km KeyState) (ok bool, missing []schema.GroupResource, needsRemigration bool, reason string) {
 	var missingStrings []string
 	for _, gr := range grs {
 		found := false
@@ -28,16 +31,20 @@ func MigratedFor(grs []schema.GroupResource, km KeyState) (ok bool, missing []sc
 	}
 
 	if len(missing) > 0 {
-		return false, missing, fmt.Sprintf("key ID %s misses resource %s among migrated resources", km.Key.Name, strings.Join(missingStrings, ","))
+		return false, missing, false, fmt.Sprintf("key ID %s misses resource %s among migrated resources", km.Key.Name, strings.Join(missingStrings, ","))
 	}
 
-	return true, nil, ""
+	if km.MigrationGeneration > km.Migrated.Generation {
+		return true, nil, true, fmt.Sprintf("key ID %s needs remigration: requested generation %d > migrated generation %d", km.Key.Name, km.MigrationGeneration, km.Migrated.Generation)
+	}
+
+	return true, nil, false, ""
 }
 
 // KeysWithPotentiallyPersistedDataAndNextReadKey returns the minimal, recent secrets which have migrated all given GRs.
 func KeysWithPotentiallyPersistedDataAndNextReadKey(grs []schema.GroupResource, recentFirstSortedKeys []KeyState) []KeyState {
 	for i, k := range recentFirstSortedKeys {
-		if allMigrated, missing, _ := MigratedFor(grs, k); allMigrated {
+		if allMigrated, missing, _, _ := MigratedFor(grs, k); allMigrated {
 			if i+1 < len(recentFirstSortedKeys) {
 				return recentFirstSortedKeys[:i+2]
 			} else {

--- a/pkg/operator/encryption/state/helpers_test.go
+++ b/pkg/operator/encryption/state/helpers_test.go
@@ -1,0 +1,124 @@
+package state
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
+)
+
+func TestMigratedFor(t *testing.T) {
+	secrets := schema.GroupResource{Group: "", Resource: "secrets"}
+	configmaps := schema.GroupResource{Group: "", Resource: "configmaps"}
+
+	tests := []struct {
+		name                 string
+		grs                  []schema.GroupResource
+		keyState             KeyState
+		wantOK               bool
+		wantMissing          []schema.GroupResource
+		wantNeedsRemigration bool
+	}{
+		{
+			name: "all resources migrated, no generation",
+			grs:  []schema.GroupResource{secrets, configmaps},
+			keyState: KeyState{
+				Key:      apiserverconfigv1.Key{Name: "1"},
+				Migrated: MigrationState{Resources: []schema.GroupResource{secrets, configmaps}},
+			},
+			wantOK:               true,
+			wantNeedsRemigration: false,
+		},
+		{
+			name: "missing resource",
+			grs:  []schema.GroupResource{secrets, configmaps},
+			keyState: KeyState{
+				Key:      apiserverconfigv1.Key{Name: "1"},
+				Migrated: MigrationState{Resources: []schema.GroupResource{secrets}},
+			},
+			wantOK:               false,
+			wantMissing:          []schema.GroupResource{configmaps},
+			wantNeedsRemigration: false,
+		},
+		{
+			name: "all migrated, generation matches — no remigration",
+			grs:  []schema.GroupResource{secrets},
+			keyState: KeyState{
+				Key:                 apiserverconfigv1.Key{Name: "1"},
+				Migrated:            MigrationState{Resources: []schema.GroupResource{secrets}, Generation: 2},
+				MigrationGeneration: 2,
+			},
+			wantOK:               true,
+			wantNeedsRemigration: false,
+		},
+		{
+			name: "all migrated, generation mismatch — needs remigration",
+			grs:  []schema.GroupResource{secrets},
+			keyState: KeyState{
+				Key:                 apiserverconfigv1.Key{Name: "1"},
+				Migrated:            MigrationState{Resources: []schema.GroupResource{secrets}, Generation: 1},
+				MigrationGeneration: 2,
+			},
+			wantOK:               true,
+			wantNeedsRemigration: true,
+		},
+		{
+			name: "all migrated, first generation bump — needs remigration",
+			grs:  []schema.GroupResource{secrets, configmaps},
+			keyState: KeyState{
+				Key:                 apiserverconfigv1.Key{Name: "5"},
+				Migrated:            MigrationState{Resources: []schema.GroupResource{secrets, configmaps}, Generation: 0},
+				MigrationGeneration: 1,
+			},
+			wantOK:               true,
+			wantNeedsRemigration: true,
+		},
+		{
+			name: "missing resources takes precedence over generation mismatch",
+			grs:  []schema.GroupResource{secrets, configmaps},
+			keyState: KeyState{
+				Key:                 apiserverconfigv1.Key{Name: "1"},
+				Migrated:            MigrationState{Resources: []schema.GroupResource{secrets}, Generation: 1},
+				MigrationGeneration: 2,
+			},
+			wantOK:               false,
+			wantMissing:          []schema.GroupResource{configmaps},
+			wantNeedsRemigration: false,
+		},
+		{
+			name: "no resources to check",
+			grs:  []schema.GroupResource{},
+			keyState: KeyState{
+				Key: apiserverconfigv1.Key{Name: "1"},
+			},
+			wantOK:               true,
+			wantNeedsRemigration: false,
+		},
+		{
+			name: "zero generations — backward compatible",
+			grs:  []schema.GroupResource{secrets},
+			keyState: KeyState{
+				Key:                 apiserverconfigv1.Key{Name: "1"},
+				Migrated:            MigrationState{Resources: []schema.GroupResource{secrets}, Generation: 0},
+				MigrationGeneration: 0,
+			},
+			wantOK:               true,
+			wantNeedsRemigration: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ok, missing, needsRemigration, _ := MigratedFor(tt.grs, tt.keyState)
+			if ok != tt.wantOK {
+				t.Errorf("ok: got %v, want %v", ok, tt.wantOK)
+			}
+			if needsRemigration != tt.wantNeedsRemigration {
+				t.Errorf("needsRemigration: got %v, want %v", needsRemigration, tt.wantNeedsRemigration)
+			}
+			if len(missing) != len(tt.wantMissing) {
+				t.Errorf("missing: got %v, want %v", missing, tt.wantMissing)
+			}
+		})
+	}
+}

--- a/pkg/operator/encryption/state/types.go
+++ b/pkg/operator/encryption/state/types.go
@@ -50,6 +50,11 @@ type KeyState struct {
 	ExternalReason string
 	// stores all the KMS encryption mode related configurations
 	KMS *KMSState
+
+	// MigrationGeneration is the requested migration generation from the
+	// migration-generation annotation. A value greater than Migrated.Generation
+	// signals that re-migration is needed (e.g. after a remote KMS key rotation).
+	MigrationGeneration uint
 }
 
 func (k *KeyState) HasKMSEncryption() bool {
@@ -157,6 +162,9 @@ type MigrationState struct {
 	Timestamp time.Time
 	// the resources that were migrated at some point in time to this key.
 	Resources []schema.GroupResource
+	// Generation is the generation for which migration was last completed,
+	// from the migrated-generation annotation.
+	Generation uint
 }
 
 // Mode is the value associated with the encryptionSecretMode annotation

--- a/pkg/operator/encryption/statemachine/transition.go
+++ b/pkg/operator/encryption/statemachine/transition.go
@@ -193,8 +193,8 @@ func getDesiredEncryptionState(oldSecretData *encryptiondata.Config, encryptionS
 	// STEP 4: with consistent read-keys and write-keys, remove every read-key other than the write-key and one last read key.
 	//
 	// Note: because read-keys are consistent, currentlyEncryptedGRs equals toBeEncryptedGRs
-	allMigrated, _, reason := state.MigratedFor(currentlyEncryptedGRs, writeKey)
-	if !allMigrated {
+	allMigrated, _, needsRemigration, reason := state.MigratedFor(currentlyEncryptedGRs, writeKey)
+	if !allMigrated || needsRemigration {
 		klog.V(4).Infof("%s", reason)
 		return desiredEncryptionState
 	}


### PR DESCRIPTION
For KMS encryption mode, the remote key (e.g. Vault KEK) rotates independently without requiring a new local key secret. This commit introduces a generation counter mechanism that allows triggering re-migration of etcd data without creating a new key.

Two new annotations on the key secret:
- migration-generation: the requested migration generation
- migrated-generation: the generation migration was last completed for

When migration-generation > migrated-generation, MigratedFor() returns needsRemigration=true. The migration controller encodes the generation into the writeKey passed to EnsureMigration (e.g. "5-1"), causing the migrator to delete the old StorageVersionMigration CR and create a new one. After all resources complete re-migration, migrated-generation is updated to match.

The trigger mechanism that bumps migration-generation is left for a follow-up commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for encryption key re-migration with generation tracking to handle scenarios such as KMS key rotation.
  * Enhanced the migration controller to distinguish between initial migration and re-migration of resources using generation-based lifecycle management.

* **Tests**
  * Added test coverage for migration generation scenarios and state serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->