### PR TITLE
Assert also provider name in encrypted resource

### DIFF
--- a/test/library/encryption/assertion.go
+++ b/test/library/encryption/assertion.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -147,7 +148,7 @@ func verifyPrefixForRawData(expectedMode string, data []byte) error {
 	if expectedEncrypted != isEncrypted {
 		return fmt.Errorf("unexpected encrypted state, expected data to be %q but was %q with mode %q", conditionToStr(expectedEncrypted), conditionToStr(isEncrypted), actualMode)
 	}
-	if actualMode != expectedMode {
+	if !strings.HasPrefix(actualMode, expectedMode) {
 		return fmt.Errorf("unexpected encryption mode %q, expected %q, was data encrypted/decrypted with a wrong key", actualMode, expectedMode)
 	}
 
@@ -165,6 +166,9 @@ func encryptionModeFromEtcdValue(data []byte) (string, bool) {
 		case hasPrefixAndTrailingData(data, []byte(secretboxTransformerPrefixV1)): // Secretbox has this prefix
 			return "secretbox"
 		case hasPrefixAndTrailingData(data, []byte(kmsTransformerPrefixV2)): // KMS v2 has this prefix
+			if providerName := KMSProviderNameFromEtcdValue(data); providerName != "" {
+				return "KMS:" + providerName
+			}
 			return "KMS"
 		case hasPrefixAndTrailingData(data, []byte(jsonEncodingPrefix)): // unencrypted json data has this prefix
 			return "identity-json"
@@ -178,4 +182,20 @@ func encryptionModeFromEtcdValue(data []byte) (string, bool) {
 
 func hasPrefixAndTrailingData(data, prefix []byte) bool {
 	return bytes.HasPrefix(data, prefix) && len(data) > len(prefix)
+}
+
+// KMSProviderNameFromEtcdValue extracts the KMS v2 provider name from raw etcd data.
+// The KMS v2 etcd value format is: k8s:enc:kms:v2:<providerName>:<encrypted-data>.
+// Returns empty string if the data is not KMS v2 encrypted.
+func KMSProviderNameFromEtcdValue(data []byte) string {
+	prefix := kmsTransformerPrefixV2
+	if !bytes.HasPrefix(data, []byte(prefix)) {
+		return ""
+	}
+	rest := data[len(prefix):]
+	idx := bytes.IndexByte(rest, ':')
+	if idx <= 0 {
+		return ""
+	}
+	return string(rest[:idx])
 }


### PR DESCRIPTION
Currently we only compare the prefixes of the encrypted resources in etcd. This works until now because we only exercise migrations from one encryption mode to another. However, in kms to kms migration scenarios, all the prefixes are made up of `KMS:`. That's why, we need to inspect the encrypted resources with more granularity. 

This PR appends provider name in KMS modes rather than plain `KMS` prefix. So that operators will have to update their assertion functions like this;

```go
 func AssertSecretOfLifeEncryptedByKMSProvider(t testing.TB, clientSet encryption.ClientSet, resource runtime.Object) {
      secret := resource.(*corev1.Secret)

      lastKeyMeta, err := encryption.GetLastKeyMeta(t, clientSet.Kube, namespace, labelSelector)
      require.NoError(t, err)

      parts := strings.Split(lastKeyMeta.Name, "-")
      expectedMode := "KMS:" + parts[len(parts)-1] + "_"

      _, err = encryption.VerifyResources(t, clientSet.Etcd,
          "/kubernetes.io/secrets/"+secret.Namespace+"/"+secret.Name,
          expectedMode, false)
      require.NoError(t, err)
  }
```

Thanks to that we'll verify that resources are migration from 1_secret to 2_secret.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved encryption mode checks so KMS v2 values are recognized more accurately, including provider-specific modes.
  * Mode matching is now more flexible, reducing false failures when encrypted/decrypted values include a compatible prefix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->