### PR TITLE
CNTRLPLANE-3237: encryption/controllers/kms_preflight_controller: manage preflight pod lifecycle

### DIFF
--- a/pkg/operator/encryption/controllers/kms_preflight_controller.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/klog/v2"
@@ -120,6 +121,27 @@ func (h *kmsConfigHasher) hashReferencedConfigMap(ctx context.Context, hasher ha
 	return nil
 }
 
+// Pod readiness gate condition types set by the preflight checker running inside
+// the pod. The checker PATCHes its own pod status with these conditions.
+const (
+	// KMSPreflightConfigHashPodCondition carries the config hash the pod was
+	// deployed for. The controller compares this against the required hash to
+	// detect stale pods from a previous config.
+	KMSPreflightConfigHashPodCondition corev1.PodConditionType = "KMSPreflightConfigHash"
+
+	// KMSPreflightResultPodCondition carries the outcome of the preflight check.
+	// Status True means the check passed; False means it failed, with details
+	// in the condition message.
+	KMSPreflightResultPodCondition corev1.PodConditionType = "KMSPreflightResult"
+
+	// KMSPreflightKEKIDPodCondition carries the current key encryption key (KEK)
+	// ID reported by the KMS plugin during the preflight evaluation.
+	KMSPreflightKEKIDPodCondition corev1.PodConditionType = "KMSPreflightKekID"
+
+	preflightPodRetention      = 1 * time.Hour
+	preflightPodStartupTimeout = 3 * time.Minute
+)
+
 // KMSPreflightDeployer abstracts the lifecycle of a preflight workload that
 // validates KMS plugin configuration before an encryption key is created.
 // All methods are idempotent.
@@ -149,6 +171,7 @@ type kmsPreflightController struct {
 	apiServerClient configv1client.APIServerInterface
 	coreClient      corev1client.CoreV1Interface
 
+	deployer                 KMSPreflightDeployer
 	provider                 Provider
 	preconditionsFulfilledFn preconditionsFulfilled
 }
@@ -226,6 +249,7 @@ func NewKMSPreflightController(
 	instanceName string,
 	provider Provider,
 	preconditionsFulfilledFn preconditionsFulfilled,
+	deployer KMSPreflightDeployer,
 	operatorClient operatorv1helpers.OperatorClient,
 	apiServerClient configv1client.APIServerInterface,
 	apiServerInformer configv1informers.APIServerInformer,
@@ -243,6 +267,7 @@ func NewKMSPreflightController(
 		apiServerClient: apiServerClient,
 		coreClient:      coreClient,
 
+		deployer:                 deployer,
 		provider:                 provider,
 		preconditionsFulfilledFn: preconditionsFulfilledFn,
 	}
@@ -260,6 +285,7 @@ func NewKMSPreflightController(
 	)
 }
 
