### PR TITLE
CNTRLPLANE-3363: Inject health reporter as sidecar container

### DIFF
--- a/pkg/operator/encryption/kms/health/cmd.go
+++ b/pkg/operator/encryption/kms/health/cmd.go
@@ -19,7 +19,7 @@ import (
 	"k8s.io/klog/v2"
 )
 
-const providerName = "kms-health-reporter"
+const Subcommand = "kms-health-reporter"
 
 // kmsSocketPattern matches the socket path each co-located KMSv2 plugin is
 // mounted at, e.g. unix:///var/run/kmsplugin/kms-1.sock.
@@ -53,7 +53,7 @@ func NewCommand(ctx context.Context, newOperatorClient func(*rest.Config) (v1hel
 	}
 
 	cmd := &cobra.Command{
-		Use:   "kms-health-reporter",
+		Use:   Subcommand,
 		Short: "Observes co-located KMSv2 plugins and publishes status as an OperatorCondition.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -168,7 +168,7 @@ func buildPlugins(ctx context.Context, sockets []string, timeout time.Duration) 
 
 		// Unique name per plugin so the gRPC client's KMS operation metrics
 		// don't merge both plugins into one series.
-		service, err := k8senvelopekmsv2.NewGRPCService(ctx, socket, providerName+"-"+keyID, timeout)
+		service, err := k8senvelopekmsv2.NewGRPCService(ctx, socket, Subcommand+"-"+keyID, timeout)
 		if err != nil {
 			// With the current dependency version this should never happen with a validated GRPC endpoint.
 			return nil, fmt.Errorf("setting up grpc service failed at %q: %w", socket, err)

--- a/pkg/operator/encryption/kms/pluginlifecycle/builder.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/builder.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
+	"github.com/openshift/library-go/pkg/operator/encryption/kms/health"
 )
 
 // KMSPluginBuilder constructs KMS plugin pod spec contributions for injection
@@ -20,6 +21,8 @@ type KMSPluginBuilder struct {
 	encryptionConfig           *encryptiondata.Config
 	encryptionConfigSecretName string
 	staticPod                  bool
+
+	healthReporter *healthReporter
 }
 
 // NewKMSPluginBuilder creates a builder that defaults to deployment mode.
@@ -41,6 +44,19 @@ func (b *KMSPluginBuilder) FromEncryptionConfig(encryptionConfigSecretName strin
 // data from the resource-dir volume and run as root (UID 0).
 func (b *KMSPluginBuilder) AsStaticPod() *KMSPluginBuilder {
 	b.staticPod = true
+	return b
+}
+
+// WithHealthReporter enables injection of a health-reporter sidecar.
+// operatorBinary is the parent binary (e.g. "cluster-kube-apiserver-operator");
+// when empty, the subcommand is invoked directly via the image ENTRYPOINT.
+func (b *KMSPluginBuilder) WithHealthReporter(operatorBinary, operatorImage string) *KMSPluginBuilder {
+	b.healthReporter = &healthReporter{
+		name:           "kms-health-reporter",
+		operatorBinary: operatorBinary,
+		subcommand:     health.Subcommand,
+		image:          operatorImage,
+	}
 	return b
 }
 
@@ -83,9 +99,11 @@ func (b *KMSPluginBuilder) Apply(podSpec *corev1.PodSpec, containerName string) 
 	socketVolumeMount := corev1.VolumeMount{Name: kmsPluginSocketVolumeName, MountPath: kmsPluginSocketMountPath, ReadOnly: false}
 	refDataVolumeMount := corev1.VolumeMount{Name: refDataVolumeName, MountPath: refDataMountPath, ReadOnly: true}
 
+	sockets := make([]string, 0, len(kmsConfigurations))
 	for _, kmsConfiguration := range kmsConfigurations {
 		// ExtractUniqueAndSortedKMSConfigurations function rewrites the .Name field to include only the key ID
 		keyID := kmsConfiguration.Name
+		sockets = append(sockets, kmsConfiguration.Endpoint)
 
 		pluginConfig, ok := b.encryptionConfig.KMSPlugins[keyID]
 		if !ok {
@@ -135,6 +153,10 @@ func (b *KMSPluginBuilder) Apply(podSpec *corev1.PodSpec, containerName string) 
 		if err := ensureReferenceDataVolume(podSpec, b.encryptionConfigSecretName); err != nil {
 			return err
 		}
+	}
+
+	if err := b.applyHealthReporter(podSpec, sockets); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/operator/encryption/kms/pluginlifecycle/health_reporter.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/health_reporter.go
@@ -1,0 +1,124 @@
+package pluginlifecycle
+
+import (
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/utils/ptr"
+)
+
+// defaultStaticPodKubeconfig is reused from the cert-syncer kubeconfig because
+// in-cluster config does not work on host-network static pods (kubernetes.default.svc
+// does not resolve). This matches the pattern used by the startup monitor.
+// TODO: move to a dedicated least-privilege kubeconfig once available.
+const defaultStaticPodKubeconfig = "/etc/kubernetes/static-pod-resources/configmaps/kube-apiserver-cert-syncer-kubeconfig/kubeconfig"
+
+// applyHealthReporter injects the health reporter sidecar. It is opt-in via
+// WithHealthReporter. Plugin lifecycle callers enable it; preflight callers
+// do not, since they only verify plugin reachability.
+func (b *KMSPluginBuilder) applyHealthReporter(podSpec *corev1.PodSpec, sockets []string) error {
+	if b.healthReporter == nil {
+		return nil
+	}
+
+	if len(sockets) == 0 {
+		return nil
+	}
+
+	if b.healthReporter.name == "" || b.healthReporter.operatorBinary == "" || b.healthReporter.image == "" || b.healthReporter.subcommand == "" {
+		return fmt.Errorf("health reporter name, operatorBinary, image and subcommand are required when WithHealthReporter is used")
+	}
+
+	b.healthReporter.sockets = sockets
+	if b.staticPod {
+		b.healthReporter.kubeconfig = defaultStaticPodKubeconfig
+	}
+
+	if err := ensureSidecarContainer(podSpec, b.healthReporter); err != nil {
+		return err
+	}
+
+	if err := ensureSocketVolume(podSpec); err != nil {
+		return err
+	}
+
+	socketMount := corev1.VolumeMount{Name: kmsPluginSocketVolumeName, MountPath: kmsPluginSocketMountPath, ReadOnly: true}
+	if err := ensureVolumeMountInContainer(podSpec.InitContainers, b.healthReporter.Name(), socketMount); err != nil {
+		return err
+	}
+
+	if b.staticPod {
+		resourceDirMount := corev1.VolumeMount{Name: resourceDirVolumeName, MountPath: resourcesDir, ReadOnly: true}
+		if err := ensureVolumeMountInContainer(podSpec.InitContainers, b.healthReporter.Name(), resourceDirMount); err != nil {
+			return err
+		}
+		if err := setRunAsRoot(podSpec.InitContainers, b.healthReporter.Name()); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+type healthReporter struct {
+	name           string
+	operatorBinary string
+	subcommand     string
+	image          string
+	sockets        []string
+	kubeconfig     string
+}
+
+func (h *healthReporter) Name() string {
+	return h.name
+}
+
+func (h *healthReporter) BuildSidecarContainer() (corev1.Container, error) {
+	if len(h.sockets) == 0 {
+		return corev1.Container{}, fmt.Errorf("at least one KMS socket is required")
+	}
+
+	args := []string{
+		fmt.Sprintf("--kms-sockets=%s", strings.Join(h.sockets, ",")),
+		"--node-name=$(NODE_NAME)",
+	}
+	if h.kubeconfig != "" {
+		args = append(args, fmt.Sprintf("--kubeconfig=%s", h.kubeconfig))
+	}
+
+	return corev1.Container{
+		Name:                     h.Name(),
+		Image:                    h.image,
+		Command:                  []string{h.operatorBinary, h.subcommand},
+		Args:                     args,
+		ImagePullPolicy:          corev1.PullIfNotPresent,
+		RestartPolicy:            ptr.To(corev1.ContainerRestartPolicyAlways),
+		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+		// NODE_NAME is expanded in --node-name=$(NODE_NAME) above so the
+		// health reporter can identify which node's health it is reporting.
+		Env: []corev1.EnvVar{
+			{
+				Name: "NODE_NAME",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: "spec.nodeName",
+					},
+				},
+			},
+		},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("32Mi"),
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+			},
+		},
+		SecurityContext: &corev1.SecurityContext{
+			ReadOnlyRootFilesystem:   ptr.To(true),
+			AllowPrivilegeEscalation: ptr.To(false),
+			Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+			SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+		},
+	}, nil
+}

--- a/pkg/operator/encryption/kms/pluginlifecycle/health_reporter_test.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/health_reporter_test.go
@@ -1,0 +1,105 @@
+package pluginlifecycle
+
+import (
+	"testing"
+
+	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+)
+
+func TestKMSPluginBuilder_WithHealthReporter(t *testing.T) {
+	f := newSidecarTestFixtures(t)
+	cfg, err := encryptiondata.FromSecret(f.encryptionConfigSecret)
+	require.NoError(t, err)
+
+	t.Run("health reporter injected with correct args and socket mount", func(t *testing.T) {
+		podSpec := &corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "kube-apiserver"}},
+			Volumes:    []corev1.Volume{f.resourceDirVolume},
+		}
+		err := NewKMSPluginBuilder().
+			FromEncryptionConfig("encryption-config", cfg).
+			WithHealthReporter("cluster-kube-apiserver-operator", "quay.io/test/operator:latest").
+			Apply(podSpec, "kube-apiserver")
+		require.NoError(t, err)
+
+		var reporter *corev1.Container
+		for i := range podSpec.InitContainers {
+			if podSpec.InitContainers[i].Name == "kms-health-reporter" {
+				reporter = &podSpec.InitContainers[i]
+				break
+			}
+		}
+		require.NotNil(t, reporter, "health reporter container must be injected")
+		require.Equal(t, "quay.io/test/operator:latest", reporter.Image)
+		require.Equal(t, []string{"cluster-kube-apiserver-operator", "kms-health-reporter"}, reporter.Command)
+		require.Contains(t, reporter.Args, "--kms-sockets=unix:///var/run/kmsplugin/kms-555.sock")
+		require.Contains(t, reporter.Args, "--node-name=$(NODE_NAME)")
+
+		hasSocketMount := false
+		for _, m := range reporter.VolumeMounts {
+			if m.Name == "kms-plugin-socket" {
+				hasSocketMount = true
+				require.True(t, m.ReadOnly)
+			}
+		}
+		require.True(t, hasSocketMount)
+
+		require.Len(t, reporter.Env, 1)
+		require.Equal(t, "NODE_NAME", reporter.Env[0].Name)
+		require.Equal(t, "spec.nodeName", reporter.Env[0].ValueFrom.FieldRef.FieldPath)
+	})
+
+	t.Run("static pod mode: health reporter gets root UID", func(t *testing.T) {
+		podSpec := &corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "kube-apiserver"}},
+			Volumes:    []corev1.Volume{f.resourceDirVolume},
+		}
+		err := NewKMSPluginBuilder().
+			FromEncryptionConfig("encryption-config", cfg).
+			AsStaticPod().
+			WithHealthReporter("cluster-kube-apiserver-operator", "quay.io/test/operator:latest").
+			Apply(podSpec, "kube-apiserver")
+		require.NoError(t, err)
+
+		var reporter *corev1.Container
+		for i := range podSpec.InitContainers {
+			if podSpec.InitContainers[i].Name == "kms-health-reporter" {
+				reporter = &podSpec.InitContainers[i]
+				break
+			}
+		}
+		require.NotNil(t, reporter)
+		require.Equal(t, ptr.To(int64(0)), reporter.SecurityContext.RunAsUser)
+		require.Contains(t, reporter.Args, "--kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/kube-apiserver-cert-syncer-kubeconfig/kubeconfig")
+	})
+
+	t.Run("without WithHealthReporter: no health reporter", func(t *testing.T) {
+		podSpec := &corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "kube-apiserver"}},
+			Volumes:    []corev1.Volume{f.resourceDirVolume},
+		}
+		err := NewKMSPluginBuilder().
+			FromEncryptionConfig("encryption-config", cfg).
+			Apply(podSpec, "kube-apiserver")
+		require.NoError(t, err)
+
+		for _, c := range podSpec.InitContainers {
+			require.NotEqual(t, "kms-health-reporter", c.Name, "health reporter must not be injected without WithHealthReporter")
+		}
+	})
+
+	t.Run("empty image: returns error", func(t *testing.T) {
+		podSpec := &corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "kube-apiserver"}},
+			Volumes:    []corev1.Volume{f.resourceDirVolume},
+		}
+		err := NewKMSPluginBuilder().
+			FromEncryptionConfig("encryption-config", cfg).
+			WithHealthReporter("cluster-kube-apiserver-operator", "").
+			Apply(podSpec, "kube-apiserver")
+		require.ErrorContains(t, err, "health reporter name, operatorBinary, image and subcommand are required")
+	})
+}

