### PR TITLE
CNTRLPLANE-3363: Introduce kms plugin builder for reusability

### DIFF
--- a/pkg/operator/encryption/kms/pluginlifecycle/builder.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/builder.go
@@ -1,0 +1,163 @@
+package pluginlifecycle
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/klog/v2"
+
+	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
+)
+
+// KMSPluginBuilder constructs KMS plugin pod spec contributions for injection
+// into API server pods.
+type KMSPluginBuilder struct {
+	encryptionConfig           *encryptiondata.Config
+	encryptionConfigSecretName string
+	staticPod                  bool
+}
+
+// NewKMSPluginBuilder creates a builder that defaults to deployment mode.
+func NewKMSPluginBuilder() *KMSPluginBuilder {
+	return &KMSPluginBuilder{}
+}
+
+// FromEncryptionConfig loads all KMS plugins from a parsed encryption config.
+// The encryptionConfigSecretName identifies the Secret the config was parsed
+// from; it is used for volume configuration in both deployment and static pod
+// modes.
+func (b *KMSPluginBuilder) FromEncryptionConfig(encryptionConfigSecretName string, cfg *encryptiondata.Config) *KMSPluginBuilder {
+	b.encryptionConfigSecretName = encryptionConfigSecretName
+	b.encryptionConfig = cfg
+	return b
+}
+
+// AsStaticPod switches the builder to static pod mode. Sidecars will reference
+// data from the resource-dir volume and run as root (UID 0).
+func (b *KMSPluginBuilder) AsStaticPod() *KMSPluginBuilder {
+	b.staticPod = true
+	return b
+}
+
+// Apply mutates the given pod spec by injecting KMS plugin sidecars, volumes,
+// and volume mounts. containerName identifies the API server container that
+// needs the socket volume mount.
+//
+// It is a no-op (returns nil error) when no KMS plugins are found.
+// It is idempotent.
+func (b *KMSPluginBuilder) Apply(podSpec *corev1.PodSpec, containerName string) error {
+	if podSpec == nil {
+		return fmt.Errorf("pod spec cannot be nil")
+	}
+	if containerName == "" {
+		return fmt.Errorf("container name cannot be empty")
+	}
+
+	kmsConfigurations, err := encryptiondata.ExtractUniqueAndSortedKMSConfigurations(b.encryptionConfig)
+	if err != nil {
+		return fmt.Errorf("failed to get KMS configurations: %w", err)
+	}
+	if len(kmsConfigurations) == 0 {
+		klog.V(4).Infof("skipping KMS sidecar injection: no KMS plugins found in EncryptionConfiguration")
+		return nil
+	}
+
+	var refDataVolumeName, refDataMountPath, referenceDataDir string
+	if b.staticPod {
+		refDataVolumeName = resourceDirVolumeName
+		refDataMountPath = resourcesDir
+		referenceDataDir = filepath.Join(resourcesDir, "secrets", b.encryptionConfigSecretName)
+	} else {
+		refDataVolumeName = referenceDataVolumeName
+		refDataMountPath = referenceDataMountPath
+		referenceDataDir = referenceDataMountPath
+	}
+
+	klog.V(4).Infof("injecting %d KMS sidecar(s)", len(kmsConfigurations))
+
+	socketVolumeMount := corev1.VolumeMount{Name: kmsPluginSocketVolumeName, MountPath: kmsPluginSocketMountPath, ReadOnly: false}
+	refDataVolumeMount := corev1.VolumeMount{Name: refDataVolumeName, MountPath: refDataMountPath, ReadOnly: true}
+
+	for _, kmsConfiguration := range kmsConfigurations {
+		// ExtractUniqueAndSortedKMSConfigurations function rewrites the .Name field to include only the key ID
+		keyID := kmsConfiguration.Name
+
+		pluginConfig, ok := b.encryptionConfig.KMSPlugins[keyID]
+		if !ok {
+			return fmt.Errorf("missing plugin config for keyID %s", keyID)
+		}
+
+		refData := &referenceDataResolver{
+			pluginsSecretData:    b.encryptionConfig.KMSPluginsSecretData,
+			pluginsConfigMapData: b.encryptionConfig.KMSPluginsConfigMapData,
+			referenceDataDir:     referenceDataDir,
+			keyID:                keyID,
+		}
+
+		provider, err := newSidecarProvider(keyID, kmsConfiguration.Endpoint, pluginConfig, refData)
+		if err != nil {
+			return fmt.Errorf("failed to create a sidecar provider for keyID %s: %w", keyID, err)
+		}
+
+		if err := ensureSidecarContainer(podSpec, provider); err != nil {
+			return err
+		}
+
+		if err := ensureVolumeMountInContainer(podSpec.InitContainers, provider.Name(), socketVolumeMount); err != nil {
+			return err
+		}
+
+		if err := ensureVolumeMountInContainer(podSpec.InitContainers, provider.Name(), refDataVolumeMount); err != nil {
+			return err
+		}
+
+		if b.staticPod {
+			if err := setRunAsRoot(podSpec.InitContainers, provider.Name()); err != nil {
+				return err
+			}
+		}
+	}
+
+	if err := ensureVolumeMountInContainer(podSpec.Containers, containerName, socketVolumeMount); err != nil {
+		return err
+	}
+
+	if err := ensureSocketVolume(podSpec); err != nil {
+		return err
+	}
+
+	if !b.staticPod {
+		if err := ensureReferenceDataVolume(podSpec, b.encryptionConfigSecretName); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func fetchEncryptionConfig(ctx context.Context, encryptionConfigNamespace, encryptionConfigSecretName string, secretClient corev1client.SecretsGetter) (*encryptiondata.Config, error) {
+	encryptionConfigurationSecret, err := secretClient.Secrets(encryptionConfigNamespace).Get(ctx, encryptionConfigSecretName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		klog.V(4).Infof("skipping KMS sidecar injection: %s/%s secret not found", encryptionConfigNamespace, encryptionConfigSecretName)
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get %s/%s secret: %w", encryptionConfigNamespace, encryptionConfigSecretName, err)
+	}
+
+	encryptionConfig, err := encryptiondata.FromSecret(encryptionConfigurationSecret)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract encryption config from %s/%s secret: %w", encryptionConfigNamespace, encryptionConfigSecretName, err)
+	}
+
+	if encryptionConfig == nil {
+		return nil, fmt.Errorf("encryption configuration is required in %s/%s secret", encryptionConfigNamespace, encryptionConfigSecretName)
+	}
+
+	return encryptionConfig, nil
+}

--- a/pkg/operator/encryption/kms/pluginlifecycle/builder_test.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/builder_test.go
@@ -1,0 +1,178 @@
+package pluginlifecycle
+
+import (
+	"testing"
+
+	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+)
+
+func TestKMSPluginBuilder_Apply(t *testing.T) {
+	f := newSidecarTestFixtures(t)
+	cfg, err := encryptiondata.FromSecret(f.encryptionConfigSecret)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		builder *KMSPluginBuilder
+		podSpec *corev1.PodSpec
+		verify  func(t *testing.T, podSpec *corev1.PodSpec)
+		wantErr string
+	}{
+		{
+			name: "static pod mode: resource-dir mount and root UID",
+			builder: NewKMSPluginBuilder().
+				FromEncryptionConfig("encryption-config", cfg).
+				AsStaticPod(),
+			podSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "kube-apiserver"}},
+				Volumes:    []corev1.Volume{f.resourceDirVolume},
+			},
+			verify: func(t *testing.T, podSpec *corev1.PodSpec) {
+				require.Len(t, podSpec.InitContainers, 1)
+				sidecar := podSpec.InitContainers[0]
+				require.Equal(t, "vault-kms-plugin-555", sidecar.Name)
+				require.Equal(t, ptr.To(int64(0)), sidecar.SecurityContext.RunAsUser)
+
+				hasResourceDirMount := false
+				for _, m := range sidecar.VolumeMounts {
+					if m.Name == "resource-dir" {
+						hasResourceDirMount = true
+						require.Equal(t, "/etc/kubernetes/static-pod-resources", m.MountPath)
+						require.True(t, m.ReadOnly)
+					}
+				}
+				require.True(t, hasResourceDirMount, "sidecar must have resource-dir volume mount")
+
+				for _, v := range podSpec.Volumes {
+					require.NotEqual(t, "kms-plugins-data", v.Name, "static pod mode should not add kms-plugins-data volume")
+				}
+			},
+		},
+		{
+			name: "deployment mode: secret volume mount and no root UID",
+			builder: NewKMSPluginBuilder().
+				FromEncryptionConfig("encryption-config", cfg),
+			podSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "kube-apiserver"}},
+				Volumes:    []corev1.Volume{f.resourceDirVolume},
+			},
+			verify: func(t *testing.T, podSpec *corev1.PodSpec) {
+				require.Len(t, podSpec.InitContainers, 1)
+				sidecar := podSpec.InitContainers[0]
+				require.Equal(t, "vault-kms-plugin-555", sidecar.Name)
+				require.Nil(t, sidecar.SecurityContext.RunAsUser)
+
+				hasRefDataMount := false
+				for _, m := range sidecar.VolumeMounts {
+					if m.Name == "kms-plugins-data" {
+						hasRefDataMount = true
+						require.Equal(t, "/var/run/secrets/kms-plugin", m.MountPath)
+						require.True(t, m.ReadOnly)
+					}
+				}
+				require.True(t, hasRefDataMount, "sidecar must have kms-plugins-data volume mount")
+
+				hasRefDataVolume := false
+				for _, v := range podSpec.Volumes {
+					if v.Name == "kms-plugins-data" {
+						hasRefDataVolume = true
+						require.Equal(t, "encryption-config", v.Secret.SecretName)
+					}
+				}
+				require.True(t, hasRefDataVolume, "deployment mode must add kms-plugins-data volume")
+			},
+		},
+		{
+			name:    "no encryption config: returns error",
+			builder: NewKMSPluginBuilder(),
+			podSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "test"}},
+			},
+			wantErr: "encryption configuration is required",
+		},
+		{
+			name: "nil pod spec: returns error",
+			builder: NewKMSPluginBuilder().
+				FromEncryptionConfig("encryption-config", cfg),
+			podSpec: nil,
+			wantErr: "pod spec cannot be nil",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var original *corev1.PodSpec
+			if tt.podSpec != nil {
+				original = tt.podSpec.DeepCopy()
+			}
+
+			err := tt.builder.Apply(tt.podSpec, "kube-apiserver")
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				if original != nil {
+					require.Equal(t, original, tt.podSpec, "pod spec should be unchanged on error")
+				}
+				return
+			}
+			require.NoError(t, err)
+			tt.verify(t, tt.podSpec)
+		})
+	}
+}
+
+func TestKMSPluginBuilder_OrderIndependence(t *testing.T) {
+	f := newSidecarTestFixtures(t)
+	cfg, err := encryptiondata.FromSecret(f.encryptionConfigSecret)
+	require.NoError(t, err)
+
+	podSpec1 := &corev1.PodSpec{
+		Containers: []corev1.Container{{Name: "kube-apiserver"}},
+		Volumes:    []corev1.Volume{f.resourceDirVolume},
+	}
+	podSpec2 := &corev1.PodSpec{
+		Containers: []corev1.Container{{Name: "kube-apiserver"}},
+		Volumes:    []corev1.Volume{f.resourceDirVolume},
+	}
+
+	err = NewKMSPluginBuilder().
+		FromEncryptionConfig("encryption-config", cfg).
+		AsStaticPod().
+		Apply(podSpec1, "kube-apiserver")
+	require.NoError(t, err)
+
+	err = NewKMSPluginBuilder().
+		AsStaticPod().
+		FromEncryptionConfig("encryption-config", cfg).
+		Apply(podSpec2, "kube-apiserver")
+	require.NoError(t, err)
+
+	require.Equal(t, podSpec1, podSpec2, "order of builder calls must not affect the result")
+}
+
+func TestKMSPluginBuilder_Idempotent(t *testing.T) {
+	f := newSidecarTestFixtures(t)
+	cfg, err := encryptiondata.FromSecret(f.encryptionConfigSecret)
+	require.NoError(t, err)
+
+	podSpec := &corev1.PodSpec{
+		Containers: []corev1.Container{{Name: "kube-apiserver"}},
+		Volumes:    []corev1.Volume{f.resourceDirVolume},
+	}
+
+	apply := func() {
+		t.Helper()
+		err := NewKMSPluginBuilder().
+			FromEncryptionConfig("encryption-config", cfg).
+			Apply(podSpec, "kube-apiserver")
+		require.NoError(t, err)
+	}
+
+	apply()
+	afterFirst := podSpec.DeepCopy()
+
+	apply()
+	require.Equal(t, afterFirst, podSpec, "second Apply must not change the pod spec")
+}

