### PR TITLE
NO-JIRA: add label to preflight pod for network policies

### DIFF
--- a/pkg/operator/encryption/kms/preflight/assets/kms-preflight-pod.yaml
+++ b/pkg/operator/encryption/kms/preflight/assets/kms-preflight-pod.yaml
@@ -3,6 +3,9 @@ kind: Pod
 metadata:
   name: {{.PodName}}
   namespace: {{.Namespace}}
+  labels:
+    # This is used in the operands network AllowLists. Changes here need to reflect in all dependent operators.
+    app: openshift-kms-preflight
   annotations:
     encryption.apiserver.operator.openshift.io/kms-preflight-config-hash: {{.ConfigHash}}
 spec:

--- a/pkg/operator/encryption/kms/preflight/deployer_test.go
+++ b/pkg/operator/encryption/kms/preflight/deployer_test.go
@@ -32,6 +32,8 @@ kind: Pod
 metadata:
   name: kms-preflight
   namespace: openshift-kube-apiserver
+  labels:
+    app: openshift-kms-preflight
   annotations:
     encryption.apiserver.operator.openshift.io/kms-preflight-config-hash: abc123
 spec:

--- a/pkg/operator/encryption/kms/preflight/pod_template_test.go
+++ b/pkg/operator/encryption/kms/preflight/pod_template_test.go
@@ -14,6 +14,8 @@ kind: Pod
 metadata:
   name: kms-preflight
   namespace: test-ns
+  labels:
+    app: openshift-kms-preflight
   annotations:
     encryption.apiserver.operator.openshift.io/kms-preflight-config-hash: abc123
 spec:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an identification label to the KMS preflight pod manifest to improve environment coordination and ensure downstream allow-listing aligns with the updated pod metadata.

* **Tests**
  * Updated unit test fixtures to match the new KMS preflight pod metadata, ensuring pod template/deployer output comparisons remain consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->