### PR TITLE
CNTRLPLANE-3545: kms: wire CA bundle to Vault sidecar

### DIFF
--- a/pkg/operator/encryption/controllers/key_controller_test.go
+++ b/pkg/operator/encryption/controllers/key_controller_test.go
@@ -1101,6 +1101,9 @@ func TestGetCurrentModeReasonAndEncryptionConfig(t *testing.T) {
 							Secret: configv1.VaultSecretReference{Name: "vault-approle-secret"},
 						},
 					},
+					TLS: configv1.VaultTLSConfig{
+						CABundle: configv1.VaultConfigMapReference{Name: "vault-ca-bundle"},
+					},
 					TransitKey: "test-transit-key",
 				},
 			}}}}},

--- a/pkg/operator/encryption/controllers/state_controller_test.go
+++ b/pkg/operator/encryption/controllers/state_controller_test.go
@@ -928,6 +928,9 @@ func TestStateController(t *testing.T) {
 								Secret: configv1.VaultSecretReference{Name: "vault-approle-secret-2"},
 							},
 						},
+						TLS: configv1.VaultTLSConfig{
+							CABundle: configv1.VaultConfigMapReference{Name: "vault-ca-bundle-2"},
+						},
 						TransitKey: "test-transit-key-2",
 					},
 				}),
@@ -1024,6 +1027,9 @@ func TestStateController(t *testing.T) {
 								AppRole: configv1.VaultAppRoleAuthentication{
 									Secret: configv1.VaultSecretReference{Name: "vault-approle-secret-2"},
 								},
+							},
+							TLS: configv1.VaultTLSConfig{
+								CABundle: configv1.VaultConfigMapReference{Name: "vault-ca-bundle-2"},
 							},
 							TransitKey: "test-transit-key-2",
 						},

--- a/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
@@ -178,9 +178,10 @@ func addKMSPluginSidecars(ctx context.Context, podSpec *corev1.PodSpec, containe
 		}
 
 		refData := &referenceDataResolver{
-			pluginsSecretData: encryptionConfig.KMSPluginsSecretData,
-			referenceDataDir:  referenceDataDir,
-			keyID:             keyID,
+			pluginsConfigMapData: encryptionConfig.KMSPluginsConfigMapData,
+			pluginsSecretData:    encryptionConfig.KMSPluginsSecretData,
+			referenceDataDir:     referenceDataDir,
+			keyID:                keyID,
 		}
 
 		provider, err := newSidecarProvider(keyID, udsPath, pluginConfig, refData)

--- a/pkg/operator/encryption/kms/pluginlifecycle/sidecar_test.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/sidecar_test.go
@@ -45,6 +45,10 @@ func newSidecarTestFixtures(t *testing.T) sidecarTestFixtures {
 					Secret: configv1.VaultSecretReference{Name: "vault-approle"},
 				},
 			},
+			TLS: configv1.VaultTLSConfig{
+				CABundle:   configv1.VaultConfigMapReference{Name: "vault-ca-bundle"},
+				ServerName: "vault.internal.example.com",
+			},
 		},
 	}
 	pluginConfigBytes, err := encoding.EncodeKMSPluginConfig(*vaultConfig)
@@ -78,8 +82,9 @@ func newSidecarTestFixtures(t *testing.T) sidecarTestFixtures {
 		Data: map[string][]byte{
 			"encryption-config": encryptionConfigBytes,
 			pluginConfigKey:     pluginConfigBytes,
-			"kms-plugin-secret-vault-approle_role-id-555":   []byte("test-role-id"),
-			"kms-plugin-secret-vault-approle_secret-id-555": []byte("test-secret-id"),
+			"kms-plugin-secret-vault-approle_role-id-555":            []byte("test-role-id"),
+			"kms-plugin-secret-vault-approle_secret-id-555":          []byte("test-secret-id"),
+			"kms-plugin-configmap-vault-ca-bundle_ca-bundle.crt-555": []byte("test-ca-cert"),
 		},
 	}
 
@@ -115,8 +120,9 @@ func TestAddKMSPluginSidecarToPodSpec(t *testing.T) {
 		"-transit-key=my-key",
 		"-approle-role-id=test-role-id",
 		"-approle-secret-id-path=/var/run/secrets/kms-plugin/kms-plugin-secret-vault-approle_secret-id-555",
+		"-tls-ca-file=/var/run/secrets/kms-plugin/kms-plugin-configmap-vault-ca-bundle_ca-bundle.crt-555",
+		"-tls-sni=vault.internal.example.com",
 		"-vault-namespace=my-namespace",
-		"-tls-skip-verify=true",
 		"-metrics-port=0",
 	}
 
