### PR TITLE
CNTRLPLANE-3237: encryption/controllers: use PodScheduled as fallback for startup timeout

### DIFF
--- a/pkg/operator/encryption/controllers/kms_preflight_controller.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller.go
@@ -341,7 +341,7 @@ func (c *kmsPreflightController) sync(ctx context.Context, syncCtx factory.SyncC
 //     If Deploy fails, report the error.
 //
 //  3. Preflight required, pod exists (Status returns a PodStatus).
-//     Evaluate the pod state via readiness-gate conditions and phase:
+//     Evaluate the pod state via conditions and phase:
 //
 //     a) Pod phase is Failed — the pod crashed before or after posting
 //     conditions. Report degraded and keep the pod for inspection. The
@@ -486,7 +486,8 @@ func podFailureError(podStatus corev1.PodStatus) *preflightError {
 }
 
 func podStartupTimeoutError(podStatus corev1.PodStatus, msgPrefix string) *preflightError {
-	if podStatus.StartTime == nil || time.Since(podStatus.StartTime.Time) <= preflightPodStartupTimeout {
+	startTime := podStartupTimestamp(podStatus)
+	if startTime == nil || time.Since(startTime.Time) <= preflightPodStartupTimeout {
 		return nil
 	}
 	reason, detail := podStuckReasonAndMessage(podStatus)
@@ -494,6 +495,20 @@ func podStartupTimeoutError(podStatus corev1.PodStatus, msgPrefix string) *prefl
 		reason:  reason,
 		message: fmt.Sprintf("%s after %s: %s", msgPrefix, preflightPodStartupTimeout, detail),
 	}
+}
+
+// podStartupTimestamp returns the best available timestamp for when the pod
+// began its startup. It prefers StartTime (set by kubelet), falling back to the
+// PodScheduled condition's LastTransitionTime for pods that never reached the
+// kubelet (e.g., stuck in Pending due to unschedulable resources).
+func podStartupTimestamp(podStatus corev1.PodStatus) *metav1.Time {
+	if podStatus.StartTime != nil {
+		return podStatus.StartTime
+	}
+	if c := findPodCondition(podStatus.Conditions, corev1.PodScheduled); c != nil {
+		return &c.LastTransitionTime
+	}
+	return nil
 }
 
 func podStuckReasonAndMessage(podStatus corev1.PodStatus) (string, string) {

--- a/pkg/operator/encryption/controllers/kms_preflight_controller_test.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller_test.go
@@ -578,6 +578,26 @@ func TestKMSPreflightController(t *testing.T) {
 			},
 		},
 		{
+			name: "pod stuck in Pending with no StartTime, falls back to PodScheduled condition for timeout",
+			deployer: &fakeDeployer{podStatus: corev1.PodStatus{
+				Phase: corev1.PodPending,
+				Conditions: []corev1.PodCondition{
+					{Type: corev1.PodScheduled, Status: corev1.ConditionTrue, LastTransitionTime: metav1.Time{Time: time.Now().Add(-5 * time.Minute)}},
+				},
+			}},
+			apiServerObjects: []runtime.Object{apiServerWithKMS},
+			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			operatorConditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
+			},
+			preconditionsMet: true,
+			expectedError:    "preflight pod has not reported config hash after 3m0s: pod is in Pending phase",
+			expectedConditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "Unknown", Message: "preflight pod has not reported config hash after 3m0s: pod is in Pending phase"},
+				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
+			},
+		},
+		{
 			name: "pod stuck in Pending without reporting hash, goes degraded with phase",
 			deployer: &fakeDeployer{podStatus: corev1.PodStatus{
 				Phase:     corev1.PodPending,


### PR DESCRIPTION
Pods that never reach the kubelet (e.g., unschedulable) have a nil StartTime, so the startup timeout never fires and the controller waits forever. Fall back to the PodScheduled condition timestamp when StartTime is nil.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of stalled preflight pods so timeout errors are reported more consistently, even when a pod never fully starts.
  * Added coverage for pods stuck in Pending state to ensure the expected degraded status and timeout message appear.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->