### PR TITLE
CNTRLPLANE-2589: test/library/encryption: Accept testing.TB for OTE compatibility

### DIFF
--- a/test/library/encryption/perf_scenarios.go
+++ b/test/library/encryption/perf_scenarios.go
@@ -23,7 +23,7 @@ type PerfScenario struct {
 	EncryptionProvider EncryptionProvider
 }
 
-func TestPerfEncryption(ctx context.Context, t *testing.T, scenario PerfScenario) {
+func TestPerfEncryption(ctx context.Context, t testing.TB, scenario PerfScenario) {
 	e := NewE(t, PrintEventsOnFailure(scenario.OperatorNamespace))
 	migrationStartedCh := make(chan time.Time, 1)
 
@@ -39,7 +39,7 @@ func TestPerfEncryption(ctx context.Context, t *testing.T, scenario PerfScenario
 	}
 }
 
-func runTestEncryption(ctx context.Context, tt *testing.T, scenario PerfScenario) time.Time {
+func runTestEncryption(ctx context.Context, tt testing.TB, scenario PerfScenario) time.Time {
 	var ts time.Time
 	TestEncryptionType(ctx, tt, BasicScenario{
 		Namespace:                       scenario.Namespace,


### PR DESCRIPTION
Change TestPerfEncryption and runTestEncryption to accept testing.TB interface instead of *testing.T concrete type. This enables these functions to be used with both standard Go tests and Ginkgo/OTE framework tests.

The testing.TB interface is implemented by both *testing.T and *testing.B, as well as Ginkgo's GinkgoTB. This change is 100% backwards compatible - all existing callers passing *testing.T will continue to work.

This eliminates the need for downstream operators to duplicate these functions when migrating to the OpenShift Tests Extension (OTE) framework. Currently, operators must copy ~400+ lines of code from library-go just to change *testing.T to testing.TB.

Benefits:
- Enables OTE framework migration across OpenShift operators
- Reduces code duplication in downstream repos
- Maintains full backwards compatibility
- No behavior changes, only signature widening

Related: https://github.com/openshift/cluster-authentication-operator/pull/926
Discussion: https://redhat-internal.slack.com/archives/C07RDCVEYJG/p1782475409270789


For PR: https://github.com/openshift/cluster-authentication-operator/pull/859 the changes are already present in this repo. 
```
  test/library/encryption/scenarios.go:
    1. ✅ TestEncryptionTypeIdentity - Line 36 (testing.TB)
    2. ✅ TestEncryptionTypeUnset - Line 42 (testing.TB)
    3. ✅ TestEncryptionTypeAESCBC - Line 59 (testing.TB)
    4. ✅ TestEncryptionTypeAESGCM - Line 67 (testing.TB)
    5. ✅ TestEncryptionTypeKMS - Line 75 (testing.TB)
    6. ✅ TestEncryptionType - Line 83 (testing.TB)
    7. ✅ TestEncryptionTurnOnAndOff - Line 113 (testing.TB)
    8. ✅ TestEncryptionProvidersMigration - Line 184 (testing.TB)
    9. ✅ TestEncryptionRotation - Line 249 (testing.TB)
    10. ✅ TestKMSInvalidEncryptionRecovery - Line 309 (testing.TB)

  test/library/encryption/perf_helpers.go:
    11. ✅ watchForMigrationControllerProgressingConditionAsync - Line 17 (testing.TB)
    12. ✅ watchForMigrationControllerProgressingCondition - Line 22 (testing.TB)
    13. ✅ populateDatabase - Line 45 (testing.TB)
    14. ✅ runner.run - Line 85 (testing.TB)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test compatibility by aligning test helper interfaces with standard testing types.
  * No user-facing behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->