### PR TITLE
NO-JIRA: inject kms sidecar in preflight deployer

### DIFF
--- a/pkg/operator/encryption/kms/preflight/assets/kms-preflight-pod.yaml
+++ b/pkg/operator/encryption/kms/preflight/assets/kms-preflight-pod.yaml
@@ -41,9 +41,3 @@ spec:
         requests:
           memory: 50Mi
           cpu: 5m
-      volumeMounts:
-        - name: kms-plugin-socket
-          mountPath: /var/run/kmsplugin
-  volumes:
-    - name: kms-plugin-socket
-      emptyDir: {}

--- a/pkg/operator/encryption/kms/preflight/deployer.go
+++ b/pkg/operator/encryption/kms/preflight/deployer.go
@@ -2,9 +2,11 @@ package preflight
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
+	"github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -12,7 +14,9 @@ import (
 )
 
 const (
-	preflightPodName = "kms-preflight"
+	preflightPodName                    = "kms-preflight"
+	preflightCheckContainerName         = "kms-preflight-check"
+	preflightEncryptionConfigSecretName = "kms-preflight-encryption-config"
 )
 
 // PodPreflightDeployer creates a one-shot pod to run the preflight checker as a command,
@@ -28,7 +32,27 @@ type PodPreflightDeployer struct {
 	kmsCallTimeout  time.Duration
 }
 
