### PR TITLE
CNTRLPLANE-3659: Add AGENTS.md and update README.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,65 @@
+# AI Agent Instructions for library-go
+
+## What This Repo Is
+
+library-go is a shared Go helper library consumed by dozens of OpenShift operators and components. It provides reusable building blocks: operator controller framework, certificate management, configuration observers, encryption/KMS integration, manifest-based clients, and more.
+
+**This is a library, not an application.** There is no main binary. Changes here affect every OpenShift component that vendors this repo.
+
+## Critical Rules
+
+1. **Never add imports from `k8s.io/kubernetes` or `openshift/origin`.** This is an absolute constraint — the library must remain independent of those repos.
+2. **Always run `go mod tidy && go mod vendor` after any dependency change.** The vendor directory is checked in and CI validates it.
+3. **Run `make verify` and `make test-unit` before considering any change complete.**
+4. **Do not introduce breaking API changes** to existing public functions or types without explicit direction. Dozens of repos depend on these interfaces.
+
+## Repository Structure
+
+```text
+pkg/
+├── operator/          # Controller framework (33 subpackages) — the core of the library
+│   ├── certrotation/  # Certificate lifecycle and rotation controllers
+│   ├── configobserver/ # Watches config inputs, produces RawExtension outputs
+│   ├── encryption/    # KMS/encryption state machine (11 subdirs) — very complex
+│   ├── staticpod/     # Static pod management with atomic directory swaps
+│   ├── resourcesynccontroller/ # Cross-namespace secret/configmap sync
+│   └── ...
+├── crypto/            # Low-level TLS, certificates, key generation, cipher suites
+├── pki/               # High-level API-driven PKI profiles (newer)
+├── config/            # Configuration management, serving, leader election
+├── manifestclient/    # Manifest-based client operations (offline-capable)
+├── controller/        # Controller utilities, factory, file observer
+├── assets/            # Asset creation and templating
+└── ...                # 35+ top-level packages total
+test/
+├── e2e-encryption/    # Encryption end-to-end tests
+├── e2e-monitoring/    # Monitoring end-to-end tests
+└── library/           # Shared test helpers
+```
+
+## Key Patterns to Follow
+
+- **ConfigObserver pattern**: Controllers watch multiple config inputs and produce a single `RawExtension` output. Changes are detected by comparing the merged observer output against the existing observed config. Follow this pattern for any new observer.
+- **Preconditions over defaults**: `StaticResourceController` uses preconditions (feature gates, platform checks) to decide behavior. Do not try to handle all combinations with defaults.
+- **Controller naming**: Controllers follow the pattern `NewXxxController(...)` returning a `factory.Controller`. Follow existing naming and constructor conventions.
+
+## High-Risk Areas — Proceed with Caution
+
+- **`pkg/operator/encryption/`** — State machine with complex preconditions, crypto providers, KMS plugin integration, and etcd encryption config management. Do not modify without deep understanding.
+- **`pkg/crypto/`** and **`pkg/operator/certrotation/`** — Certificate rotation triggers at 80% of validity (4/5 of cert lifetime) and handles multi-CA chain support. Subtle bugs here cause cluster outages. Note: CSR handling is in `pkg/operator/csr/`, not in certrotation.
+- **`pkg/operator/staticpod/`** — Atomic directory swaps use `renameat2(RENAME_EXCHANGE)` on Linux; non-Linux platforms are not supported and return an error. Platform-specific code needs careful testing.
+
+## Build and Test
+
+```bash
+make build       # Compile all packages
+make test-unit   # Run unit tests
+make verify      # Linters, gofmt, vet
+```
+
+## What NOT to Do
+
+- Do not add new top-level packages without a strong reason — the bar for inclusion is high.
+- Do not modify OWNERS or OWNERS_ALIASES files.
+- Do not use Kubernetes code generators (deepcopy-gen, client-gen, informer-gen). Some CRD manifests are synced from `openshift/api` via the Makefile, but the Go code is hand-written.
+- Do not add test dependencies on real cloud providers or external services in unit tests. Use fakes and mocks from `k8s.io/client-go/kubernetes/fake`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # library-go
 Helpers for going from apis and clients to useful runtime constructs.  `config.ServingInfo` to useful serving constructs is the canonical example.  Anything introduced here must have concrete use-cases in at least two separate openshift repos and be of some reasonable complexity.  The bar here is high.  We'll start with openshift/api-review as the approvers.
 
-This repo **must not depend on k8s.io/kubernetes or openshift/origin**.  
+This repo **must not depend on k8s.io/kubernetes or openshift/origin**.
+
+## Proof PRs
+
+Changes to library-go must be accompanied by "proof PRs" that bump this dependency in at least one consuming repo and run presubmits there. This validates that the change works correctly in context before merging.


### PR DESCRIPTION
## Summary
- Add **AGENTS.md** with AI agent instructions: forbidden imports, repo structure, key patterns, build/test commands
- Add **CLAUDE.md** as a symlink to AGENTS.md
- Update **README.md** with proof-PR guidance

Part of the Hybrid Platforms Agentic SDLC initiative ([OCPSTRAT-3200](https://redhat.atlassian.net/browse/OCPSTRAT-3200)) — Shift Week contextification effort.

Jira: [CNTRLPLANE-3659](https://redhat.atlassian.net/browse/CNTRLPLANE-3659)

## Test plan
- [ ] Verify markdown renders correctly on GitHub
- [ ] Review with team for accuracy and completeness