### PR TITLE
CNTRLPLANE-3545: kms: expand credentials resolver to include configMap data

### DIFF
--- a/pkg/operator/encryption/encryptiondata/secret.go
+++ b/pkg/operator/encryption/encryptiondata/secret.go
@@ -177,7 +177,7 @@ func ToSecret(ns, name string, secretData *Config) (*corev1.Secret, error) {
 
 	for keyID, flatEntries := range secretData.KMSPluginsConfigMapData.FlatEntriesByKeyID() {
 		for rawKey, value := range flatEntries {
-			s.Data[formatKMSConfigMapDataKey(rawKey, keyID)] = value
+			s.Data[FormatKMSConfigMapDataKey(rawKey, keyID)] = value
 		}
 	}
 
@@ -239,7 +239,7 @@ func FormatKMSSecretDataKey(rawKey, keyID string) string {
 	return fmt.Sprintf("%s%s-%s", encryptionConfigSecretDataPrefix, rawKey, keyID)
 }
 
-// formatKMSConfigMapDataKey returns the data key used in the encryption-config Secret
+// FormatKMSConfigMapDataKey returns the data key used in the encryption-config Secret
 // for a KMS plugin configmap entry: "kms-plugin-configmap-{rawKey}-{keyID}",
 // where rawKey is the combined "configMapName_dataKey" from KMSReferenceData.FlatEntry.
 //
@@ -247,7 +247,7 @@ func FormatKMSSecretDataKey(rawKey, keyID string) string {
 //
 // It does not validate inputs. The callers are expected to use KMSReferenceData.Set,
 // which rejects empty values and underscores in referenceName.
-func formatKMSConfigMapDataKey(rawKey, keyID string) string {
+func FormatKMSConfigMapDataKey(rawKey, keyID string) string {
 	return fmt.Sprintf("%s%s-%s", encryptionConfigConfigMapDataPrefix, rawKey, keyID)
 }
 

--- a/pkg/operator/encryption/kms/pluginlifecycle/credentials.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/credentials.go
@@ -7,17 +7,17 @@ import (
 	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
 )
 
-// credentialResolver resolves KMS plugin credentials for a specific keyID
-// by looking up secret data and mapping it to values or file paths on disk.
-type credentialResolver struct {
+// referenceDataResolver resolves KMS plugin reference data for a specific keyID
+// by looking up secret and configMap data and mapping it to values or file paths on disk.
+type referenceDataResolver struct {
 	keyID                string
-	credentialsDir       string
+	referenceDataDir     string
 	pluginsSecretData    encryptiondata.KMSPluginsReferenceData
 	pluginsConfigMapData encryptiondata.KMSPluginsReferenceData
 }
 
 // SecretValue returns the value for the given secret name and data key.
-func (r *credentialResolver) SecretValue(secretName, dataKey string) (string, error) {
+func (r *referenceDataResolver) SecretValue(secretName, dataKey string) (string, error) {
 	sd, ok := r.pluginsSecretData.Get(r.keyID)
 	if !ok {
 		return "", fmt.Errorf("missing secret data for keyID %s", r.keyID)
@@ -30,7 +30,7 @@ func (r *credentialResolver) SecretValue(secretName, dataKey string) (string, er
 }
 
 // SecretFilePath returns the on-disk path where the data for the given secret name and data key is mounted.
-func (r *credentialResolver) SecretFilePath(secretName, dataKey string) (string, error) {
+func (r *referenceDataResolver) SecretFilePath(secretName, dataKey string) (string, error) {
 	sd, ok := r.pluginsSecretData.Get(r.keyID)
 	if !ok {
 		return "", fmt.Errorf("missing secret data for keyID %s", r.keyID)
@@ -40,11 +40,11 @@ func (r *credentialResolver) SecretFilePath(secretName, dataKey string) (string,
 		return "", fmt.Errorf("missing %s in secret %s for keyID %s", dataKey, secretName, r.keyID)
 	}
 	secretDataKey := encryptiondata.FormatKMSSecretDataKey(rawKey, r.keyID)
-	return filepath.Join(r.credentialsDir, secretDataKey), nil
+	return filepath.Join(r.referenceDataDir, secretDataKey), nil
 }
 
 // ConfigMapFilePath returns the on-disk path where the data for the given configMap name and data key is mounted.
-func (r *credentialResolver) ConfigMapFilePath(configMapName, dataKey string) (string, error) {
+func (r *referenceDataResolver) ConfigMapFilePath(configMapName, dataKey string) (string, error) {
 	cd, ok := r.pluginsConfigMapData.Get(r.keyID)
 	if !ok {
 		return "", fmt.Errorf("missing configMap data for keyID %s", r.keyID)
@@ -54,5 +54,5 @@ func (r *credentialResolver) ConfigMapFilePath(configMapName, dataKey string) (s
 		return "", fmt.Errorf("missing %s in configMap %s for keyID %s", dataKey, configMapName, r.keyID)
 	}
 	configMapDataKey := encryptiondata.FormatKMSConfigMapDataKey(rawKey, r.keyID)
-	return filepath.Join(r.credentialsDir, configMapDataKey), nil
+	return filepath.Join(r.referenceDataDir, configMapDataKey), nil
 }

--- a/pkg/operator/encryption/kms/pluginlifecycle/credentials.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/credentials.go
@@ -10,13 +10,14 @@ import (
 // credentialResolver resolves KMS plugin credentials for a specific keyID
 // by looking up secret data and mapping it to values or file paths on disk.
 type credentialResolver struct {
-	keyID             string
-	credentialsDir    string
-	pluginsSecretData encryptiondata.KMSPluginsReferenceData
+	keyID                string
+	credentialsDir       string
+	pluginsSecretData    encryptiondata.KMSPluginsReferenceData
+	pluginsConfigMapData encryptiondata.KMSPluginsReferenceData
 }
 
-// Value returns the credential value for the given secret name and data key.
-func (r *credentialResolver) Value(secretName, dataKey string) (string, error) {
+// SecretValue returns the value for the given secret name and data key.
+func (r *credentialResolver) SecretValue(secretName, dataKey string) (string, error) {
 	sd, ok := r.pluginsSecretData.Get(r.keyID)
 	if !ok {
 		return "", fmt.Errorf("missing secret data for keyID %s", r.keyID)
@@ -28,8 +29,8 @@ func (r *credentialResolver) Value(secretName, dataKey string) (string, error) {
 	return string(v), nil
 }
 
-// FilePath returns the on-disk path where the credential for the given secret name and data key is mounted.
-func (r *credentialResolver) FilePath(secretName, dataKey string) (string, error) {
+// SecretFilePath returns the on-disk path where the data for the given secret name and data key is mounted.
+func (r *credentialResolver) SecretFilePath(secretName, dataKey string) (string, error) {
 	sd, ok := r.pluginsSecretData.Get(r.keyID)
 	if !ok {
 		return "", fmt.Errorf("missing secret data for keyID %s", r.keyID)
@@ -40,4 +41,18 @@ func (r *credentialResolver) FilePath(secretName, dataKey string) (string, error
 	}
 	secretDataKey := encryptiondata.FormatKMSSecretDataKey(rawKey, r.keyID)
 	return filepath.Join(r.credentialsDir, secretDataKey), nil
+}
+
+// ConfigMapFilePath returns the on-disk path where the data for the given configMap name and data key is mounted.
+func (r *credentialResolver) ConfigMapFilePath(configMapName, dataKey string) (string, error) {
+	cd, ok := r.pluginsConfigMapData.Get(r.keyID)
+	if !ok {
+		return "", fmt.Errorf("missing configMap data for keyID %s", r.keyID)
+	}
+	rawKey, ok := cd.FlatEntry(configMapName, dataKey)
+	if !ok {
+		return "", fmt.Errorf("missing %s in configMap %s for keyID %s", dataKey, configMapName, r.keyID)
+	}
+	configMapDataKey := encryptiondata.FormatKMSConfigMapDataKey(rawKey, r.keyID)
+	return filepath.Join(r.credentialsDir, configMapDataKey), nil
 }

--- a/pkg/operator/encryption/kms/pluginlifecycle/credentials_test.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/credentials_test.go
@@ -5,10 +5,11 @@ import (
 	"testing"
 
 	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
+	"github.com/openshift/library-go/pkg/operator/encryption/state"
 	"github.com/stretchr/testify/require"
 )
 
-func TestCredentialResolver_Value(t *testing.T) {
+func TestCredentialResolver_SecretValue(t *testing.T) {
 	const keyID = "42"
 	pluginsSecretData := newTestPluginsSecretData(t, keyID, "my-role-id", "my-secret-id")
 
@@ -50,7 +51,7 @@ func TestCredentialResolver_Value(t *testing.T) {
 				pluginsSecretData: pluginsSecretData,
 			}
 
-			got, err := r.Value(tc.secretName, tc.dataKey)
+			got, err := r.SecretValue(tc.secretName, tc.dataKey)
 			if tc.expectErr != "" {
 				require.EqualError(t, err, tc.expectErr)
 				return
@@ -61,7 +62,7 @@ func TestCredentialResolver_Value(t *testing.T) {
 	}
 }
 
-func TestCredentialResolver_FilePath(t *testing.T) {
+func TestCredentialResolver_SecretFilePath(t *testing.T) {
 	const keyID = "42"
 	const credentialsDir = "/etc/kubernetes/static-pod-resources/secrets/encryption-config"
 
@@ -106,7 +107,7 @@ func TestCredentialResolver_FilePath(t *testing.T) {
 				pluginsSecretData: pluginsSecretData,
 			}
 
-			got, err := r.FilePath(tc.secretName, tc.dataKey)
+			got, err := r.SecretFilePath(tc.secretName, tc.dataKey)
 			if tc.expectErr != "" {
 				require.EqualError(t, err, tc.expectErr)
 				return
@@ -115,6 +116,73 @@ func TestCredentialResolver_FilePath(t *testing.T) {
 			require.Equal(t, tc.expected, got)
 		})
 	}
+}
+
+func TestCredentialResolver_ConfigMapFilePath(t *testing.T) {
+	const keyID = "42"
+	const credentialsDir = "/etc/kubernetes/static-pod-resources/secrets/encryption-config"
+
+	pluginsConfigMapData := newTestPluginsConfigMapData(t, keyID, "my-ca-bundle")
+
+	tests := []struct {
+		name          string
+		keyID         string
+		configMapName string
+		dataKey       string
+		expected      string
+		expectErr     string
+	}{
+		{
+			name:          "returns correct path",
+			keyID:         keyID,
+			configMapName: "vault-ca-bundle",
+			dataKey:       "ca-bundle.crt",
+			expected:      filepath.Join(credentialsDir, encryptiondata.FormatKMSConfigMapDataKey("vault-ca-bundle_ca-bundle.crt", keyID)),
+		},
+		{
+			name:          "missing keyID",
+			keyID:         "unknown",
+			configMapName: "vault-ca-bundle",
+			dataKey:       "ca-bundle.crt",
+			expectErr:     "missing configMap data for keyID unknown",
+		},
+		{
+			name:          "missing data key",
+			keyID:         keyID,
+			configMapName: "vault-ca-bundle",
+			dataKey:       "nonexistent",
+			expectErr:     "missing nonexistent in configMap vault-ca-bundle for keyID 42",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &credentialResolver{
+				keyID:                tc.keyID,
+				credentialsDir:       credentialsDir,
+				pluginsConfigMapData: pluginsConfigMapData,
+			}
+
+			got, err := r.ConfigMapFilePath(tc.configMapName, tc.dataKey)
+			if tc.expectErr != "" {
+				require.EqualError(t, err, tc.expectErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func newTestPluginsConfigMapData(t *testing.T, keyID, caBundle string) encryptiondata.KMSPluginsReferenceData {
+	t.Helper()
+	var rd state.KMSReferenceData
+	require.NoError(t, rd.Set("vault-ca-bundle", "ca-bundle.crt", []byte(caBundle)))
+	var pluginsConfigMapData encryptiondata.KMSPluginsReferenceData
+	for rawKey, value := range rd.FlatEntries() {
+		require.NoError(t, pluginsConfigMapData.SetFromRawKey(keyID, rawKey, value))
+	}
+	return pluginsConfigMapData
 }
 
 func newTestPluginsSecretData(t *testing.T, keyID, roleID, secretID string) encryptiondata.KMSPluginsReferenceData {

--- a/pkg/operator/encryption/kms/pluginlifecycle/credentials_test.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/credentials_test.go
@@ -46,7 +46,7 @@ func TestCredentialResolver_SecretValue(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			r := &credentialResolver{
+			r := &referenceDataResolver{
 				keyID:             tc.keyID,
 				pluginsSecretData: pluginsSecretData,
 			}
@@ -101,9 +101,9 @@ func TestCredentialResolver_SecretFilePath(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			r := &credentialResolver{
+			r := &referenceDataResolver{
 				keyID:             tc.keyID,
-				credentialsDir:    credentialsDir,
+				referenceDataDir:  credentialsDir,
 				pluginsSecretData: pluginsSecretData,
 			}
 
@@ -157,9 +157,9 @@ func TestCredentialResolver_ConfigMapFilePath(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			r := &credentialResolver{
+			r := &referenceDataResolver{
 				keyID:                tc.keyID,
-				credentialsDir:       credentialsDir,
+				referenceDataDir:     credentialsDir,
 				pluginsConfigMapData: pluginsConfigMapData,
 			}
 

--- a/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
@@ -39,8 +39,8 @@ type sidecarProvider interface {
 }
 
 // newSidecarProvider creates a provider-specific sidecarProvider for the given keyID and plugin configuration,
-// wiring in credentials via the credentialResolver.
-func newSidecarProvider(keyID string, udsPath string, pluginConfig configv1.KMSPluginConfig, creds *credentialResolver) (sidecarProvider, error) {
+// wiring in credentials via the referenceDataResolver.
+func newSidecarProvider(keyID string, udsPath string, pluginConfig configv1.KMSPluginConfig, creds *referenceDataResolver) (sidecarProvider, error) {
 	switch pluginConfig.Type {
 	case configv1.VaultKMSProvider:
 		return newVaultSidecarProvider("vault-kms-plugin", keyID, udsPath, pluginConfig.Vault, creds)
@@ -59,9 +59,9 @@ func newSidecarProvider(keyID string, udsPath string, pluginConfig configv1.KMSP
 // The secretClient should be uncached to avoid injecting sidecars based on a stale encryption configuration.
 func AddKMSPluginSidecarToStaticPodSpec(ctx context.Context, podSpec *corev1.PodSpec, containerName string, encryptionConfigNamespace string, encryptionConfigSecretName string, secretClient corev1client.SecretsGetter, featureGateAccessor featuregates.FeatureGateAccess) error {
 	// The static pod revision controller copies secret data to disk under resourcesDir/secrets/<secretName>/.
-	credentialsDir := filepath.Join(resourcesDir, "secrets", encryptionConfigSecretName)
+	referenceDataDir := filepath.Join(resourcesDir, "secrets", encryptionConfigSecretName)
 
-	sidecarNames, err := addKMSPluginSidecars(ctx, podSpec, containerName, encryptionConfigNamespace, encryptionConfigSecretName, secretClient, featureGateAccessor, credentialsDir)
+	sidecarNames, err := addKMSPluginSidecars(ctx, podSpec, containerName, encryptionConfigNamespace, encryptionConfigSecretName, secretClient, featureGateAccessor, referenceDataDir)
 	if err != nil {
 		return err
 	}
@@ -118,7 +118,7 @@ func AddKMSPluginSidecarToPodSpec(ctx context.Context, podSpec *corev1.PodSpec, 
 
 // addKMSPluginSidecars contains the shared logic for discovering KMS plugins and injecting sidecar containers.
 // It returns the names of the sidecar containers that were injected, so callers can add deployment-mode-specific volume mounts.
-func addKMSPluginSidecars(ctx context.Context, podSpec *corev1.PodSpec, containerName string, encryptionConfigNamespace string, encryptionConfigSecretName string, secretClient corev1client.SecretsGetter, featureGateAccessor featuregates.FeatureGateAccess, credentialsDir string) ([]string, error) {
+func addKMSPluginSidecars(ctx context.Context, podSpec *corev1.PodSpec, containerName string, encryptionConfigNamespace string, encryptionConfigSecretName string, secretClient corev1client.SecretsGetter, featureGateAccessor featuregates.FeatureGateAccess, referenceDataDir string) ([]string, error) {
 	if podSpec == nil {
 		return nil, fmt.Errorf("pod spec cannot be nil")
 	}
@@ -177,9 +177,9 @@ func addKMSPluginSidecars(ctx context.Context, podSpec *corev1.PodSpec, containe
 			return nil, fmt.Errorf("missing plugin config for keyID %s", keyID)
 		}
 
-		creds := &credentialResolver{
+		creds := &referenceDataResolver{
 			pluginsSecretData: encryptionConfig.KMSPluginsSecretData,
-			credentialsDir:    credentialsDir,
+			referenceDataDir:  referenceDataDir,
 			keyID:             keyID,
 		}
 

--- a/pkg/operator/encryption/kms/pluginlifecycle/vault.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/vault.go
@@ -17,7 +17,7 @@ func newVaultSidecarProvider(name, keyID, udsPath string, vaultConfig configv1.V
 		return nil, fmt.Errorf("vault AppRole authentication secret name cannot be empty")
 	}
 
-	roleID, err := creds.Value(secretName, "role-id")
+	roleID, err := creds.SecretValue(secretName, "role-id")
 	if err != nil {
 		return nil, err
 	}
@@ -26,7 +26,7 @@ func newVaultSidecarProvider(name, keyID, udsPath string, vaultConfig configv1.V
 		return nil, fmt.Errorf("role ID cannot be empty")
 	}
 
-	secretIDPath, err := creds.FilePath(secretName, "secret-id")
+	secretIDPath, err := creds.SecretFilePath(secretName, "secret-id")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operator/encryption/kms/pluginlifecycle/vault.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/vault.go
@@ -11,7 +11,7 @@ import (
 
 // newVaultSidecarProvider creates a Vault sidecar provider from the given KMS plugin data.
 // It assumes the input data has been already been validated.
-func newVaultSidecarProvider(name, keyID, udsPath string, vaultConfig configv1.VaultKMSPluginConfig, creds *credentialResolver) (*vault, error) {
+func newVaultSidecarProvider(name, keyID, udsPath string, vaultConfig configv1.VaultKMSPluginConfig, creds *referenceDataResolver) (*vault, error) {
 	secretName := vaultConfig.Authentication.AppRole.Secret.Name
 	if secretName == "" {
 		return nil, fmt.Errorf("vault AppRole authentication secret name cannot be empty")

--- a/pkg/operator/encryption/kms/pluginlifecycle/vault_test.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/vault_test.go
@@ -206,9 +206,9 @@ func TestVaultSidecarProvider_BuildSidecarContainer(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			creds := &credentialResolver{
+			creds := &referenceDataResolver{
 				pluginsSecretData: pluginsSecretData,
-				credentialsDir:    tt.credentialsDir,
+				referenceDataDir:  tt.credentialsDir,
 				keyID:             tt.keyID,
 			}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed and reorganized internal credential/resolver interfaces and switched to a unified "reference data" concept; added support for resolving credentials from ConfigMap-backed entries.

* **Tests**
  * Updated and expanded tests to reflect the resolver API changes and to cover ConfigMap-backed credential path handling.

No direct user-facing changes; internal credential handling and test coverage improved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->