### PR TITLE
Add new KMS to KMS migration test cases

### DIFF
--- a/test/library/encryption/helpers.go
+++ b/test/library/encryption/helpers.go
@@ -94,17 +94,26 @@ func SetAndWaitForEncryptionType(ctx context.Context, t testing.TB, provider Enc
 
 	apiServer, err := clientSet.ApiServerConfig.Get(ctx, "cluster", metav1.GetOptions{})
 	require.NoError(t, err)
-	needsUpdate := !equality.Semantic.DeepEqual(apiServer.Spec.Encryption, provider.APIServerEncryption)
+	previousEncryption := apiServer.Spec.Encryption
+	needsUpdate := !equality.Semantic.DeepEqual(previousEncryption, provider.APIServerEncryption)
 	if needsUpdate {
 		if provider.Setup != nil {
 			provider.Setup(ctx, t)
 		}
-		t.Logf("Updating encryption configuration for APIServer from %#v to %#v", apiServer.Spec.Encryption, provider.APIServerEncryption)
+		t.Logf("Updating encryption configuration for APIServer from %#v to %#v", previousEncryption, provider.APIServerEncryption)
 		apiServer.Spec.Encryption = provider.APIServerEncryption
 		_, err = clientSet.ApiServerConfig.Update(ctx, apiServer, metav1.UpdateOptions{})
 		require.NoError(t, err)
 	} else {
 		t.Logf("APIServer is already configured to use %q mode", provider.Type)
+	}
+
+	// KMS-to-KMS migration: when both old and new are KMS but the config differs,
+	// the key controller creates a new key. We must wait for the next migrated key
+	// rather than asserting no new key is created.
+	if needsUpdate && provider.Type == configv1.EncryptionTypeKMS && previousEncryption.Type == configv1.EncryptionTypeKMS {
+		WaitForNextMigratedKey(t, clientSet.Kube, lastMigratedKeyMeta, defaultTargetGRs, namespace, labelSelector)
+		return clientSet
 	}
 
 	WaitForEncryptionKeyBasedOn(t, clientSet.Kube, lastMigratedKeyMeta, provider.Type, defaultTargetGRs, namespace, labelSelector)

--- a/test/library/encryption/scenarios.go
+++ b/test/library/encryption/scenarios.go
@@ -354,6 +354,107 @@ func TestKMSInvalidEncryptionRecovery(ctx context.Context, t testing.TB, scenari
 	}
 }
 