--- a/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
@@ -52,7 +52,7 @@ func newSidecarProvider(keyID string, udsPath string, pluginConfig configv1.KMSP
 //
 // It is a no-op when the KMSEncryption feature gate is not enabled or the encryption-config secret does not exist.
 // The secretClient should be uncached to avoid injecting sidecars based on a stale encryption configuration.
-func AddKMSPluginSidecarToStaticPodSpec(ctx context.Context, podSpec *corev1.PodSpec, containerName string, encryptionConfigNamespace string, encryptionConfigSecretName string, secretClient corev1client.SecretsGetter, featureGateAccessor featuregates.FeatureGateAccess) error {
+func AddKMSPluginSidecarToStaticPodSpec(ctx context.Context, podSpec *corev1.PodSpec, containerName string, encryptionConfigNamespace string, encryptionConfigSecretName string, operatorBinary string, operatorImage string, secretClient corev1client.SecretsGetter, featureGateAccessor featuregates.FeatureGateAccess) error {
 	if !featureGateAccessor.AreInitialFeatureGatesObserved() {
 		return nil
 	}
@@ -75,6 +75,7 @@ func AddKMSPluginSidecarToStaticPodSpec(ctx context.Context, podSpec *corev1.Pod
 	return NewKMSPluginBuilder().
 		FromEncryptionConfig(encryptionConfigSecretName, cfg).
 		AsStaticPod().
+		WithHealthReporter(operatorBinary, operatorImage).
 		Apply(podSpec, containerName)
 }
 
@@ -82,7 +83,7 @@ func AddKMSPluginSidecarToStaticPodSpec(ctx context.Context, podSpec *corev1.Pod
 //
 // It is a no-op when the KMSEncryption feature gate is not enabled or the encryption-config secret does not exist.
 // The secretClient should be uncached to avoid injecting sidecars based on a stale encryption configuration.
-func AddKMSPluginSidecarToPodSpec(ctx context.Context, podSpec *corev1.PodSpec, containerName string, encryptionConfigNamespace string, encryptionConfigSecretName string, secretClient corev1client.SecretsGetter, featureGateAccessor featuregates.FeatureGateAccess) error {
+func AddKMSPluginSidecarToPodSpec(ctx context.Context, podSpec *corev1.PodSpec, containerName string, encryptionConfigNamespace string, encryptionConfigSecretName string, operatorBinary string, operatorImage string, secretClient corev1client.SecretsGetter, featureGateAccessor featuregates.FeatureGateAccess) error {
 	if !featureGateAccessor.AreInitialFeatureGatesObserved() {
 		return nil
 	}
@@ -104,6 +105,7 @@ func AddKMSPluginSidecarToPodSpec(ctx context.Context, podSpec *corev1.PodSpec, 
 
 	return NewKMSPluginBuilder().
 		FromEncryptionConfig(encryptionConfigSecretName, cfg).
+		WithHealthReporter(operatorBinary, operatorImage).
 		Apply(podSpec, containerName)
 }
 

--- a/pkg/operator/encryption/kms/pluginlifecycle/sidecar_test.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/sidecar_test.go
@@ -126,6 +126,39 @@ func TestAddKMSPluginSidecarToPodSpec(t *testing.T) {
 		"-metrics-port=0",
 	}
 
+	expectedHealthReporter := func(sockets string) corev1.Container {
+		return corev1.Container{
+			Name:                     "kms-health-reporter",
+			Image:                    "quay.io/test/operator:latest",
+			Command:                  []string{"cluster-kube-apiserver-operator", "kms-health-reporter"},
+			Args:                     []string{fmt.Sprintf("--kms-sockets=%s", sockets), "--node-name=$(NODE_NAME)"},
+			ImagePullPolicy:          corev1.PullIfNotPresent,
+			RestartPolicy:            ptr.To(corev1.ContainerRestartPolicyAlways),
+			TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+			Env: []corev1.EnvVar{
+				{
+					Name: "NODE_NAME",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
+					},
+				},
+			},
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("32Mi"),
+					corev1.ResourceCPU:    resource.MustParse("10m"),
+				},
+			},
+			SecurityContext: &corev1.SecurityContext{
+				ReadOnlyRootFilesystem:   ptr.To(true),
+				AllowPrivilegeEscalation: ptr.To(false),
+				Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+				SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+			},
+			VolumeMounts: []corev1.VolumeMount{{Name: "kms-plugin-socket", MountPath: "/var/run/kmsplugin", ReadOnly: true}},
+		}
+	}
+
 	socketMount := corev1.VolumeMount{
 		Name:      "kms-plugin-socket",
 		MountPath: "/var/run/kmsplugin",
@@ -194,6 +227,7 @@ func TestAddKMSPluginSidecarToPodSpec(t *testing.T) {
 						},
 						VolumeMounts: []corev1.VolumeMount{socketMount, refDataMount},
 					},
+					expectedHealthReporter("unix:///var/run/kmsplugin/kms-555.sock"),
 				},
 				Volumes: []corev1.Volume{f.resourceDirVolume, socketVolume, refDataVolume},
 			},
@@ -279,6 +313,7 @@ func TestAddKMSPluginSidecarToPodSpec(t *testing.T) {
 						},
 						VolumeMounts: []corev1.VolumeMount{socketMount, refDataMount},
 					},
