### PR TITLE
NO-JIRA: Moving auth and oas helper funcs to library-go

### DIFF
--- a/test/library/encryption/assertion_auth.go
+++ b/test/library/encryption/assertion_auth.go
@@ -1,0 +1,57 @@
+package encryption
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+var AuthTargetGRs = []schema.GroupResource{
+	{Group: "oauth.openshift.io", Resource: "oauthaccesstokens"},
+	{Group: "oauth.openshift.io", Resource: "oauthauthorizetokens"},
+}
+
+func AssertTokenOfLifeEncrypted(t testing.TB, clientSet ClientSet, _ runtime.Object) {
+	t.Helper()
+	rawTokenValue := GetRawTokenOfLife(t, clientSet)
+	marker := "I have no special talents. I am only passionately curious"
+	if strings.Contains(rawTokenValue, marker) {
+		t.Errorf("access token not encrypted, etcd value contains refresh token marker in plain text")
+	}
+}
+
+func AssertTokenOfLifeNotEncrypted(t testing.TB, clientSet ClientSet, _ runtime.Object) {
+	t.Helper()
+	rawTokenValue := GetRawTokenOfLife(t, clientSet)
+	marker := "I have no special talents. I am only passionately curious"
+	if !strings.Contains(rawTokenValue, marker) {
+		t.Errorf("access token not decrypted, etcd value does not contain refresh token marker in plain text")
+	}
+}
+
+func AssertTokens(t testing.TB, clientSet ClientSet, expectedMode configv1.EncryptionType, namespace, labelSelector string) {
+	t.Helper()
+	assertAccessTokens(t, clientSet.Etcd, string(expectedMode))
+	assertAuthTokens(t, clientSet.Etcd, string(expectedMode))
+	AssertLastMigratedKey(t, clientSet.Kube, AuthTargetGRs, namespace, labelSelector)
+}
+
+func assertAccessTokens(t testing.TB, etcdClient EtcdClient, expectedMode string) {
+	t.Logf("Checking if all OauthAccessTokens where encrypted/decrypted for %q mode", expectedMode)
+	totalAccessTokens, err := VerifyResources(t, etcdClient, "/openshift.io/oauth/accesstokens/", expectedMode, true)
+	t.Logf("Verified %d OauthAccessTokens", totalAccessTokens)
+	require.NoError(t, err)
+}
+
+func assertAuthTokens(t testing.TB, etcdClient EtcdClient, expectedMode string) {
+	t.Logf("Checking if all OAuthAuthorizeTokens where encrypted/decrypted for %q mode", expectedMode)
+	totalAuthTokens, err := VerifyResources(t, etcdClient, "/openshift.io/oauth/authorizetokens/", expectedMode, true)
+	t.Logf("Verified %d OAuthAuthorizeTokens", totalAuthTokens)
+	require.NoError(t, err)
+}

