### PR TITLE
NO-JIRA: report preflight pod status in status condition

### DIFF
--- a/pkg/operator/encryption/kms/preflight/assets/kms-preflight-pod.yaml
+++ b/pkg/operator/encryption/kms/preflight/assets/kms-preflight-pod.yaml
@@ -29,6 +29,10 @@ spec:
       command: [{{.Command}}]
       args:
         - --kms-call-timeout={{.KMSCallTimeout}}
+        - --config-hash=$(CONFIG_HASH)
+        - --pod-name=$(POD_NAME)
+        - --pod-namespace=$(POD_NAMESPACE){{if .Kubeconfig}}
+        - --kubeconfig={{.Kubeconfig}}{{end}}
       env:
       - name: POD_NAME
         valueFrom: { fieldRef: { fieldPath: metadata.name } }

--- a/pkg/operator/encryption/kms/preflight/checker.go
+++ b/pkg/operator/encryption/kms/preflight/checker.go
@@ -37,19 +37,21 @@ func newChecker(service kmsservice.Service) *checker {
 	}
 }
 
-func (c *checker) check(ctx context.Context) error {
-	if err := c.checkStatus(ctx); err != nil {
-		return err
+func (c *checker) check(ctx context.Context) (*kmsservice.StatusResponse, error) {
+	status, err := c.checkStatus(ctx)
+	if err != nil {
+		return status, err
 	}
-	return c.checkEncryptDecrypt(ctx)
+	return status, c.checkEncryptDecrypt(ctx)
 }
 
 // checkStatus polls the KMS plugin status endpoint until it reports healthy.
 // The plugin may not be immediately available after startup, so we retry
 // before reporting a failure.
-func (c *checker) checkStatus(ctx context.Context) error {
+func (c *checker) checkStatus(ctx context.Context) (*kmsservice.StatusResponse, error) {
 	klog.Infof("[1/3] Checking KMS plugin status endpoint (interval %v, timeout %v)", c.statusInterval, c.statusTimeout)
-	return wait.PollUntilContextTimeout(ctx, c.statusInterval, c.statusTimeout, true, func(ctx context.Context) (bool, error) {
+	var status *kmsservice.StatusResponse
+	err := wait.PollUntilContextTimeout(ctx, c.statusInterval, c.statusTimeout, true, func(ctx context.Context) (bool, error) {
 		start := time.Now()
 		resp, err := c.service.Status(ctx)
 		elapsed := time.Since(start)
@@ -65,8 +67,10 @@ func (c *checker) checkStatus(ctx context.Context) error {
 			return false, nil
 		}
 		klog.Infof("  Status: healthz=%q, version=%q, keyID=%q, latency=%v", resp.Healthz, resp.Version, resp.KeyID, elapsed)
+		status = resp
 		return true, nil
 	})
+	return status, err
 }
 
 func (c *checker) checkEncryptDecrypt(ctx context.Context) error {

--- a/pkg/operator/encryption/kms/preflight/checker_test.go
+++ b/pkg/operator/encryption/kms/preflight/checker_test.go
@@ -159,13 +159,19 @@ func TestCheck(t *testing.T) {
 		t.Run(scenario.name, func(t *testing.T) {
 			target := newTestChecker(scenario.service)
 
-			err := target.check(context.Background())
+			status, err := target.check(context.Background())
 
 			if scenario.expectErr == "" && err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			if scenario.expectErr != "" && (err == nil || !strings.Contains(err.Error(), scenario.expectErr)) {
 				t.Fatalf("expected error containing %q, got: %v", scenario.expectErr, err)
+			}
+			if scenario.expectErr == "" && status == nil {
+				t.Fatal("expected status on success")
+			}
+			if scenario.expectErr == "" && status.KeyID != "key-1" {
+				t.Fatalf("expected keyID key-1, got %q", status.KeyID)
 			}
 		})
 	}

--- a/pkg/operator/encryption/kms/preflight/cmd.go
+++ b/pkg/operator/encryption/kms/preflight/cmd.go
@@ -2,6 +2,7 @@ package preflight
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -9,6 +10,8 @@ import (
 	"github.com/spf13/pflag"
 
 	k8senvelopekmsv2 "k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 )
 
@@ -16,6 +19,10 @@ const kmsSocketEndpoint = "unix:///var/run/kmsplugin/kms.sock"
 
 type options struct {
 	kmsCallTimeout time.Duration
+	podName        string
+	podNamespace   string
+	configHash     string
+	kubeconfig     string
 }
 
 // NewCommand creates the kms-preflight cobra command.
@@ -39,12 +46,26 @@ func NewCommand(ctx context.Context) *cobra.Command {
 
 func (o *options) addFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&o.kmsCallTimeout, "kms-call-timeout", 0, "timeout for each gRPC call to the KMS plugin")
+	fs.StringVar(&o.configHash, "config-hash", o.configHash, "hash of config to use for encryption")
+	fs.StringVar(&o.podName, "pod-name", o.podName, "name of pod to use to report checker status")
+	fs.StringVar(&o.podNamespace, "pod-namespace", o.podNamespace, "namespace of pod to report checker status")
+	fs.StringVar(&o.kubeconfig, "kubeconfig", o.kubeconfig, "path to a kubeconfig; empty uses in-cluster config")
 }
 
 func (o *options) validate() error {
 	if o.kmsCallTimeout <= 0 {
 		return fmt.Errorf("--kms-call-timeout must be greater than 0")
 	}
+	if o.configHash == "" {
+		return fmt.Errorf("--config-hash is required")
+	}
+	if o.podName == "" {
+		return fmt.Errorf("--pod-name is required")
+	}
+	if o.podNamespace == "" {
+		return fmt.Errorf("--pod-namespace is required")
+	}
+
 	return nil
 }
 
@@ -58,10 +79,24 @@ func (o *options) run(ctx context.Context) error {
 		return fmt.Errorf("failed to create KMS gRPC client: %w", err)
 	}
 
+	kubeConfig, err := clientcmd.BuildConfigFromFlags("", o.kubeconfig)
+	if err != nil {
+		return fmt.Errorf("failed to build kubeconfig: %w", err)
+	}
+	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create kube client: %w", err)
+	}
+
 	checker := newChecker(service)
 	start := time.Now()
-	if err = checker.check(ctx); err != nil {
-		return fmt.Errorf("kms preflight check failed: %w", err)
+	status, checkErr := checker.check(ctx)
+
+	podClient := kubeClient.CoreV1().Pods(o.podNamespace)
+	reportErr := setPodCheckCondition(ctx, podClient, o.podName, o.configHash, status, checkErr)
+	// join the errors to not lose the original error message
+	if err := errors.Join(checkErr, reportErr); err != nil {
+		return err
 	}
 
 	klog.Infof("KMS preflight check passed, total latency=%v", time.Since(start))

--- a/pkg/operator/encryption/kms/preflight/deployer.go
+++ b/pkg/operator/encryption/kms/preflight/deployer.go
@@ -60,6 +60,7 @@ func (d *PodPreflightDeployer) Deploy(ctx context.Context, configHash string, en
 		d.operatorImage,
 		d.operatorCommand,
 		d.kmsCallTimeout,
+		"",
 	)
 	if err != nil {
 		return fmt.Errorf("failed to generate preflight pod template: %w", err)

--- a/pkg/operator/encryption/kms/preflight/deployer_test.go
+++ b/pkg/operator/encryption/kms/preflight/deployer_test.go
@@ -92,6 +92,9 @@ spec:
       command: ["cluster-kube-apiserver-operator","kms-preflight"]
       args:
         - --kms-call-timeout=10s
+        - --config-hash=$(CONFIG_HASH)
+        - --pod-name=$(POD_NAME)
+        - --pod-namespace=$(POD_NAMESPACE)
       env:
       - name: POD_NAME
         valueFrom:

--- a/pkg/operator/encryption/kms/preflight/pod_status.go
+++ b/pkg/operator/encryption/kms/preflight/pod_status.go
@@ -1,0 +1,83 @@
+package preflight
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openshift/library-go/pkg/operator/encryption/controllers"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/util/retry"
+	kmsservice "k8s.io/kms/pkg/service"
+)
+
+func setPodCheckCondition(ctx context.Context, podClient corev1client.PodInterface, podName string, configHash string,
+	status *kmsservice.StatusResponse, checkErr error) error {
+	conditions := podCheckConditions(configHash, status, checkErr)
+	return updatePodCheckConditions(ctx, podClient, podName, conditions)
+}
+
+func updatePodCheckConditions(ctx context.Context, podClient corev1client.PodInterface, name string, conditions []corev1.PodCondition) error {
+	err := retry.OnError(retry.DefaultRetry, func(err error) bool { return true }, func() error {
+		pod, err := podClient.Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		for _, newCond := range conditions {
+			found := false
+			for i, existingCond := range pod.Status.Conditions {
+				if existingCond.Type == newCond.Type {
+					pod.Status.Conditions[i] = newCond
+					found = true
+					break
+				}
+			}
+			if !found {
+				pod.Status.Conditions = append(pod.Status.Conditions, newCond)
+			}
+		}
+		_, err = podClient.UpdateStatus(ctx, pod, metav1.UpdateOptions{})
+		return err
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update pod status for %s: %w", name, err)
+	}
+	return nil
+}
+
+func podCheckConditions(configHash string, status *kmsservice.StatusResponse, checkErr error) []corev1.PodCondition {
+	now := metav1.Now()
+
+	checkStatus, checkReason, checkMessage := corev1.ConditionTrue, "Succeeded", ""
+	if checkErr != nil {
+		checkStatus, checkReason, checkMessage = corev1.ConditionFalse, "Failed", checkErr.Error()
+	}
+
+	conditions := []corev1.PodCondition{
+		{
+			Type:               controllers.KMSPreflightResultPodCondition,
+			Status:             checkStatus,
+			Reason:             checkReason,
+			Message:            checkMessage,
+			LastTransitionTime: now,
+		},
+		{
+			Type:               controllers.KMSPreflightConfigHashPodCondition,
+			Status:             corev1.ConditionTrue,
+			Message:            configHash,
+			LastTransitionTime: now,
+		},
+	}
+
+	if status != nil {
+		conditions = append(conditions, corev1.PodCondition{
+			Type:               controllers.KMSPreflightKEKIDPodCondition,
+			Status:             corev1.ConditionTrue,
+			Message:            status.KeyID,
+			LastTransitionTime: now,
+		})
+	}
+
+	return conditions
+}

--- a/pkg/operator/encryption/kms/preflight/pod_status_test.go
+++ b/pkg/operator/encryption/kms/preflight/pod_status_test.go
@@ -1,0 +1,123 @@
+package preflight
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/openshift/library-go/pkg/operator/encryption/controllers"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+	kmsservice "k8s.io/kms/pkg/service"
+)
+
+func TestPodCheckConditions(t *testing.T) {
+	status := &kmsservice.StatusResponse{Version: "v2", KeyID: "key-1"}
+	configHash := "abc123def456"
+
+	conditions := podCheckConditions(configHash, status, nil)
+	if len(conditions) != 3 {
+		t.Fatalf("expected 3 conditions, got %d", len(conditions))
+	}
+
+	check := conditions[0]
+	if check.Type != controllers.KMSPreflightResultPodCondition || check.Status != corev1.ConditionTrue {
+		t.Fatalf("unexpected check condition: %#v", check)
+	}
+	if check.Message != "" {
+		t.Fatalf("expected empty check message on success, got %q", check.Message)
+	}
+
+	configHashCondition := conditions[1]
+	if configHashCondition.Type != controllers.KMSPreflightConfigHashPodCondition || configHashCondition.Message != configHash {
+		t.Fatalf("unexpected config hash condition: %#v", configHashCondition)
+	}
+
+	kekId := conditions[2]
+	if kekId.Type != controllers.KMSPreflightKEKIDPodCondition || kekId.Message != "key-1" {
+		t.Fatalf("unexpected kekID condition: %#v", kekId)
+	}
+
+	failed := podCheckConditions(configHash, status, fmt.Errorf("encrypt call failed"))
+	if failed[0].Status != corev1.ConditionFalse {
+		t.Fatalf("expected failed check condition, got %#v", failed[0])
+	}
+	if failed[0].Message != "encrypt call failed" {
+		t.Fatalf("unexpected failure message: %q", failed[0].Message)
+	}
+	if failed[1].Message != configHash {
+		t.Fatalf("expected config hash condition to remain populated, got %#v", failed[1])
+	}
+	if failed[2].Message != "key-1" {
+		t.Fatalf("expected keyID condition to remain populated, got %#v", failed[2])
+	}
+
+	withoutStatus := podCheckConditions(configHash, nil, fmt.Errorf("context deadline exceeded"))
+	if len(withoutStatus) != 2 {
+		t.Fatalf("expected 2 conditions without status, got %d", len(withoutStatus))
+	}
+	if withoutStatus[1].Message != configHash {
+		t.Fatalf("expected config hash condition, got %#v", withoutStatus[1])
+	}
+}
+
+func TestUpdatePodCheckConditions(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kms-preflight-abc123",
+			Namespace: "openshift-kube-apiserver",
+		},
+	}
+	kubeClient := fake.NewSimpleClientset(pod)
+	podClient := kubeClient.CoreV1().Pods(pod.Namespace)
+
+	conditions := podCheckConditions("abc123def456", &kmsservice.StatusResponse{Version: "v2", KeyID: "key-1"}, nil)
+	if err := updatePodCheckConditions(context.Background(), podClient, pod.Name, conditions); err != nil {
+		t.Fatalf("updatePodCheckConditions() error = %v", err)
+	}
+
+	updated, err := podClient.Get(context.Background(), pod.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if len(updated.Status.Conditions) != 3 {
+		t.Fatalf("expected 3 conditions, got %d", len(updated.Status.Conditions))
+	}
+}
+
+func TestUpdatePodCheckConditions_retriesOnConflict(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kms-preflight-abc123",
+			Namespace: "openshift-kube-apiserver",
+		},
+	}
+	kubeClient := fake.NewSimpleClientset(pod)
+	podClient := kubeClient.CoreV1().Pods(pod.Namespace)
+
+	attempts := 0
+	kubeClient.PrependReactor("update", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		updateAction := action.(clienttesting.UpdateAction)
+		if updateAction.GetSubresource() != "status" {
+			return false, nil, nil
+		}
+		attempts++
+		if attempts == 1 {
+			return true, nil, apierrors.NewConflict(schema.GroupResource{Resource: "pods"}, pod.Name, fmt.Errorf("conflict"))
+		}
+		return false, nil, nil
+	})
+
+	conditions := podCheckConditions("abc123def456", &kmsservice.StatusResponse{Version: "v2", KeyID: "key-1"}, nil)
+	if err := updatePodCheckConditions(context.Background(), podClient, pod.Name, conditions); err != nil {
+		t.Fatalf("updatePodCheckConditions() error = %v", err)
+	}
+	if attempts < 2 {
+		t.Fatalf("expected at least 2 update attempts, got %d", attempts)
+	}
+}

--- a/pkg/operator/encryption/kms/preflight/pod_template.go
+++ b/pkg/operator/encryption/kms/preflight/pod_template.go
@@ -19,6 +19,7 @@ type kmsPreflightTemplate struct {
 	OperatorImage  string
 	Command        string
 	KMSCallTimeout string
+	Kubeconfig     string
 }
 
 // generatePodTemplate renders the KMS preflight pod YAML template.
@@ -31,6 +32,7 @@ func generatePodTemplate(
 	operatorImage string,
 	operatorCommand []string,
 	kmsCallTimeout time.Duration,
+	kubeconfig string,
 ) (*corev1.Pod, error) {
 	rawManifest := mustAsset("assets/kms-preflight-pod.yaml")
 
@@ -46,6 +48,7 @@ func generatePodTemplate(
 		OperatorImage:  operatorImage,
 		Command:        strings.Join(operatorCommandQuoted, ","),
 		KMSCallTimeout: kmsCallTimeout.String(),
+		Kubeconfig:     kubeconfig,
 	}
 	tmpl, err := template.New("kms-preflight").Parse(string(rawManifest))
 	if err != nil {

--- a/pkg/operator/encryption/kms/preflight/pod_template_test.go
+++ b/pkg/operator/encryption/kms/preflight/pod_template_test.go
@@ -36,6 +36,9 @@ spec:
       command: ["operator","kms-preflight"]
       args:
         - --kms-call-timeout=10s
+        - --config-hash=$(CONFIG_HASH)
+        - --pod-name=$(POD_NAME)
+        - --pod-namespace=$(POD_NAMESPACE)
       env:
       - name: POD_NAME
         valueFrom:
@@ -61,6 +64,7 @@ func TestGeneratePodTemplate(t *testing.T) {
 		"quay.io/openshift/operator:latest",
 		[]string{"operator", "kms-preflight"},
 		10*time.Second,
+		"",
 	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
Uses the downward API to post the status of the check in dedicated pod conditions.
This also adds the kekId that is important for the rotation later.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * KMS preflight now publishes additional Pod readiness gate conditions for the preflight result, config hash, and detected KMS key ID.

* **Improvements**
  * The `kms-preflight` command now supports config-hash and pod identity inputs, polls plugin health before running checks, and records both checker and reporting outcomes.
  * Pod status updates for preflight conditions are now applied via a patch.

* **Tests**
  * Expanded unit tests to verify returned key details and Pod condition generation/update behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->