### PR TITLE
WIP: kms: reconcile sidecar containers and volumes to match encryption config

### DIFF
--- a/pkg/operator/encryption/kms/pluginlifecycle/builder.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/builder.go
@@ -61,7 +61,7 @@ func (b *KMSPluginBuilder) WithSecretRequired() *KMSPluginBuilder {
 // when empty, the subcommand is invoked directly via the image ENTRYPOINT.
 func (b *KMSPluginBuilder) WithHealthReporter(operatorBinary, operatorImage string) *KMSPluginBuilder {
 	b.healthReporter = &healthReporter{
-		name:           "kms-health-reporter",
+		name:           kmsHealthReporterContainerName,
 		operatorBinary: operatorBinary,
 		subcommand:     health.Subcommand,
 		image:          operatorImage,

--- a/pkg/operator/encryption/kms/pluginlifecycle/builder.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/builder.go
@@ -111,6 +111,10 @@ func (b *KMSPluginBuilder) Apply(ctx context.Context, podSpec *corev1.PodSpec, c
 	if err != nil {
 		return fmt.Errorf("failed to get KMS configurations: %w", err)
 	}
+
+	// Strip all existing KMS-related resources before re-adding exactly what the current encryption config requires
+	removeAllKMSManagedResources(podSpec, containerName)
+
 	if len(kmsConfigurations) == 0 {
 		klog.V(4).Infof("skipping KMS sidecar injection: no KMS plugins found in EncryptionConfiguration")
 		return nil

--- a/pkg/operator/encryption/kms/pluginlifecycle/builder.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/builder.go
@@ -21,6 +21,7 @@ type KMSPluginBuilder struct {
 	secretClient               corev1client.SecretsGetter
 	encryptionConfigNamespace  string
 	encryptionConfigSecretName string
+	diskSecretName             string
 	staticPod                  bool
 	errorIfNotFound            bool
 
@@ -45,6 +46,17 @@ func (b *KMSPluginBuilder) FromEncryptionConfigSecret(namespace, secretName stri
 // data from the resource-dir volume and run as root (UID 0).
 func (b *KMSPluginBuilder) AsStaticPod() *KMSPluginBuilder {
 	b.staticPod = true
+	return b
+}
+
+// WithDiskSecretName overrides the name used to compute the on-disk referenceDataDir
+// path in static pod mode. The static pod installer strips the revision suffix when
+// placing secrets on disk (e.g. it places "encryption-config-7" at
+// …/secrets/encryption-config/), so callers that validate a revision-specific secret
+// must pass the base name here to match the paths baked into the pod spec.
+// Defaults to encryptionConfigSecretName when not set.
+func (b *KMSPluginBuilder) WithDiskSecretName(name string) *KMSPluginBuilder {
+	b.diskSecretName = name
 	return b
 }
 
@@ -108,7 +120,11 @@ func (b *KMSPluginBuilder) Apply(ctx context.Context, podSpec *corev1.PodSpec, c
 	if b.staticPod {
 		refDataVolumeName = resourceDirVolumeName
 		refDataMountPath = resourcesDir
-		referenceDataDir = filepath.Join(resourcesDir, "secrets", b.encryptionConfigSecretName)
+		pathName := b.encryptionConfigSecretName
+		if b.diskSecretName != "" {
+			pathName = b.diskSecretName
+		}
+		referenceDataDir = filepath.Join(resourcesDir, "secrets", pathName)
 	} else {
 		refDataVolumeName = referenceDataVolumeName
 		refDataMountPath = referenceDataMountPath

--- a/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
@@ -53,11 +53,12 @@ func newSidecarProvider(keyID string, udsPath string, pluginConfig configv1.KMSP
 // populates on disk from the encryption-config Secret. Because those files are owned by root, each sidecar
 // is configured to run as UID 0.
 //
+// diskSecretName, when non-empty, overrides the name used to compute the on-disk referenceDataDir
+// path (see KMSPluginBuilder.WithDiskSecretName). Pass "" to use encryptionConfigSecretName.
+//
 // It is a no-op when the KMSEncryption feature gate is not enabled or the encryption-config secret does not exist.
 // The secretClient should be uncached to avoid injecting sidecars based on a stale encryption configuration.
-func EnsureKMSPluginSidecarInStaticPodSpec(ctx context.Context, podSpec *corev1.PodSpec, containerName string, encryptionConfigNamespace string, encryptionConfigSecretName string, operatorBinary string, operatorImage string, secretClient corev1client.SecretsGetter, featureGateAccessor featuregates.FeatureGateAccess) error {
-	removeAllKMSManagedResources(podSpec, containerName)
-
+func EnsureKMSPluginSidecarInStaticPodSpec(ctx context.Context, podSpec *corev1.PodSpec, containerName string, encryptionConfigNamespace string, encryptionConfigSecretName string, diskSecretName string, operatorBinary string, operatorImage string, secretClient corev1client.SecretsGetter, featureGateAccessor featuregates.FeatureGateAccess) error {
 	if !featureGateAccessor.AreInitialFeatureGatesObserved() {
 		return nil
 	}
@@ -69,9 +70,14 @@ func EnsureKMSPluginSidecarInStaticPodSpec(ctx context.Context, podSpec *corev1.
 		return nil
 	}
 
+	// To make sure sidecars not present in the encryption configuration are also not present
+	// in the pod spec, remove every KMS-related resource that might already exist
+	removeAllKMSManagedResources(podSpec, containerName)
+
 	return NewKMSPluginBuilder().
 		FromEncryptionConfigSecret(encryptionConfigNamespace, encryptionConfigSecretName, secretClient).
 		AsStaticPod().
+		WithDiskSecretName(diskSecretName).
 		WithHealthReporter(operatorBinary, operatorImage).
 		Apply(ctx, podSpec, containerName)
 }
@@ -197,6 +203,7 @@ func isKMSManagedVolume(name string) bool {
 }
 
 func removeAllKMSManagedResources(podSpec *corev1.PodSpec, containerName string) {
+	// First, filter out all the sidecars from the pod spec
 	filtered := podSpec.InitContainers[:0]
 	for _, c := range podSpec.InitContainers {
 		if !isKMSManagedContainer(c.Name) {
@@ -205,6 +212,7 @@ func removeAllKMSManagedResources(podSpec *corev1.PodSpec, containerName string)
 	}
 	podSpec.InitContainers = filtered
 
+	// Then, filter out the KMS volumes
 	filteredVolumes := podSpec.Volumes[:0]
 	for _, v := range podSpec.Volumes {
 		if !isKMSManagedVolume(v.Name) {
@@ -213,6 +221,7 @@ func removeAllKMSManagedResources(podSpec *corev1.PodSpec, containerName string)
 	}
 	podSpec.Volumes = filteredVolumes
 
+	// Finally, filter out the KMS-related volume mounts added to containers (e.g., to share the unix domain socket)
 	for i, c := range podSpec.Containers {
 		if c.Name == containerName {
 			mounts := c.VolumeMounts[:0]

--- a/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
@@ -70,10 +70,6 @@ func EnsureKMSPluginSidecarInStaticPodSpec(ctx context.Context, podSpec *corev1.
 		return nil
 	}
 
-	// To make sure sidecars not present in the encryption configuration are also not present
-	// in the pod spec, remove every KMS-related resource that might already exist
-	removeAllKMSManagedResources(podSpec, containerName)
-
 	return NewKMSPluginBuilder().
 		FromEncryptionConfigSecret(encryptionConfigNamespace, encryptionConfigSecretName, secretClient).
 		AsStaticPod().

--- a/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
@@ -3,6 +3,7 @@ package pluginlifecycle
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/api/features"
@@ -44,7 +45,9 @@ func newSidecarProvider(keyID string, udsPath string, pluginConfig configv1.KMSP
 	}
 }
 
-// AddKMSPluginSidecarToStaticPodSpec injects KMS plugin sidecar containers into a kube-apiserver static pod spec.
+// EnsureKMSPluginSidecarInStaticPodSpec reconciles KMS plugin sidecar containers in a kube-apiserver static pod spec.
+// It removes all KMS-managed resources (sidecars, volumes, volume mounts) and then re-adds exactly what the
+// current encryption config requires, ensuring stale resources from a previous configuration are pruned.
 //
 // Static pods access KMS plugin data through the resource-dir volume, which the static pod revision controller
 // populates on disk from the encryption-config Secret. Because those files are owned by root, each sidecar
@@ -52,7 +55,9 @@ func newSidecarProvider(keyID string, udsPath string, pluginConfig configv1.KMSP
 //
 // It is a no-op when the KMSEncryption feature gate is not enabled or the encryption-config secret does not exist.
 // The secretClient should be uncached to avoid injecting sidecars based on a stale encryption configuration.
-func AddKMSPluginSidecarToStaticPodSpec(ctx context.Context, podSpec *corev1.PodSpec, containerName string, encryptionConfigNamespace string, encryptionConfigSecretName string, operatorBinary string, operatorImage string, secretClient corev1client.SecretsGetter, featureGateAccessor featuregates.FeatureGateAccess) error {
+func EnsureKMSPluginSidecarInStaticPodSpec(ctx context.Context, podSpec *corev1.PodSpec, containerName string, encryptionConfigNamespace string, encryptionConfigSecretName string, operatorBinary string, operatorImage string, secretClient corev1client.SecretsGetter, featureGateAccessor featuregates.FeatureGateAccess) error {
+	removeAllKMSManagedResources(podSpec, containerName)
+
 	if !featureGateAccessor.AreInitialFeatureGatesObserved() {
 		return nil
 	}
@@ -169,6 +174,57 @@ func ensureReferenceDataVolume(podSpec *corev1.PodSpec, secretName string) error
 		},
 	}
 	return ensureVolume(podSpec, volume)
+}
+
+var kmsSidecarPrefixes = []string{"vault-kms-plugin-"}
+
+const kmsHealthReporterContainerName = "kms-health-reporter"
+
+func isKMSManagedContainer(name string) bool {
+	if name == kmsHealthReporterContainerName {
+		return true
+	}
+	for _, prefix := range kmsSidecarPrefixes {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func isKMSManagedVolume(name string) bool {
+	return name == kmsPluginSocketVolumeName || name == referenceDataVolumeName
+}
+
+func removeAllKMSManagedResources(podSpec *corev1.PodSpec, containerName string) {
+	filtered := podSpec.InitContainers[:0]
+	for _, c := range podSpec.InitContainers {
+		if !isKMSManagedContainer(c.Name) {
+			filtered = append(filtered, c)
+		}
+	}
+	podSpec.InitContainers = filtered
+
+	filteredVolumes := podSpec.Volumes[:0]
+	for _, v := range podSpec.Volumes {
+		if !isKMSManagedVolume(v.Name) {
+			filteredVolumes = append(filteredVolumes, v)
+		}
+	}
+	podSpec.Volumes = filteredVolumes
+
+	for i, c := range podSpec.Containers {
+		if c.Name == containerName {
+			mounts := c.VolumeMounts[:0]
+			for _, m := range c.VolumeMounts {
+				if m.Name != kmsPluginSocketVolumeName {
+					mounts = append(mounts, m)
+				}
+			}
+			podSpec.Containers[i].VolumeMounts = mounts
+			break
+		}
+	}
 }
 
 // setRunAsRoot sets RunAsUser=0 on the named container.

--- a/pkg/operator/encryption/kms/pluginlifecycle/sidecar_test.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/sidecar_test.go
@@ -815,7 +815,7 @@ func TestEnsureKMSPluginSidecarInStaticPodSpec(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := EnsureKMSPluginSidecarInStaticPodSpec(context.Background(), tt.actualPodSpec, "kube-apiserver", "openshift-kube-apiserver", "encryption-config", "cluster-kube-apiserver-operator", "quay.io/test/operator:latest", tt.secretClient, tt.featureGateAccessor)
+			err := EnsureKMSPluginSidecarInStaticPodSpec(context.Background(), tt.actualPodSpec, "kube-apiserver", "openshift-kube-apiserver", "encryption-config", "", "cluster-kube-apiserver-operator", "quay.io/test/operator:latest", tt.secretClient, tt.featureGateAccessor)
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
 				return

--- a/pkg/operator/encryption/kms/pluginlifecycle/sidecar_test.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/sidecar_test.go
@@ -611,3 +611,217 @@ func TestAddKMSPluginSidecarToPodSpecIdempotency(t *testing.T) {
 	call()
 	require.Equal(t, afterFirstCall, podSpec)
 }
+
+func TestEnsureKMSPluginSidecarInStaticPodSpec(t *testing.T) {
+	f := newSidecarTestFixtures(t)
+
+	secretClient := func(objs ...runtime.Object) corev1client.SecretsGetter {
+		return fake.NewClientset(objs...).CoreV1()
+	}
+
+	socketMount := corev1.VolumeMount{
+		Name:      "kms-plugin-socket",
+		MountPath: "/var/run/kmsplugin",
+	}
+	resourceDirMount := corev1.VolumeMount{
+		Name:      "resource-dir",
+		MountPath: "/etc/kubernetes/static-pod-resources",
+		ReadOnly:  true,
+	}
+	socketVolume := corev1.Volume{
+		Name: "kms-plugin-socket",
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	}
+
+	sidecarArgs := []string{
+		"-listen-address=unix:///var/run/kmsplugin/kms-555.sock",
+		"-vault-address=https://vault.example.com:8200",
+		"-transit-mount=transit",
+		"-transit-key=my-key",
+		"-approle-role-id=test-role-id",
+		"-approle-secret-id-path=/etc/kubernetes/static-pod-resources/secrets/encryption-config/kms-plugin-secret-vault-approle_secret-id-555",
+		"-tls-ca-file=/etc/kubernetes/static-pod-resources/secrets/encryption-config/kms-plugin-configmap-vault-ca-bundle_ca-bundle.crt-555",
+		"-tls-sni=vault.internal.example.com",
+		"-vault-namespace=my-namespace",
+		"-metrics-port=0",
+	}
+
+	expectedHealthReporter := func(sockets string) corev1.Container {
+		return corev1.Container{
+			Name:                     "kms-health-reporter",
+			Image:                    "quay.io/test/operator:latest",
+			Command:                  []string{"cluster-kube-apiserver-operator", "kms-health-reporter"},
+			Args:                     []string{fmt.Sprintf("--kms-sockets=%s", sockets), "--node-name=$(NODE_NAME)", "--kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/kube-apiserver-cert-syncer-kubeconfig/kubeconfig"},
+			ImagePullPolicy:          corev1.PullIfNotPresent,
+			RestartPolicy:            ptr.To(corev1.ContainerRestartPolicyAlways),
+			TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+			Env: []corev1.EnvVar{
+				{
+					Name: "NODE_NAME",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
+					},
+				},
+			},
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("32Mi"),
+					corev1.ResourceCPU:    resource.MustParse("10m"),
+				},
+			},
+			SecurityContext: &corev1.SecurityContext{
+				RunAsUser:                ptr.To(int64(0)),
+				ReadOnlyRootFilesystem:   ptr.To(true),
+				AllowPrivilegeEscalation: ptr.To(false),
+				Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+				SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{Name: "kms-plugin-socket", MountPath: "/var/run/kmsplugin", ReadOnly: true},
+				{Name: "resource-dir", MountPath: "/etc/kubernetes/static-pod-resources", ReadOnly: true},
+			},
+		}
+	}
+
+	tests := []struct {
+		name                string
+		actualPodSpec       *corev1.PodSpec
+		expectedPodSpec     *corev1.PodSpec
+		secretClient        corev1client.SecretsGetter
+		featureGateAccessor featuregates.FeatureGateAccess
+		wantErr             string
+	}{
+		{
+			name: "stale sidecar from removed provider is pruned",
+			actualPodSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:         "kube-apiserver",
+						VolumeMounts: []corev1.VolumeMount{socketMount},
+					},
+				},
+				InitContainers: []corev1.Container{
+					{
+						Name:  "vault-kms-plugin-777",
+						Image: "quay.io/test/vault:v2",
+						Args:  []string{"-old-arg"},
+					},
+					{
+						Name:  "vault-kms-plugin-555",
+						Image: "quay.io/test/vault:v1",
+						Args:  []string{"-old-arg"},
+					},
+					{
+						Name:  "kms-health-reporter",
+						Image: "quay.io/test/operator:latest",
+					},
+				},
+				Volumes: []corev1.Volume{f.resourceDirVolume, socketVolume},
+			},
+			expectedPodSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:         "kube-apiserver",
+						VolumeMounts: []corev1.VolumeMount{socketMount},
+					},
+				},
+				InitContainers: []corev1.Container{
+					{
+						Name:                     "vault-kms-plugin-555",
+						Image:                    "quay.io/test/vault:v1",
+						Args:                     sidecarArgs,
+						ImagePullPolicy:          corev1.PullIfNotPresent,
+						RestartPolicy:            ptr.To(corev1.ContainerRestartPolicyAlways),
+						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("64Mi"),
+								corev1.ResourceCPU:    resource.MustParse("10m"),
+							},
+						},
+						SecurityContext: &corev1.SecurityContext{
+							RunAsUser:                ptr.To(int64(0)),
+							ReadOnlyRootFilesystem:   ptr.To(true),
+							AllowPrivilegeEscalation: ptr.To(false),
+							Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+							SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+						},
+						VolumeMounts: []corev1.VolumeMount{socketMount, resourceDirMount},
+					},
+					expectedHealthReporter("unix:///var/run/kmsplugin/kms-555.sock"),
+				},
+				Volumes: []corev1.Volume{f.resourceDirVolume, socketVolume},
+			},
+			secretClient:        secretClient(f.encryptionConfigSecret),
+			featureGateAccessor: featuregates.NewHardcodedFeatureGateAccess([]configv1.FeatureGateName{features.FeatureGateKMSEncryption}, nil),
+		},
+		{
+			name: "all KMS resources removed when no KMS plugins in config",
+			actualPodSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:         "kube-apiserver",
+						VolumeMounts: []corev1.VolumeMount{socketMount},
+					},
+				},
+				InitContainers: []corev1.Container{
+					{
+						Name:  "vault-kms-plugin-555",
+						Image: "quay.io/test/vault:v1",
+					},
+					{
+						Name:  "kms-health-reporter",
+						Image: "quay.io/test/operator:latest",
+					},
+				},
+				Volumes: []corev1.Volume{f.resourceDirVolume, socketVolume},
+			},
+			expectedPodSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:         "kube-apiserver",
+						VolumeMounts: []corev1.VolumeMount{},
+					},
+				},
+				InitContainers: []corev1.Container{},
+				Volumes:        []corev1.Volume{f.resourceDirVolume},
+			},
+			secretClient: func() corev1client.SecretsGetter {
+				noKMSConfig := &apiserverv1.EncryptionConfiguration{
+					Resources: []apiserverv1.ResourceConfiguration{
+						{
+							Resources: []string{"secrets"},
+							Providers: []apiserverv1.ProviderConfiguration{
+								{AESCBC: &apiserverv1.AESConfiguration{}},
+							},
+						},
+					},
+				}
+				noKMSBytes, err := encoding.EncodeEncryptionConfiguration(noKMSConfig)
+				require.NoError(t, err)
+				return secretClient(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "encryption-config",
+						Namespace: "openshift-kube-apiserver",
+					},
+					Data: map[string][]byte{"encryption-config": noKMSBytes},
+				})
+			}(),
+			featureGateAccessor: featuregates.NewHardcodedFeatureGateAccess([]configv1.FeatureGateName{features.FeatureGateKMSEncryption}, nil),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := EnsureKMSPluginSidecarInStaticPodSpec(context.Background(), tt.actualPodSpec, "kube-apiserver", "openshift-kube-apiserver", "encryption-config", "cluster-kube-apiserver-operator", "quay.io/test/operator:latest", tt.secretClient, tt.featureGateAccessor)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedPodSpec, tt.actualPodSpec)
+		})
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced kube-apiserver **static pod** KMS sidecar handling, including the ability to customize which on-disk encryption-config Secret is referenced in static-pod mode.

* **Bug Fixes**
  * Improved idempotent reconciliation by pruning previously injected KMS-managed init containers and volumes, and refreshing static-pod socket mounts before reapplying configuration.
  * More reliable updates to the KMS health-reporter sidecar to ensure correct container wiring.

* **Tests**
  * Added and expanded tests to validate static-pod reconciliation and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->