### PR TITLE
CNTRLPLANE-3237: encryption/controllers: move KMSPreflightDeployer interface to the consumer package and document the deployer contract

### DIFF
--- a/pkg/operator/encryption/controllers/kms_preflight_controller.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 
@@ -116,6 +117,28 @@ func (h *kmsConfigHasher) hashReferencedConfigMap(ctx context.Context, hasher ha
 		}
 	}
 	return nil
+}
+
+// KMSPreflightDeployer abstracts the lifecycle of a preflight workload that
+// validates KMS plugin configuration before an encryption key is created.
+// All methods are idempotent.
+//
+// Deploy creates all resources the workload needs (ServiceAccount, Secret,
+// RBAC, Pod). The controller only calls Deploy when Status reports no pod
+// exists, so no running pod can be affected.
+//
+// Cleanup removes all resources created by Deploy.
+type KMSPreflightDeployer interface {
+	// Deploy creates the preflight workload with the given config hash
+	// and encryption configuration. It is idempotent.
+	Deploy(ctx context.Context, configHash string, encryptionConfiguration *corev1.Secret) error
+
+	// Status returns the current pod status of the preflight workload.
+	// It returns an apierrors.IsNotFound error when no preflight pod exists.
+	Status(ctx context.Context) (corev1.PodStatus, error)
+
+	// Cleanup removes all resources created by Deploy.
+	Cleanup(ctx context.Context) error
 }
 
 type kmsPreflightController struct {

--- a/pkg/operator/encryption/kms/preflight/deployer.go
+++ b/pkg/operator/encryption/kms/preflight/deployer.go
@@ -15,14 +15,6 @@ const (
 	preflightPodName = "kms-preflight"
 )
 
-type KMSPreflightDeployer interface {
-	// Deploy creates the preflight checker with the given config hash
-	Deploy(ctx context.Context, configHash string) error
-	Status(ctx context.Context) (corev1.PodStatus, error)
-	// Cleanup cleans up anything previously created.
-	Cleanup(ctx context.Context) error
-}
-
 // PodPreflightDeployer creates a one-shot pod to run the preflight checker as a command,
 // with the plugin injected as a sidecar container.
 type PodPreflightDeployer struct {


### PR DESCRIPTION
https://go.dev/wiki/CodeReviewComments#interfaces

`Go interfaces generally belong in the package that uses values of the interface type, not the package that implements those values`


In addition to that the PR documents the contract between the preflight controller and the deployers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated internal KMS preflight deployment handling for improved structure and maintainability.
  * Preserved existing deployment, status, and cleanup behavior without changing the user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->