### PR TITLE
NO-JIRA: configure kms socket endpoint in cmd

### DIFF
--- a/pkg/operator/encryption/kms/preflight/cmd.go
+++ b/pkg/operator/encryption/kms/preflight/cmd.go
@@ -12,10 +12,9 @@ import (
 	"k8s.io/klog/v2"
 )
 
-const kmsSocketEndpoint = "unix:///var/run/kmsplugin/kms.sock"
-
 type options struct {
-	kmsCallTimeout time.Duration
+	kmsCallTimeout    time.Duration
+	kmsSocketEndpoint string
 }
 
 // NewCommand creates the kms-preflight cobra command.
@@ -39,21 +38,27 @@ func NewCommand(ctx context.Context) *cobra.Command {
 
 func (o *options) addFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&o.kmsCallTimeout, "kms-call-timeout", 0, "timeout for each gRPC call to the KMS plugin")
+	fs.StringVarP(&o.kmsSocketEndpoint, "endpoint", "e", "", "kms socket endpoint of KMS plugin")
 }
 
 func (o *options) validate() error {
 	if o.kmsCallTimeout <= 0 {
 		return fmt.Errorf("--kms-call-timeout must be greater than 0")
 	}
+
+	// parsing the endpoint is taken care of in k8senvelopekmsv2.NewGRPCService below
+	if o.kmsSocketEndpoint == "" {
+		return fmt.Errorf("--kms-socket-endpoint is required")
+	}
 	return nil
 }
 
 func (o *options) run(ctx context.Context) error {
-	klog.Infof("Running KMS preflight check at %s", kmsSocketEndpoint)
+	klog.Infof("Running KMS preflight check at %s", o.kmsSocketEndpoint)
 
 	// k8senvelopekmsv2.NewGRPCService is not a public API and may change.
 	// If it breaks, we can inline a minimal gRPC client using k8s.io/kms directly.
-	service, err := k8senvelopekmsv2.NewGRPCService(ctx, kmsSocketEndpoint, "preflight", o.kmsCallTimeout)
+	service, err := k8senvelopekmsv2.NewGRPCService(ctx, o.kmsSocketEndpoint, "preflight", o.kmsCallTimeout)
 	if err != nil {
 		return fmt.Errorf("failed to create KMS gRPC client: %w", err)
 	}


### PR DESCRIPTION
This adds a new required arg to the preflight checker cmd.