@@ -214,8 +220,8 @@ func TestAddKMSPluginSidecarToPodSpec(t *testing.T) {
 							"-transit-key=other-key",
 							"-approle-role-id=test-role-id-777",
 							"-approle-secret-id-path=/var/run/secrets/kms-plugin/kms-plugin-secret-vault-approle-2_secret-id-777",
+							"-tls-ca-file=/var/run/secrets/kms-plugin/kms-plugin-configmap-vault-ca-bundle-2_ca-bundle.crt-777",
 							"-vault-namespace=other-namespace",
-							"-tls-skip-verify=true",
 							"-metrics-port=0",
 						},
 						ImagePullPolicy:          corev1.PullIfNotPresent,
@@ -239,8 +245,9 @@ func TestAddKMSPluginSidecarToPodSpec(t *testing.T) {
 							"-transit-key=my-key",
 							"-approle-role-id=test-role-id",
 							"-approle-secret-id-path=/var/run/secrets/kms-plugin/kms-plugin-secret-vault-approle_secret-id-555",
+							"-tls-ca-file=/var/run/secrets/kms-plugin/kms-plugin-configmap-vault-ca-bundle_ca-bundle.crt-555",
+							"-tls-sni=vault.internal.example.com",
 							"-vault-namespace=my-namespace",
-							"-tls-skip-verify=true",
 							"-metrics-port=0",
 						},
 						ImagePullPolicy:          corev1.PullIfNotPresent,
@@ -271,6 +278,9 @@ func TestAddKMSPluginSidecarToPodSpec(t *testing.T) {
 							AppRole: configv1.VaultAppRoleAuthentication{
 								Secret: configv1.VaultSecretReference{Name: "vault-approle-2"},
 							},
+						},
+						TLS: configv1.VaultTLSConfig{
+							CABundle: configv1.VaultConfigMapReference{Name: "vault-ca-bundle-2"},
 						},
 					},
 				}
@@ -314,10 +324,12 @@ func TestAddKMSPluginSidecarToPodSpec(t *testing.T) {
 						"encryption-config": multiEncConfigBytes,
 						f.pluginConfigKey:   f.pluginConfigBytes,
 						pluginConfigKey2:    pluginConfig2Bytes,
-						"kms-plugin-secret-vault-approle_role-id-555":     []byte("test-role-id"),
-						"kms-plugin-secret-vault-approle_secret-id-555":   []byte("test-secret-id"),
-						"kms-plugin-secret-vault-approle-2_role-id-777":   []byte("test-role-id-777"),
-						"kms-plugin-secret-vault-approle-2_secret-id-777": []byte("test-secret-id-777"),
+						"kms-plugin-secret-vault-approle_role-id-555":              []byte("test-role-id"),
+						"kms-plugin-secret-vault-approle_secret-id-555":            []byte("test-secret-id"),
+						"kms-plugin-configmap-vault-ca-bundle_ca-bundle.crt-555":   []byte("test-ca-cert"),
+						"kms-plugin-secret-vault-approle-2_role-id-777":            []byte("test-role-id-777"),
+						"kms-plugin-secret-vault-approle-2_secret-id-777":          []byte("test-secret-id-777"),
+						"kms-plugin-configmap-vault-ca-bundle-2_ca-bundle.crt-777": []byte("test-ca-cert-777"),
 					},
 				})
 			}(),

--- a/pkg/operator/encryption/kms/pluginlifecycle/vault.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/vault.go
@@ -35,6 +35,14 @@ func newVaultSidecarProvider(name, keyID, udsPath string, vaultConfig configv1.V
 		return nil, fmt.Errorf("secret ID path cannot be empty")
 	}
 