--- a/test/library/encryption/assertion_oas.go
+++ b/test/library/encryption/assertion_oas.go
@@ -1,0 +1,55 @@
+package encryption
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	configv1 "github.com/openshift/api/config/v1"
+	routev1 "github.com/openshift/api/route/v1"
+)
+
+var OASTargetGRs = []schema.GroupResource{
+	{Group: "route.openshift.io", Resource: "routes"},
+}
+
+func AssertRouteOfLifeEncrypted(t testing.TB, clientSet ClientSet, resource runtime.Object) {
+	t.Helper()
+	routeOfLife, ok := resource.(*routev1.Route)
+	if !ok {
+		t.Fatalf("expected *routev1.Route, got %T", resource)
+	}
+	rawRouteValue := GetRawRouteOfLife(t, clientSet, routeOfLife.Namespace)
+	if strings.Contains(rawRouteValue, routeOfLife.Spec.To.Name) {
+		t.Errorf("route not encrypted, etcd value contains target name %q in plain text", routeOfLife.Spec.To.Name)
+	}
+}
+
+func AssertRouteOfLifeNotEncrypted(t testing.TB, clientSet ClientSet, resource runtime.Object) {
+	t.Helper()
+	routeOfLife, ok := resource.(*routev1.Route)
+	if !ok {
+		t.Fatalf("expected *routev1.Route, got %T", resource)
+	}
+	rawRouteValue := GetRawRouteOfLife(t, clientSet, routeOfLife.Namespace)
+	if !strings.Contains(rawRouteValue, routeOfLife.Spec.To.Name) {
+		t.Errorf("route not decrypted, etcd value does not contain target name %q in plain text", routeOfLife.Spec.To.Name)
+	}
+}
+
+func AssertRoutes(t testing.TB, clientSet ClientSet, expectedMode configv1.EncryptionType, namespace, labelSelector string) {
+	t.Helper()
+	assertRoutes(t, clientSet.Etcd, string(expectedMode))
+	AssertLastMigratedKey(t, clientSet.Kube, OASTargetGRs, namespace, labelSelector)
+}
+
+func assertRoutes(t testing.TB, etcdClient EtcdClient, expectedMode string) {
+	t.Logf("Checking if all Routes where encrypted/decrypted for %q mode", expectedMode)
+	totalRoutes, err := VerifyResources(t, etcdClient, "/openshift.io/routes/", expectedMode, false)
+	t.Logf("Verified %d Routes", totalRoutes)
+	require.NoError(t, err)
+}

--- a/test/library/encryption/helpers.go
+++ b/test/library/encryption/helpers.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
 
