### PR TITLE
NO-JIRA: apply RBAC on preflight deploys

### DIFF
--- a/pkg/operator/encryption/kms/preflight/assets/kms-preflight-pod.yaml
+++ b/pkg/operator/encryption/kms/preflight/assets/kms-preflight-pod.yaml
@@ -12,6 +12,7 @@ spec:
   # This is a one-shot preflight check, not a long-running pod.
   # The operator creates it, waits for completion, and inspects the result.
   restartPolicy: Never
+  serviceAccountName: kms-preflight
   priorityClassName: system-cluster-critical
   nodeSelector:
     node-role.kubernetes.io/master: ""

--- a/pkg/operator/encryption/kms/preflight/deployer.go
+++ b/pkg/operator/encryption/kms/preflight/deployer.go
@@ -7,16 +7,29 @@ import (
 	"time"
 
 	"github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle"
+	"github.com/openshift/library-go/pkg/operator/events"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	rbacclientv1 "k8s.io/client-go/kubernetes/typed/rbac/v1"
+
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	rbacv1 "k8s.io/api/rbac/v1"
 )
 
 const (
 	preflightPodName                    = "kms-preflight"
 	preflightCheckContainerName         = "kms-preflight-check"
 	preflightEncryptionConfigSecretName = "kms-preflight-encryption-config"
+	preflightRBACName                   = "kms-preflight"
+	preflightAppLabel                   = "openshift-kms-preflight"
+)
+
+var (
+	labels = map[string]string{
+		"app": preflightAppLabel,
+	}
 )
 
 // PodPreflightDeployer creates a one-shot pod to run the preflight checker as a command,
