### PR TITLE
kms/health: add options -> config split, set-based check

### DIFF
--- a/pkg/operator/encryption/kms/health/cmd.go
+++ b/pkg/operator/encryption/kms/health/cmd.go
@@ -25,16 +25,6 @@ const providerName = "kms-health-reporter"
 // mounted at, e.g. unix:///var/run/kmsplugin/kms-1.sock.
 var kmsSocketPattern = regexp.MustCompile(`^unix:///var/run/kmsplugin/kms-(\d+)\.sock$`)
 
-// keyIDFromSocket extracts the sequential key id captured by kmsSocketPattern,
-// e.g. "1" from unix:///var/run/kmsplugin/kms-1.sock.
-func keyIDFromSocket(socket string) (string, error) {
-	m := kmsSocketPattern.FindStringSubmatch(socket)
-	if m == nil {
-		return "", fmt.Errorf("socket %q must match %s", socket, kmsSocketPattern)
-	}
-	return m[1], nil
-}
-
 // options' flag-bound fields are exported so the struct can be logged as a
 // whole via klog.InfoS, which JSON-marshals its values.
 type options struct {
@@ -188,6 +178,16 @@ func buildPlugins(ctx context.Context, sockets []string, timeout time.Duration) 
 	}
 
 	return plugins, nil
+}
+
+// keyIDFromSocket extracts the sequential key id captured by kmsSocketPattern,
+// e.g. "1" from unix:///var/run/kmsplugin/kms-1.sock.
+func keyIDFromSocket(socket string) (string, error) {
+	m := kmsSocketPattern.FindStringSubmatch(socket)
+	if m == nil {
+		return "", fmt.Errorf("socket %q must match %s", socket, kmsSocketPattern)
+	}
+	return m[1], nil
 }
 
 // setupSignalContext registers for SIGTERM and SIGINT and returns a context

--- a/pkg/operator/encryption/kms/health/cmd.go
+++ b/pkg/operator/encryption/kms/health/cmd.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/server"
 	k8senvelopekmsv2 "k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2"
@@ -80,15 +81,15 @@ func (o *options) validate() error {
 	if len(o.KMSSockets) == 0 {
 		return fmt.Errorf("--kms-sockets is required, at least one")
 	}
-	socketSet := make(map[string]struct{}, len(o.KMSSockets))
+	socketSet := sets.New[string]()
 	for _, s := range o.KMSSockets {
 		if !kmsSocketPattern.MatchString(s) {
 			return fmt.Errorf("--kms-sockets entry %q must match %s", s, kmsSocketPattern)
 		}
-		if _, ok := socketSet[s]; ok {
+		if socketSet.Has(s) {
 			return fmt.Errorf("--kms-sockets entry %q is duplicated", s)
 		}
-		socketSet[s] = struct{}{}
+		socketSet.Insert(s)
 	}
 
 	if o.Interval <= 0 {

--- a/pkg/operator/encryption/kms/health/cmd.go
+++ b/pkg/operator/encryption/kms/health/cmd.go
@@ -48,6 +48,15 @@ type options struct {
 	newOperatorClient func(*rest.Config) (v1helpers.OperatorClient, error)
 }
 
+type Config struct {
+	operatorClient v1helpers.OperatorClient
+	prober         *prober
+
+	interval     time.Duration
+	writeTimeout time.Duration
+	nodeName     string
+}
+
 func NewCommand(ctx context.Context, newOperatorClient func(*rest.Config) (v1helpers.OperatorClient, error)) *cobra.Command {
 	o := &options{
 		newOperatorClient: newOperatorClient,
@@ -61,7 +70,18 @@ func NewCommand(ctx context.Context, newOperatorClient func(*rest.Config) (v1hel
 			if err := o.validate(); err != nil {
 				return err
 			}
-			return o.run(ctx)
+
+			// Arm signal handling before Config builds anything needing graceful teardown.
+			// Idiomatically the caller's main would own this; kept here because
+			// library-go ships the command, not the main.
+			ctx := setupSignalContext(ctx)
+			klog.InfoS("kms-health-reporter starting", "config", o)
+
+			cfg, err := o.Config(ctx)
+			if err != nil {
+				return err
+			}
+			return cfg.Run(ctx)
 		},
 	}
 	o.addFlags(cmd.Flags())
@@ -108,35 +128,41 @@ func (o *options) validate() error {
 	return nil
 }
 
-func (o *options) run(ctx context.Context) error {
-	ctx = setupSignalContext(ctx)
-
+func (o *options) Config(ctx context.Context) (*Config, error) {
 	// Empty kubeconfig falls back to the in-cluster config (service account
 	// token + KUBERNETES_SERVICE_HOST), which is the deployed path.
-	cfg, err := clientcmd.BuildConfigFromFlags("", o.Kubeconfig)
+	restCfg, err := clientcmd.BuildConfigFromFlags("", o.Kubeconfig)
 	if err != nil {
-		return fmt.Errorf("build rest config: %w", err)
+		return nil, fmt.Errorf("build rest config: %w", err)
 	}
 
-	if _, err := o.newOperatorClient(cfg); err != nil {
-		return fmt.Errorf("build operator client: %w", err)
+	operatorClient, err := o.newOperatorClient(restCfg)
+	if err != nil {
+		return nil, fmt.Errorf("build operator client: %w", err)
 	}
 
 	plugins, err := buildPlugins(ctx, o.KMSSockets, o.ReadTimeout)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	prober := newProber(plugins)
 
-	klog.InfoS("kms-health-reporter starting", "config", o)
+	return &Config{
+		operatorClient: operatorClient,
+		prober:         newProber(plugins),
+		interval:       o.Interval,
+		writeTimeout:   o.WriteTimeout,
+		nodeName:       o.NodeName,
+	}, nil
+}
 
+func (c *Config) Run(ctx context.Context) error {
 	wait.JitterUntilWithContext(ctx, func(ctx context.Context) {
-		// Each Status RPC enforces o.ReadTimeout internally (set at dial time);
-		// ctx here only carries shutdown cancellation.
-		conditions := prober.probeAll(ctx)
+		// Each Status RPC enforces the read timeout internally (set at dial
+		// time); ctx here only carries shutdown cancellation.
+		conditions := c.prober.probeAll(ctx)
 		// TODO: hand conditions to the writer once it lands; logging is a placeholder.
 		klog.InfoS("kms plugin health", "conditions", conditions)
-	}, o.Interval, 0.1, false)
+	}, c.interval, 0.1, false)
 
 	return nil
 }


### PR DESCRIPTION
Refactors the `kms-health-reporter` command into the idiomatic options -> Config -> Run split:

- `options` stays the raw flag layer; `validate()` stays pure.
- `options.Config(ctx)` builds the runnable wiring (rest config, operator client, plugins): the startup I/O that can fail.
- `Config.Run(ctx)` drives the steady-state probe loop.

Also dedups sockets with a `sets.Set` in `validate`, and moves `keyIDFromSocket` below the lifecycle funcs so the spotlight stays on the lifecycle.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved KMS health reporter implementation with enhanced health status logging and clearer code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->