### PR TITLE
NO-JIRA: KMS Health Prober - hash nodename

### DIFF
--- a/pkg/operator/encryption/kms/health/options.go
+++ b/pkg/operator/encryption/kms/health/options.go
@@ -2,12 +2,12 @@ package health
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"time"
 
 	"github.com/spf13/pflag"
 
-	metav1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -61,11 +61,18 @@ func (o *options) validate() error {
 	if o.NodeName == "" {
 		return fmt.Errorf("--node-name is required")
 	}
-	if fieldManager := fmt.Sprintf("%s-%s", Subcommand, o.NodeName); len(fieldManager) > metav1validation.FieldManagerMaxLength {
-		return fmt.Errorf("--node-name too long: reporter identity %q is %d chars, exceeds the %d-char fieldManager limit", fieldManager, len(fieldManager), metav1validation.FieldManagerMaxLength)
-	}
 
 	return nil
+}
+
+// fieldManagerForNode returns the SSA field manager for a reporter on nodeName.
+// Node names can exceed the fieldManager length limit, so the name is hashed to
+// a fixed-size SHA-256 hex digest while the prober still reports the real name.
+// The node UID would also fit, but it is not exposed through the downward API in
+// the sidecar; querying the Node API for it would add unnecessary complexity.
+func fieldManagerForNode(nodeName string) string {
+	sum := sha256.Sum256([]byte(nodeName))
+	return fmt.Sprintf("%s-%x", Subcommand, sum)
 }
 
 func (o *options) Config(ctx context.Context) (*Config, error) {
@@ -82,7 +89,7 @@ func (o *options) Config(ctx context.Context) (*Config, error) {
 	// kube-apiserver runs one reporter per node: node-name must be unique!
 	// single-reporter operators, like oauth- / openshift-apiserver, can pass
 	// any constant value.
-	fieldManager := fmt.Sprintf("%s-%s", Subcommand, o.NodeName)
+	fieldManager := fieldManagerForNode(o.NodeName)
 	writeStatus, err := o.newWriter(restCfg, fieldManager)
 	if err != nil {
 		return nil, fmt.Errorf("build encryption status writer: %w", err)

--- a/pkg/operator/encryption/kms/health/options_test.go
+++ b/pkg/operator/encryption/kms/health/options_test.go
@@ -1,11 +1,15 @@
 package health
 
 import (
+	"crypto/sha256"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	metav1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 )
 
 // validOptions returns an options value that passes validate. Each test case
@@ -105,13 +109,8 @@ func TestValidate(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:   "node name at fieldManager limit",
-			mutate: func(o *options) { o.NodeName = strings.Repeat("n", 108) }, // 20-char prefix + 108 == 128
-		},
-		{
-			name:    "node name over fieldManager limit",
-			mutate:  func(o *options) { o.NodeName = strings.Repeat("n", 109) }, // 20-char prefix + 109 > 128
-			wantErr: true,
+			name:   "long node name",
+			mutate: func(o *options) { o.NodeName = strings.Repeat("n", 253) },
 		},
 	}
 
@@ -128,4 +127,15 @@ func TestValidate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFieldManagerForNode(t *testing.T) {
+	const nodeName = "node-1"
+	want := fmt.Sprintf("%s-%x", Subcommand, sha256.Sum256([]byte(nodeName)))
+
+	require.Equal(t, want, fieldManagerForNode(nodeName))
+	require.Equal(t, fieldManagerForNode(nodeName), fieldManagerForNode(nodeName))
+	require.NotEqual(t, fieldManagerForNode("node-1"), fieldManagerForNode("node-2"))
+	require.LessOrEqual(t, len(fieldManagerForNode(nodeName)), metav1validation.FieldManagerMaxLength)
+	require.LessOrEqual(t, len(fieldManagerForNode(strings.Repeat("n", 253))), metav1validation.FieldManagerMaxLength)
 }


### PR DESCRIPTION
This adds a simple SHA-256 hash of the nodename, with additional reasoning as to why we couldn't use anything else at this point.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of long node names so configuration no longer fails because of field manager length limits.
  * Made resource update identities consistent and deterministic across runs, including for long names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->