@@ -27,6 +40,8 @@ type PodPreflightDeployer struct {
 	// encryption controllers/components actually use.
 	// In addition to that running the preflight check is not a very frequent operation.
 	coreClient      corev1client.CoreV1Interface
+	rbacClient      rbacclientv1.RbacV1Interface
+	eventRecorder   events.Recorder
 	operatorImage   string
 	operatorCommand []string
 	kmsCallTimeout  time.Duration
@@ -47,7 +62,7 @@ func (d *PodPreflightDeployer) Deploy(ctx context.Context, configHash string, en
 
 	encryptionConfigSecret = encryptionConfigSecret.DeepCopy()
 	// rewrite the entire ObjectMeta to avoid copying resource versions or managed fields
-	encryptionConfigSecret.ObjectMeta = metav1.ObjectMeta{Namespace: d.namespace, Name: preflightEncryptionConfigSecretName}
+	encryptionConfigSecret.ObjectMeta = metav1.ObjectMeta{Namespace: d.namespace, Name: preflightEncryptionConfigSecretName, Labels: labels}
 	_, err := d.coreClient.Secrets(d.namespace).Create(ctx, encryptionConfigSecret, metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to create preflight encryption config secret: %w", err)
@@ -73,6 +88,13 @@ func (d *PodPreflightDeployer) Deploy(ctx context.Context, configHash string, en
 		return fmt.Errorf("failed to apply preflight plugin: %w", err)
 	}
 
+	// RBAC is applied but not cleaned up: the rules change rarely (and apply updates them
+	// when they do), and the cost of leaving the service account, role, and role binding
+	// in the namespace is negligible.
+	if err = d.applyPreflightRBAC(ctx); err != nil {
+		return fmt.Errorf("failed to apply preflight RBAC: %w", err)
+	}
+
 	_, err = d.coreClient.Pods(d.namespace).Create(ctx, pod, metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to create preflight pod: %w", err)
@@ -92,6 +114,7 @@ func (d *PodPreflightDeployer) Status(ctx context.Context) (corev1.PodStatus, er
 }
 
 func (d *PodPreflightDeployer) Cleanup(ctx context.Context) error {
+	// See Deploy: preflight RBAC is intentionally not deleted here.
 	var errs []error
 
 	err := d.coreClient.Pods(d.namespace).Delete(ctx, preflightPodName, metav1.DeleteOptions{})
@@ -107,9 +130,73 @@ func (d *PodPreflightDeployer) Cleanup(ctx context.Context) error {
 	return errors.Join(errs...)
 }
 
+func (d *PodPreflightDeployer) applyPreflightRBAC(ctx context.Context) error {
+
+	_, _, err := resourceapply.ApplyServiceAccount(ctx, d.coreClient, d.eventRecorder, &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      preflightRBACName,
+			Namespace: d.namespace,
+			Labels:    labels,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to apply preflight service account: %w", err)
+	}
+
+	_, _, err = resourceapply.ApplyRole(ctx, d.rbacClient, d.eventRecorder, &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      preflightRBACName,
+			Namespace: d.namespace,
+			Labels:    labels,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods"},
+				Verbs:     []string{"get"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods/status"},
+				Verbs:     []string{"update"},
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to apply preflight role: %w", err)
+	}
+
+	_, _, err = resourceapply.ApplyRoleBinding(ctx, d.rbacClient, d.eventRecorder, &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      preflightRBACName,
+			Namespace: d.namespace,
+			Labels:    labels,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "Role",
+			Name:     preflightRBACName,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      preflightRBACName,
+				Namespace: d.namespace,
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to apply preflight role binding: %w", err)
+	}
+
+	return nil
+}
+
 func NewPodPreflightDeployer(
 	namespace string,
 	coreClient corev1client.CoreV1Interface,
+	rbacClient rbacclientv1.RbacV1Interface,
+	eventRecorder events.Recorder,
 	operatorImage string,
 	operatorCommand []string,
 	kmsCallTimeout time.Duration,
@@ -117,6 +204,8 @@ func NewPodPreflightDeployer(
 	return &PodPreflightDeployer{
 		namespace:       namespace,
 		coreClient:      coreClient,
+		rbacClient:      rbacClient,
+		eventRecorder:   eventRecorder,
 		operatorImage:   operatorImage,
 		operatorCommand: operatorCommand,
 		kmsCallTimeout:  kmsCallTimeout,

--- a/pkg/operator/encryption/kms/preflight/deployer_test.go
+++ b/pkg/operator/encryption/kms/preflight/deployer_test.go
@@ -9,6 +9,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
 	encryptiontesting "github.com/openshift/library-go/pkg/operator/encryption/testing"
+	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -18,6 +19,7 @@ import (
 	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
+	"k8s.io/utils/clock"
 )
 
 const (
@@ -43,6 +45,7 @@ metadata:
     encryption.apiserver.operator.openshift.io/kms-preflight-config-hash: abc123
 spec:
   restartPolicy: Never
+  serviceAccountName: kms-preflight
   priorityClassName: system-cluster-critical
   nodeSelector:
     node-role.kubernetes.io/master: ""
@@ -211,6 +214,8 @@ func newTestDeployer(t *testing.T, objects ...runtime.Object) (*PodPreflightDepl
 	deployer := NewPodPreflightDeployer(
 		testNamespace,
 		kubeClient.CoreV1(),
+		kubeClient.RbacV1(),
+		events.NewInMemoryRecorder("kms-preflight-deployer-test", clock.RealClock{}),
 		testOperatorImage,
 		testOperatorCommand,
 		testDeployerTimeout,
@@ -243,21 +248,14 @@ func TestPodPreflightDeployer_Deploy(t *testing.T) {
 	}
 
 	actions := kubeClient.Actions()
-	if len(actions) != 5 {
-		t.Fatalf("expected 5 actions, got %d: %#v", len(actions), actions)
+	if len(actions) != 11 {
+		t.Fatalf("expected 11 actions, got %d: %#v", len(actions), actions)
 	}
 	if !actions[0].Matches("delete", "pods") {
 		t.Fatalf("unexpected action: %#v", actions[0])
 	}
 	if !actions[1].Matches("delete", "secrets") {
 		t.Fatalf("unexpected action: %#v", actions[1])
-	}
-	deleteAction, ok := actions[1].(clienttesting.DeleteAction)
-	if !ok {
-		t.Fatalf("expected DeleteAction, got %T", actions[1])
-	}
-	if deleteAction.GetName() != preflightEncryptionConfigSecretName {
-		t.Fatalf("unexpected secret name %q", deleteAction.GetName())
 	}
 	if !actions[2].Matches("create", "secrets") {
 		t.Fatalf("unexpected action: %#v", actions[2])
@@ -276,10 +274,28 @@ func TestPodPreflightDeployer_Deploy(t *testing.T) {
 	if !actions[3].Matches("get", "secrets") {
 		t.Fatalf("unexpected action: %#v", actions[3])
 	}
-	if !actions[4].Matches("create", "pods") {
+	if !actions[4].Matches("get", "serviceaccounts") {
 		t.Fatalf("unexpected action: %#v", actions[4])
 	}
-	createAction, ok := actions[4].(clienttesting.CreateAction)
+	if !actions[5].Matches("create", "serviceaccounts") {
+		t.Fatalf("unexpected action: %#v", actions[5])
+	}
+	if !actions[6].Matches("get", "roles") {
+		t.Fatalf("unexpected action: %#v", actions[6])
+	}
+	if !actions[7].Matches("create", "roles") {
+		t.Fatalf("unexpected action: %#v", actions[7])
+	}
+	if !actions[8].Matches("get", "rolebindings") {
+		t.Fatalf("unexpected action: %#v", actions[8])
+	}
+	if !actions[9].Matches("create", "rolebindings") {
+		t.Fatalf("unexpected action: %#v", actions[9])
+	}
+	if !actions[10].Matches("create", "pods") {
+		t.Fatalf("unexpected action: %#v", actions[10])
+	}
+	createAction, ok := actions[10].(clienttesting.CreateAction)
 	if !ok {
 		t.Fatalf("expected CreateAction, got %T", actions[4])
 	}
@@ -403,8 +419,8 @@ func TestPodPreflightDeployer_Deploy_podCreateFailure(t *testing.T) {
 	}
 
 	actions := kubeClient.Actions()
-	if len(actions) != 5 {
-		t.Fatalf("expected 5 actions, got %d: %#v", len(actions), actions)
+	if len(actions) != 11 {
+		t.Fatalf("expected 11 actions, got %d: %#v", len(actions), actions)
 	}
 	if !actions[0].Matches("delete", "pods") {
 		t.Fatalf("unexpected action: %#v", actions[0])
@@ -418,8 +434,26 @@ func TestPodPreflightDeployer_Deploy_podCreateFailure(t *testing.T) {
 	if !actions[3].Matches("get", "secrets") {
 		t.Fatalf("unexpected action: %#v", actions[3])
 	}
-	if !actions[4].Matches("create", "pods") {
+	if !actions[4].Matches("get", "serviceaccounts") {
 		t.Fatalf("unexpected action: %#v", actions[4])
+	}
+	if !actions[5].Matches("create", "serviceaccounts") {
+		t.Fatalf("unexpected action: %#v", actions[5])
+	}
+	if !actions[6].Matches("get", "roles") {
+		t.Fatalf("unexpected action: %#v", actions[6])
+	}
+	if !actions[7].Matches("create", "roles") {
+		t.Fatalf("unexpected action: %#v", actions[7])
+	}
+	if !actions[8].Matches("get", "rolebindings") {
+		t.Fatalf("unexpected action: %#v", actions[8])
+	}
+	if !actions[9].Matches("create", "rolebindings") {
+		t.Fatalf("unexpected action: %#v", actions[9])
+	}
+	if !actions[10].Matches("create", "pods") {
+		t.Fatalf("unexpected action: %#v", actions[10])
 	}
 }
 
@@ -474,8 +508,8 @@ func TestPodPreflightDeployer_Deploy_deletesStaleResources(t *testing.T) {
 	}
 
 	actions := kubeClient.Actions()
-	if len(actions) != 5 {
-		t.Fatalf("expected 5 actions, got %d: %#v", len(actions), actions)
+	if len(actions) != 11 {
+		t.Fatalf("expected 11 actions, got %d: %#v", len(actions), actions)
 	}
 	if !actions[0].Matches("delete", "pods") {
 		t.Fatalf("unexpected action: %#v", actions[0])
@@ -489,8 +523,26 @@ func TestPodPreflightDeployer_Deploy_deletesStaleResources(t *testing.T) {
 	if !actions[3].Matches("get", "secrets") {
 		t.Fatalf("unexpected action: %#v", actions[3])
 	}
-	if !actions[4].Matches("create", "pods") {
+	if !actions[4].Matches("get", "serviceaccounts") {
 		t.Fatalf("unexpected action: %#v", actions[4])
+	}
+	if !actions[5].Matches("create", "serviceaccounts") {
+		t.Fatalf("unexpected action: %#v", actions[5])
+	}
+	if !actions[6].Matches("get", "roles") {
+		t.Fatalf("unexpected action: %#v", actions[6])
+	}
+	if !actions[7].Matches("create", "roles") {
+		t.Fatalf("unexpected action: %#v", actions[7])
+	}
+	if !actions[8].Matches("get", "rolebindings") {
+		t.Fatalf("unexpected action: %#v", actions[8])
+	}
+	if !actions[9].Matches("create", "rolebindings") {
+		t.Fatalf("unexpected action: %#v", actions[9])
+	}
+	if !actions[10].Matches("create", "pods") {
+		t.Fatalf("unexpected action: %#v", actions[10])
 	}
 }
 

--- a/pkg/operator/encryption/kms/preflight/pod_template_test.go
+++ b/pkg/operator/encryption/kms/preflight/pod_template_test.go
@@ -20,6 +20,7 @@ metadata:
     encryption.apiserver.operator.openshift.io/kms-preflight-config-hash: abc123
 spec:
   restartPolicy: Never
+  serviceAccountName: kms-preflight
   priorityClassName: system-cluster-critical
   nodeSelector:
     node-role.kubernetes.io/master: ""


### PR DESCRIPTION
This adds an deploy-only RBAC to ensure we can update the pod status conditions. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preflight checks now run with a dedicated service account.
  * Required RBAC access for the preflight pod is created automatically before the pod starts.
* **Bug Fixes**
  * Improved preflight reliability by granting permissions to read pods and update pod status.
  * Updated validation so generated pod definitions match the new service account setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->