### PR TITLE
NO-JIRA: Remove invalid config recovery scenario

### DIFF
--- a/test/library/encryption/scenarios.go
+++ b/test/library/encryption/scenarios.go
@@ -295,65 +295,6 @@ func ApplyEncryption(ctx context.Context, t testing.TB, encryption configv1.APIS
 	t.Logf("Applied encryption config (type=%s)", encryption.Type)
 }
 
-type KMSInvalidEncryptionRecoveryScenario struct {
-	BasicScenario
-	InvalidProvider EncryptionProvider
-	ValidProvider   EncryptionProvider
-	WaitForStuck    func(ctx context.Context, t testing.TB)
-}
-
-// TestInvalidEncryptionRecovery validates recovery from an invalid encryption config:
-//  1. Apply invalid config — operator stuck (e.g. ImagePullBackOff, connection timeout)
-//  2. Switch to AESCBC — verify no new encryption key is created (revisions stuck)
-//  3. Apply valid config — verify recovery and successful encryption
-func TestKMSInvalidEncryptionRecovery(ctx context.Context, t testing.TB, scenario KMSInvalidEncryptionRecoveryScenario) {
-	e := NewE(t, PrintEventsOnFailure(scenario.OperatorNamespace))
-	clientSet := GetClients(e)
-
-	require.NotNil(t, scenario.InvalidProvider.Setup, "InvalidProvider.Setup must not be nil")
-	require.NotNil(t, scenario.ValidProvider.Setup, "ValidProvider.Setup must not be nil")
-	require.Equal(t, configv1.EncryptionTypeKMS, scenario.InvalidProvider.Type, "InvalidProvider must use KMS encryption type")
-	require.Equal(t, configv1.EncryptionTypeKMS, scenario.ValidProvider.Type, "ValidProvider must use KMS encryption type")
-
-	steps := []testStep{
-		{name: "ApplyInvalidConfig", testFunc: func(t testing.TB) {
-			scenario.InvalidProvider.Setup(ctx, t)
-			ApplyEncryption(ctx, t, scenario.InvalidProvider.APIServerEncryption)
-		}},
-		{name: "WaitForStuck", testFunc: func(t testing.TB) {
-			scenario.WaitForStuck(ctx, t)
-		}},
-		{name: "SwitchToAESCBCAndVerifyNoNewKey", testFunc: func(t testing.TB) {
-			prevKeyMeta, err := GetLastKeyMeta(t, clientSet.Kube,
-				scenario.Namespace, scenario.LabelSelector)
-			require.NoError(t, err)
-			ApplyEncryption(ctx, t, configv1.APIServerEncryption{Type: configv1.EncryptionTypeAESCBC})
-			WaitForNoNewEncryptionKey(t, clientSet.Kube, prevKeyMeta,
-				scenario.Namespace, scenario.LabelSelector)
-		}},
-		{name: "ApplyValidConfigAndVerifyRecovery", testFunc: func(t testing.TB) {
-			scenario.ValidProvider.Setup(ctx, t)
-			prevKeyMeta, err := GetLastKeyMeta(t, clientSet.Kube,
-				scenario.Namespace, scenario.LabelSelector)
-			require.NoError(t, err)
-			ApplyEncryption(ctx, t, scenario.ValidProvider.APIServerEncryption)
-			WaitForCurrentKeyMigrated(t, clientSet.Kube, prevKeyMeta,
-				scenario.TargetGRs, scenario.Namespace, scenario.LabelSelector)
-			scenario.AssertFunc(t, clientSet, scenario.ValidProvider.Type,
-				scenario.Namespace, scenario.LabelSelector)
-		}},
-	}
-
-	for _, step := range steps {
-		t.Logf("=== STEP: %s ===", step.name)
-		step.testFunc(e)
-		if t.Failed() {
-			t.Errorf("stopping the test as %q step failed", step.name)
-			return
-		}
-	}
-}
-
 // KMSInPlaceUpdateScenario tests that updating an in-place KMS config field
 // (e.g. kmsPluginImage) takes effect without creating a new encryption key.
 // The caller supplies Provider (initial valid config) and UpdatedProvider (same config


### PR DESCRIPTION
Initially we added this scenario for in-place field updates. However, it seems that preflight checker will catch all these invalid configurations. As a result, this PR removes this redundant in-place field update scenario.

With regards to in-place field updates, we'll use [valid config update scenario](https://github.com/openshift/library-go/blob/master/test/library/encryption/scenarios.go#L357-L418) (e.g. image).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed an obsolete encryption recovery test scenario from the test suite.
  * Simplified test coverage around invalid KMS encryption recovery and key migration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->