+// TODO: in the future report "progress" and "success" conditions.
 func (c *kmsPreflightController) sync(ctx context.Context, syncCtx factory.SyncContext) (err error) {
 	degradedCondition := applyoperatorv1.OperatorCondition().WithType("EncryptionKMSPreflightControllerDegraded")
 
@@ -282,12 +308,19 @@ func (c *kmsPreflightController) sync(ctx context.Context, syncCtx factory.SyncC
 		return err // we will get re-kicked when the operator status updates
 	}
 
-	preflightErr := c.runPreflightChecks(ctx)
+	requeue, preflightErr := c.runPreflightChecks(ctx)
+	if requeue {
+		syncCtx.Queue().AddAfter(syncCtx.QueueKey(), 30*time.Second)
+	}
 	if preflightErr != nil {
+		reason, msg := "Error", preflightErr.Error()
+		if pe, ok := preflightErr.(*preflightError); ok {
+			reason = pe.reason
+		}
 		degradedCondition = degradedCondition.
 			WithStatus(operatorv1.ConditionTrue).
-			WithReason("Error").
-			WithMessage(preflightErr.Error())
+			WithReason(reason).
+			WithMessage(msg)
 	} else {
 		degradedCondition = degradedCondition.
 			WithStatus(operatorv1.ConditionFalse)
@@ -295,21 +328,206 @@ func (c *kmsPreflightController) sync(ctx context.Context, syncCtx factory.SyncC
 	return preflightErr
 }
 
-func (c *kmsPreflightController) runPreflightChecks(ctx context.Context) error {
-	requiredHash, err := c.requiredPreflightHash(ctx)
+// runPreflightChecks manages the preflight pod lifecycle across sync iterations.
+// It returns whether to requeue and any error.
+//
+// Scenarios:
+//
+//  1. No preflight required (condition absent, False, or hash mismatch in preflightRequired).
+//     Cleanup any lingering resources (pod, SA, RBAC) from a previous run.
+//
+//  2. Preflight required, no pod exists (Status returns NotFound).
+//     Call Deploy. On success, requeue and wait for the pod to report results.
+//     If Deploy fails, report the error.
+//
+//  3. Preflight required, pod exists (Status returns a PodStatus).
+//     Evaluate the pod state via readiness-gate conditions and phase:
+//
+//     a) Pod phase is Failed — the pod crashed before or after posting
+//     conditions. Report degraded and keep the pod for inspection. The
+//     admin fixes the config, which triggers a new hash and cleanup
+//     via scenario (c).
+//
+//     b) No KMSPreflightConfigHash condition yet — the checker has not
+//     started reporting. If the pod phase is Succeeded, it exited
+//     without reporting; return an error. Otherwise requeue and wait.
+//     If the pod has exceeded the startup timeout (3m) without
+//     reporting, return an error with the reason the pod is stuck
+//     (e.g. ImagePullBackOff, Pending).
+//
+//     c) KMSPreflightConfigHash does not match the required hash — stale
+//     pod from a previous config. Clean up; next sync deploys fresh.
+//
+//     d) Hash matches, no KMSPreflightResult yet — check is running.
+//     If the pod phase is Succeeded, it exited without reporting the
+//     result; return an error. Otherwise requeue and wait. If past
+//     the startup timeout, return an error with the stuck reason.
+//
+//     e) Hash matches, KMSPreflightResult is True — check passed.
+//     Keep the pod for retention (1h), then clean up.
+//
+//     f) Hash matches, KMSPreflightResult is False — check failed. Report
+//     degraded with the failure message. Keep the pod for inspection.
+//     The admin fixes the config, which triggers a new hash and cleanup
+//     via scenario (c).
+//
+// TODO: in the future we might want to add retries for failed preflights.
+func (c *kmsPreflightController) runPreflightChecks(ctx context.Context) (requeue bool, err error) {
+	requiredHash, err := c.preflightRequired(ctx)
 	if err != nil {
-		return err
-	}
-	if requiredHash == "" {
-		return nil
+		return false, err
 	}
 
-	return fmt.Errorf("preflight checks not yet implemented for hash %s", requiredHash)
+	// Scenario 1: no preflight required, cleanup lingering resources.
+	if requiredHash == "" {
+		return false, c.deployer.Cleanup(ctx)
+	}
+
+	// Check whether a preflight pod already exists.
+	podStatus, err := c.deployer.Status(ctx)
+	// Scenario 2: no pod exists, deploy a new one.
+	if apierrors.IsNotFound(err) {
+		// TODO: compute the encryption configuration and pass it to the deployer
+		return true, c.deployer.Deploy(ctx, requiredHash, nil)
+	}
+	if err != nil {
+		return false, fmt.Errorf("failed to get preflight pod status: %w", err)
+	}
+
+	// Scenario 3a: pod crashed. Keep for inspection; the admin will update
+	// the config which triggers a new hash and cleanup via scenario 3c.
+	if podStatus.Phase == corev1.PodFailed {
+		pe := podFailureError(podStatus)
+		pe.message = fmt.Sprintf("preflight pod failed for hash %s: %s", requiredHash, pe.message)
+		return false, pe
+	}
+
+	// Scenario 3b: pod has not reported its config hash yet.
+	hashCondition := findPodCondition(podStatus.Conditions, KMSPreflightConfigHashPodCondition)
+	if hashCondition == nil {
+		if podStatus.Phase == corev1.PodSucceeded {
+			return false, &preflightError{reason: "PodCompletedWithoutResult", message: fmt.Sprintf("preflight pod completed without reporting result for hash %s", requiredHash)}
+		}
+		if pe := podStartupTimeoutError(podStatus, "preflight pod has not reported config hash"); pe != nil {
+			return true, pe
+		}
+		return true, nil
+	}
+
+	// Scenario 3c: stale pod from a different config.
+	if hashCondition.Message != requiredHash {
+		return true, c.deployer.Cleanup(ctx)
+	}
+
+	// Scenario 3d: hash matches, waiting for result.
+	resultCondition := findPodCondition(podStatus.Conditions, KMSPreflightResultPodCondition)
+	if resultCondition == nil {
+		if podStatus.Phase == corev1.PodSucceeded {
+			return false, &preflightError{reason: "PodCompletedWithoutResult", message: fmt.Sprintf("preflight pod completed without reporting result for hash %s", requiredHash)}
+		}
+		if pe := podStartupTimeoutError(podStatus, "preflight pod has not reported result"); pe != nil {
+			return true, pe
+		}
+		return true, nil
+	}
+
+	// Scenario 3e: check passed.
+	if resultCondition.Status == corev1.ConditionTrue {
+		return false, c.cleanupAfterRetention(ctx, resultCondition.LastTransitionTime.Time)
+	}
+
+	// Scenario 3f: check failed. Keep pod for inspection; the admin will
+	// update the config which triggers a new hash and cleanup via scenario 3c.
+	return false, &preflightError{
+		reason:  "PreflightCheckFailed",
+		message: fmt.Sprintf("preflight check failed for hash %s: %s", requiredHash, resultCondition.Message),
+	}
 }
 
-// requiredPreflightHash returns the config hash that needs preflight validation,
+func (c *kmsPreflightController) cleanupAfterRetention(ctx context.Context, completedAt time.Time) error {
+	age := time.Since(completedAt)
+	if age < preflightPodRetention {
+		klog.V(4).Infof("Preflight pod completed %s ago, keeping for inspection (retention %s)", age.Truncate(time.Second), preflightPodRetention)
+		return nil
+	}
+	klog.V(2).Infof("Preflight pod retention period elapsed (%s), cleaning up", preflightPodRetention)
+	return c.deployer.Cleanup(ctx)
+}
+
+type preflightError struct {
+	reason  string
+	message string
+}
+
+func (e *preflightError) Error() string { return e.message }
+
+func podFailureError(podStatus corev1.PodStatus) *preflightError {
+	for _, cs := range podStatus.ContainerStatuses {
+		if cs.State.Terminated != nil && cs.State.Terminated.ExitCode != 0 {
+			reason := cs.State.Terminated.Reason
+			if reason == "" {
+				reason = "Unknown"
+			}
+			msg := fmt.Sprintf("at least one container %s exited with %d (%s)", cs.Name, cs.State.Terminated.ExitCode, reason)
+			if cs.State.Terminated.Message != "" {
+				msg = fmt.Sprintf("%s: %s", msg, cs.State.Terminated.Message)
+			}
+			return &preflightError{reason: reason, message: msg}
+		}
+	}
+	reason := "Unknown"
+	if podStatus.Reason != "" {
+		reason = podStatus.Reason
+	}
+	if podStatus.Message != "" {
+		return &preflightError{reason: reason, message: podStatus.Message}
+	}
+	return &preflightError{reason: reason, message: "unknown"}
+}
+
+func podStartupTimeoutError(podStatus corev1.PodStatus, msgPrefix string) *preflightError {
+	if podStatus.StartTime == nil || time.Since(podStatus.StartTime.Time) <= preflightPodStartupTimeout {
+		return nil
+	}
+	reason, detail := podStuckReasonAndMessage(podStatus)
+	return &preflightError{
+		reason:  reason,
+		message: fmt.Sprintf("%s after %s: %s", msgPrefix, preflightPodStartupTimeout, detail),
+	}
+}
+
+func podStuckReasonAndMessage(podStatus corev1.PodStatus) (string, string) {
+	for _, cs := range podStatus.ContainerStatuses {
+		if cs.State.Waiting != nil && cs.State.Waiting.Reason != "" {
+			msg := fmt.Sprintf("at least one container %s is waiting: %s", cs.Name, cs.State.Waiting.Reason)
+			if cs.State.Waiting.Message != "" {
+				msg = fmt.Sprintf("%s: %s", msg, cs.State.Waiting.Message)
+			}
+			return cs.State.Waiting.Reason, msg
+		}
+	}
+	reason := "Unknown"
+	if podStatus.Reason != "" {
+		reason = podStatus.Reason
+	}
+	if podStatus.Message != "" {
+		return reason, podStatus.Message
+	}
+	return reason, fmt.Sprintf("pod is in %s phase", podStatus.Phase)
+}
+
+func findPodCondition(conditions []corev1.PodCondition, condType corev1.PodConditionType) *corev1.PodCondition {
+	for i := range conditions {
+		if conditions[i].Type == condType {
+			return &conditions[i]
+		}
+	}
+	return nil
+}
+
+// preflightRequired returns the config hash that needs preflight validation,
 // or an empty string when no preflight is needed.
-func (c *kmsPreflightController) requiredPreflightHash(ctx context.Context) (string, error) {
+func (c *kmsPreflightController) preflightRequired(ctx context.Context) (string, error) {
 	_, operatorStatus, _, err := c.operatorClient.GetOperatorState()
 	if err != nil {
 		return "", fmt.Errorf("failed to get operator state: %w", err)

--- a/pkg/operator/encryption/controllers/kms_preflight_controller_test.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller_test.go
@@ -2,11 +2,13 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -304,6 +306,29 @@ func TestKMSConfigHasher(t *testing.T) {
 	}
 }
 
+type fakeDeployer struct {
+	deployed   bool
+	cleaned    bool
+	deployErr  error
+	statusErr  error
+	cleanupErr error
+	podStatus  corev1.PodStatus
+}
+
+func (f *fakeDeployer) Deploy(_ context.Context, _ string, _ *corev1.Secret) error {
+	f.deployed = true
+	return f.deployErr
+}
+
+func (f *fakeDeployer) Status(_ context.Context) (corev1.PodStatus, error) {
+	return f.podStatus, f.statusErr
+}
+
+func (f *fakeDeployer) Cleanup(_ context.Context) error {
+	f.cleaned = true
+	return f.cleanupErr
+}
+
 func TestKMSPreflightController(t *testing.T) {
 	apiServerWithKMS := &configv1.APIServer{
 		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
@@ -323,6 +348,7 @@ func TestKMSPreflightController(t *testing.T) {
 
 	scenarios := []struct {
 		name               string
+		deployer           KMSPreflightDeployer
 		apiServerObjects   []runtime.Object
 		coreObjects        []runtime.Object
 		operatorConditions []operatorv1.OperatorCondition
@@ -339,7 +365,7 @@ func TestKMSPreflightController(t *testing.T) {
 			},
 		},
 		{
-			name:             "no EncryptionKMSPreflightRequired condition, no-op",
+			name:             "no EncryptionKMSPreflightRequired condition, cleans up",
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
 			preconditionsMet: true,
@@ -348,7 +374,7 @@ func TestKMSPreflightController(t *testing.T) {
 			},
 		},
 		{
-			name:             "EncryptionKMSPreflightRequired condition is False, no-op",
+			name:             "EncryptionKMSPreflightRequired condition is False, cleans up",
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
 			operatorConditions: []operatorv1.OperatorCondition{
@@ -361,21 +387,363 @@ func TestKMSPreflightController(t *testing.T) {
 			},
 		},
 		{
-			name:             "hashes match, preflight needed but not yet implemented",
+			name:             "hashes match, no pod exists, deploys and returns",
+			deployer:         &fakeDeployer{statusErr: apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "kms-preflight")},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
 			operatorConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
 			},
 			preconditionsMet: true,
-			expectedError:    "preflight checks not yet implemented for hash k6dSVA==",
 			expectedConditions: []operatorv1.OperatorCondition{
-				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "Error", Message: "preflight checks not yet implemented for hash k6dSVA=="},
+				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
 				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
 			},
 		},
 		{
-			name:             "hashes differ, config changed since condition was posted, no-op",
+			name: "pod exists, hash matches, no result yet, requeues",
+			deployer: &fakeDeployer{podStatus: corev1.PodStatus{
+				Conditions: []corev1.PodCondition{
+					{Type: KMSPreflightConfigHashPodCondition, Message: wellKnownMatchingHashForBaseVaultConfig},
+				},
+			}},
+			apiServerObjects: []runtime.Object{apiServerWithKMS},
+			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			operatorConditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
+			},
+			preconditionsMet: true,
+			expectedConditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
+				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
+			},
+		},
+		{
+			name: "pod succeeded without reporting hash, reports error",
+			deployer: &fakeDeployer{podStatus: corev1.PodStatus{
+				Phase: corev1.PodSucceeded,
+			}},
+			apiServerObjects: []runtime.Object{apiServerWithKMS},
+			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			operatorConditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
+			},
+			preconditionsMet: true,
+			expectedError:    "preflight pod completed without reporting result for hash k6dSVA==",
+			expectedConditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "PodCompletedWithoutResult", Message: "preflight pod completed without reporting result for hash k6dSVA=="},
+				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
+			},
+		},
+		{
+			name: "pod succeeded without reporting result after hash posted, reports error",
+			deployer: &fakeDeployer{podStatus: corev1.PodStatus{
+				Phase: corev1.PodSucceeded,
+				Conditions: []corev1.PodCondition{
+					{Type: KMSPreflightConfigHashPodCondition, Message: wellKnownMatchingHashForBaseVaultConfig},
+				},
+			}},
+			apiServerObjects: []runtime.Object{apiServerWithKMS},
+			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			operatorConditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
+			},
+			preconditionsMet: true,
+			expectedError:    "preflight pod completed without reporting result for hash k6dSVA==",
+			expectedConditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "PodCompletedWithoutResult", Message: "preflight pod completed without reporting result for hash k6dSVA=="},
+				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
+			},
+		},
+		{
+			name: "pod succeeded recently, keeps pod for inspection",
+			deployer: &fakeDeployer{podStatus: corev1.PodStatus{
+				Conditions: []corev1.PodCondition{
+					{Type: KMSPreflightConfigHashPodCondition, Message: wellKnownMatchingHashForBaseVaultConfig},
+					{Type: KMSPreflightResultPodCondition, Status: corev1.ConditionTrue, LastTransitionTime: metav1.Now()},
+				},
+			}},
+			apiServerObjects: []runtime.Object{apiServerWithKMS},
+			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			operatorConditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
+			},
+			preconditionsMet: true,
+			expectedConditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
+				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
+			},
+		},
+		{
+			name: "pod succeeded, retention period elapsed, cleans up",
+			deployer: &fakeDeployer{podStatus: corev1.PodStatus{
+				Conditions: []corev1.PodCondition{
+					{Type: KMSPreflightConfigHashPodCondition, Message: wellKnownMatchingHashForBaseVaultConfig},
+					{Type: KMSPreflightResultPodCondition, Status: corev1.ConditionTrue, LastTransitionTime: metav1.NewTime(time.Now().Add(-2 * time.Hour))},
+				},
+			}},
+			apiServerObjects: []runtime.Object{apiServerWithKMS},
+			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			operatorConditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
+			},
+			preconditionsMet: true,
+			expectedConditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
+				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
+			},
+		},
+		{
+			name: "pod exists, hash matches, result is False, reports error",
+			deployer: &fakeDeployer{podStatus: corev1.PodStatus{
+				Conditions: []corev1.PodCondition{
+					{Type: KMSPreflightConfigHashPodCondition, Message: wellKnownMatchingHashForBaseVaultConfig},
+					{Type: KMSPreflightResultPodCondition, Status: corev1.ConditionFalse, Message: "encrypt call failed", LastTransitionTime: metav1.Now()},
+				},
+			}},
+			apiServerObjects: []runtime.Object{apiServerWithKMS},
+			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			operatorConditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
+			},
+			preconditionsMet: true,
+			expectedError:    "preflight check failed for hash k6dSVA==: encrypt call failed",
+			expectedConditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "PreflightCheckFailed", Message: "preflight check failed for hash k6dSVA==: encrypt call failed"},
+				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
+			},
+		},
+		{
+			name: "pod exists, hash is stale, cleans up",
+			deployer: &fakeDeployer{podStatus: corev1.PodStatus{
+				Conditions: []corev1.PodCondition{
+					{Type: KMSPreflightConfigHashPodCondition, Message: "old-hash"},
+					{Type: KMSPreflightResultPodCondition, Status: corev1.ConditionTrue},
+				},
+			}},
+			apiServerObjects: []runtime.Object{apiServerWithKMS},
+			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			operatorConditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
+			},
+			preconditionsMet: true,
+			expectedConditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
+				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
+			},
+		},
+		{
+			name: "pod crashed without reporting conditions, keeps pod for inspection",
+			deployer: &fakeDeployer{podStatus: corev1.PodStatus{
+				Phase: corev1.PodFailed,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name: "kms-preflight-check",
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								ExitCode:   1,
+								Message:    "connection refused",
+								FinishedAt: metav1.Now(),
+							},
+						},
+					},
+				},
+			}},
+			apiServerObjects: []runtime.Object{apiServerWithKMS},
+			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			operatorConditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
+			},
+			preconditionsMet: true,
+			expectedError:    "preflight pod failed for hash k6dSVA==: at least one container kms-preflight-check exited with 1 (Unknown): connection refused",
+			expectedConditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "Unknown", Message: "preflight pod failed for hash k6dSVA==: at least one container kms-preflight-check exited with 1 (Unknown): connection refused"},
+				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
+			},
+		},
+		{
+			name: "pod exists, no hash condition yet, waits for pod to report",
+			deployer: &fakeDeployer{podStatus: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+			}},
+			apiServerObjects: []runtime.Object{apiServerWithKMS},
+			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			operatorConditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
+			},
+			preconditionsMet: true,
+			expectedConditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
+				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
+			},
+		},
+		{
+			name: "pod stuck in Pending without reporting hash, goes degraded with phase",
+			deployer: &fakeDeployer{podStatus: corev1.PodStatus{
+				Phase:     corev1.PodPending,
+				StartTime: &metav1.Time{Time: time.Now().Add(-5 * time.Minute)},
+			}},
+			apiServerObjects: []runtime.Object{apiServerWithKMS},
+			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			operatorConditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
+			},
+			preconditionsMet: true,
+			expectedError:    "preflight pod has not reported config hash after 3m0s: pod is in Pending phase",
+			expectedConditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "Unknown", Message: "preflight pod has not reported config hash after 3m0s: pod is in Pending phase"},
+				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
+			},
+		},
+		{
+			name: "pod stuck with ImagePullBackOff, goes degraded with container reason",
+			deployer: &fakeDeployer{podStatus: corev1.PodStatus{
+				Phase:     corev1.PodPending,
+				StartTime: &metav1.Time{Time: time.Now().Add(-5 * time.Minute)},
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name: "kms-preflight-check",
+						State: corev1.ContainerState{
+							Waiting: &corev1.ContainerStateWaiting{
+								Reason:  "ImagePullBackOff",
+								Message: "back-off pulling image",
+							},
+						},
+					},
+				},
+			}},
+			apiServerObjects: []runtime.Object{apiServerWithKMS},
+			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			operatorConditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
+			},
+			preconditionsMet: true,
+			expectedError:    "preflight pod has not reported config hash after 3m0s: at least one container kms-preflight-check is waiting: ImagePullBackOff: back-off pulling image",
+			expectedConditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "ImagePullBackOff", Message: "preflight pod has not reported config hash after 3m0s: at least one container kms-preflight-check is waiting: ImagePullBackOff: back-off pulling image"},
+				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
+			},
+		},
+		{
+			name: "pod stuck without reporting result past timeout, goes degraded",
+			deployer: &fakeDeployer{podStatus: corev1.PodStatus{
+				Phase:     corev1.PodRunning,
+				StartTime: &metav1.Time{Time: time.Now().Add(-5 * time.Minute)},
+				Conditions: []corev1.PodCondition{
+					{Type: KMSPreflightConfigHashPodCondition, Message: wellKnownMatchingHashForBaseVaultConfig},
+				},
+			}},
+			apiServerObjects: []runtime.Object{apiServerWithKMS},
+			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			operatorConditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
+			},
+			preconditionsMet: true,
+			expectedError:    "preflight pod has not reported result after 3m0s: pod is in Running phase",
+			expectedConditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "Unknown", Message: "preflight pod has not reported result after 3m0s: pod is in Running phase"},
+				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
+			},
+		},
+		{
+			name:             "deploy fails, reports error",
+			deployer:         &fakeDeployer{statusErr: apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "kms-preflight"), deployErr: fmt.Errorf("quota exceeded")},
+			apiServerObjects: []runtime.Object{apiServerWithKMS},
+			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			operatorConditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
+			},
+			preconditionsMet: true,
+			expectedError:    "quota exceeded",
+			expectedConditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "Error", Message: "quota exceeded"},
+				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
+			},
+		},
+		{
+			name:             "status returns unexpected error",
+			deployer:         &fakeDeployer{statusErr: fmt.Errorf("connection refused")},
+			apiServerObjects: []runtime.Object{apiServerWithKMS},
+			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			operatorConditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
+			},
+			preconditionsMet: true,
+			expectedError:    "failed to get preflight pod status",
+			expectedConditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "Error", Message: "failed to get preflight pod status: connection refused"},
+				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
+			},
+		},
+		{
+			name: "cleanup fails on stale hash, reports error",
+			deployer: &fakeDeployer{
+				cleanupErr: fmt.Errorf("delete forbidden"),
+				podStatus: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{Type: KMSPreflightConfigHashPodCondition, Message: "old-hash"},
+					},
+				},
+			},
+			apiServerObjects: []runtime.Object{apiServerWithKMS},
+			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			operatorConditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
+			},
+			preconditionsMet: true,
+			expectedError:    "delete forbidden",
+			expectedConditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "Error", Message: "delete forbidden"},
+				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
+			},
+		},
+		{
+			name: "pod crashed, no terminated container, keeps pod for inspection",
+			deployer: &fakeDeployer{podStatus: corev1.PodStatus{
+				Phase:   corev1.PodFailed,
+				Message: "node lost",
+			}},
+			apiServerObjects: []runtime.Object{apiServerWithKMS},
+			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			operatorConditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
+			},
+			preconditionsMet: true,
+			expectedError:    "preflight pod failed for hash k6dSVA==: node lost",
+			expectedConditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "Unknown", Message: "preflight pod failed for hash k6dSVA==: node lost"},
+				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
+			},
+		},
+		{
+			name: "pod crashed with terminated container, no message, uses exit code",
+			deployer: &fakeDeployer{podStatus: corev1.PodStatus{
+				Phase: corev1.PodFailed,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name: "kms-preflight-check",
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								ExitCode: 137,
+							},
+						},
+					},
+				},
+			}},
+			apiServerObjects: []runtime.Object{apiServerWithKMS},
+			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			operatorConditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
+			},
+			preconditionsMet: true,
+			expectedError:    "preflight pod failed for hash k6dSVA==: at least one container kms-preflight-check exited with 137 (Unknown)",
+			expectedConditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "Unknown", Message: "preflight pod failed for hash k6dSVA==: at least one container kms-preflight-check exited with 137 (Unknown)"},
+				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
+			},
+		},
+		{
+			name:             "hashes differ, config changed since condition was posted, cleans up",
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
 			operatorConditions: []operatorv1.OperatorCondition{
@@ -448,10 +816,16 @@ func TestKMSPreflightController(t *testing.T) {
 			preconditionsFn := func() (bool, error) { return scenario.preconditionsMet, nil }
 			provider := newTestProvider([]schema.GroupResource{{Group: "", Resource: "secrets"}})
 
+			deployer := scenario.deployer
+			if deployer == nil {
+				deployer = &fakeDeployer{}
+			}
+
 			target := NewKMSPreflightController(
 				"test",
 				provider,
 				preconditionsFn,
+				deployer,
 				fakeOperatorClient,
 				fakeApiServerClient,
 				fakeApiServerInformer,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Implemented KMS preflight workflow end-to-end: workload deployment, readiness/result signal interpretation, operator degraded updates, and controlled cleanup/retention.
  * Added new readiness/result condition signals to more accurately reflect preflight progress and outcomes.

* **Bug Fixes**
  * Improved handling for stale pods, crashed pods, missing readiness reporting (startup timeout), and failure propagation with clearer error messaging.

* **Tests**
  * Refreshed and expanded preflight controller tests with an injectable deployer to validate lifecycle, requeue behavior, retention vs. cleanup, and degraded conditions across many scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->