### PR TITLE
pkg/operator/encryption/kms/preflight: add e2e tests, move checker to parent

### DIFF
--- a/pkg/operator/encryption/kms/checker.go
+++ b/pkg/operator/encryption/kms/checker.go
@@ -1,4 +1,4 @@
-package preflight
+package kms
 
 import (
 	"bytes"
@@ -18,18 +18,18 @@ import (
 // See https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kms/apis/v2/api.proto#L39
 const healthzOK = "ok"
 
-// checker runs the preflight check against a KMS plugin by calling
+// Checker runs the preflight check against a KMS plugin by calling
 // Status, Encrypt, and Decrypt on the kmsservice.Service interface.
 // this is the same interface the apiserver uses.
-type checker struct {
+type Checker struct {
 	service        kmsservice.Service
 	randReader     io.Reader
 	statusTimeout  time.Duration
 	statusInterval time.Duration
 }
 
-func newChecker(service kmsservice.Service, statusTimeout, statusInterval time.Duration) *checker {
-	return &checker{
+func NewChecker(service kmsservice.Service, statusTimeout, statusInterval time.Duration) *Checker {
+	return &Checker{
 		service:        service,
 		randReader:     rand.Reader,
 		statusTimeout:  statusTimeout,
@@ -37,7 +37,7 @@ func newChecker(service kmsservice.Service, statusTimeout, statusInterval time.D
 	}
 }
 
-func (c *checker) check(ctx context.Context) error {
+func (c *Checker) Check(ctx context.Context) error {
 	if err := c.checkStatus(ctx); err != nil {
 		return err
 	}
@@ -47,7 +47,7 @@ func (c *checker) check(ctx context.Context) error {
 // checkStatus polls the KMS plugin status endpoint until it reports healthy.
 // The plugin may not be immediately available after startup, so we retry
 // before reporting a failure.
-func (c *checker) checkStatus(ctx context.Context) error {
+func (c *Checker) checkStatus(ctx context.Context) error {
 	klog.Infof("[1/3] Checking KMS plugin status endpoint (interval %v, timeout %v)", c.statusInterval, c.statusTimeout)
 	return wait.PollUntilContextTimeout(ctx, c.statusInterval, c.statusTimeout, true, func(ctx context.Context) (bool, error) {
 		start := time.Now()
@@ -69,7 +69,7 @@ func (c *checker) checkStatus(ctx context.Context) error {
 	})
 }
 
-func (c *checker) checkEncryptDecrypt(ctx context.Context) error {
+func (c *Checker) checkEncryptDecrypt(ctx context.Context) error {
 	klog.Info("[2/3] Checking KMS plugin encrypt endpoint")
 	plainText := make([]byte, 32)
 	if _, err := io.ReadFull(c.randReader, plainText); err != nil {

--- a/pkg/operator/encryption/kms/checker_test.go
+++ b/pkg/operator/encryption/kms/checker_test.go
@@ -1,4 +1,4 @@
-package preflight
+package kms
 
 import (
 	"bytes"
@@ -29,8 +29,8 @@ func (f *fakeService) Decrypt(ctx context.Context, uid string, req *kmsservice.D
 	return f.DecryptFn(ctx, uid, req)
 }
 
-func newTestChecker(service *fakeService) *checker {
-	return &checker{
+func newTestChecker(service *fakeService) *Checker {
+	return &Checker{
 		service: service,
 		// deterministic reader so encrypt/decrypt assertions are predictable
 		randReader: bytes.NewReader(bytes.Repeat([]byte{0xAB}, 32)),
@@ -159,7 +159,7 @@ func TestCheck(t *testing.T) {
 		t.Run(scenario.name, func(t *testing.T) {
 			target := newTestChecker(scenario.service)
 
-			err := target.check(context.Background())
+			err := target.Check(context.Background())
 
 			if scenario.expectErr == "" && err != nil {
 				t.Fatalf("unexpected error: %v", err)

--- a/pkg/operator/encryption/kms/preflight/checker.go
+++ b/pkg/operator/encryption/kms/preflight/checker.go
@@ -28,12 +28,12 @@ type checker struct {
 	statusInterval time.Duration
 }
 
-func newChecker(service kmsservice.Service) *checker {
+func newChecker(service kmsservice.Service, statusTimeout, statusInterval time.Duration) *checker {
 	return &checker{
 		service:        service,
 		randReader:     rand.Reader,
-		statusTimeout:  30 * time.Second,
-		statusInterval: 2 * time.Second,
+		statusTimeout:  statusTimeout,
+		statusInterval: statusInterval,
 	}
 }
 

--- a/pkg/operator/encryption/kms/preflight/cmd.go
+++ b/pkg/operator/encryption/kms/preflight/cmd.go
@@ -10,6 +10,8 @@ import (
 
 	k8senvelopekmsv2 "k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2"
 	"k8s.io/klog/v2"
+
+	"github.com/openshift/library-go/pkg/operator/encryption/kms"
 )
 
 const kmsSocketEndpoint = "unix:///var/run/kmsplugin/kms.sock"
@@ -67,9 +69,9 @@ func (o *options) run(ctx context.Context) error {
 		return fmt.Errorf("failed to create KMS gRPC client: %w", err)
 	}
 
-	checker := newChecker(service, o.statusTimeout, o.statusInterval)
+	checker := kms.NewChecker(service, o.statusTimeout, o.statusInterval)
 	start := time.Now()
-	if err = checker.check(ctx); err != nil {
+	if err = checker.Check(ctx); err != nil {
 		return fmt.Errorf("kms preflight check failed: %w", err)
 	}
 

--- a/pkg/operator/encryption/kms/preflight/cmd.go
+++ b/pkg/operator/encryption/kms/preflight/cmd.go
@@ -16,11 +16,20 @@ const kmsSocketEndpoint = "unix:///var/run/kmsplugin/kms.sock"
 
 type options struct {
 	kmsCallTimeout time.Duration
+	// endpoint and the status timeouts are fields rather than flags so tests can
+	// drive run() against an in-process mock; production uses the defaults below.
+	endpoint       string
+	statusTimeout  time.Duration
+	statusInterval time.Duration
 }
 
 // NewCommand creates the kms-preflight cobra command.
 func NewCommand(ctx context.Context) *cobra.Command {
-	o := &options{}
+	o := &options{
+		endpoint:       kmsSocketEndpoint,
+		statusTimeout:  30 * time.Second,
+		statusInterval: 2 * time.Second,
+	}
 
 	cmd := &cobra.Command{
 		Use:   "kms-preflight",
@@ -49,16 +58,16 @@ func (o *options) validate() error {
 }
 
 func (o *options) run(ctx context.Context) error {
-	klog.Infof("Running KMS preflight check at %s", kmsSocketEndpoint)
+	klog.Infof("Running KMS preflight check at %s", o.endpoint)
 
 	// k8senvelopekmsv2.NewGRPCService is not a public API and may change.
 	// If it breaks, we can inline a minimal gRPC client using k8s.io/kms directly.
-	service, err := k8senvelopekmsv2.NewGRPCService(ctx, kmsSocketEndpoint, "preflight", o.kmsCallTimeout)
+	service, err := k8senvelopekmsv2.NewGRPCService(ctx, o.endpoint, "preflight", o.kmsCallTimeout)
 	if err != nil {
 		return fmt.Errorf("failed to create KMS gRPC client: %w", err)
 	}
 
-	checker := newChecker(service)
+	checker := newChecker(service, o.statusTimeout, o.statusInterval)
 	start := time.Now()
 	if err = checker.check(ctx); err != nil {
 		return fmt.Errorf("kms preflight check failed: %w", err)

--- a/pkg/operator/encryption/kms/preflight/cmd_e2e_test.go
+++ b/pkg/operator/encryption/kms/preflight/cmd_e2e_test.go
@@ -1,0 +1,206 @@
+package preflight
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	kmsapi "k8s.io/kms/apis/v2"
+)
+
+type mockPlugin struct {
+	kmsapi.UnimplementedKeyManagementServiceServer
+	StatusFn  func(context.Context, *kmsapi.StatusRequest) (*kmsapi.StatusResponse, error)
+	EncryptFn func(context.Context, *kmsapi.EncryptRequest) (*kmsapi.EncryptResponse, error)
+	DecryptFn func(context.Context, *kmsapi.DecryptRequest) (*kmsapi.DecryptResponse, error)
+}
+
+func (m *mockPlugin) Status(ctx context.Context, req *kmsapi.StatusRequest) (*kmsapi.StatusResponse, error) {
+	return m.StatusFn(ctx, req)
+}
+
+func (m *mockPlugin) Encrypt(ctx context.Context, req *kmsapi.EncryptRequest) (*kmsapi.EncryptResponse, error) {
+	return m.EncryptFn(ctx, req)
+}
+
+func (m *mockPlugin) Decrypt(ctx context.Context, req *kmsapi.DecryptRequest) (*kmsapi.DecryptResponse, error) {
+	return m.DecryptFn(ctx, req)
+}
+
+func healthyPlugin() *mockPlugin {
+	return &mockPlugin{
+		StatusFn: func(context.Context, *kmsapi.StatusRequest) (*kmsapi.StatusResponse, error) {
+			return &kmsapi.StatusResponse{Healthz: "ok", Version: "v2", KeyId: "key-1"}, nil
+		},
+		EncryptFn: func(_ context.Context, req *kmsapi.EncryptRequest) (*kmsapi.EncryptResponse, error) {
+			ciphertext := []byte(base64.StdEncoding.EncodeToString(req.Plaintext))
+			return &kmsapi.EncryptResponse{Ciphertext: ciphertext, KeyId: "key-1"}, nil
+		},
+		DecryptFn: func(_ context.Context, req *kmsapi.DecryptRequest) (*kmsapi.DecryptResponse, error) {
+			plaintext, err := base64.StdEncoding.DecodeString(string(req.Ciphertext))
+			if err != nil {
+				return nil, err
+			}
+			return &kmsapi.DecryptResponse{Plaintext: plaintext}, nil
+		},
+	}
+}
+
+func startMockPlugin(t *testing.T, plugin kmsapi.KeyManagementServiceServer) string {
+	t.Helper()
+	endpoint, sockPath := tempSocket(t)
+
+	listener, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen on unix socket: %v", err)
+	}
+	server := grpc.NewServer()
+	kmsapi.RegisterKeyManagementServiceServer(server, plugin)
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(server.Stop)
+
+	return endpoint
+}
+
+// os.MkdirTemp, not t.TempDir: the latter embeds the long subtest name and
+// unix socket paths are capped at ~108 bytes.
+func tempSocket(t *testing.T) (endpoint, sockPath string) {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "kms-preflight")
+	if err != nil {
+		t.Fatalf("create temp dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	sockPath = filepath.Join(dir, "kms.sock")
+	return "unix://" + sockPath, sockPath
+}
+
+func testOptions(endpoint string) *options {
+	return &options{
+		kmsCallTimeout: 5 * time.Second,
+		endpoint:       endpoint,
+		// short so the status-poll cases fail in well under a second
+		statusTimeout:  200 * time.Millisecond,
+		statusInterval: 20 * time.Millisecond,
+	}
+}
+
+// TestRunE2E covers run()'s wiring over a real socket, independently of where checker lives.
+func TestRunE2E(t *testing.T) {
+	tests := []struct {
+		name string
+		// plugin nil means: start no server, point run() at a dead socket.
+		plugin    *mockPlugin
+		expectErr string
+	}{
+		{
+			name:   "happy path",
+			plugin: healthyPlugin(),
+		},
+		{
+			name: "healthy after transient status error",
+			plugin: func() *mockPlugin {
+				p := healthyPlugin()
+				var calls atomic.Int32
+				p.StatusFn = func(context.Context, *kmsapi.StatusRequest) (*kmsapi.StatusResponse, error) {
+					if calls.Add(1) == 1 {
+						return nil, fmt.Errorf("connection refused")
+					}
+					return &kmsapi.StatusResponse{Healthz: "ok", Version: "v2", KeyId: "key-1"}, nil
+				}
+				return p
+			}(),
+		},
+		{
+			name: "persistent unhealthy status exceeds timeout",
+			plugin: func() *mockPlugin {
+				p := healthyPlugin()
+				p.StatusFn = func(context.Context, *kmsapi.StatusRequest) (*kmsapi.StatusResponse, error) {
+					return &kmsapi.StatusResponse{Healthz: "not-ready"}, nil
+				}
+				return p
+			}(),
+			expectErr: "context deadline exceeded",
+		},
+		{
+			name: "encrypt error",
+			plugin: func() *mockPlugin {
+				p := healthyPlugin()
+				p.EncryptFn = func(context.Context, *kmsapi.EncryptRequest) (*kmsapi.EncryptResponse, error) {
+					return nil, fmt.Errorf("key not found")
+				}
+				return p
+			}(),
+			expectErr: "encrypt call failed",
+		},
+		{
+			name: "encrypt returns plaintext unchanged",
+			plugin: func() *mockPlugin {
+				p := healthyPlugin()
+				p.EncryptFn = func(_ context.Context, req *kmsapi.EncryptRequest) (*kmsapi.EncryptResponse, error) {
+					return &kmsapi.EncryptResponse{Ciphertext: req.Plaintext, KeyId: "key-1"}, nil
+				}
+				return p
+			}(),
+			expectErr: "encrypt returned plaintext unchanged",
+		},
+		{
+			name: "decrypt error",
+			plugin: func() *mockPlugin {
+				p := healthyPlugin()
+				p.DecryptFn = func(context.Context, *kmsapi.DecryptRequest) (*kmsapi.DecryptResponse, error) {
+					return nil, fmt.Errorf("decryption failed")
+				}
+				return p
+			}(),
+			expectErr: "decrypt call failed",
+		},
+		{
+			name: "decrypt roundtrip mismatch",
+			plugin: func() *mockPlugin {
+				p := healthyPlugin()
+				p.DecryptFn = func(context.Context, *kmsapi.DecryptRequest) (*kmsapi.DecryptResponse, error) {
+					return &kmsapi.DecryptResponse{Plaintext: []byte("wrong-plaintext")}, nil
+				}
+				return p
+			}(),
+			expectErr: "decrypt roundtrip mismatch",
+		},
+		{
+			name:      "dead socket exceeds timeout",
+			plugin:    nil,
+			expectErr: "context deadline exceeded",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var endpoint string
+			if tc.plugin != nil {
+				endpoint = startMockPlugin(t, tc.plugin)
+			} else {
+				endpoint, _ = tempSocket(t)
+			}
+
+			err := testOptions(endpoint).run(context.Background())
+
+			if tc.expectErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.expectErr) {
+				t.Fatalf("expected error containing %q, got: %v", tc.expectErr, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Add an end-to-end test for the preflight command, then move `checker.go` from `preflight` into the parent `kms` package (exported as `Checker`).

## Why

The checker is a generic KMS status/encrypt/decrypt probe, not preflight-specific, so it belongs in the `kms` package where other callers can reuse it. The e2e test was added first so the move is a provable no-op for `preflight`.

## Notes

- The e2e test lives in `preflight` and is unchanged across the move, that is the regression guard.
- Endpoint and status-poll timeouts became `options` fields so `run()` is testable; production defaults are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced KMS preflight checker with configurable timeout and status check interval parameters for improved operational flexibility.

* **Tests**
  * Added comprehensive end-to-end tests for KMS preflight validation covering normal operation, error handling, and timeout scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->