### PR TITLE
CNTRLPLANE-3363: Internalize encryption config Secret retrieval in Builder

### DIFF
--- a/pkg/operator/encryption/kms/pluginlifecycle/builder.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/builder.go
@@ -18,25 +18,28 @@ import (
 // KMSPluginBuilder constructs KMS plugin pod spec contributions for injection
 // into API server pods.
 type KMSPluginBuilder struct {
-	encryptionConfig           *encryptiondata.Config
+	secretClient               corev1client.SecretsGetter
+	encryptionConfigNamespace  string
 	encryptionConfigSecretName string
 	staticPod                  bool
+	errorIfNotFound            bool
 
 	healthReporter *healthReporter
 }
 
 // NewKMSPluginBuilder creates a builder that defaults to deployment mode.
-func NewKMSPluginBuilder() *KMSPluginBuilder {
-	return &KMSPluginBuilder{}
+// The secretClient is used to fetch the encryption-config Secret at Apply time.
+func NewKMSPluginBuilder(secretClient corev1client.SecretsGetter) *KMSPluginBuilder {
+	return &KMSPluginBuilder{
+		secretClient: secretClient,
+	}
 }
 
-// FromEncryptionConfig loads all KMS plugins from a parsed encryption config.
-// The encryptionConfigSecretName identifies the Secret the config was parsed
-// from; it is used for volume configuration in both deployment and static pod
-// modes.
-func (b *KMSPluginBuilder) FromEncryptionConfig(encryptionConfigSecretName string, cfg *encryptiondata.Config) *KMSPluginBuilder {
-	b.encryptionConfigSecretName = encryptionConfigSecretName
-	b.encryptionConfig = cfg
+// FromEncryptionConfig configures the builder to load KMS plugins from the
+// named encryption-config Secret. The Secret is fetched at Apply time.
+func (b *KMSPluginBuilder) FromEncryptionConfig(namespace, secretName string) *KMSPluginBuilder {
+	b.encryptionConfigNamespace = namespace
+	b.encryptionConfigSecretName = secretName
 	return b
 }
 
@@ -44,6 +47,14 @@ func (b *KMSPluginBuilder) FromEncryptionConfig(encryptionConfigSecretName strin
 // data from the resource-dir volume and run as root (UID 0).
 func (b *KMSPluginBuilder) AsStaticPod() *KMSPluginBuilder {
 	b.staticPod = true
+	return b
+}
+
+// ErrorIfNotFound makes Apply return an error when the encryption-config Secret
+// does not exist, instead of silently treating it as a no-op. This is useful for
+// callers like the preflight checker that expect the Secret to be present.
+func (b *KMSPluginBuilder) ErrorIfNotFound() *KMSPluginBuilder {
+	b.errorIfNotFound = true
 	return b
 }
 
@@ -66,7 +77,7 @@ func (b *KMSPluginBuilder) WithHealthReporter(operatorBinary, operatorImage stri
 //
 // It is a no-op (returns nil error) when no KMS plugins are found.
 // It is idempotent.
-func (b *KMSPluginBuilder) Apply(podSpec *corev1.PodSpec, containerName string) error {
+func (b *KMSPluginBuilder) Apply(ctx context.Context, podSpec *corev1.PodSpec, containerName string) error {
 	if podSpec == nil {
 		return fmt.Errorf("pod spec cannot be nil")
 	}
@@ -74,7 +85,19 @@ func (b *KMSPluginBuilder) Apply(podSpec *corev1.PodSpec, containerName string) 
 		return fmt.Errorf("container name cannot be empty")
 	}
 
-	kmsConfigurations, err := encryptiondata.ExtractUniqueAndSortedKMSConfigurations(b.encryptionConfig)
+	if b.secretClient == nil {
+		return fmt.Errorf("secret client cannot be nil")
+	}
+
+	cfg, err := fetchEncryptionConfig(ctx, b.encryptionConfigNamespace, b.encryptionConfigSecretName, b.secretClient, b.errorIfNotFound)
+	if err != nil {
+		return err
+	}
+	if cfg == nil {
+		return nil
+	}
+
+	kmsConfigurations, err := encryptiondata.ExtractUniqueAndSortedKMSConfigurations(cfg)
 	if err != nil {
 		return fmt.Errorf("failed to get KMS configurations: %w", err)
 	}
@@ -101,18 +124,17 @@ func (b *KMSPluginBuilder) Apply(podSpec *corev1.PodSpec, containerName string) 
 
 	sockets := make([]string, 0, len(kmsConfigurations))
 	for _, kmsConfiguration := range kmsConfigurations {
-		// ExtractUniqueAndSortedKMSConfigurations function rewrites the .Name field to include only the key ID
 		keyID := kmsConfiguration.Name
 		sockets = append(sockets, kmsConfiguration.Endpoint)
 
-		pluginConfig, ok := b.encryptionConfig.KMSPlugins[keyID]
+		pluginConfig, ok := cfg.KMSPlugins[keyID]
 		if !ok {
 			return fmt.Errorf("missing plugin config for keyID %s", keyID)
 		}
 
 		refData := &referenceDataResolver{
-			pluginsSecretData:    b.encryptionConfig.KMSPluginsSecretData,
-			pluginsConfigMapData: b.encryptionConfig.KMSPluginsConfigMapData,
+			pluginsSecretData:    cfg.KMSPluginsSecretData,
+			pluginsConfigMapData: cfg.KMSPluginsConfigMapData,
 			referenceDataDir:     referenceDataDir,
 			keyID:                keyID,
 		}
@@ -162,9 +184,12 @@ func (b *KMSPluginBuilder) Apply(podSpec *corev1.PodSpec, containerName string) 
 	return nil
 }
 
-func fetchEncryptionConfig(ctx context.Context, encryptionConfigNamespace, encryptionConfigSecretName string, secretClient corev1client.SecretsGetter) (*encryptiondata.Config, error) {
+func fetchEncryptionConfig(ctx context.Context, encryptionConfigNamespace, encryptionConfigSecretName string, secretClient corev1client.SecretsGetter, errorIfNotFound bool) (*encryptiondata.Config, error) {
 	encryptionConfigurationSecret, err := secretClient.Secrets(encryptionConfigNamespace).Get(ctx, encryptionConfigSecretName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
+		if errorIfNotFound {
+			return nil, fmt.Errorf("encryption-config secret %s/%s not found", encryptionConfigNamespace, encryptionConfigSecretName)
+		}
 		klog.V(4).Infof("skipping KMS sidecar injection: %s/%s secret not found", encryptionConfigNamespace, encryptionConfigSecretName)
 		return nil, nil
 	}

--- a/pkg/operator/encryption/kms/pluginlifecycle/builder_test.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/builder_test.go
@@ -1,18 +1,23 @@
 package pluginlifecycle
 
 import (
+	"context"
 	"testing"
 
-	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fake "k8s.io/client-go/kubernetes/fake"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/utils/ptr"
 )
 
 func TestKMSPluginBuilder_Apply(t *testing.T) {
 	f := newSidecarTestFixtures(t)
-	cfg, err := encryptiondata.FromSecret(f.encryptionConfigSecret)
-	require.NoError(t, err)
+
+	secretClient := func(objs ...runtime.Object) corev1client.SecretsGetter {
+		return fake.NewClientset(objs...).CoreV1()
+	}
 
 	tests := []struct {
 		name    string
@@ -23,8 +28,8 @@ func TestKMSPluginBuilder_Apply(t *testing.T) {
 	}{
 		{
 			name: "static pod mode: resource-dir mount and root UID",
-			builder: NewKMSPluginBuilder().
-				FromEncryptionConfig("encryption-config", cfg).
+			builder: NewKMSPluginBuilder(secretClient(f.encryptionConfigSecret)).
+				FromEncryptionConfig("openshift-kube-apiserver", "encryption-config").
 				AsStaticPod(),
 			podSpec: &corev1.PodSpec{
 				Containers: []corev1.Container{{Name: "kube-apiserver"}},
@@ -53,8 +58,8 @@ func TestKMSPluginBuilder_Apply(t *testing.T) {
 		},
 		{
 			name: "deployment mode: secret volume mount and no root UID",
-			builder: NewKMSPluginBuilder().
-				FromEncryptionConfig("encryption-config", cfg),
+			builder: NewKMSPluginBuilder(secretClient(f.encryptionConfigSecret)).
+				FromEncryptionConfig("openshift-kube-apiserver", "encryption-config"),
 			podSpec: &corev1.PodSpec{
 				Containers: []corev1.Container{{Name: "kube-apiserver"}},
 				Volumes:    []corev1.Volume{f.resourceDirVolume},
@@ -86,17 +91,20 @@ func TestKMSPluginBuilder_Apply(t *testing.T) {
 			},
 		},
 		{
-			name:    "no encryption config: returns error",
-			builder: NewKMSPluginBuilder(),
+			name: "missing secret: no-op",
+			builder: NewKMSPluginBuilder(secretClient()).
+				FromEncryptionConfig("openshift-kube-apiserver", "encryption-config"),
 			podSpec: &corev1.PodSpec{
 				Containers: []corev1.Container{{Name: "test"}},
 			},
-			wantErr: "encryption configuration is required",
+			verify: func(t *testing.T, podSpec *corev1.PodSpec) {
+				require.Len(t, podSpec.InitContainers, 0, "no sidecars should be injected when secret is missing")
+			},
 		},
 		{
 			name: "nil pod spec: returns error",
-			builder: NewKMSPluginBuilder().
-				FromEncryptionConfig("encryption-config", cfg),
+			builder: NewKMSPluginBuilder(secretClient(f.encryptionConfigSecret)).
+				FromEncryptionConfig("openshift-kube-apiserver", "encryption-config"),
 			podSpec: nil,
 			wantErr: "pod spec cannot be nil",
 		},
@@ -109,7 +117,7 @@ func TestKMSPluginBuilder_Apply(t *testing.T) {
 				original = tt.podSpec.DeepCopy()
 			}
 
-			err := tt.builder.Apply(tt.podSpec, "kube-apiserver")
+			err := tt.builder.Apply(context.Background(), tt.podSpec, "kube-apiserver")
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
 				if original != nil {
@@ -125,8 +133,10 @@ func TestKMSPluginBuilder_Apply(t *testing.T) {
 
 func TestKMSPluginBuilder_OrderIndependence(t *testing.T) {
 	f := newSidecarTestFixtures(t)
-	cfg, err := encryptiondata.FromSecret(f.encryptionConfigSecret)
-	require.NoError(t, err)
+
+	secretClient := func() corev1client.SecretsGetter {
+		return fake.NewClientset(f.encryptionConfigSecret).CoreV1()
+	}
 
 	podSpec1 := &corev1.PodSpec{
 		Containers: []corev1.Container{{Name: "kube-apiserver"}},
@@ -137,16 +147,16 @@ func TestKMSPluginBuilder_OrderIndependence(t *testing.T) {
 		Volumes:    []corev1.Volume{f.resourceDirVolume},
 	}
 
-	err = NewKMSPluginBuilder().
-		FromEncryptionConfig("encryption-config", cfg).
+	err := NewKMSPluginBuilder(secretClient()).
+		FromEncryptionConfig("openshift-kube-apiserver", "encryption-config").
 		AsStaticPod().
-		Apply(podSpec1, "kube-apiserver")
+		Apply(context.Background(), podSpec1, "kube-apiserver")
 	require.NoError(t, err)
 
-	err = NewKMSPluginBuilder().
+	err = NewKMSPluginBuilder(secretClient()).
 		AsStaticPod().
-		FromEncryptionConfig("encryption-config", cfg).
-		Apply(podSpec2, "kube-apiserver")
+		FromEncryptionConfig("openshift-kube-apiserver", "encryption-config").
+		Apply(context.Background(), podSpec2, "kube-apiserver")
 	require.NoError(t, err)
 
 	require.Equal(t, podSpec1, podSpec2, "order of builder calls must not affect the result")
@@ -154,8 +164,7 @@ func TestKMSPluginBuilder_OrderIndependence(t *testing.T) {
 
 func TestKMSPluginBuilder_Idempotent(t *testing.T) {
 	f := newSidecarTestFixtures(t)
-	cfg, err := encryptiondata.FromSecret(f.encryptionConfigSecret)
-	require.NoError(t, err)
+	sc := fake.NewClientset(f.encryptionConfigSecret).CoreV1()
 
 	podSpec := &corev1.PodSpec{
 		Containers: []corev1.Container{{Name: "kube-apiserver"}},
@@ -164,9 +173,9 @@ func TestKMSPluginBuilder_Idempotent(t *testing.T) {
 
 	apply := func() {
 		t.Helper()
-		err := NewKMSPluginBuilder().
-			FromEncryptionConfig("encryption-config", cfg).
-			Apply(podSpec, "kube-apiserver")
+		err := NewKMSPluginBuilder(sc).
+			FromEncryptionConfig("openshift-kube-apiserver", "encryption-config").
+			Apply(context.Background(), podSpec, "kube-apiserver")
 		require.NoError(t, err)
 	}
 

--- a/pkg/operator/encryption/kms/pluginlifecycle/health_reporter_test.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/health_reporter_test.go
@@ -1,28 +1,28 @@
 package pluginlifecycle
 
 import (
+	"context"
 	"testing"
 
-	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	fake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/utils/ptr"
 )
 
 func TestKMSPluginBuilder_WithHealthReporter(t *testing.T) {
 	f := newSidecarTestFixtures(t)
-	cfg, err := encryptiondata.FromSecret(f.encryptionConfigSecret)
-	require.NoError(t, err)
+	sc := fake.NewClientset(f.encryptionConfigSecret).CoreV1()
 
 	t.Run("health reporter injected with correct args and socket mount", func(t *testing.T) {
 		podSpec := &corev1.PodSpec{
 			Containers: []corev1.Container{{Name: "kube-apiserver"}},
 			Volumes:    []corev1.Volume{f.resourceDirVolume},
 		}
-		err := NewKMSPluginBuilder().
-			FromEncryptionConfig("encryption-config", cfg).
+		err := NewKMSPluginBuilder(sc).
+			FromEncryptionConfig("openshift-kube-apiserver", "encryption-config").
 			WithHealthReporter("cluster-kube-apiserver-operator", "quay.io/test/operator:latest").
-			Apply(podSpec, "kube-apiserver")
+			Apply(context.Background(), podSpec, "kube-apiserver")
 		require.NoError(t, err)
 
 		var reporter *corev1.Container
@@ -57,11 +57,11 @@ func TestKMSPluginBuilder_WithHealthReporter(t *testing.T) {
 			Containers: []corev1.Container{{Name: "kube-apiserver"}},
 			Volumes:    []corev1.Volume{f.resourceDirVolume},
 		}
-		err := NewKMSPluginBuilder().
-			FromEncryptionConfig("encryption-config", cfg).
+		err := NewKMSPluginBuilder(sc).
+			FromEncryptionConfig("openshift-kube-apiserver", "encryption-config").
 			AsStaticPod().
 			WithHealthReporter("cluster-kube-apiserver-operator", "quay.io/test/operator:latest").
-			Apply(podSpec, "kube-apiserver")
+			Apply(context.Background(), podSpec, "kube-apiserver")
 		require.NoError(t, err)
 
 		var reporter *corev1.Container
@@ -81,9 +81,9 @@ func TestKMSPluginBuilder_WithHealthReporter(t *testing.T) {
 			Containers: []corev1.Container{{Name: "kube-apiserver"}},
 			Volumes:    []corev1.Volume{f.resourceDirVolume},
 		}
-		err := NewKMSPluginBuilder().
-			FromEncryptionConfig("encryption-config", cfg).
-			Apply(podSpec, "kube-apiserver")
+		err := NewKMSPluginBuilder(sc).
+			FromEncryptionConfig("openshift-kube-apiserver", "encryption-config").
+			Apply(context.Background(), podSpec, "kube-apiserver")
 		require.NoError(t, err)
 
 		for _, c := range podSpec.InitContainers {
@@ -96,10 +96,10 @@ func TestKMSPluginBuilder_WithHealthReporter(t *testing.T) {
 			Containers: []corev1.Container{{Name: "kube-apiserver"}},
 			Volumes:    []corev1.Volume{f.resourceDirVolume},
 		}
-		err := NewKMSPluginBuilder().
-			FromEncryptionConfig("encryption-config", cfg).
+		err := NewKMSPluginBuilder(sc).
+			FromEncryptionConfig("openshift-kube-apiserver", "encryption-config").
 			WithHealthReporter("cluster-kube-apiserver-operator", "").
-			Apply(podSpec, "kube-apiserver")
+			Apply(context.Background(), podSpec, "kube-apiserver")
 		require.ErrorContains(t, err, "health reporter name, operatorBinary, image and subcommand are required")
 	})
 }

--- a/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
@@ -64,19 +64,11 @@ func AddKMSPluginSidecarToStaticPodSpec(ctx context.Context, podSpec *corev1.Pod
 		return nil
 	}
 
-	cfg, err := fetchEncryptionConfig(ctx, encryptionConfigNamespace, encryptionConfigSecretName, secretClient)
-	if err != nil {
-		return err
-	}
-	if cfg == nil {
-		return nil
-	}
-
-	return NewKMSPluginBuilder().
-		FromEncryptionConfig(encryptionConfigSecretName, cfg).
+	return NewKMSPluginBuilder(secretClient).
+		FromEncryptionConfig(encryptionConfigNamespace, encryptionConfigSecretName).
 		AsStaticPod().
 		WithHealthReporter(operatorBinary, operatorImage).
-		Apply(podSpec, containerName)
+		Apply(ctx, podSpec, containerName)
 }
 
 // AddKMSPluginSidecarToPodSpec injects KMS plugin sidecar containers into an aggregated API server pod spec (e.g., openshift-apiserver, oauth-apiserver).
@@ -95,18 +87,10 @@ func AddKMSPluginSidecarToPodSpec(ctx context.Context, podSpec *corev1.PodSpec, 
 		return nil
 	}
 
-	cfg, err := fetchEncryptionConfig(ctx, encryptionConfigNamespace, encryptionConfigSecretName, secretClient)
-	if err != nil {
-		return err
-	}
-	if cfg == nil {
-		return nil
-	}
-
-	return NewKMSPluginBuilder().
-		FromEncryptionConfig(encryptionConfigSecretName, cfg).
+	return NewKMSPluginBuilder(secretClient).
+		FromEncryptionConfig(encryptionConfigNamespace, encryptionConfigSecretName).
 		WithHealthReporter(operatorBinary, operatorImage).
-		Apply(podSpec, containerName)
+		Apply(ctx, podSpec, containerName)
 }
 
 func ensureSidecarContainer(podSpec *corev1.PodSpec, provider sidecarProvider) error {


### PR DESCRIPTION
After this refactoring, preflight checker simply call this;

```go
_, err := d.secretClient.Secrets(d.namespace).Create(ctx, encryptionConfigSecret, metav1.CreateOptions{})

err = pluginlifecycle.NewKMSPluginBuilder(d.secretClient).
      FromEncryptionConfig(d.namespace, preflightEncryptionConfigSecretName).
      Apply(ctx, podSpec, preflightCheckContainerName)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved KMS sidecar injection to load the encryption-config from the cluster at execution time rather than using pre-parsed data.
  * If the encryption-config Secret is missing or resolves to no usable configuration, injection now safely performs a no-op instead of failing.
  * Maintains consistent, idempotent results regardless of builder call order, including for static pod handling.
* **Tests**
  * Updated KMS plugin builder and health reporter tests to match the new secret-loading and `Apply` control flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->