### PR TITLE
CNTRLPLANE-3545: kms: update comment to use referenceData terminology

### DIFF
--- a/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
@@ -107,7 +107,7 @@ func AddKMSPluginSidecarToPodSpec(ctx context.Context, podSpec *corev1.PodSpec, 
 		}
 	}
 
-	// Unlike static pods, aggregated API servers access credentials by mounting the encryption-config Secret directly as a volume.
+	// Unlike static pods, aggregated API servers access KMS plugin data by mounting the encryption-config Secret directly as a volume.
 	// Callers include the revision number in encryptionConfigSecretName (e.g. "encryption-config-7"), so each revision maps to a distinct Secret and volume.
 	if err := ensureReferenceDataVolume(podSpec, encryptionConfigSecretName); err != nil {
 		return err


### PR DESCRIPTION
Follow-up to 1c75dec867f6258dc16015c072755af512b7e208.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified KMS plugin sidecar documentation regarding how aggregated API servers access KMS plugin data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->