--- a/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
@@ -3,18 +3,13 @@ package pluginlifecycle
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/api/features"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
-	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
-	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 )
 
@@ -58,30 +53,29 @@ func newSidecarProvider(keyID string, udsPath string, pluginConfig configv1.KMSP
 // It is a no-op when the KMSEncryption feature gate is not enabled or the encryption-config secret does not exist.
 // The secretClient should be uncached to avoid injecting sidecars based on a stale encryption configuration.
 func AddKMSPluginSidecarToStaticPodSpec(ctx context.Context, podSpec *corev1.PodSpec, containerName string, encryptionConfigNamespace string, encryptionConfigSecretName string, secretClient corev1client.SecretsGetter, featureGateAccessor featuregates.FeatureGateAccess) error {
-	// The static pod revision controller copies secret data to disk under resourcesDir/secrets/<secretName>/.
-	referenceDataDir := filepath.Join(resourcesDir, "secrets", encryptionConfigSecretName)
-
-	sidecarNames, err := addKMSPluginSidecars(ctx, podSpec, containerName, encryptionConfigNamespace, encryptionConfigSecretName, secretClient, featureGateAccessor, referenceDataDir)
-	if err != nil {
-		return err
+	if !featureGateAccessor.AreInitialFeatureGatesObserved() {
+		return nil
 	}
-
-	// Don't touch the pod spec further when there are no sidecars.
-	if len(sidecarNames) == 0 {
+	featureGates, err := featureGateAccessor.CurrentFeatureGates()
+	if err != nil {
+		return fmt.Errorf("failed to get feature gates: %w", err)
+	}
+	if !featureGates.Enabled(features.FeatureGateKMSEncryption) {
 		return nil
 	}
 
-	for _, name := range sidecarNames {
-		volumeMount := corev1.VolumeMount{Name: resourceDirVolumeName, MountPath: resourcesDir, ReadOnly: true}
-		if err := ensureVolumeMountInContainer(podSpec.InitContainers, name, volumeMount); err != nil {
-			return err
-		}
-		if err := setRunAsRoot(podSpec.InitContainers, name); err != nil {
-			return err
-		}
+	cfg, err := fetchEncryptionConfig(ctx, encryptionConfigNamespace, encryptionConfigSecretName, secretClient)
+	if err != nil {
+		return err
+	}
+	if cfg == nil {
+		return nil
 	}
 
-	return nil
+	return NewKMSPluginBuilder().
+		FromEncryptionConfig(encryptionConfigSecretName, cfg).
+		AsStaticPod().
+		Apply(podSpec, containerName)
 }
 
 // AddKMSPluginSidecarToPodSpec injects KMS plugin sidecar containers into an aggregated API server pod spec (e.g., openshift-apiserver, oauth-apiserver).
@@ -89,126 +83,28 @@ func AddKMSPluginSidecarToStaticPodSpec(ctx context.Context, podSpec *corev1.Pod
 // It is a no-op when the KMSEncryption feature gate is not enabled or the encryption-config secret does not exist.
 // The secretClient should be uncached to avoid injecting sidecars based on a stale encryption configuration.
 func AddKMSPluginSidecarToPodSpec(ctx context.Context, podSpec *corev1.PodSpec, containerName string, encryptionConfigNamespace string, encryptionConfigSecretName string, secretClient corev1client.SecretsGetter, featureGateAccessor featuregates.FeatureGateAccess) error {
-	sidecarNames, err := addKMSPluginSidecars(ctx, podSpec, containerName, encryptionConfigNamespace, encryptionConfigSecretName, secretClient, featureGateAccessor, referenceDataMountPath)
-	if err != nil {
-		return err
+	if !featureGateAccessor.AreInitialFeatureGatesObserved() {
+		return nil
 	}
-
-	// Don't touch the pod spec further when there are no sidecars.
-	if len(sidecarNames) == 0 {
+	featureGates, err := featureGateAccessor.CurrentFeatureGates()
+	if err != nil {
+		return fmt.Errorf("failed to get feature gates: %w", err)
+	}
+	if !featureGates.Enabled(features.FeatureGateKMSEncryption) {
 		return nil
 	}
 
-	for _, name := range sidecarNames {
-		volumeMount := corev1.VolumeMount{Name: referenceDataVolumeName, MountPath: referenceDataMountPath, ReadOnly: true}
-		if err := ensureVolumeMountInContainer(podSpec.InitContainers, name, volumeMount); err != nil {
-			return err
-		}
-	}
-
-	// Unlike static pods, aggregated API servers access KMS plugin data by mounting the encryption-config Secret directly as a volume.
-	// Callers include the revision number in encryptionConfigSecretName (e.g. "encryption-config-7"), so each revision maps to a distinct Secret and volume.
-	if err := ensureReferenceDataVolume(podSpec, encryptionConfigSecretName); err != nil {
+	cfg, err := fetchEncryptionConfig(ctx, encryptionConfigNamespace, encryptionConfigSecretName, secretClient)
+	if err != nil {
 		return err
 	}
-
-	return nil
-}
-
-// addKMSPluginSidecars contains the shared logic for discovering KMS plugins and injecting sidecar containers.
-// It returns the names of the sidecar containers that were injected, so callers can add deployment-mode-specific volume mounts.
-func addKMSPluginSidecars(ctx context.Context, podSpec *corev1.PodSpec, containerName string, encryptionConfigNamespace string, encryptionConfigSecretName string, secretClient corev1client.SecretsGetter, featureGateAccessor featuregates.FeatureGateAccess, referenceDataDir string) ([]string, error) {
-	if podSpec == nil {
-		return nil, fmt.Errorf("pod spec cannot be nil")
+	if cfg == nil {
+		return nil
 	}
 
-	if containerName == "" {
-		return nil, fmt.Errorf("container name cannot be empty")
-	}
-
-	if !featureGateAccessor.AreInitialFeatureGatesObserved() {
-		return nil, nil
-	}
-
-	featureGates, err := featureGateAccessor.CurrentFeatureGates()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get feature gates: %w", err)
-	}
-
-	if !featureGates.Enabled(features.FeatureGateKMSEncryption) {
-		return nil, nil
-	}
-
-	encryptionConfigurationSecret, err := secretClient.Secrets(encryptionConfigNamespace).Get(ctx, encryptionConfigSecretName, metav1.GetOptions{})
-	if apierrors.IsNotFound(err) {
-		klog.V(4).Infof("skipping KMS sidecar injection: %s/%s secret not found", encryptionConfigNamespace, encryptionConfigSecretName)
-		return nil, nil
-	}
-	if err != nil {
-		return nil, fmt.Errorf("failed to get %s/%s secret: %w", encryptionConfigNamespace, encryptionConfigSecretName, err)
-	}
-
-	encryptionConfig, err := encryptiondata.FromSecret(encryptionConfigurationSecret)
-	if err != nil {
-		return nil, fmt.Errorf("failed to extract encryption config from %s/%s secret: %w", encryptionConfigNamespace, encryptionConfigSecretName, err)
-	}
-
-	kmsConfigurations, err := encryptiondata.ExtractUniqueAndSortedKMSConfigurations(encryptionConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get KMS configurations: %w", err)
-	}
-	if len(kmsConfigurations) == 0 {
-		klog.V(4).Infof("skipping KMS sidecar injection: no KMS plugins found in EncryptionConfiguration")
-		return nil, nil
-	}
-
-	klog.V(4).Infof("injecting %d KMS sidecar(s)", len(kmsConfigurations))
-
-	var sidecarNames []string
-	socketVolumeMount := corev1.VolumeMount{Name: kmsPluginSocketVolumeName, MountPath: kmsPluginSocketMountPath, ReadOnly: false}
-	for _, kmsConfiguration := range kmsConfigurations {
-		// ExtractUniqueAndSortedKMSConfigurations function rewrites the .Name field to include only the key ID
-		keyID := kmsConfiguration.Name
-		udsPath := kmsConfiguration.Endpoint
-
-		pluginConfig, ok := encryptionConfig.KMSPlugins[keyID]
-		if !ok {
-			return nil, fmt.Errorf("missing plugin config for keyID %s", keyID)
-		}
-
-		refData := &referenceDataResolver{
-			pluginsConfigMapData: encryptionConfig.KMSPluginsConfigMapData,
-			pluginsSecretData:    encryptionConfig.KMSPluginsSecretData,
-			referenceDataDir:     referenceDataDir,
-			keyID:                keyID,
-		}
-
-		provider, err := newSidecarProvider(keyID, udsPath, pluginConfig, refData)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create a sidecar provider for keyID %s: %w", keyID, err)
-		}
-
-		if err := ensureSidecarContainer(podSpec, provider); err != nil {
-			return nil, err
-		}
-
-		if err := ensureVolumeMountInContainer(podSpec.InitContainers, provider.Name(), socketVolumeMount); err != nil {
-			return nil, err
-		}
-
-		sidecarNames = append(sidecarNames, provider.Name())
-	}
-
-	if err := ensureVolumeMountInContainer(podSpec.Containers, containerName, socketVolumeMount); err != nil {
-		return nil, err
-	}
-
-	// The volume mount in the kube-apiserver and KMS plugin containers requires a volume in the podSpec
-	if err := ensureSocketVolume(podSpec); err != nil {
-		return nil, err
-	}
-
-	return sidecarNames, nil
+	return NewKMSPluginBuilder().
+		FromEncryptionConfig(encryptionConfigSecretName, cfg).
+		Apply(podSpec, containerName)
 }
 
 func ensureSidecarContainer(podSpec *corev1.PodSpec, provider sidecarProvider) error {


### PR DESCRIPTION
This PR introduces kms plugin builder pattern to be reusable by different components with different set of configurations. 

Changes in this PR must not provide any logical changes. 