### PR TITLE
CNTRLPLANE-3545: kms: rename credentials references to referenceData

### DIFF
--- a/pkg/operator/encryption/kms/pluginlifecycle/credentials_test.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/credentials_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCredentialResolver_SecretValue(t *testing.T) {
+func TestReferenceDataResolver_SecretValue(t *testing.T) {
 	const keyID = "42"
 	pluginsSecretData := newTestPluginsSecretData(t, keyID, "my-role-id", "my-secret-id")
 
@@ -62,9 +62,9 @@ func TestCredentialResolver_SecretValue(t *testing.T) {
 	}
 }
 
-func TestCredentialResolver_SecretFilePath(t *testing.T) {
+func TestReferenceDataResolver_SecretFilePath(t *testing.T) {
 	const keyID = "42"
-	const credentialsDir = "/etc/kubernetes/static-pod-resources/secrets/encryption-config"
+	const referenceDataDir = "/etc/kubernetes/static-pod-resources/secrets/encryption-config"
 
 	pluginsSecretData := newTestPluginsSecretData(t, keyID, "my-role-id", "my-secret-id")
 
@@ -81,7 +81,7 @@ func TestCredentialResolver_SecretFilePath(t *testing.T) {
 			keyID:      keyID,
 			secretName: "vault-approle",
 			dataKey:    "secret-id",
-			expected:   filepath.Join(credentialsDir, encryptiondata.FormatKMSSecretDataKey("vault-approle_secret-id", keyID)),
+			expected:   filepath.Join(referenceDataDir, encryptiondata.FormatKMSSecretDataKey("vault-approle_secret-id", keyID)),
 		},
 		{
 			name:       "missing keyID",
@@ -103,7 +103,7 @@ func TestCredentialResolver_SecretFilePath(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			r := &referenceDataResolver{
 				keyID:             tc.keyID,
-				referenceDataDir:  credentialsDir,
+				referenceDataDir:  referenceDataDir,
 				pluginsSecretData: pluginsSecretData,
 			}
 
@@ -118,9 +118,9 @@ func TestCredentialResolver_SecretFilePath(t *testing.T) {
 	}
 }
 
-func TestCredentialResolver_ConfigMapFilePath(t *testing.T) {
+func TestReferenceDataResolver_ConfigMapFilePath(t *testing.T) {
 	const keyID = "42"
-	const credentialsDir = "/etc/kubernetes/static-pod-resources/secrets/encryption-config"
+	const referenceDataDir = "/etc/kubernetes/static-pod-resources/secrets/encryption-config"
 
 	pluginsConfigMapData := newTestPluginsConfigMapData(t, keyID, "my-ca-bundle")
 
@@ -137,7 +137,7 @@ func TestCredentialResolver_ConfigMapFilePath(t *testing.T) {
 			keyID:         keyID,
 			configMapName: "vault-ca-bundle",
 			dataKey:       "ca-bundle.crt",
-			expected:      filepath.Join(credentialsDir, encryptiondata.FormatKMSConfigMapDataKey("vault-ca-bundle_ca-bundle.crt", keyID)),
+			expected:      filepath.Join(referenceDataDir, encryptiondata.FormatKMSConfigMapDataKey("vault-ca-bundle_ca-bundle.crt", keyID)),
 		},
 		{
 			name:          "missing keyID",
@@ -159,7 +159,7 @@ func TestCredentialResolver_ConfigMapFilePath(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			r := &referenceDataResolver{
 				keyID:                tc.keyID,
-				referenceDataDir:     credentialsDir,
+				referenceDataDir:     referenceDataDir,
 				pluginsConfigMapData: pluginsConfigMapData,
 			}
 

--- a/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
@@ -19,10 +19,10 @@ import (
 )
 
 const (
-	resourceDirVolumeName = "resource-dir"
-	credentialsVolumeName = "kms-plugin-credentials"
-	credentialsMountPath  = "/var/run/secrets/kms-plugin"
-	resourcesDir          = "/etc/kubernetes/static-pod-resources"
+	resourceDirVolumeName   = "resource-dir"
+	referenceDataVolumeName = "kms-plugins-data"
+	referenceDataMountPath  = "/var/run/secrets/kms-plugin"
+	resourcesDir            = "/etc/kubernetes/static-pod-resources"
 )
 
 const (
@@ -39,11 +39,11 @@ type sidecarProvider interface {
 }
 
 // newSidecarProvider creates a provider-specific sidecarProvider for the given keyID and plugin configuration,
-// wiring in credentials via the referenceDataResolver.
-func newSidecarProvider(keyID string, udsPath string, pluginConfig configv1.KMSPluginConfig, creds *referenceDataResolver) (sidecarProvider, error) {
+// wiring in reference data (secrets, configmaps) via the referenceDataResolver.
+func newSidecarProvider(keyID string, udsPath string, pluginConfig configv1.KMSPluginConfig, refData *referenceDataResolver) (sidecarProvider, error) {
 	switch pluginConfig.Type {
 	case configv1.VaultKMSProvider:
-		return newVaultSidecarProvider("vault-kms-plugin", keyID, udsPath, pluginConfig.Vault, creds)
+		return newVaultSidecarProvider("vault-kms-plugin", keyID, udsPath, pluginConfig.Vault, refData)
 	default:
 		return nil, fmt.Errorf("unsupported KMS plugin configuration")
 	}
@@ -51,7 +51,7 @@ func newSidecarProvider(keyID string, udsPath string, pluginConfig configv1.KMSP
 
 // AddKMSPluginSidecarToStaticPodSpec injects KMS plugin sidecar containers into a kube-apiserver static pod spec.
 //
-// Static pods access credentials through the resource-dir volume, which the static pod revision controller
+// Static pods access KMS plugin data through the resource-dir volume, which the static pod revision controller
 // populates on disk from the encryption-config Secret. Because those files are owned by root, each sidecar
 // is configured to run as UID 0.
 //
@@ -76,7 +76,7 @@ func AddKMSPluginSidecarToStaticPodSpec(ctx context.Context, podSpec *corev1.Pod
 		if err := ensureVolumeMountInContainer(podSpec.InitContainers, name, volumeMount); err != nil {
 			return err
 		}
-		// The resource-dir files are owned by root, so the sidecar needs root to read credential files.
+		// The resource-dir files are owned by root, so the sidecar needs root to read files in that directory.
 		if err := setRunAsUser(podSpec.InitContainers, name, 0); err != nil {
 			return err
 		}
@@ -90,7 +90,7 @@ func AddKMSPluginSidecarToStaticPodSpec(ctx context.Context, podSpec *corev1.Pod
 // It is a no-op when the KMSEncryption feature gate is not enabled or the encryption-config secret does not exist.
 // The secretClient should be uncached to avoid injecting sidecars based on a stale encryption configuration.
 func AddKMSPluginSidecarToPodSpec(ctx context.Context, podSpec *corev1.PodSpec, containerName string, encryptionConfigNamespace string, encryptionConfigSecretName string, secretClient corev1client.SecretsGetter, featureGateAccessor featuregates.FeatureGateAccess) error {
-	sidecarNames, err := addKMSPluginSidecars(ctx, podSpec, containerName, encryptionConfigNamespace, encryptionConfigSecretName, secretClient, featureGateAccessor, credentialsMountPath)
+	sidecarNames, err := addKMSPluginSidecars(ctx, podSpec, containerName, encryptionConfigNamespace, encryptionConfigSecretName, secretClient, featureGateAccessor, referenceDataMountPath)
 	if err != nil {
 		return err
 	}
@@ -101,7 +101,7 @@ func AddKMSPluginSidecarToPodSpec(ctx context.Context, podSpec *corev1.PodSpec, 
 	}
 
 	for _, name := range sidecarNames {
-		volumeMount := corev1.VolumeMount{Name: credentialsVolumeName, MountPath: credentialsMountPath, ReadOnly: true}
+		volumeMount := corev1.VolumeMount{Name: referenceDataVolumeName, MountPath: referenceDataMountPath, ReadOnly: true}
 		if err := ensureVolumeMountInContainer(podSpec.InitContainers, name, volumeMount); err != nil {
 			return err
 		}
@@ -109,7 +109,7 @@ func AddKMSPluginSidecarToPodSpec(ctx context.Context, podSpec *corev1.PodSpec, 
 
 	// Unlike static pods, aggregated API servers access credentials by mounting the encryption-config Secret directly as a volume.
 	// Callers include the revision number in encryptionConfigSecretName (e.g. "encryption-config-7"), so each revision maps to a distinct Secret and volume.
-	if err := ensureCredentialsVolume(podSpec, encryptionConfigSecretName); err != nil {
+	if err := ensureReferenceDataVolume(podSpec, encryptionConfigSecretName); err != nil {
 		return err
 	}
 
@@ -177,13 +177,13 @@ func addKMSPluginSidecars(ctx context.Context, podSpec *corev1.PodSpec, containe
 			return nil, fmt.Errorf("missing plugin config for keyID %s", keyID)
 		}
 
-		creds := &referenceDataResolver{
+		refData := &referenceDataResolver{
 			pluginsSecretData: encryptionConfig.KMSPluginsSecretData,
 			referenceDataDir:  referenceDataDir,
 			keyID:             keyID,
 		}
 
-		provider, err := newSidecarProvider(keyID, udsPath, pluginConfig, creds)
+		provider, err := newSidecarProvider(keyID, udsPath, pluginConfig, refData)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create a sidecar provider for keyID %s: %w", keyID, err)
 		}
@@ -277,9 +277,9 @@ func ensureSocketVolume(podSpec *corev1.PodSpec) error {
 	return ensureVolume(podSpec, volume)
 }
 
-func ensureCredentialsVolume(podSpec *corev1.PodSpec, secretName string) error {
+func ensureReferenceDataVolume(podSpec *corev1.PodSpec, secretName string) error {
 	volume := corev1.Volume{
-		Name: credentialsVolumeName,
+		Name: referenceDataVolumeName,
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
 				SecretName: secretName,

--- a/pkg/operator/encryption/kms/pluginlifecycle/sidecar_test.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/sidecar_test.go
@@ -124,8 +124,8 @@ func TestAddKMSPluginSidecarToPodSpec(t *testing.T) {
 		Name:      "kms-plugin-socket",
 		MountPath: "/var/run/kmsplugin",
 	}
-	credentialsMount := corev1.VolumeMount{
-		Name:      "kms-plugin-credentials",
+	refDataMount := corev1.VolumeMount{
+		Name:      "kms-plugins-data",
 		MountPath: "/var/run/secrets/kms-plugin",
 		ReadOnly:  true,
 	}
@@ -135,8 +135,8 @@ func TestAddKMSPluginSidecarToPodSpec(t *testing.T) {
 			EmptyDir: &corev1.EmptyDirVolumeSource{},
 		},
 	}
-	credentialsVolume := corev1.Volume{
-		Name: "kms-plugin-credentials",
+	refDataVolume := corev1.Volume{
+		Name: "kms-plugins-data",
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
 				SecretName: "encryption-config",
@@ -180,10 +180,10 @@ func TestAddKMSPluginSidecarToPodSpec(t *testing.T) {
 								corev1.ResourceCPU:    resource.MustParse("10m"),
 							},
 						},
-						VolumeMounts: []corev1.VolumeMount{socketMount, credentialsMount},
+						VolumeMounts: []corev1.VolumeMount{socketMount, refDataMount},
 					},
 				},
-				Volumes: []corev1.Volume{f.resourceDirVolume, socketVolume, credentialsVolume},
+				Volumes: []corev1.Volume{f.resourceDirVolume, socketVolume, refDataVolume},
 			},
 			secretClient:        secretClient(f.encryptionConfigSecret),
 			featureGateAccessor: featuregates.NewHardcodedFeatureGateAccess([]configv1.FeatureGateName{features.FeatureGateKMSEncryption}, nil),
@@ -227,7 +227,7 @@ func TestAddKMSPluginSidecarToPodSpec(t *testing.T) {
 								corev1.ResourceCPU:    resource.MustParse("10m"),
 							},
 						},
-						VolumeMounts: []corev1.VolumeMount{socketMount, credentialsMount},
+						VolumeMounts: []corev1.VolumeMount{socketMount, refDataMount},
 					},
 					{
 						Name:  "vault-kms-plugin-555",
@@ -252,10 +252,10 @@ func TestAddKMSPluginSidecarToPodSpec(t *testing.T) {
 								corev1.ResourceCPU:    resource.MustParse("10m"),
 							},
 						},
-						VolumeMounts: []corev1.VolumeMount{socketMount, credentialsMount},
+						VolumeMounts: []corev1.VolumeMount{socketMount, refDataMount},
 					},
 				},
-				Volumes: []corev1.Volume{f.resourceDirVolume, socketVolume, credentialsVolume},
+				Volumes: []corev1.Volume{f.resourceDirVolume, socketVolume, refDataVolume},
 			},
 			secretClient: func() corev1client.SecretsGetter {
 				vaultConfig2 := &configv1.KMSPluginConfig{
@@ -475,10 +475,10 @@ func TestAddKMSPluginSidecarToPodSpec(t *testing.T) {
 								corev1.ResourceCPU:    resource.MustParse("10m"),
 							},
 						},
-						VolumeMounts: []corev1.VolumeMount{socketMount, credentialsMount},
+						VolumeMounts: []corev1.VolumeMount{socketMount, refDataMount},
 					},
 				},
-				Volumes: []corev1.Volume{f.resourceDirVolume, socketVolume, credentialsVolume},
+				Volumes: []corev1.Volume{f.resourceDirVolume, socketVolume, refDataVolume},
 			},
 			secretClient:        secretClient(f.encryptionConfigSecret),
 			featureGateAccessor: featuregates.NewHardcodedFeatureGateAccess([]configv1.FeatureGateName{features.FeatureGateKMSEncryption}, nil),

--- a/pkg/operator/encryption/kms/pluginlifecycle/vault.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/vault.go
@@ -11,13 +11,13 @@ import (
 
 // newVaultSidecarProvider creates a Vault sidecar provider from the given KMS plugin data.
 // It assumes the input data has been already been validated.
-func newVaultSidecarProvider(name, keyID, udsPath string, vaultConfig configv1.VaultKMSPluginConfig, creds *referenceDataResolver) (*vault, error) {
+func newVaultSidecarProvider(name, keyID, udsPath string, vaultConfig configv1.VaultKMSPluginConfig, refData *referenceDataResolver) (*vault, error) {
 	secretName := vaultConfig.Authentication.AppRole.Secret.Name
 	if secretName == "" {
 		return nil, fmt.Errorf("vault AppRole authentication secret name cannot be empty")
 	}
 
-	roleID, err := creds.SecretValue(secretName, "role-id")
+	roleID, err := refData.SecretValue(secretName, "role-id")
 	if err != nil {
 		return nil, err
 	}
@@ -26,7 +26,7 @@ func newVaultSidecarProvider(name, keyID, udsPath string, vaultConfig configv1.V
 		return nil, fmt.Errorf("role ID cannot be empty")
 	}
 
-	secretIDPath, err := creds.SecretFilePath(secretName, "secret-id")
+	secretIDPath, err := refData.SecretFilePath(secretName, "secret-id")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operator/encryption/kms/pluginlifecycle/vault_test.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/vault_test.go
@@ -25,7 +25,7 @@ func TestVaultSidecarProvider_BuildSidecarContainer(t *testing.T) {
 		name               string
 		vaultConfig        configv1.VaultKMSPluginConfig
 		secretData         state.KMSReferenceData
-		credentialsDir     string
+		referenceDataDir   string
 		containerName      string
 		keyID              string
 		udsPath            string
@@ -47,12 +47,12 @@ func TestVaultSidecarProvider_BuildSidecarContainer(t *testing.T) {
 					},
 				},
 			},
-			secretData:      newVaultAppRoleSecretData(t, "test-role-id", "test-secret-id"),
-			credentialsDir:  "/etc/kubernetes/static-pod-resources/secrets/encryption-config",
-			containerName:   "kms-plugin",
-			keyID:           "555",
-			udsPath:         "unix:///var/run/kmsplugin/kms-555.sock",
-			inputContainers: nil,
+			secretData:       newVaultAppRoleSecretData(t, "test-role-id", "test-secret-id"),
+			referenceDataDir: "/etc/kubernetes/static-pod-resources/secrets/encryption-config",
+			containerName:    "kms-plugin",
+			keyID:            "555",
+			udsPath:          "unix:///var/run/kmsplugin/kms-555.sock",
+			inputContainers:  nil,
 			expectedContainers: []corev1.Container{
 				{
 					Name:  "kms-plugin-555",
@@ -94,11 +94,11 @@ func TestVaultSidecarProvider_BuildSidecarContainer(t *testing.T) {
 					},
 				},
 			},
-			secretData:     newVaultAppRoleSecretData(t, "test-role-id", "test-secret-id"),
-			credentialsDir: "/etc/kubernetes/static-pod-resources/secrets/encryption-config",
-			containerName:  "kms-plugin",
-			keyID:          "555",
-			udsPath:        "unix:///var/run/kmsplugin/kms-555.sock",
+			secretData:       newVaultAppRoleSecretData(t, "test-role-id", "test-secret-id"),
+			referenceDataDir: "/etc/kubernetes/static-pod-resources/secrets/encryption-config",
+			containerName:    "kms-plugin",
+			keyID:            "555",
+			udsPath:          "unix:///var/run/kmsplugin/kms-555.sock",
 			inputContainers: []corev1.Container{
 				{
 					Name:  "kube-apiserver",
@@ -150,12 +150,12 @@ func TestVaultSidecarProvider_BuildSidecarContainer(t *testing.T) {
 					},
 				},
 			},
-			secretData:      newVaultAppRoleSecretData(t, "test-role-id-999", "test-secret-id-999"),
-			credentialsDir:  "/var/run/secrets/kms-plugin",
-			containerName:   "kms-plugin",
-			keyID:           "999",
-			udsPath:         "unix:///var/run/kmsplugin/kms.sock",
-			inputContainers: nil,
+			secretData:       newVaultAppRoleSecretData(t, "test-role-id-999", "test-secret-id-999"),
+			referenceDataDir: "/var/run/secrets/kms-plugin",
+			containerName:    "kms-plugin",
+			keyID:            "999",
+			udsPath:          "unix:///var/run/kmsplugin/kms.sock",
+			inputContainers:  nil,
 			expectedContainers: []corev1.Container{
 				{
 					Name:  "kms-plugin-999",
@@ -206,13 +206,13 @@ func TestVaultSidecarProvider_BuildSidecarContainer(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			creds := &referenceDataResolver{
+			refData := &referenceDataResolver{
 				pluginsSecretData: pluginsSecretData,
-				referenceDataDir:  tt.credentialsDir,
+				referenceDataDir:  tt.referenceDataDir,
 				keyID:             tt.keyID,
 			}
 
-			provider, err := newVaultSidecarProvider(tt.containerName, tt.keyID, tt.udsPath, tt.vaultConfig, creds)
+			provider, err := newVaultSidecarProvider(tt.containerName, tt.keyID, tt.udsPath, tt.vaultConfig, refData)
 			if tt.expectErr != "" {
 				require.EqualError(t, err, tt.expectErr)
 				return


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * KMS plugin sidecar credential handling migrated to use "reference data" volumes and mounts.
  * Volume names, mount paths, and init-container wiring updated so injected sidecars mount reference data read-only.
  * Resolver and provider wiring consolidated into a unified reference-data resolver used when constructing sidecars.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->