### PR TITLE
Combine kms to kms migration

### DIFF
--- a/pkg/operator/encryption/controllers/key_controller.go
+++ b/pkg/operator/encryption/controllers/key_controller.go
@@ -199,9 +199,18 @@ func (c *keyController) checkAndCreateKeys(ctx context.Context, syncContext fact
 	// fills up the state with all resources and set identity write key if write key secrets
 	// are missing.
 
+	var providerCfg kmsProviderConfig = noopKMSProviderConfig{}
+	if currentMode == state.KMS {
+		var err error
+		providerCfg, err = newKMSProviderConfig(apiEncryptionConfiguration.KMS)
+		if err != nil {
+			return err
+		}
+	}
+
 	var commonReason *string
 	for gr, grKeys := range desiredEncryptionState {
-		latestKeyID, internalReason, needed := needsNewKey(grKeys, currentMode, externalReason, encryptedGRs)
+		latestKeyID, internalReason, needed := needsNewKey(grKeys, currentMode, externalReason, encryptedGRs, providerCfg)
 		if !needed {
 			continue
 		}
@@ -228,7 +237,7 @@ func (c *keyController) checkAndCreateKeys(ctx context.Context, syncContext fact
 
 	sort.Sort(sort.StringSlice(reasons))
 	internalReason := strings.Join(reasons, ", ")
-	keySecret, err := c.generateKeySecret(ctx, newKeyID, currentMode, apiEncryptionConfiguration, internalReason, externalReason)
+	keySecret, err := c.generateKeySecret(ctx, newKeyID, currentMode, apiEncryptionConfiguration, providerCfg, internalReason, externalReason)
 	if err != nil {
 		return fmt.Errorf("failed to create key: %v", err)
 	}
@@ -265,7 +274,7 @@ func (c *keyController) validateExistingSecret(ctx context.Context, keySecret *c
 	return nil // we made this key earlier
 }
 
-func (c *keyController) generateKeySecret(ctx context.Context, keyID uint64, currentMode state.Mode, apiServerEncryption configv1.APIServerEncryption, internalReason, externalReason string) (*corev1.Secret, error) {
+func (c *keyController) generateKeySecret(ctx context.Context, keyID uint64, currentMode state.Mode, apiServerEncryption configv1.APIServerEncryption, providerCfg kmsProviderConfig, internalReason, externalReason string) (*corev1.Secret, error) {
 	bs := crypto.ModeToNewKeyFunc[currentMode]()
 	ks := state.KeyState{
 		Key: apiserverv1.Key{
@@ -285,11 +294,6 @@ func (c *keyController) generateKeySecret(ctx context.Context, keyID uint64, cur
 				Timeout:    &metav1.Duration{Duration: defaultKMSTimeout},
 			},
 			Plugin: apiServerEncryption.KMS,
-		}
-
-		providerCfg, err := newKMSProviderConfig(apiServerEncryption.KMS)
-		if err != nil {
-			return nil, err
 		}
 
 		if secretName, expectedKeys, err := providerCfg.referencedSecretName(); err != nil {
@@ -363,7 +367,7 @@ func (c *keyController) getCurrentModeReasonAndEncryptionConfig(ctx context.Cont
 
 // needsNewKey checks whether a new key must be created for the given resource. If true, it also returns the latest
 // used key ID and a reason string.
-func needsNewKey(grKeys state.GroupResourceState, currentMode state.Mode, externalReason string, encryptedGRs []schema.GroupResource) (uint64, string, bool) {
+func needsNewKey(grKeys state.GroupResourceState, currentMode state.Mode, externalReason string, encryptedGRs []schema.GroupResource, providerCfg kmsProviderConfig) (uint64, string, bool) {
 	// we always need to have some encryption keys unless we are turned off
 	if len(grKeys.ReadKeys) == 0 {
 		return 0, "key-does-not-exist", currentMode != state.Identity
@@ -408,13 +412,20 @@ func needsNewKey(grKeys state.GroupResourceState, currentMode state.Mode, extern
 
 	if currentMode == state.KMS {
 		// We are here because Encryption Mode is not changed
+		// However, we need to create a new key if migration-triggering fields
+		// in the KMS provider configuration have changed.
+		if latestKey.KMS == nil {
+			// A KMS-mode key without KMS state indicates a corrupted key secret.
+			// Do not create a new key on corrupted data.
+			klog.Warningf("KMS-mode key %q has nil KMS state, possibly corrupted key secret; skipping new key creation", latestKey.Key.Name)
+			return 0, "", false
+		}
+		if providerCfg.migrationRequired(latestKey.KMS.Plugin) {
+			return latestKeyID, "kms-provider-changed", true
+		}
 
-		// For now in Tech Preview v1, we don't support configurational changes. Therefore,
-		// it is pointless comparing the secrets.
-
-		// For KMS mode, we don't do time-based rotation. Therefore, we shortcut here
-		// KMS keys are rotated externally by the KMS system.
-		// Moreover, we don't trigger new key when external reason is changed.
+		// For KMS mode, we don't do time-based rotation. KMS keys are rotated
+		// externally by the KMS provider. Moreover, we don't trigger new key when external reason is changed.
 		// Because it would lead to duplicate providers which is not allowed.
 		return 0, "", false
 	}
@@ -440,7 +451,18 @@ type kmsProviderConfig interface {
 	// config and the specific data keys to carry from that configmap. Only the listed keys
 	// are copied into the Key Secret; any other data in the referenced configmap is ignored.
 	referencedConfigMapName() (string, []string, error)
+	// migrationRequired reports whether switching from latest (stored in
+	// the key secret) to this provider config requires a new encryption key.
+	migrationRequired(latest configv1.KMSPluginConfig) bool
 }
+
+// noopKMSProviderConfig is a safe zero-value implementation used for non-KMS modes.
+// All methods return empty/false so callers never need nil checks.
+type noopKMSProviderConfig struct{}
+
+func (noopKMSProviderConfig) referencedSecretName() (string, []string, error)    { return "", nil, nil }
+func (noopKMSProviderConfig) referencedConfigMapName() (string, []string, error) { return "", nil, nil }
+func (noopKMSProviderConfig) migrationRequired(configv1.KMSPluginConfig) bool    { return false }
 
 func newKMSProviderConfig(plugin configv1.KMSPluginConfig) (kmsProviderConfig, error) {
 	switch plugin.Type {
@@ -471,6 +493,30 @@ func (v *vaultProviderConfig) referencedConfigMapName() (string, []string, error
 		return "", nil, nil
 	}
 	return v.vault.TLS.CABundle.Name, []string{"ca-bundle.crt"}, nil
+}
+
+func (v *vaultProviderConfig) migrationRequired(latest configv1.KMSPluginConfig) bool {
+	if latest.Type != configv1.VaultKMSProvider {
+		klog.V(2).Infof("KMS migration required: provider type changed from %q to %q", latest.Type, configv1.VaultKMSProvider)
+		return true
+	}
+	if v.vault.VaultAddress != latest.Vault.VaultAddress {
+		klog.V(2).Infof("KMS migration required: VaultAddress changed from %q to %q", latest.Vault.VaultAddress, v.vault.VaultAddress)
+		return true
+	}
+	if v.vault.VaultNamespace != latest.Vault.VaultNamespace {
+		klog.V(2).Infof("KMS migration required: VaultNamespace changed from %q to %q", latest.Vault.VaultNamespace, v.vault.VaultNamespace)
+		return true
+	}
+	if v.vault.TransitMount != latest.Vault.TransitMount {
+		klog.V(2).Infof("KMS migration required: TransitMount changed from %q to %q", latest.Vault.TransitMount, v.vault.TransitMount)
+		return true
+	}
+	if v.vault.TransitKey != latest.Vault.TransitKey {
+		klog.V(2).Infof("KMS migration required: TransitKey changed from %q to %q", latest.Vault.TransitKey, v.vault.TransitKey)
+		return true
+	}
+	return false
 }
 
 // TODO make this un-settable once set

--- a/pkg/operator/encryption/controllers/key_controller_test.go
+++ b/pkg/operator/encryption/controllers/key_controller_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	clocktesting "k8s.io/utils/clock/testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -768,6 +769,164 @@ func TestKeyController(t *testing.T) {
 				}
 			},
 		},
+
+		{
+			name: "creates a new KMS key when VaultAddress changes",
+			targetGRs: []schema.GroupResource{
+				{Group: "", Resource: "secrets"},
+			},
+			initialObjects: []runtime.Object{
+				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
+				encryptiontesting.CreateMigratedEncryptionKeySecretWithKMSPluginConfig("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 5, time.Now()),
+				encryptiontesting.CreateVaultAppRoleSecret("vault-approle-secret", "test-role-id", "test-secret-id"),
+				encryptiontesting.CreateVaultCABundleConfigMap("vault-ca-bundle", "test-ca-cert"),
+			},
+			apiServerObjects: []runtime.Object{func() runtime.Object {
+				s := simpleAPIServer.DeepCopy()
+				changedConfig := encryptiontesting.DefaultKMSPluginConfig.DeepCopy()
+				changedConfig.Vault.VaultAddress = "https://vault-new.example.com"
+				s.Spec.Encryption = configv1.APIServerEncryption{Type: "KMS", KMS: *changedConfig}
+				return s
+			}()},
+			targetNamespace: "kms",
+			expectedActions: []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config", "get:configmaps:openshift-config", "create:secrets:openshift-config-managed", "create:events:kms"},
+			validateFunc: func(ts *testing.T, actions []clientgotesting.Action, targetNamespace string, targetGRs []schema.GroupResource) {
+				for _, action := range actions {
+					if action.Matches("create", "secrets") {
+						createAction := action.(clientgotesting.CreateAction)
+						actualSecret := createAction.GetObject().(*corev1.Secret)
+
+						if actualSecret.Annotations["encryption.apiserver.operator.openshift.io/mode"] != "KMS" {
+							ts.Errorf("expected mode KMS, got %s", actualSecret.Annotations["encryption.apiserver.operator.openshift.io/mode"])
+						}
+						if actualSecret.Annotations["encryption.apiserver.operator.openshift.io/internal-reason"] != "secrets-kms-provider-changed" {
+							ts.Errorf("unexpected internal reason: %s", actualSecret.Annotations["encryption.apiserver.operator.openshift.io/internal-reason"])
+						}
+						if actualSecret.Name != "encryption-key-kms-6" {
+							ts.Errorf("expected key ID 6, got %s", actualSecret.Name)
+						}
+
+						kmsProviderConfigData := actualSecret.Data["encryption.apiserver.operator.openshift.io-kms-plugin-config"]
+						providerConfig, err := encoding.DecodeKMSPluginConfig(kmsProviderConfigData)
+						if err != nil {
+							ts.Fatalf("failed to encode KMS config: %v", err)
+						}
+						if providerConfig.Vault.VaultAddress != "https://vault-new.example.com" {
+							ts.Errorf("expected new VaultAddress, got %s", providerConfig.Vault.VaultAddress)
+						}
+						return
+					}
+				}
+				ts.Errorf("the secret wasn't created")
+			},
+		},
+
+		{
+			name: "creates a new KMS key when TransitKey changes",
+			targetGRs: []schema.GroupResource{
+				{Group: "", Resource: "secrets"},
+			},
+			initialObjects: []runtime.Object{
+				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
+				encryptiontesting.CreateMigratedEncryptionKeySecretWithKMSPluginConfig("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 5, time.Now()),
+				encryptiontesting.CreateVaultAppRoleSecret("vault-approle-secret", "test-role-id", "test-secret-id"),
+				encryptiontesting.CreateVaultCABundleConfigMap("vault-ca-bundle", "test-ca-cert"),
+			},
+			apiServerObjects: []runtime.Object{func() runtime.Object {
+				s := simpleAPIServer.DeepCopy()
+				changedConfig := encryptiontesting.DefaultKMSPluginConfig.DeepCopy()
+				changedConfig.Vault.TransitKey = "new-transit-key"
+				s.Spec.Encryption = configv1.APIServerEncryption{Type: "KMS", KMS: *changedConfig}
+				return s
+			}()},
+			targetNamespace: "kms",
+			expectedActions: []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config", "get:configmaps:openshift-config", "create:secrets:openshift-config-managed", "create:events:kms"},
+			validateFunc: func(ts *testing.T, actions []clientgotesting.Action, targetNamespace string, targetGRs []schema.GroupResource) {
+				for _, action := range actions {
+					if action.Matches("create", "secrets") {
+						createAction := action.(clientgotesting.CreateAction)
+						actualSecret := createAction.GetObject().(*corev1.Secret)
+
+						if actualSecret.Annotations["encryption.apiserver.operator.openshift.io/internal-reason"] != "secrets-kms-provider-changed" {
+							ts.Errorf("unexpected internal reason: %s", actualSecret.Annotations["encryption.apiserver.operator.openshift.io/internal-reason"])
+						}
+
+						kmsProviderConfigData := actualSecret.Data["encryption.apiserver.operator.openshift.io-kms-plugin-config"]
+						providerConfig, err := encoding.DecodeKMSPluginConfig(kmsProviderConfigData)
+						if err != nil {
+							ts.Fatalf("failed to encode KMS config: %v", err)
+						}
+						if providerConfig.Vault.TransitKey != "new-transit-key" {
+							ts.Errorf("expected new TransitKey, got %s", providerConfig.Vault.TransitKey)
+						}
+						return
+					}
+				}
+				ts.Errorf("the secret wasn't created")
+			},
+		},
+
+		{
+			name: "no-op when only KMSPluginImage changes (non-migration field)",
+			targetGRs: []schema.GroupResource{
+				{Group: "", Resource: "secrets"},
+			},
+			initialObjects: []runtime.Object{
+				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
+				encryptiontesting.CreateMigratedEncryptionKeySecretWithKMSPluginConfig("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 5, time.Now()),
+			},
+			apiServerObjects: []runtime.Object{func() runtime.Object {
+				s := simpleAPIServer.DeepCopy()
+				changedConfig := encryptiontesting.DefaultKMSPluginConfig.DeepCopy()
+				changedConfig.Vault.KMSPluginImage = "registry.example.com/kms-plugin@sha256:0000000000000000000000000000000000000000000000000000000000000000"
+				s.Spec.Encryption = configv1.APIServerEncryption{Type: "KMS", KMS: *changedConfig}
+				return s
+			}()},
+			targetNamespace: "kms",
+			expectedActions: []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed"},
+		},
+
+		{
+			name: "no-op when only Authentication changes (non-migration field)",
+			targetGRs: []schema.GroupResource{
+				{Group: "", Resource: "secrets"},
+			},
+			initialObjects: []runtime.Object{
+				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
+				encryptiontesting.CreateMigratedEncryptionKeySecretWithKMSPluginConfig("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 5, time.Now()),
+			},
+			apiServerObjects: []runtime.Object{func() runtime.Object {
+				s := simpleAPIServer.DeepCopy()
+				changedConfig := encryptiontesting.DefaultKMSPluginConfig.DeepCopy()
+				changedConfig.Vault.Authentication.AppRole.Secret.Name = "new-approle-secret"
+				s.Spec.Encryption = configv1.APIServerEncryption{Type: "KMS", KMS: *changedConfig}
+				return s
+			}()},
+			targetNamespace: "kms",
+			expectedActions: []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed"},
+		},
+
+		{
+			name: "no-op when only TLS changes (non-migration field)",
+			targetGRs: []schema.GroupResource{
+				{Group: "", Resource: "secrets"},
+			},
+			initialObjects: []runtime.Object{
+				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
+				encryptiontesting.CreateMigratedEncryptionKeySecretWithKMSPluginConfig("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 5, time.Now()),
+			},
+			apiServerObjects: []runtime.Object{func() runtime.Object {
+				s := simpleAPIServer.DeepCopy()
+				changedConfig := encryptiontesting.DefaultKMSPluginConfig.DeepCopy()
+				changedConfig.Vault.TLS = configv1.VaultTLSConfig{
+					CABundle: configv1.VaultConfigMapReference{Name: "my-ca"},
+				}
+				s.Spec.Encryption = configv1.APIServerEncryption{Type: "KMS", KMS: *changedConfig}
+				return s
+			}()},
+			targetNamespace: "kms",
+			expectedActions: []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed"},
+		},
 	}
 
 	for _, scenario := range scenarios {
@@ -1137,6 +1296,120 @@ func TestGetCurrentModeReasonAndEncryptionConfig(t *testing.T) {
 			if currentMode == "KMS" && encryption.KMS == (configv1.KMSPluginConfig{}) {
 				t.Errorf("expected non-empty KMS config when mode is KMS")
 			}
+		})
+	}
+}
+
+func TestNeedsNewKey(t *testing.T) {
+	baseConfig := &configv1.KMSPluginConfig{
+		Type: configv1.VaultKMSProvider,
+		Vault: configv1.VaultKMSPluginConfig{
+			KMSPluginImage: "registry.example.com/kms-plugin@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+			VaultAddress:   "https://vault.example.com",
+			VaultNamespace: "ns1",
+			TransitMount:   "transit",
+			TransitKey:     "my-key",
+			Authentication: configv1.VaultAuthentication{
+				Type: configv1.VaultAuthenticationTypeAppRole,
+				AppRole: configv1.VaultAppRoleAuthentication{
+					Secret: configv1.VaultSecretReference{Name: "vault-approle-secret"},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		latest   *configv1.KMSPluginConfig
+		current  *configv1.KMSPluginConfig
+		expected bool
+	}{
+		{
+			name:     "identical configs",
+			latest:   baseConfig.DeepCopy(),
+			current:  baseConfig.DeepCopy(),
+			expected: false,
+		},
+		{
+			name:   "different VaultAddress",
+			latest: baseConfig.DeepCopy(),
+			current: func() *configv1.KMSPluginConfig {
+				c := baseConfig.DeepCopy()
+				c.Vault.VaultAddress = "https://vault-new.example.com"
+				return c
+			}(),
+			expected: true,
+		},
+		{
+			name:   "different VaultNamespace",
+			latest: baseConfig.DeepCopy(),
+			current: func() *configv1.KMSPluginConfig {
+				c := baseConfig.DeepCopy()
+				c.Vault.VaultNamespace = "ns2"
+				return c
+			}(),
+			expected: true,
+		},
+		{
+			name:   "different TransitKey",
+			latest: baseConfig.DeepCopy(),
+			current: func() *configv1.KMSPluginConfig {
+				c := baseConfig.DeepCopy()
+				c.Vault.TransitKey = "new-key"
+				return c
+			}(),
+			expected: true,
+		},
+		{
+			name:   "different TransitMount",
+			latest: baseConfig.DeepCopy(),
+			current: func() *configv1.KMSPluginConfig {
+				c := baseConfig.DeepCopy()
+				c.Vault.TransitMount = "custom-transit"
+				return c
+			}(),
+			expected: true,
+		},
+		{
+			name:   "different KMSPluginImage only",
+			latest: baseConfig.DeepCopy(),
+			current: func() *configv1.KMSPluginConfig {
+				c := baseConfig.DeepCopy()
+				c.Vault.KMSPluginImage = "registry.example.com/kms-plugin@sha256:0000000000000000000000000000000000000000000000000000000000000000"
+				return c
+			}(),
+			expected: false,
+		},
+		{
+			name:   "different TLS only",
+			latest: baseConfig.DeepCopy(),
+			current: func() *configv1.KMSPluginConfig {
+				c := baseConfig.DeepCopy()
+				c.Vault.TLS = configv1.VaultTLSConfig{
+					CABundle: configv1.VaultConfigMapReference{Name: "my-ca"},
+				}
+				return c
+			}(),
+			expected: false,
+		},
+		{
+			name:   "different Authentication only",
+			latest: baseConfig.DeepCopy(),
+			current: func() *configv1.KMSPluginConfig {
+				c := baseConfig.DeepCopy()
+				c.Vault.Authentication.AppRole.Secret.Name = "new-secret"
+				return c
+			}(),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			providerCfg, err := newKMSProviderConfig(*tt.current)
+			require.NoError(t, err)
+			got := providerCfg.migrationRequired(*tt.latest)
+			require.Equal(t, tt.expected, got)
 		})
 	}
 }

--- a/test/e2e-encryption/encryption_test.go
+++ b/test/e2e-encryption/encryption_test.go
@@ -634,33 +634,64 @@ func TestEncryptionIntegration(tt *testing.T) {
 	verifyKMSSecretData()
 	verifyKMSConfigMapData()
 
+	t.Logf("KMS-to-KMS migration: change VaultAddress")
+	_, err = fakeApiServerClient.Patch(ctx, "cluster", types.MergePatchType, []byte(`{"spec":{"encryption":{"kms":{"vault":{"vaultAddress":"https://vault-new.example.com"}}}}}`), metav1.PatchOptions{})
+	require.NoError(t, err)
+	waitForKeys(12)
+	kms13 := kmsPluginName("kubeapiservers", "13")
+	kms13Sched := kmsPluginName("kubeschedulers", "13")
+	waitForConfigs(
+		fmt.Sprintf("kubeapiservers.operator.openshift.io=kms:%s,kms:%s,aescbc:11,identity;kubeschedulers.operator.openshift.io=kms:%s,kms:%s,aescbc:11,identity", kms12, kms13, kms12Sched, kms13Sched),
+		fmt.Sprintf("kubeapiservers.operator.openshift.io=kms:%s,kms:%s,aescbc:11,identity;kubeschedulers.operator.openshift.io=kms:%s,kms:%s,aescbc:11,identity", kms13, kms12, kms13Sched, kms12Sched),
+		fmt.Sprintf("kubeapiservers.operator.openshift.io=kms:%s,kms:%s,identity;kubeschedulers.operator.openshift.io=kms:%s,kms:%s,identity", kms13, kms12, kms13Sched, kms12Sched),
+	)
+	waitForMigration("13")
+	waitForConditionStatus("Encrypted", operatorv1.ConditionTrue)
+
+	t.Logf("Verify KMS-to-KMS migration key secret contains updated plugin config")
+	kmsKeySecret13, err := kubeClient.CoreV1().Secrets("openshift-config-managed").Get(ctx, fmt.Sprintf("encryption-key-%s-13", component), metav1.GetOptions{})
+	require.NoError(t, err)
+	kmsPluginConfigData13 := kmsKeySecret13.Data["encryption.apiserver.operator.openshift.io-kms-plugin-config"]
+	require.NotEmpty(t, kmsPluginConfigData13)
+	pluginConfig13, err := encoding.DecodeKMSPluginConfig(kmsPluginConfigData13)
+	require.NoError(t, err)
+	require.Equal(t, "https://vault-new.example.com", pluginConfig13.Vault.VaultAddress)
+	require.Equal(t, "test-transit-key", pluginConfig13.Vault.TransitKey)
+
+	t.Logf("KMS non-migration change: only KMSPluginImage changes (no new key expected)")
+	_, err = fakeApiServerClient.Patch(ctx, "cluster", types.MergePatchType, []byte(`{"spec":{"encryption":{"type":"KMS","kms":{"type":"Vault","vault":{"kmsPluginImage":"registry.example.com/kms-plugin@sha256:0000000000000000000000000000000000000000000000000000000000000000","vaultAddress":"https://vault-new.example.com","authentication":{"type":"AppRole","appRole":{"secret":{"name":"vault-approle-secret"}}},"transitKey":"test-transit-key"}}}}}`), metav1.PatchOptions{})
+	require.NoError(t, err)
+	time.Sleep(5 * time.Second)
+	waitForKeys(12)
+	waitForConditionStatus("Encrypted", operatorv1.ConditionTrue)
+
 	t.Logf("Delete the encryption-config while in KMS mode")
 	_, err = kubeClient.CoreV1().Secrets("openshift-config-managed").Patch(ctx, fmt.Sprintf("encryption-config-%s", component), types.JSONPatchType, []byte(`[{"op":"remove","path":"/metadata/finalizers"}]`), metav1.PatchOptions{})
 	require.NoError(t, err)
 	err = kubeClient.CoreV1().Secrets("openshift-config-managed").Delete(ctx, fmt.Sprintf("encryption-config-%s", component), metav1.DeleteOptions{})
 	require.NoError(t, err)
 	waitForConfigs(
-		fmt.Sprintf("kubeapiservers.operator.openshift.io=kms:%s,aescbc:11,identity;kubeschedulers.operator.openshift.io=kms:%s,aescbc:11,identity", kms12, kms12Sched),
+		fmt.Sprintf("kubeapiservers.operator.openshift.io=kms:%s,kms:%s,identity;kubeschedulers.operator.openshift.io=kms:%s,kms:%s,identity", kms13, kms12, kms13Sched, kms12Sched),
 	)
 	waitForConditionStatus("Encrypted", operatorv1.ConditionTrue)
 
 	t.Logf("Delete the operand config while in KMS mode")
 	deployer.DeleteOperandConfig()
 	waitForConfigs(
-		// kms12 is migrated and hence only one needed, but we rotate through identity
-		fmt.Sprintf("kubeapiservers.operator.openshift.io=identity,kms:%s,aescbc:11;kubeschedulers.operator.openshift.io=identity,kms:%s,aescbc:11", kms12, kms12Sched),
-		// kms12 is migrated, plus one backed key (11)
-		fmt.Sprintf("kubeapiservers.operator.openshift.io=kms:%s,aescbc:11,identity;kubeschedulers.operator.openshift.io=kms:%s,aescbc:11,identity", kms12, kms12Sched),
+		// kms13 is migrated and hence only one needed, but we rotate through identity
+		fmt.Sprintf("kubeapiservers.operator.openshift.io=identity,kms:%s,kms:%s;kubeschedulers.operator.openshift.io=identity,kms:%s,kms:%s", kms13, kms12, kms13Sched, kms12Sched),
+		// kms13 is migrated, plus one backed key (12)
+		fmt.Sprintf("kubeapiservers.operator.openshift.io=kms:%s,kms:%s,identity;kubeschedulers.operator.openshift.io=kms:%s,kms:%s,identity", kms13, kms12, kms13Sched, kms12Sched),
 	)
 	waitForConditionStatus("Encrypted", operatorv1.ConditionTrue)
 
 	t.Logf("Switch to identity from KMS")
 	_, err = fakeApiServerClient.Patch(ctx, "cluster", types.MergePatchType, []byte(`{"spec":{"encryption":{"type":"identity","kms":null}}}`), metav1.PatchOptions{})
 	require.NoError(t, err)
-	waitForKeys(12)
+	waitForKeys(13)
 	waitForConfigs(
-		fmt.Sprintf("kubeapiservers.operator.openshift.io=kms:%s,aescbc:11,identity,aesgcm:13;kubeschedulers.operator.openshift.io=kms:%s,aescbc:11,identity,aesgcm:13", kms12, kms12Sched),
-		fmt.Sprintf("kubeapiservers.operator.openshift.io=identity,kms:%s,aescbc:11,aesgcm:13;kubeschedulers.operator.openshift.io=identity,kms:%s,aescbc:11,aesgcm:13", kms12, kms12Sched),
+		fmt.Sprintf("kubeapiservers.operator.openshift.io=kms:%s,kms:%s,identity,aesgcm:14;kubeschedulers.operator.openshift.io=kms:%s,kms:%s,identity,aesgcm:14", kms13, kms12, kms13Sched, kms12Sched),
+		fmt.Sprintf("kubeapiservers.operator.openshift.io=identity,kms:%s,kms:%s,aesgcm:14;kubeschedulers.operator.openshift.io=identity,kms:%s,kms:%s,aesgcm:14", kms13, kms12, kms13Sched, kms12Sched),
 	)
 	waitForConditionStatus("Encrypted", operatorv1.ConditionFalse)
 }

--- a/test/library/encryption/helpers.go
+++ b/test/library/encryption/helpers.go
@@ -94,17 +94,26 @@ func SetAndWaitForEncryptionType(ctx context.Context, t testing.TB, provider Enc
 
 	apiServer, err := clientSet.ApiServerConfig.Get(ctx, "cluster", metav1.GetOptions{})
 	require.NoError(t, err)
-	needsUpdate := !equality.Semantic.DeepEqual(apiServer.Spec.Encryption, provider.APIServerEncryption)
+	previousEncryption := apiServer.Spec.Encryption
+	needsUpdate := !equality.Semantic.DeepEqual(previousEncryption, provider.APIServerEncryption)
 	if needsUpdate {
 		if provider.Setup != nil {
 			provider.Setup(ctx, t)
 		}
-		t.Logf("Updating encryption configuration for APIServer from %#v to %#v", apiServer.Spec.Encryption, provider.APIServerEncryption)
+		t.Logf("Updating encryption configuration for APIServer from %#v to %#v", previousEncryption, provider.APIServerEncryption)
 		apiServer.Spec.Encryption = provider.APIServerEncryption
 		_, err = clientSet.ApiServerConfig.Update(ctx, apiServer, metav1.UpdateOptions{})
 		require.NoError(t, err)
 	} else {
 		t.Logf("APIServer is already configured to use %q mode", provider.Type)
+	}
+
+	// KMS-to-KMS migration: when both old and new are KMS but the config differs,
+	// the key controller creates a new key. We must wait for the next migrated key
+	// rather than asserting no new key is created.
+	if needsUpdate && provider.Type == configv1.EncryptionTypeKMS && previousEncryption.Type == configv1.EncryptionTypeKMS {
+		WaitForNextMigratedKey(t, clientSet.Kube, lastMigratedKeyMeta, defaultTargetGRs, namespace, labelSelector)
+		return clientSet
 	}
 
 	WaitForEncryptionKeyBasedOn(t, clientSet.Kube, lastMigratedKeyMeta, provider.Type, defaultTargetGRs, namespace, labelSelector)

--- a/test/library/encryption/scenarios.go
+++ b/test/library/encryption/scenarios.go
@@ -354,6 +354,107 @@ func TestKMSInvalidEncryptionRecovery(ctx context.Context, t testing.TB, scenari
 	}
 }
 
+// KMSToKMSMigrationScenario tests migration between two distinct KMS configurations
+// (e.g. different Vault instances or transit keys). Unlike in-place updates, changing a
+// key-triggering field (transit key, vault address, etc.) causes the operator to mint a
+// new encryption key and re-encrypt all resources.
+type KMSToKMSMigrationScenario struct {
+	BasicScenario
+	CreateResourceFunc             func(t testing.TB, clientSet ClientSet, namespace string) runtime.Object
+	AssertResourceEncryptedFunc    func(t testing.TB, clientSet ClientSet, resource runtime.Object)
+	AssertResourceNotEncryptedFunc func(t testing.TB, clientSet ClientSet, resource runtime.Object)
+	ResourceFunc                   func(t testing.TB, namespace string) runtime.Object
+	ResourceName                   string
+	PrimaryProvider                EncryptionProvider
+	SecondaryProvider              EncryptionProvider
+}
+
+// TestKMSToKMSMigration validates round-trip migration between two KMS providers:
+//  1. Create a test resource
+//  2. Encrypt with primary KMS provider and verify
+//  3. Migrate to secondary KMS provider — a new key is created and resources re-encrypted
+//  4. Migrate back to primary KMS provider — verifies returning to original works
+//  5. Switch to identity — verify resources are decrypted
+func TestKMSToKMSMigration(ctx context.Context, t testing.TB, scenario KMSToKMSMigrationScenario) {
+	require.NotNil(t, scenario.PrimaryProvider.Setup, "PrimaryProvider.Setup must not be nil")
+	require.NotNil(t, scenario.SecondaryProvider.Setup, "SecondaryProvider.Setup must not be nil")
+	require.Equal(t, configv1.EncryptionTypeKMS, scenario.PrimaryProvider.Type, "PrimaryProvider must use KMS encryption type")
+	require.Equal(t, configv1.EncryptionTypeKMS, scenario.SecondaryProvider.Type, "SecondaryProvider must use KMS encryption type")
+
+	TestEncryptionProvidersMigration(ctx, t, ProvidersMigrationScenario{
+		BasicScenario:                  scenario.BasicScenario,
+		CreateResourceFunc:             scenario.CreateResourceFunc,
+		AssertResourceEncryptedFunc:    scenario.AssertResourceEncryptedFunc,
+		AssertResourceNotEncryptedFunc: scenario.AssertResourceNotEncryptedFunc,
+		ResourceFunc:                   scenario.ResourceFunc,
+		ResourceName:                   scenario.ResourceName,
+		EncryptionProviders: []EncryptionProvider{
+			scenario.PrimaryProvider,
+			scenario.SecondaryProvider,
+			scenario.PrimaryProvider,
+		},
+	})
+}
+
+// TestKMSToKMSOnOff validates KMS on/off cycle using the KMS-to-KMS scenario struct:
+//  1. Create a test resource
+//  2. Encrypt with primary KMS → verify encrypted
+//  3. Switch to identity → verify decrypted
+//  4. Encrypt with secondary KMS → verify encrypted
+//  5. Switch to identity → verify decrypted
+func TestKMSToKMSOnOff(ctx context.Context, t testing.TB, scenario KMSToKMSMigrationScenario) {
+	require.NotNil(t, scenario.PrimaryProvider.Setup, "PrimaryProvider.Setup must not be nil")
+	require.NotNil(t, scenario.SecondaryProvider.Setup, "SecondaryProvider.Setup must not be nil")
+	require.Equal(t, configv1.EncryptionTypeKMS, scenario.PrimaryProvider.Type, "PrimaryProvider must use KMS encryption type")
+	require.Equal(t, configv1.EncryptionTypeKMS, scenario.SecondaryProvider.Type, "SecondaryProvider must use KMS encryption type")
+
+	e := NewE(t, PrintEventsOnFailure(scenario.OperatorNamespace))
+
+	steps := []testStep{
+		{name: "CreateResource", testFunc: func(t testing.TB) {
+			clientSet := GetClients(t)
+			scenario.CreateResourceFunc(t, clientSet, scenario.Namespace)
+		}},
+		{name: "EncryptWithPrimaryKMS", testFunc: func(t testing.TB) {
+			TestEncryptionType(ctx, t, scenario.BasicScenario, scenario.PrimaryProvider)
+		}},
+		{name: "AssertEncryptedWithPrimary", testFunc: func(t testing.TB) {
+			clientSet := GetClients(t)
+			scenario.AssertResourceEncryptedFunc(t, clientSet, scenario.ResourceFunc(t, scenario.Namespace))
+		}},
+		{name: "OffIdentityAfterPrimary", testFunc: func(t testing.TB) {
+			TestEncryptionTypeIdentity(ctx, t, scenario.BasicScenario)
+		}},
+		{name: "AssertDecryptedAfterPrimary", testFunc: func(t testing.TB) {
+			clientSet := GetClients(t)
+			scenario.AssertResourceNotEncryptedFunc(t, clientSet, scenario.ResourceFunc(t, scenario.Namespace))
+		}},
+		{name: "EncryptWithSecondaryKMS", testFunc: func(t testing.TB) {
+			TestEncryptionType(ctx, t, scenario.BasicScenario, scenario.SecondaryProvider)
+		}},
+		{name: "AssertEncryptedWithSecondary", testFunc: func(t testing.TB) {
+			clientSet := GetClients(t)
+			scenario.AssertResourceEncryptedFunc(t, clientSet, scenario.ResourceFunc(t, scenario.Namespace))
+		}},
+		{name: "OffIdentityAfterSecondary", testFunc: func(t testing.TB) {
+			TestEncryptionTypeIdentity(ctx, t, scenario.BasicScenario)
+		}},
+		{name: "AssertDecryptedAfterSecondary", testFunc: func(t testing.TB) {
+			clientSet := GetClients(t)
+			scenario.AssertResourceNotEncryptedFunc(t, clientSet, scenario.ResourceFunc(t, scenario.Namespace))
+		}},
+	}
+
+	for _, step := range steps {
+		t.Logf("=== STEP: %s ===", step.name)
+		step.testFunc(e)
+		if t.Failed() {
+			t.Errorf("stopping the test as %q step failed", step.name)
+			return
+		}
+	}
+}
+
 // KMSInPlaceUpdateScenario tests that updating an in-place KMS config field
 // (e.g. kmsPluginImage) takes effect without creating a new encryption key.
 // The caller supplies Provider (initial valid config) and UpdatedProvider (same config


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * KMS-mode encryption now automatically rotates/migrates keys when the active KMS provider settings materially change (for example Vault address or transit key).
  * End-to-end support added for KMS-to-KMS migration and full KMS on/off cycling.

* **Bug Fixes**
  * Changes to non-migration KMS settings (such as plugin image/TLS/auth) no longer trigger unnecessary key recreation.

* **Tests**
  * Added and expanded unit coverage for KMS migration decision logic.
  * Extended end-to-end scenarios and updated expected key sequencing for KMS migrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->