@@ -47,6 +48,7 @@ type ClientSet struct {
 	Etcd            EtcdClient
 	ApiServerConfig configv1client.APIServerInterface
 	Kube            kubernetes.Interface
+	DynamicClient   dynamic.Interface
 }
 
 type EncryptionKeyMeta struct {
@@ -132,7 +134,10 @@ func GetClients(t testing.TB) ClientSet {
 	kubeClient := kubernetes.NewForConfigOrDie(kubeConfig)
 	etcdClient := NewEtcdClient(kubeClient)
 
-	return ClientSet{Etcd: etcdClient, ApiServerConfig: apiServerConfigClient, Kube: kubeClient}
+	dynamicClient, err := dynamic.NewForConfig(kubeConfig)
+	require.NoError(t, err)
+
+	return ClientSet{Etcd: etcdClient, ApiServerConfig: apiServerConfigClient, Kube: kubeClient, DynamicClient: dynamicClient}
 }
 
 func WaitForEncryptionKeyBasedOn(t testing.TB, kubeClient kubernetes.Interface, prevKeyMeta EncryptionKeyMeta, encryptionType configv1.EncryptionType, defaultTargetGRs []schema.GroupResource, namespace, labelSelector string) {

--- a/test/library/encryption/helpers_auth.go
+++ b/test/library/encryption/helpers_auth.go
@@ -1,0 +1,80 @@
+package encryption
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	oauthapiv1 "github.com/openshift/api/oauth/v1"
+)
+
+var oauthAccessTokenGVR = schema.GroupVersionResource{Group: "oauth.openshift.io", Version: "v1", Resource: "oauthaccesstokens"}
+
+const tokenOfLifeName = "sha256~token-aaaaaaaa-of-aaaaaaaa-life-aaaaaaaa"
+
+func CreateAndStoreTokenOfLife(ctx context.Context, t testing.TB, cs ClientSet) runtime.Object {
+	t.Helper()
+	tokens := cs.DynamicClient.Resource(oauthAccessTokenGVR)
+
+	oldToken, err := tokens.Get(ctx, tokenOfLifeName, metav1.GetOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		t.Fatalf("Failed to check if the token already exists: %v", err)
+	}
+	if oldToken != nil && len(oldToken.GetName()) > 0 {
+		t.Log("The access token already exists, removing it first")
+		require.NoError(t, tokens.Delete(ctx, oldToken.GetName(), metav1.DeleteOptions{}))
+	}
+
+	t.Logf("Creating %q at cluster scope level", tokenOfLifeName)
+	token := TokenOfLife(t, "")
+	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(token)
+	require.NoError(t, err)
+
+	created, err := tokens.Create(ctx, &unstructured.Unstructured{Object: obj}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	var result oauthapiv1.OAuthAccessToken
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(created.Object, &result)
+	require.NoError(t, err)
+	return &result
+}
+
+func TokenOfLife(_ testing.TB, _ string) runtime.Object {
+	return &oauthapiv1.OAuthAccessToken{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "oauth.openshift.io/v1",
+			Kind:       "OAuthAccessToken",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: tokenOfLifeName,
+		},
+		RefreshToken: "I have no special talents. I am only passionately curious",
+		UserName:     "kube:admin",
+		Scopes:       []string{"user:full"},
+		RedirectURI:  "redirect.me.to.token.of.life",
+		ClientName:   "console",
+		UserUID:      "non-existing-user-id",
+	}
+}
+
+func GetRawTokenOfLife(t testing.TB, clientSet ClientSet) string {
+	t.Helper()
+	timeout, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	tokenOfLifeKey := fmt.Sprintf("/openshift.io/oauth/accesstokens/%s", tokenOfLifeName)
+	resp, err := clientSet.Etcd.Get(timeout, tokenOfLifeKey)
+	require.NoError(t, err)
+	require.Len(t, resp.Kvs, 1, "expected exactly one key from etcd for token-of-life")
+
+	return string(resp.Kvs[0].Value)
+}

--- a/test/library/encryption/helpers_oas.go
+++ b/test/library/encryption/helpers_oas.go
@@ -1,0 +1,72 @@
+package encryption
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	routev1 "github.com/openshift/api/route/v1"
+)
+
+var routeGVR = schema.GroupVersionResource{Group: "route.openshift.io", Version: "v1", Resource: "routes"}
+
+func CreateAndStoreRouteOfLife(ctx context.Context, t testing.TB, cs ClientSet, ns string) runtime.Object {
+	t.Helper()
+	t.Logf("Creating %q in %q namespace", "route-of-life", ns)
+
+	route := RouteOfLife(t, ns)
+	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(route)
+	require.NoError(t, err)
+
+	created, err := cs.DynamicClient.Resource(routeGVR).Namespace(ns).Create(ctx, &unstructured.Unstructured{Object: obj}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	var result routev1.Route
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(created.Object, &result)
+	require.NoError(t, err)
+	return &result
+}
+
+func RouteOfLife(_ testing.TB, ns string) runtime.Object {
+	return &routev1.Route{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "route.openshift.io/v1",
+			Kind:       "Route",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "route-of-life",
+			Namespace: ns,
+		},
+		Spec: routev1.RouteSpec{
+			Host: "devcluster.openshift.io",
+			Port: &routev1.RoutePort{
+				TargetPort: intstr.FromInt(2014),
+			},
+			To: routev1.RouteTargetReference{
+				Name: "dummyroute",
+			},
+		},
+	}
+}
+
+func GetRawRouteOfLife(t testing.TB, clientSet ClientSet, ns string) string {
+	t.Helper()
+	timeout, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	routeOfLifeKey := fmt.Sprintf("/openshift.io/routes/%s/%s", ns, "route-of-life")
+	resp, err := clientSet.Etcd.Get(timeout, routeOfLifeKey)
+	require.NoError(t, err)
+	require.Len(t, resp.Kvs, 1, "expected exactly one key from etcd for route-of-life")
+
+	return string(resp.Kvs[0].Value)
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded encryption test coverage for OAuth “token of life” and OpenShift “route of life” resources.
  * Added helper utilities to create these resources and read their raw stored values directly from etcd to confirm encrypted vs plaintext behavior.
  * Introduced assertions that validate both access/authorize token encryption state and that the latest migrated key is recorded for the relevant encryption targets.
  * Enhanced the test client setup with dynamic Kubernetes access to support these helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->