### PR TITLE
NO-JIRA: Rename kms builder functions accordingly

### DIFF
--- a/pkg/operator/encryption/kms/pluginlifecycle/builder.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/builder.go
@@ -28,18 +28,16 @@ type KMSPluginBuilder struct {
 }
 
 // NewKMSPluginBuilder creates a builder that defaults to deployment mode.
-// The secretClient is used to fetch the encryption-config Secret at Apply time.
-func NewKMSPluginBuilder(secretClient corev1client.SecretsGetter) *KMSPluginBuilder {
-	return &KMSPluginBuilder{
-		secretClient: secretClient,
-	}
+func NewKMSPluginBuilder() *KMSPluginBuilder {
+	return &KMSPluginBuilder{}
 }
 
-// FromEncryptionConfig configures the builder to load KMS plugins from the
+// FromEncryptionConfigSecret configures the builder to load KMS plugins from the
 // named encryption-config Secret. The Secret is fetched at Apply time.
-func (b *KMSPluginBuilder) FromEncryptionConfig(namespace, secretName string) *KMSPluginBuilder {
+func (b *KMSPluginBuilder) FromEncryptionConfigSecret(namespace, secretName string, secretClient corev1client.SecretsGetter) *KMSPluginBuilder {
 	b.encryptionConfigNamespace = namespace
 	b.encryptionConfigSecretName = secretName
+	b.secretClient = secretClient
 	return b
 }
 
@@ -50,10 +48,10 @@ func (b *KMSPluginBuilder) AsStaticPod() *KMSPluginBuilder {
 	return b
 }
 
-// ErrorIfNotFound makes Apply return an error when the encryption-config Secret
+// WithSecretRequired makes Apply return an error when the encryption-config Secret
 // does not exist, instead of silently treating it as a no-op. This is useful for
 // callers like the preflight checker that expect the Secret to be present.
-func (b *KMSPluginBuilder) ErrorIfNotFound() *KMSPluginBuilder {
+func (b *KMSPluginBuilder) WithSecretRequired() *KMSPluginBuilder {
 	b.errorIfNotFound = true
 	return b
 }

--- a/pkg/operator/encryption/kms/pluginlifecycle/builder_test.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/builder_test.go
@@ -28,8 +28,8 @@ func TestKMSPluginBuilder_Apply(t *testing.T) {
 	}{
 		{
 			name: "static pod mode: resource-dir mount and root UID",
-			builder: NewKMSPluginBuilder(secretClient(f.encryptionConfigSecret)).
-				FromEncryptionConfig("openshift-kube-apiserver", "encryption-config").
+			builder: NewKMSPluginBuilder().
+				FromEncryptionConfigSecret("openshift-kube-apiserver", "encryption-config", secretClient(f.encryptionConfigSecret)).
 				AsStaticPod(),
 			podSpec: &corev1.PodSpec{
 				Containers: []corev1.Container{{Name: "kube-apiserver"}},
@@ -58,8 +58,8 @@ func TestKMSPluginBuilder_Apply(t *testing.T) {
 		},
 		{
 			name: "deployment mode: secret volume mount and no root UID",
-			builder: NewKMSPluginBuilder(secretClient(f.encryptionConfigSecret)).
-				FromEncryptionConfig("openshift-kube-apiserver", "encryption-config"),
+			builder: NewKMSPluginBuilder().
+				FromEncryptionConfigSecret("openshift-kube-apiserver", "encryption-config", secretClient(f.encryptionConfigSecret)),
 			podSpec: &corev1.PodSpec{
 				Containers: []corev1.Container{{Name: "kube-apiserver"}},
 				Volumes:    []corev1.Volume{f.resourceDirVolume},
@@ -92,8 +92,8 @@ func TestKMSPluginBuilder_Apply(t *testing.T) {
 		},
 		{
 			name: "missing secret: no-op",
-			builder: NewKMSPluginBuilder(secretClient()).
-				FromEncryptionConfig("openshift-kube-apiserver", "encryption-config"),
+			builder: NewKMSPluginBuilder().
+				FromEncryptionConfigSecret("openshift-kube-apiserver", "encryption-config", secretClient()),
 			podSpec: &corev1.PodSpec{
 				Containers: []corev1.Container{{Name: "test"}},
 			},
@@ -103,8 +103,8 @@ func TestKMSPluginBuilder_Apply(t *testing.T) {
 		},
 		{
 			name: "nil pod spec: returns error",
-			builder: NewKMSPluginBuilder(secretClient(f.encryptionConfigSecret)).
-				FromEncryptionConfig("openshift-kube-apiserver", "encryption-config"),
+			builder: NewKMSPluginBuilder().
+				FromEncryptionConfigSecret("openshift-kube-apiserver", "encryption-config", secretClient(f.encryptionConfigSecret)),
 			podSpec: nil,
 			wantErr: "pod spec cannot be nil",
 		},
@@ -147,15 +147,15 @@ func TestKMSPluginBuilder_OrderIndependence(t *testing.T) {
 		Volumes:    []corev1.Volume{f.resourceDirVolume},
 	}
 
-	err := NewKMSPluginBuilder(secretClient()).
-		FromEncryptionConfig("openshift-kube-apiserver", "encryption-config").
+	err := NewKMSPluginBuilder().
+		FromEncryptionConfigSecret("openshift-kube-apiserver", "encryption-config", secretClient()).
 		AsStaticPod().
 		Apply(context.Background(), podSpec1, "kube-apiserver")
 	require.NoError(t, err)
 
-	err = NewKMSPluginBuilder(secretClient()).
+	err = NewKMSPluginBuilder().
 		AsStaticPod().
-		FromEncryptionConfig("openshift-kube-apiserver", "encryption-config").
+		FromEncryptionConfigSecret("openshift-kube-apiserver", "encryption-config", secretClient()).
 		Apply(context.Background(), podSpec2, "kube-apiserver")
 	require.NoError(t, err)
 
@@ -173,8 +173,8 @@ func TestKMSPluginBuilder_Idempotent(t *testing.T) {
 
 	apply := func() {
 		t.Helper()
-		err := NewKMSPluginBuilder(sc).
-			FromEncryptionConfig("openshift-kube-apiserver", "encryption-config").
+		err := NewKMSPluginBuilder().
+			FromEncryptionConfigSecret("openshift-kube-apiserver", "encryption-config", sc).
 			Apply(context.Background(), podSpec, "kube-apiserver")
 		require.NoError(t, err)
 	}

--- a/pkg/operator/encryption/kms/pluginlifecycle/health_reporter_test.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/health_reporter_test.go
@@ -19,8 +19,8 @@ func TestKMSPluginBuilder_WithHealthReporter(t *testing.T) {
 			Containers: []corev1.Container{{Name: "kube-apiserver"}},
 			Volumes:    []corev1.Volume{f.resourceDirVolume},
 		}
-		err := NewKMSPluginBuilder(sc).
-			FromEncryptionConfig("openshift-kube-apiserver", "encryption-config").
+		err := NewKMSPluginBuilder().
+			FromEncryptionConfigSecret("openshift-kube-apiserver", "encryption-config", sc).
 			WithHealthReporter("cluster-kube-apiserver-operator", "quay.io/test/operator:latest").
 			Apply(context.Background(), podSpec, "kube-apiserver")
 		require.NoError(t, err)
@@ -57,8 +57,8 @@ func TestKMSPluginBuilder_WithHealthReporter(t *testing.T) {
 			Containers: []corev1.Container{{Name: "kube-apiserver"}},
 			Volumes:    []corev1.Volume{f.resourceDirVolume},
 		}
-		err := NewKMSPluginBuilder(sc).
-			FromEncryptionConfig("openshift-kube-apiserver", "encryption-config").
+		err := NewKMSPluginBuilder().
+			FromEncryptionConfigSecret("openshift-kube-apiserver", "encryption-config", sc).
 			AsStaticPod().
 			WithHealthReporter("cluster-kube-apiserver-operator", "quay.io/test/operator:latest").
 			Apply(context.Background(), podSpec, "kube-apiserver")
@@ -81,8 +81,8 @@ func TestKMSPluginBuilder_WithHealthReporter(t *testing.T) {
 			Containers: []corev1.Container{{Name: "kube-apiserver"}},
 			Volumes:    []corev1.Volume{f.resourceDirVolume},
 		}
-		err := NewKMSPluginBuilder(sc).
-			FromEncryptionConfig("openshift-kube-apiserver", "encryption-config").
+		err := NewKMSPluginBuilder().
+			FromEncryptionConfigSecret("openshift-kube-apiserver", "encryption-config", sc).
 			Apply(context.Background(), podSpec, "kube-apiserver")
 		require.NoError(t, err)
 
@@ -96,8 +96,8 @@ func TestKMSPluginBuilder_WithHealthReporter(t *testing.T) {
 			Containers: []corev1.Container{{Name: "kube-apiserver"}},
 			Volumes:    []corev1.Volume{f.resourceDirVolume},
 		}
-		err := NewKMSPluginBuilder(sc).
-			FromEncryptionConfig("openshift-kube-apiserver", "encryption-config").
+		err := NewKMSPluginBuilder().
+			FromEncryptionConfigSecret("openshift-kube-apiserver", "encryption-config", sc).
 			WithHealthReporter("cluster-kube-apiserver-operator", "").
 			Apply(context.Background(), podSpec, "kube-apiserver")
 		require.ErrorContains(t, err, "health reporter name, operatorBinary, image and subcommand are required")

--- a/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
@@ -64,8 +64,8 @@ func AddKMSPluginSidecarToStaticPodSpec(ctx context.Context, podSpec *corev1.Pod
 		return nil
 	}
 
-	return NewKMSPluginBuilder(secretClient).
-		FromEncryptionConfig(encryptionConfigNamespace, encryptionConfigSecretName).
+	return NewKMSPluginBuilder().
+		FromEncryptionConfigSecret(encryptionConfigNamespace, encryptionConfigSecretName, secretClient).
 		AsStaticPod().
 		WithHealthReporter(operatorBinary, operatorImage).
 		Apply(ctx, podSpec, containerName)
@@ -87,8 +87,8 @@ func AddKMSPluginSidecarToPodSpec(ctx context.Context, podSpec *corev1.PodSpec, 
 		return nil
 	}
 
-	return NewKMSPluginBuilder(secretClient).
-		FromEncryptionConfig(encryptionConfigNamespace, encryptionConfigSecretName).
+	return NewKMSPluginBuilder().
+		FromEncryptionConfigSecret(encryptionConfigNamespace, encryptionConfigSecretName, secretClient).
 		WithHealthReporter(operatorBinary, operatorImage).
 		Apply(ctx, podSpec, containerName)
 }


### PR DESCRIPTION
This PR addresses changes requested in https://github.com/openshift/library-go/pull/2330#discussion_r3481598336 as followup PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified KMS plugin setup by making the builder configurable in separate steps instead of requiring everything up front.
  * Renamed the “secret required” option for clearer behavior.
  * Updated related internal flows to use the new builder pattern.

* **Bug Fixes**
  * Preserved existing behavior for missing encryption-config secrets, including the option to treat them as required.
  * Kept sidecar injection and static-pod handling unchanged while improving how configuration is applied.

* **Tests**
  * Adjusted test coverage to match the new configuration flow and verify ordering, idempotency, and error cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->