+					expectedHealthReporter("unix:///var/run/kmsplugin/kms-777.sock,unix:///var/run/kmsplugin/kms-555.sock"),
 				},
 				Volumes: []corev1.Volume{f.resourceDirVolume, socketVolume, refDataVolume},
 			},
@@ -513,6 +548,7 @@ func TestAddKMSPluginSidecarToPodSpec(t *testing.T) {
 						},
 						VolumeMounts: []corev1.VolumeMount{socketMount, refDataMount},
 					},
+					expectedHealthReporter("unix:///var/run/kmsplugin/kms-555.sock"),
 				},
 				Volumes: []corev1.Volume{f.resourceDirVolume, socketVolume, refDataVolume},
 			},
@@ -540,7 +576,7 @@ func TestAddKMSPluginSidecarToPodSpec(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := AddKMSPluginSidecarToPodSpec(context.Background(), tt.actualPodSpec, "kube-apiserver", "openshift-kube-apiserver", "encryption-config", tt.secretClient, tt.featureGateAccessor)
+			err := AddKMSPluginSidecarToPodSpec(context.Background(), tt.actualPodSpec, "kube-apiserver", "openshift-kube-apiserver", "encryption-config", "cluster-kube-apiserver-operator", "quay.io/test/operator:latest", tt.secretClient, tt.featureGateAccessor)
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
 				return
@@ -565,7 +601,7 @@ func TestAddKMSPluginSidecarToPodSpecIdempotency(t *testing.T) {
 
 	call := func() {
 		t.Helper()
-		err := AddKMSPluginSidecarToPodSpec(context.Background(), podSpec, "kube-apiserver", "openshift-kube-apiserver", "encryption-config", sc, fga)
+		err := AddKMSPluginSidecarToPodSpec(context.Background(), podSpec, "kube-apiserver", "openshift-kube-apiserver", "encryption-config", "cluster-kube-apiserver-operator", "quay.io/test/operator:latest", sc, fga)
 		require.NoError(t, err)
 	}
 


### PR DESCRIPTION
This PR injects health reporter container into apiserver pods, if any kms plugin container is added. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added health reporting support for KMS plugin pods. A health-reporter sidecar container can now be configured and injected into KMS plugin deployments to enable health monitoring and reporting capabilities.

* **Tests**
  * Added comprehensive test coverage for health reporter injection and configuration in KMS plugin pod specs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->