+	var caBundlePath string
+	if configMapName := vaultConfig.TLS.CABundle.Name; configMapName != "" {
+		caBundlePath, err = refData.ConfigMapFilePath(configMapName, "ca-bundle.crt")
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return &vault{
 		name:         name,
 		keyID:        keyID,
@@ -42,6 +50,7 @@ func newVaultSidecarProvider(name, keyID, udsPath string, vaultConfig configv1.V
 		config:       vaultConfig,
 		roleID:       roleID,
 		secretIDPath: secretIDPath,
+		caBundlePath: caBundlePath,
 	}, nil
 }
 
@@ -53,6 +62,7 @@ type vault struct {
 	config       configv1.VaultKMSPluginConfig
 	roleID       string
 	secretIDPath string
+	caBundlePath string
 }
 
 // Name returns the sidecar name appended by the key id.
@@ -74,14 +84,18 @@ func (v *vault) BuildSidecarContainer() (corev1.Container, error) {
 	}
 
 	// Optional fields: only pass non-empty values.
+	if v.caBundlePath != "" {
+		args = append(args, fmt.Sprintf("-tls-ca-file=%s", v.caBundlePath))
+	}
+	if v.config.TLS.ServerName != "" {
+		args = append(args, fmt.Sprintf("-tls-sni=%s", v.config.TLS.ServerName))
+	}
 	if v.config.VaultNamespace != "" {
 		args = append(args, fmt.Sprintf("-vault-namespace=%s", v.config.VaultNamespace))
 	}
 
 	// Temporary workarounds. These should go away as we progress with the feature.
 	args = append(args,
-		// TODO: remove before GA once the CA bundle is wired into the encryption config secret.
-		"-tls-skip-verify=true",
 		// TODO: remove once we support scraping metrics from each KMS plugin sidecar independently.
 		// Set the port to zero to disable metrics serving.
 		// Slack discussion: https://redhat-external.slack.com/archives/C09KZ5QCBUH/p1780926464635219

--- a/pkg/operator/encryption/kms/pluginlifecycle/vault_test.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/vault_test.go
@@ -20,11 +20,19 @@ func newVaultAppRoleSecretData(t *testing.T, roleID, secretID string) state.KMSR
 	return sd
 }
 
+func newVaultCABundleConfigMapData(t *testing.T, caBundleCrt string) state.KMSReferenceData {
+	t.Helper()
+	var cd state.KMSReferenceData
+	require.NoError(t, cd.Set("vault-ca-bundle", "ca-bundle.crt", []byte(caBundleCrt)))
+	return cd
+}
+
 func TestVaultSidecarProvider_BuildSidecarContainer(t *testing.T) {
 	tests := []struct {
 		name               string
 		vaultConfig        configv1.VaultKMSPluginConfig
 		secretData         state.KMSReferenceData
+		configMapData      state.KMSReferenceData
 		referenceDataDir   string
 		containerName      string
 		keyID              string
@@ -46,8 +54,13 @@ func TestVaultSidecarProvider_BuildSidecarContainer(t *testing.T) {
 						Secret: configv1.VaultSecretReference{Name: "vault-approle"},
 					},
 				},
+				TLS: configv1.VaultTLSConfig{
+					CABundle:   configv1.VaultConfigMapReference{Name: "vault-ca-bundle"},
+					ServerName: "vault.internal.example.com",
+				},
 			},
 			secretData:       newVaultAppRoleSecretData(t, "test-role-id", "test-secret-id"),
+			configMapData:    newVaultCABundleConfigMapData(t, "test-ca-cert"),
 			referenceDataDir: "/etc/kubernetes/static-pod-resources/secrets/encryption-config",
 			containerName:    "kms-plugin",
 			keyID:            "555",
@@ -64,8 +77,9 @@ func TestVaultSidecarProvider_BuildSidecarContainer(t *testing.T) {
 						"-transit-key=my-key",
 						"-approle-role-id=test-role-id",
 						"-approle-secret-id-path=/etc/kubernetes/static-pod-resources/secrets/encryption-config/kms-plugin-secret-vault-approle_secret-id-555",
+						"-tls-ca-file=/etc/kubernetes/static-pod-resources/secrets/encryption-config/kms-plugin-configmap-vault-ca-bundle_ca-bundle.crt-555",
+						"-tls-sni=vault.internal.example.com",
 						"-vault-namespace=my-namespace",
-						"-tls-skip-verify=true",
 						"-metrics-port=0",
 					},
 					ImagePullPolicy:          corev1.PullIfNotPresent,
@@ -93,8 +107,12 @@ func TestVaultSidecarProvider_BuildSidecarContainer(t *testing.T) {
 						Secret: configv1.VaultSecretReference{Name: "vault-approle"},
 					},
 				},