+// KMSToKMSMigrationScenario tests migration between two distinct KMS configurations
+// (e.g. different Vault instances or transit keys). Unlike in-place updates, changing a
+// key-triggering field (transit key, vault address, etc.) causes the operator to mint a
+// new encryption key and re-encrypt all resources.
+type KMSToKMSMigrationScenario struct {
+	BasicScenario
+	CreateResourceFunc             func(t testing.TB, clientSet ClientSet, namespace string) runtime.Object
+	AssertResourceEncryptedFunc    func(t testing.TB, clientSet ClientSet, resource runtime.Object)
+	AssertResourceNotEncryptedFunc func(t testing.TB, clientSet ClientSet, resource runtime.Object)
+	ResourceFunc                   func(t testing.TB, namespace string) runtime.Object
+	ResourceName                   string
+	PrimaryProvider                EncryptionProvider
+	SecondaryProvider              EncryptionProvider
+}
+
+// TestKMSToKMSMigration validates round-trip migration between two KMS providers:
+//  1. Create a test resource
+//  2. Encrypt with primary KMS provider and verify
+//  3. Migrate to secondary KMS provider — a new key is created and resources re-encrypted
+//  4. Migrate back to primary KMS provider — verifies returning to original works
+//  5. Switch to identity — verify resources are decrypted
+func TestKMSToKMSMigration(ctx context.Context, t testing.TB, scenario KMSToKMSMigrationScenario) {
+	require.NotNil(t, scenario.PrimaryProvider.Setup, "PrimaryProvider.Setup must not be nil")
+	require.NotNil(t, scenario.SecondaryProvider.Setup, "SecondaryProvider.Setup must not be nil")
+	require.Equal(t, configv1.EncryptionTypeKMS, scenario.PrimaryProvider.Type, "PrimaryProvider must use KMS encryption type")
+	require.Equal(t, configv1.EncryptionTypeKMS, scenario.SecondaryProvider.Type, "SecondaryProvider must use KMS encryption type")
+
+	TestEncryptionProvidersMigration(ctx, t, ProvidersMigrationScenario{
+		BasicScenario:                  scenario.BasicScenario,
+		CreateResourceFunc:             scenario.CreateResourceFunc,
+		AssertResourceEncryptedFunc:    scenario.AssertResourceEncryptedFunc,
+		AssertResourceNotEncryptedFunc: scenario.AssertResourceNotEncryptedFunc,
+		ResourceFunc:                   scenario.ResourceFunc,
+		ResourceName:                   scenario.ResourceName,
+		EncryptionProviders: []EncryptionProvider{
+			scenario.PrimaryProvider,
+			scenario.SecondaryProvider,
+			scenario.PrimaryProvider,
+		},
+	})
+}
+
+// TestKMSToKMSOnOff validates KMS on/off cycle using the KMS-to-KMS scenario struct:
+//  1. Create a test resource
+//  2. Encrypt with primary KMS → verify encrypted
+//  3. Switch to identity → verify decrypted
+//  4. Encrypt with secondary KMS → verify encrypted
+//  5. Switch to identity → verify decrypted
+func TestKMSToKMSOnOff(ctx context.Context, t testing.TB, scenario KMSToKMSMigrationScenario) {
+	require.NotNil(t, scenario.PrimaryProvider.Setup, "PrimaryProvider.Setup must not be nil")
+	require.NotNil(t, scenario.SecondaryProvider.Setup, "SecondaryProvider.Setup must not be nil")
+	require.Equal(t, configv1.EncryptionTypeKMS, scenario.PrimaryProvider.Type, "PrimaryProvider must use KMS encryption type")
+	require.Equal(t, configv1.EncryptionTypeKMS, scenario.SecondaryProvider.Type, "SecondaryProvider must use KMS encryption type")
+
+	e := NewE(t, PrintEventsOnFailure(scenario.OperatorNamespace))
+
+	steps := []testStep{
+		{name: "CreateResource", testFunc: func(t testing.TB) {
+			clientSet := GetClients(t)
+			scenario.CreateResourceFunc(t, clientSet, scenario.Namespace)
+		}},
+		{name: "EncryptWithPrimaryKMS", testFunc: func(t testing.TB) {
+			TestEncryptionType(ctx, t, scenario.BasicScenario, scenario.PrimaryProvider)
+		}},
+		{name: "AssertEncryptedWithPrimary", testFunc: func(t testing.TB) {
+			clientSet := GetClients(t)
+			scenario.AssertResourceEncryptedFunc(t, clientSet, scenario.ResourceFunc(t, scenario.Namespace))
+		}},
+		{name: "OffIdentityAfterPrimary", testFunc: func(t testing.TB) {
+			TestEncryptionTypeIdentity(ctx, t, scenario.BasicScenario)
+		}},
+		{name: "AssertDecryptedAfterPrimary", testFunc: func(t testing.TB) {
+			clientSet := GetClients(t)
+			scenario.AssertResourceNotEncryptedFunc(t, clientSet, scenario.ResourceFunc(t, scenario.Namespace))
+		}},
+		{name: "EncryptWithSecondaryKMS", testFunc: func(t testing.TB) {
+			TestEncryptionType(ctx, t, scenario.BasicScenario, scenario.SecondaryProvider)
+		}},
+		{name: "AssertEncryptedWithSecondary", testFunc: func(t testing.TB) {
+			clientSet := GetClients(t)
+			scenario.AssertResourceEncryptedFunc(t, clientSet, scenario.ResourceFunc(t, scenario.Namespace))
+		}},
+		{name: "OffIdentityAfterSecondary", testFunc: func(t testing.TB) {
+			TestEncryptionTypeIdentity(ctx, t, scenario.BasicScenario)
+		}},
+		{name: "AssertDecryptedAfterSecondary", testFunc: func(t testing.TB) {
+			clientSet := GetClients(t)
+			scenario.AssertResourceNotEncryptedFunc(t, clientSet, scenario.ResourceFunc(t, scenario.Namespace))
+		}},
+	}
+
+	for _, step := range steps {
+		t.Logf("=== STEP: %s ===", step.name)
+		step.testFunc(e)
+		if t.Failed() {
+			t.Errorf("stopping the test as %q step failed", step.name)
+			return
+		}
+	}
+}
+
 // KMSInPlaceUpdateScenario tests that updating an in-place KMS config field
 // (e.g. kmsPluginImage) takes effect without creating a new encryption key.
 // The caller supplies Provider (initial valid config) and UpdatedProvider (same config


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added KMS-to-KMS migration scenario coverage, including a full primary → secondary → primary transition and verification that resources can be decrypted after the final identity switch.
  * Added step-driven KMS on/off flow tests that encrypt with the primary key, switch to identity to confirm decryption, then encrypt with the secondary key and confirm decryption again after switching back.
  * Improved the waiting/verification behavior for KMS-to-KMS encryption type transitions to better account for key recreation during updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->