-func (d *PodPreflightDeployer) Deploy(ctx context.Context, configHash string) error {
+func (d *PodPreflightDeployer) Deploy(ctx context.Context, configHash string, encryptionConfigSecret *corev1.Secret) error {
+	if configHash == "" {
+		return fmt.Errorf("configHash is empty")
+	}
+	if encryptionConfigSecret == nil {
+		return fmt.Errorf("encryptionConfigSecret is nil")
+	}
+
+	// ensure that there is nothing left over from previous runs
+	if err := d.Cleanup(ctx); err != nil {
+		return fmt.Errorf("failed to clean up existing preflight resources: %w", err)
+	}
+
+	encryptionConfigSecret = encryptionConfigSecret.DeepCopy()
+	// rewrite the entire ObjectMeta to avoid copying resource versions or managed fields
+	encryptionConfigSecret.ObjectMeta = metav1.ObjectMeta{Namespace: d.namespace, Name: preflightEncryptionConfigSecretName}
+	_, err := d.coreClient.Secrets(d.namespace).Create(ctx, encryptionConfigSecret, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to create preflight encryption config secret: %w", err)
+	}
+
 	pod, err := generatePodTemplate(
 		preflightPodName,
 		d.namespace,
@@ -41,10 +65,20 @@ func (d *PodPreflightDeployer) Deploy(ctx context.Context, configHash string) er
 		return fmt.Errorf("failed to generate preflight pod template: %w", err)
 	}
 
-	// TODO(thomas): inject KMS plugin sidecar container into pod.Spec
+	err = pluginlifecycle.NewKMSPluginBuilder().
+		WithSecretRequired().
+		FromEncryptionConfigSecret(d.namespace, preflightEncryptionConfigSecretName, d.coreClient).
+		Apply(ctx, &pod.Spec, preflightCheckContainerName)
+	if err != nil {
+		return fmt.Errorf("failed to apply preflight plugin: %w", err)
+	}
 
 	_, err = d.coreClient.Pods(d.namespace).Create(ctx, pod, metav1.CreateOptions{})
-	return err
+	if err != nil {
+		return fmt.Errorf("failed to create preflight pod: %w", err)
+	}
+
+	return nil
 }
 
 func (d *PodPreflightDeployer) Status(ctx context.Context) (corev1.PodStatus, error) {
@@ -58,11 +92,19 @@ func (d *PodPreflightDeployer) Status(ctx context.Context) (corev1.PodStatus, er
 }
 
 func (d *PodPreflightDeployer) Cleanup(ctx context.Context) error {
+	var errs []error
+
 	err := d.coreClient.Pods(d.namespace).Delete(ctx, preflightPodName, metav1.DeleteOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
-		return fmt.Errorf("failed to delete pod %s/%s: %w", d.namespace, preflightPodName, err)
+		errs = append(errs, fmt.Errorf("failed to delete pod %s/%s: %w", d.namespace, preflightPodName, err))
 	}
-	return nil
+
+	err = d.coreClient.Secrets(d.namespace).Delete(ctx, preflightEncryptionConfigSecretName, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		errs = append(errs, fmt.Errorf("failed to delete secret %s/%s: %w", d.namespace, preflightEncryptionConfigSecretName, err))
+	}
+
+	return errors.Join(errs...)
 }
 
 func NewPodPreflightDeployer(

--- a/pkg/operator/encryption/kms/preflight/deployer_test.go
+++ b/pkg/operator/encryption/kms/preflight/deployer_test.go
@@ -6,12 +6,16 @@ import (
 	"testing"
 	"time"
 
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
+	encryptiontesting "github.com/openshift/library-go/pkg/operator/encryption/testing"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
 )
@@ -22,6 +26,7 @@ const (
 	testOperatorImage       = "quay.io/openshift-release-dev/ocp-v5.0-art-dev@sha256:test"
 	configHashAnnotationKey = "encryption.apiserver.operator.openshift.io/kms-preflight-config-hash"
 	testDeployerTimeout     = 10 * time.Second
+	testReferenceDataNS     = "openshift-config"
 )
 
 var testOperatorCommand = []string{"cluster-kube-apiserver-operator", "kms-preflight"}
@@ -48,6 +53,39 @@ spec:
     - key: node-role.kubernetes.io/master
       operator: Exists
       effect: NoExecute
+  initContainers:
+    - name: vault-kms-plugin-1
+      image: registry.example.com/kms-plugin@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890
+      args:
+        - -listen-address=unix:///var/run/kmsplugin/kms.sock
+        - -vault-address=https://vault.example.com
+        - -transit-mount=
+        - -transit-key=test-transit-key
+        - -approle-role-id=test-role-id
+        - -approle-secret-id-path=/var/run/secrets/kms-plugin/kms-plugin-secret-vault-approle-secret_secret-id-1
+        - -tls-ca-file=/var/run/secrets/kms-plugin/kms-plugin-configmap-vault-ca-bundle_ca-bundle.crt-1
+        - -metrics-port=0
+      imagePullPolicy: IfNotPresent
+      restartPolicy: Always
+      terminationMessagePolicy: FallbackToLogsOnError
+      resources:
+        requests:
+          memory: 64Mi
+          cpu: 10m
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        readOnlyRootFilesystem: true
+        seccompProfile:
+          type: RuntimeDefault
+      volumeMounts:
+        - name: kms-plugin-socket
+          mountPath: /var/run/kmsplugin
+        - name: kms-plugins-data
+          mountPath: /var/run/secrets/kms-plugin
+          readOnly: true
   containers:
     - name: kms-preflight-check
       image: quay.io/openshift-release-dev/ocp-v5.0-art-dev@sha256:test
@@ -75,12 +113,101 @@ spec:
   volumes:
     - name: kms-plugin-socket
       emptyDir: {}
+    - name: kms-plugins-data
+      secret:
+        secretName: kms-preflight-encryption-config
 `
+
+func testReferenceDataObjects(t *testing.T) []runtime.Object {
+	t.Helper()
+
+	return []runtime.Object{
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "vault-approle-secret",
+				Namespace: testReferenceDataNS,
+			},
+			Data: map[string][]byte{
+				"role-id":   []byte("test-role-id"),
+				"secret-id": []byte("test-secret-id"),
+			},
+		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "vault-ca-bundle",
+				Namespace: testReferenceDataNS,
+			},
+			Data: map[string]string{
+				"ca-bundle.crt": "test-ca-cert",
+			},
+		},
+	}
+}
+
+func testPreflightEncryptionConfigSecret(t *testing.T) *corev1.Secret {
+	t.Helper()
+
+	var secretData encryptiondata.KMSPluginsReferenceData
+	if err := secretData.SetFromRawKey("1", "vault-approle-secret_role-id", []byte("test-role-id")); err != nil {
+		t.Fatalf("failed to set secret reference data: %v", err)
+	}
+	if err := secretData.SetFromRawKey("1", "vault-approle-secret_secret-id", []byte("test-secret-id")); err != nil {
+		t.Fatalf("failed to set secret reference data: %v", err)
+	}
+
+	var configMapData encryptiondata.KMSPluginsReferenceData
+	if err := configMapData.SetFromRawKey("1", "vault-ca-bundle_ca-bundle.crt", []byte("test-ca-cert")); err != nil {
+		t.Fatalf("failed to set configmap reference data: %v", err)
+	}
+
+	config := testPreflightEncryptionConfigFromData(t, secretData, configMapData)
+	secret, err := encryptiondata.ToSecret(testNamespace, preflightEncryptionConfigSecretName, config)
+	if err != nil {
+		t.Fatalf("failed to build encryption config secret: %v", err)
+	}
+	return secret
+}
+
+func testPreflightEncryptionConfigFromData(
+	t *testing.T,
+	secretData encryptiondata.KMSPluginsReferenceData,
+	configMapData encryptiondata.KMSPluginsReferenceData,
+) *encryptiondata.Config {
+	t.Helper()
+
+	return &encryptiondata.Config{
+		Encryption: &apiserverconfigv1.EncryptionConfiguration{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "EncryptionConfiguration",
+				APIVersion: "apiserver.config.k8s.io/v1",
+			},
+			Resources: []apiserverconfigv1.ResourceConfiguration{{
+				Resources: []string{"secrets"},
+				Providers: []apiserverconfigv1.ProviderConfiguration{{
+					KMS: &apiserverconfigv1.KMSConfiguration{
+						APIVersion: "v2",
+						Name:       "1_secrets",
+						Endpoint:   kmsSocketEndpoint,
+						Timeout:    &metav1.Duration{Duration: testDeployerTimeout},
+					},
+				}, {
+					Identity: &apiserverconfigv1.IdentityConfiguration{},
+				}},
+			}},
+		},
+		KMSPlugins: map[string]configv1.KMSPluginConfig{
+			"1": encryptiontesting.DefaultKMSPluginConfig,
+		},
+		KMSPluginsSecretData:    secretData,
+		KMSPluginsConfigMapData: configMapData,
+	}
+}
 
 func newTestDeployer(t *testing.T, objects ...runtime.Object) (*PodPreflightDeployer, *fake.Clientset) {
 	t.Helper()
 
-	kubeClient := fake.NewSimpleClientset(objects...)
+	allObjects := append(testReferenceDataObjects(t), objects...)
+	kubeClient := fake.NewSimpleClientset(allObjects...)
 	deployer := NewPodPreflightDeployer(
 		testNamespace,
 		kubeClient.CoreV1(),
@@ -91,30 +218,70 @@ func newTestDeployer(t *testing.T, objects ...runtime.Object) (*PodPreflightDepl
 	return deployer, kubeClient
 }
 
+func assertNoActionMatching(t *testing.T, actions []clienttesting.Action, verb, resource string) {
+	t.Helper()
+
+	for _, action := range actions {
+		if action.Matches(verb, resource) {
+			t.Fatalf("unexpected %s %s action: %#v", verb, resource, action)
+		}
+	}
+}
+
 func TestPodPreflightDeployer_Deploy(t *testing.T) {
 	ctx := context.Background()
 	deployer, kubeClient := newTestDeployer(t)
+	encryptionConfigSecret := testPreflightEncryptionConfigSecret(t)
 
 	expectedPod, err := resourceread.ReadPodV1([]byte(expectedDeployPodYAML))
 	if err != nil {
 		t.Fatalf("failed to parse expected pod YAML: %v", err)
 	}
 
-	if err := deployer.Deploy(ctx, testConfigHash); err != nil {
+	if err := deployer.Deploy(ctx, testConfigHash, encryptionConfigSecret); err != nil {
 		t.Fatalf("Deploy() error = %v", err)
 	}
 
 	actions := kubeClient.Actions()
-	if len(actions) != 1 {
-		t.Fatalf("expected 1 action, got %d: %#v", len(actions), actions)
+	if len(actions) != 5 {
+		t.Fatalf("expected 5 actions, got %d: %#v", len(actions), actions)
 	}
-	if !actions[0].Matches("create", "pods") {
+	if !actions[0].Matches("delete", "pods") {
 		t.Fatalf("unexpected action: %#v", actions[0])
 	}
-
-	createAction, ok := actions[0].(clienttesting.CreateAction)
+	if !actions[1].Matches("delete", "secrets") {
+		t.Fatalf("unexpected action: %#v", actions[1])
+	}
+	deleteAction, ok := actions[1].(clienttesting.DeleteAction)
 	if !ok {
-		t.Fatalf("expected CreateAction, got %T", actions[0])
+		t.Fatalf("expected DeleteAction, got %T", actions[1])
+	}
+	if deleteAction.GetName() != preflightEncryptionConfigSecretName {
+		t.Fatalf("unexpected secret name %q", deleteAction.GetName())
+	}
+	if !actions[2].Matches("create", "secrets") {
+		t.Fatalf("unexpected action: %#v", actions[2])
+	}
+	secretCreateAction, ok := actions[2].(clienttesting.CreateAction)
+	if !ok {
+		t.Fatalf("expected CreateAction, got %T", actions[2])
+	}
+	createdSecret, ok := secretCreateAction.GetObject().(*corev1.Secret)
+	if !ok {
+		t.Fatalf("expected *corev1.Secret, got %T", secretCreateAction.GetObject())
+	}
+	if len(createdSecret.Finalizers) != 0 {
+		t.Fatalf("expected finalizers to be stripped before create, got %v", createdSecret.Finalizers)
+	}
+	if !actions[3].Matches("get", "secrets") {
+		t.Fatalf("unexpected action: %#v", actions[3])
+	}
+	if !actions[4].Matches("create", "pods") {
+		t.Fatalf("unexpected action: %#v", actions[4])
+	}
+	createAction, ok := actions[4].(clienttesting.CreateAction)
+	if !ok {
+		t.Fatalf("expected CreateAction, got %T", actions[4])
 	}
 	if createAction.GetNamespace() != testNamespace {
 		t.Fatalf("unexpected namespace %q", createAction.GetNamespace())
@@ -126,6 +293,204 @@ func TestPodPreflightDeployer_Deploy(t *testing.T) {
 	}
 	if !equality.Semantic.DeepEqual(expectedPod, actualPod) {
 		t.Fatalf("pod does not match expected:\ngot:  %+v\nwant: %+v", actualPod, expectedPod)
+	}
+}
+
+func TestPodPreflightDeployer_Deploy_emptyConfigHash(t *testing.T) {
+	deployer, kubeClient := newTestDeployer(t)
+
+	err := deployer.Deploy(context.Background(), "", testPreflightEncryptionConfigSecret(t))
+	if err == nil || !strings.Contains(err.Error(), "configHash is empty") {
+		t.Fatalf("expected configHash is empty error, got %v", err)
+	}
+	if len(kubeClient.Actions()) != 0 {
+		t.Fatalf("expected no client actions, got %d: %#v", len(kubeClient.Actions()), kubeClient.Actions())
+	}
+}
+
+func TestPodPreflightDeployer_Deploy_nilEncryptionConfigSecret(t *testing.T) {
+	deployer, kubeClient := newTestDeployer(t)
+
+	err := deployer.Deploy(context.Background(), testConfigHash, nil)
+	if err == nil || !strings.Contains(err.Error(), "encryptionConfigSecret is nil") {
+		t.Fatalf("expected encryptionConfigSecret is nil error, got %v", err)
+	}
+	if len(kubeClient.Actions()) != 0 {
+		t.Fatalf("expected no client actions, got %d: %#v", len(kubeClient.Actions()), kubeClient.Actions())
+	}
+}
+
+// Verifies that a forbidden secret create returns a wrapped error after cleanup,
+// performs only cleanup + failed create (no secret get or pod create).
+func TestPodPreflightDeployer_Deploy_secretCreateFailure(t *testing.T) {
+	deployer, kubeClient := newTestDeployer(t)
+	kubeClient.PrependReactor("create", "secrets", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(corev1.Resource("secrets"), preflightEncryptionConfigSecretName, nil)
+	})
+
+	err := deployer.Deploy(context.Background(), testConfigHash, testPreflightEncryptionConfigSecret(t))
+	if err == nil || !strings.Contains(err.Error(), "failed to create preflight encryption config secret") {
+		t.Fatalf("expected secret create error, got %v", err)
+	}
+
+	actions := kubeClient.Actions()
+	if len(actions) != 3 {
+		t.Fatalf("expected 3 actions, got %d: %#v", len(actions), actions)
+	}
+	if !actions[0].Matches("delete", "pods") {
+		t.Fatalf("unexpected action: %#v", actions[0])
+	}
+	if !actions[1].Matches("delete", "secrets") {
+		t.Fatalf("unexpected action: %#v", actions[1])
+	}
+	if !actions[2].Matches("create", "secrets") {
+		t.Fatalf("unexpected action: %#v", actions[2])
+	}
+	assertNoActionMatching(t, actions, "create", "pods")
+	assertNoActionMatching(t, actions, "get", "secrets")
+}
+
+// Verifies that plugin sidecar injection failure returns a wrapped error, leaves
+// the encryption config secret behind, and does not create a pod.
+func TestPodPreflightDeployer_Deploy_pluginApplyFailure(t *testing.T) {
+	deployer, kubeClient := newTestDeployer(t)
+
+	config := testPreflightEncryptionConfigFromData(
+		t,
+		encryptiondata.KMSPluginsReferenceData{},
+		encryptiondata.KMSPluginsReferenceData{},
+	)
+	secret, err := encryptiondata.ToSecret(testNamespace, "proposed-encryption-config", config)
+	if err != nil {
+		t.Fatalf("failed to build encryption config secret: %v", err)
+	}
+
+	err = deployer.Deploy(context.Background(), testConfigHash, secret)
+	if err == nil || !strings.Contains(err.Error(), "failed to apply preflight plugin") {
+		t.Fatalf("expected plugin apply error, got %v", err)
+	}
+
+	actions := kubeClient.Actions()
+	if len(actions) != 4 {
+		t.Fatalf("expected 4 actions, got %d: %#v", len(actions), actions)
+	}
+	if !actions[0].Matches("delete", "pods") {
+		t.Fatalf("unexpected action: %#v", actions[0])
+	}
+	if !actions[1].Matches("delete", "secrets") {
+		t.Fatalf("unexpected action: %#v", actions[1])
+	}
+	if !actions[2].Matches("create", "secrets") {
+		t.Fatalf("unexpected action: %#v", actions[2])
+	}
+	if !actions[3].Matches("get", "secrets") {
+		t.Fatalf("unexpected action: %#v", actions[3])
+	}
+	assertNoActionMatching(t, actions, "create", "pods")
+}
+
+// Verifies that a forbidden pod create returns a wrapped error with the secret
+// already created and no preflight pod present (partial deploy state).
+func TestPodPreflightDeployer_Deploy_podCreateFailure(t *testing.T) {
+	deployer, kubeClient := newTestDeployer(t)
+	kubeClient.PrependReactor("create", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(corev1.Resource("pods"), preflightPodName, nil)
+	})
+
+	err := deployer.Deploy(context.Background(), testConfigHash, testPreflightEncryptionConfigSecret(t))
+	if err == nil || !strings.Contains(err.Error(), "failed to create preflight pod") {
+		t.Fatalf("expected pod create error, got %v", err)
+	}
+
+	actions := kubeClient.Actions()
+	if len(actions) != 5 {
+		t.Fatalf("expected 5 actions, got %d: %#v", len(actions), actions)
+	}
+	if !actions[0].Matches("delete", "pods") {
+		t.Fatalf("unexpected action: %#v", actions[0])
+	}
+	if !actions[1].Matches("delete", "secrets") {
+		t.Fatalf("unexpected action: %#v", actions[1])
+	}
+	if !actions[2].Matches("create", "secrets") {
+		t.Fatalf("unexpected action: %#v", actions[2])
+	}
+	if !actions[3].Matches("get", "secrets") {
+		t.Fatalf("unexpected action: %#v", actions[3])
+	}
+	if !actions[4].Matches("create", "pods") {
+		t.Fatalf("unexpected action: %#v", actions[4])
+	}
+}
+
+// Verifies that initial cleanup failure aborts Deploy early with a wrapped error
+// and performs no secret or pod creates.
+func TestPodPreflightDeployer_Deploy_cleanupFailure(t *testing.T) {
+	existingPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      preflightPodName,
+			Namespace: testNamespace,
+		},
+	}
+	deployer, kubeClient := newTestDeployer(t, existingPod)
+	kubeClient.PrependReactor("delete", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(corev1.Resource("pods"), preflightPodName, nil)
+	})
+
+	err := deployer.Deploy(context.Background(), testConfigHash, testPreflightEncryptionConfigSecret(t))
+	if err == nil || !strings.Contains(err.Error(), "failed to clean up existing preflight resources") {
+		t.Fatalf("expected cleanup error, got %v", err)
+	}
+
+	actions := kubeClient.Actions()
+	if len(actions) != 2 {
+		t.Fatalf("expected 2 actions, got %d: %#v", len(actions), actions)
+	}
+	if !actions[0].Matches("delete", "pods") {
+		t.Fatalf("unexpected action: %#v", actions[0])
+	}
+	if !actions[1].Matches("delete", "secrets") {
+		t.Fatalf("unexpected action: %#v", actions[1])
+	}
+	assertNoActionMatching(t, actions, "create", "secrets")
+	assertNoActionMatching(t, actions, "create", "pods")
+}
+
+func TestPodPreflightDeployer_Deploy_deletesStaleResources(t *testing.T) {
+	ctx := context.Background()
+	stalePod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      preflightPodName,
+			Namespace: testNamespace,
+		},
+	}
+	staleSecret := testPreflightEncryptionConfigSecret(t)
+	staleSecret.Data = map[string][]byte{"stale": []byte("data")}
+	deployer, kubeClient := newTestDeployer(t, stalePod, staleSecret)
+
+	err := deployer.Deploy(ctx, testConfigHash, testPreflightEncryptionConfigSecret(t))
+	if err != nil {
+		t.Fatalf("Deploy() error = %v", err)
+	}
+
+	actions := kubeClient.Actions()
+	if len(actions) != 5 {
+		t.Fatalf("expected 5 actions, got %d: %#v", len(actions), actions)
+	}
+	if !actions[0].Matches("delete", "pods") {
+		t.Fatalf("unexpected action: %#v", actions[0])
+	}
+	if !actions[1].Matches("delete", "secrets") {
+		t.Fatalf("unexpected action: %#v", actions[1])
+	}
+	if !actions[2].Matches("create", "secrets") {
+		t.Fatalf("unexpected action: %#v", actions[2])
+	}
+	if !actions[3].Matches("get", "secrets") {
+		t.Fatalf("unexpected action: %#v", actions[3])
+	}
+	if !actions[4].Matches("create", "pods") {
+		t.Fatalf("unexpected action: %#v", actions[4])
 	}
 }
 
@@ -186,20 +551,22 @@ func TestPodPreflightDeployer_Cleanup(t *testing.T) {
 			},
 		},
 	}
+	existingSecret := testPreflightEncryptionConfigSecret(t)
 
 	scenarios := []struct {
-		name          string
-		objects       []runtime.Object
-		setupClient   func(*fake.Clientset)
-		expectErr     string
-		verifyActions func(t *testing.T, actions []clienttesting.Action)
+		name              string
+		objects           []runtime.Object
+		setupClient       func(*fake.Clientset)
+		expectErr         string
+		expectErrContains []string
+		verifyActions     func(t *testing.T, actions []clienttesting.Action)
 	}{
 		{
-			name:    "deletes existing pod",
-			objects: []runtime.Object{existingPod},
+			name:    "deletes existing pod and secret",
+			objects: []runtime.Object{existingPod, existingSecret},
 			verifyActions: func(t *testing.T, actions []clienttesting.Action) {
-				if len(actions) != 1 {
-					t.Fatalf("expected 1 action, got %d: %#v", len(actions), actions)
+				if len(actions) != 2 {
+					t.Fatalf("expected 2 actions, got %d: %#v", len(actions), actions)
 				}
 				if !actions[0].Matches("delete", "pods") {
 					t.Fatalf("unexpected action: %#v", actions[0])
@@ -214,21 +581,27 @@ func TestPodPreflightDeployer_Cleanup(t *testing.T) {
 				if deleteAction.GetNamespace() != testNamespace {
 					t.Fatalf("unexpected namespace %q", deleteAction.GetNamespace())
 				}
+				if !actions[1].Matches("delete", "secrets") {
+					t.Fatalf("unexpected action: %#v", actions[1])
+				}
 			},
 		},
 		{
-			name: "missing pod is not an error",
+			name: "missing resources is not an error",
 			verifyActions: func(t *testing.T, actions []clienttesting.Action) {
-				if len(actions) != 1 {
-					t.Fatalf("expected 1 action, got %d: %#v", len(actions), actions)
+				if len(actions) != 2 {
+					t.Fatalf("expected 2 actions, got %d: %#v", len(actions), actions)
 				}
 				if !actions[0].Matches("delete", "pods") {
 					t.Fatalf("unexpected action: %#v", actions[0])
 				}
+				if !actions[1].Matches("delete", "secrets") {
+					t.Fatalf("unexpected action: %#v", actions[1])
+				}
 			},
 		},
 		{
-			name:    "delete error is returned",
+			name:    "delete pod error is returned",
 			objects: []runtime.Object{existingPod},
 			setupClient: func(kubeClient *fake.Clientset) {
 				kubeClient.PrependReactor("delete", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
@@ -237,11 +610,61 @@ func TestPodPreflightDeployer_Cleanup(t *testing.T) {
 			},
 			expectErr: "failed to delete pod",
 			verifyActions: func(t *testing.T, actions []clienttesting.Action) {
-				if len(actions) != 1 {
-					t.Fatalf("expected 1 action, got %d: %#v", len(actions), actions)
+				if len(actions) != 2 {
+					t.Fatalf("expected 2 actions, got %d: %#v", len(actions), actions)
 				}
 				if !actions[0].Matches("delete", "pods") {
 					t.Fatalf("unexpected action: %#v", actions[0])
+				}
+				if !actions[1].Matches("delete", "secrets") {
+					t.Fatalf("unexpected action: %#v", actions[1])
+				}
+			},
+		},
+		{
+			name:    "delete secret error is returned",
+			objects: []runtime.Object{existingSecret},
+			setupClient: func(kubeClient *fake.Clientset) {
+				kubeClient.PrependReactor("delete", "secrets", func(action clienttesting.Action) (bool, runtime.Object, error) {
+					return true, nil, apierrors.NewForbidden(corev1.Resource("secrets"), preflightEncryptionConfigSecretName, nil)
+				})
+			},
+			expectErr: "failed to delete secret",
+			verifyActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 2 {
+					t.Fatalf("expected 2 actions, got %d: %#v", len(actions), actions)
+				}
+				if !actions[0].Matches("delete", "pods") {
+					t.Fatalf("unexpected action: %#v", actions[0])
+				}
+				if !actions[1].Matches("delete", "secrets") {
+					t.Fatalf("unexpected action: %#v", actions[1])
+				}
+			},
+		},
+		// Verifies that when both pod and secret delete fail, Cleanup returns an
+		// error containing messages for both failures.
+		{
+			name:    "both delete errors are returned",
+			objects: []runtime.Object{existingPod, existingSecret},
+			setupClient: func(kubeClient *fake.Clientset) {
+				kubeClient.PrependReactor("delete", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
+					return true, nil, apierrors.NewForbidden(corev1.Resource("pods"), preflightPodName, nil)
+				})
+				kubeClient.PrependReactor("delete", "secrets", func(action clienttesting.Action) (bool, runtime.Object, error) {
+					return true, nil, apierrors.NewForbidden(corev1.Resource("secrets"), preflightEncryptionConfigSecretName, nil)
+				})
+			},
+			expectErrContains: []string{"failed to delete pod", "failed to delete secret"},
+			verifyActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 2 {
+					t.Fatalf("expected 2 actions, got %d: %#v", len(actions), actions)
+				}
+				if !actions[0].Matches("delete", "pods") {
+					t.Fatalf("unexpected action: %#v", actions[0])
+				}
+				if !actions[1].Matches("delete", "secrets") {
+					t.Fatalf("unexpected action: %#v", actions[1])
 				}
 			},
 		},
@@ -255,13 +678,21 @@ func TestPodPreflightDeployer_Cleanup(t *testing.T) {
 			}
 
 			err := deployer.Cleanup(context.Background())
-			if scenario.expectErr != "" {
+			if len(scenario.expectErrContains) > 0 {
+				if err == nil {
+					t.Fatalf("expected cleanup error, got nil")
+				}
+				for _, fragment := range scenario.expectErrContains {
+					if !strings.Contains(err.Error(), fragment) {
+						t.Fatalf("expected error containing %q, got %v", fragment, err)
+					}
+				}
+			} else if scenario.expectErr != "" {
 				if err == nil || !strings.Contains(err.Error(), scenario.expectErr) {
 					t.Fatalf("expected error containing %q, got %v", scenario.expectErr, err)
 				}
 				return
-			}
-			if err != nil {
+			} else if err != nil {
 				t.Fatalf("Cleanup() error = %v", err)
 			}
 			if scenario.verifyActions != nil {

--- a/pkg/operator/encryption/kms/preflight/pod_template_test.go
+++ b/pkg/operator/encryption/kms/preflight/pod_template_test.go
@@ -51,12 +51,6 @@ spec:
         requests:
           memory: 50Mi
           cpu: 5m
-      volumeMounts:
-        - name: kms-plugin-socket
-          mountPath: /var/run/kmsplugin
-  volumes:
-    - name: kms-plugin-socket
-      emptyDir: {}
 `
 
 func TestGeneratePodTemplate(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preflight deployment now provisions KMS plugin components (including a plugin socket/init container) with the required encryption configuration.
  * Added support for creating and cleaning up the encryption configuration secret used by the preflight workflow.
* **Bug Fixes**
  * Deployment now validates required inputs and safely replaces stale preflight resources using a consistent delete-then-create order.
  * Cleanup performs best-effort deletion of both the preflight pod and its secret, tolerating missing resources and reporting combined failures.
* **Tests**
  * Expanded unit tests to cover secret/plugin injection and detailed cleanup/error ordering scenarios.
* **Improvements**
  * Set explicit CPU/memory resource requests for the preflight check container.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->