+				TLS: configv1.VaultTLSConfig{
+					CABundle: configv1.VaultConfigMapReference{Name: "vault-ca-bundle"},
+				},
 			},
 			secretData:       newVaultAppRoleSecretData(t, "test-role-id", "test-secret-id"),
+			configMapData:    newVaultCABundleConfigMapData(t, "test-ca-cert"),
 			referenceDataDir: "/etc/kubernetes/static-pod-resources/secrets/encryption-config",
 			containerName:    "kms-plugin",
 			keyID:            "555",
@@ -120,8 +138,8 @@ func TestVaultSidecarProvider_BuildSidecarContainer(t *testing.T) {
 						"-transit-key=my-key",
 						"-approle-role-id=test-role-id",
 						"-approle-secret-id-path=/etc/kubernetes/static-pod-resources/secrets/encryption-config/kms-plugin-secret-vault-approle_secret-id-555",
+						"-tls-ca-file=/etc/kubernetes/static-pod-resources/secrets/encryption-config/kms-plugin-configmap-vault-ca-bundle_ca-bundle.crt-555",
 						"-vault-namespace=my-namespace",
-						"-tls-skip-verify=true",
 						"-metrics-port=0",
 					},
 					ImagePullPolicy:          corev1.PullIfNotPresent,
@@ -167,7 +185,6 @@ func TestVaultSidecarProvider_BuildSidecarContainer(t *testing.T) {
 						"-transit-key=my-key",
 						"-approle-role-id=test-role-id-999",
 						"-approle-secret-id-path=/var/run/secrets/kms-plugin/kms-plugin-secret-vault-approle_secret-id-999",
-						"-tls-skip-verify=true",
 						"-metrics-port=0",
 					},
 					ImagePullPolicy:          corev1.PullIfNotPresent,
@@ -206,10 +223,17 @@ func TestVaultSidecarProvider_BuildSidecarContainer(t *testing.T) {
 				require.NoError(t, err)
 			}
 
+			var pluginsConfigMapData encryptiondata.KMSPluginsReferenceData
+			for rawKey, value := range tt.configMapData.FlatEntries() {
+				err := pluginsConfigMapData.SetFromRawKey(tt.keyID, rawKey, value)
+				require.NoError(t, err)
+			}
+
 			refData := &referenceDataResolver{
-				pluginsSecretData: pluginsSecretData,
-				referenceDataDir:  tt.referenceDataDir,
-				keyID:             tt.keyID,
+				pluginsSecretData:    pluginsSecretData,
+				pluginsConfigMapData: pluginsConfigMapData,
+				referenceDataDir:     tt.referenceDataDir,
+				keyID:                tt.keyID,
 			}
 
 			provider, err := newVaultSidecarProvider(tt.containerName, tt.keyID, tt.udsPath, tt.vaultConfig, refData)

--- a/pkg/operator/encryption/secrets/secrets_test.go
+++ b/pkg/operator/encryption/secrets/secrets_test.go
@@ -26,6 +26,9 @@ var defaultKMSPluginConfig = configv1.KMSPluginConfig{
 				Secret: configv1.VaultSecretReference{Name: "vault-approle-secret"},
 			},
 		},
+		TLS: configv1.VaultTLSConfig{
+			CABundle: configv1.VaultConfigMapReference{Name: "vault-ca-bundle"},
+		},
 		TransitKey: "test-transit-key",
 	},
 }

--- a/test/library/encryption/kms/vault.go
+++ b/test/library/encryption/kms/vault.go
@@ -99,6 +99,9 @@ var DefaultFakeKMSPluginConfig = configv1.APIServerEncryption{
 					Secret: configv1.VaultSecretReference{Name: defaultVaultAppRoleSecretName},
 				},
 			},
+			TLS: configv1.VaultTLSConfig{
+				CABundle: configv1.VaultConfigMapReference{Name: defaultVaultConfigMapName},
+			},
 			TransitKey:   "test-transit-key",
 			TransitMount: defaultVaultTransitMount,
 		},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vault KMS now supports TLS using CA bundle references from ConfigMaps, enabling certificate validation and optional SNI for plugin connections.
  * Sidecar injection now mounts reference-data (including CA bundles) for aggregated API servers so TLS artifacts are available to plugins.

* **Tests**
  * Test suite updated to validate ConfigMap-based CA bundle handling, reference-data mounting, and resulting sidecar arguments during injection and migrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->