### PR TITLE
NO-JIRA: update preflight pod manifest

### DIFF
--- a/pkg/operator/encryption/kms/preflight/assets/kms-preflight-pod.yaml
+++ b/pkg/operator/encryption/kms/preflight/assets/kms-preflight-pod.yaml
@@ -12,7 +12,9 @@ spec:
   # This is a one-shot preflight check, not a long-running pod.
   # The operator creates it, waits for completion, and inspects the result.
   restartPolicy: Never
+{{- if not .StaticPod}}
   serviceAccountName: kms-preflight
+{{- end}}
   priorityClassName: system-cluster-critical
   nodeSelector:
     node-role.kubernetes.io/master: ""
@@ -24,6 +26,13 @@ spec:
     - key: "node-role.kubernetes.io/master"
       operator: "Exists"
       effect: "NoExecute"
+{{- if .StaticPod}}
+  hostNetwork: true
+  volumes:
+    - name: resource-dir
+      hostPath:
+        path: /etc/kubernetes/manifests
+{{- end}}
   containers:
     - name: kms-preflight-check
       image: {{.OperatorImage}}
@@ -32,8 +41,10 @@ spec:
         - --kms-call-timeout={{.KMSCallTimeout}}
         - --config-hash=$(CONFIG_HASH)
         - --pod-name=$(POD_NAME)
-        - --pod-namespace=$(POD_NAMESPACE){{if .Kubeconfig}}
-        - --kubeconfig={{.Kubeconfig}}{{end}}
+        - --pod-namespace=$(POD_NAMESPACE)
+{{- if .StaticPod}}
+        - --kubeconfig=/etc/kubernetes/static-pod-resources/secrets/kms-preflight-encryption-config/lb-int.kubeconfig
+{{- end}}
       env:
       - name: POD_NAME
         valueFrom: { fieldRef: { fieldPath: metadata.name } }
@@ -46,3 +57,11 @@ spec:
         requests:
           memory: 50Mi
           cpu: 5m
+{{- if .StaticPod}}
+      securityContext:
+        runAsUser: 0
+      volumeMounts:
+        - name: resource-dir
+          mountPath: /etc/kubernetes/static-pod-resources
+          readOnly: true
+{{- end}}

--- a/pkg/operator/encryption/kms/preflight/deployer.go
+++ b/pkg/operator/encryption/kms/preflight/deployer.go
@@ -75,7 +75,6 @@ func (d *PodPreflightDeployer) Deploy(ctx context.Context, configHash string, en
 		d.operatorImage,
 		d.operatorCommand,
 		d.kmsCallTimeout,
-		"",
 	)
 	if err != nil {
 		return fmt.Errorf("failed to generate preflight pod template: %w", err)

--- a/pkg/operator/encryption/kms/preflight/pod_template.go
+++ b/pkg/operator/encryption/kms/preflight/pod_template.go
@@ -19,7 +19,32 @@ type kmsPreflightTemplate struct {
 	OperatorImage  string
 	Command        string
 	KMSCallTimeout string
-	Kubeconfig     string
+	StaticPod      bool
+}
+
+func newKmsPreflightTemplate(
+	podName string,
+	namespace string,
+	configHash string,
+	operatorImage string,
+	operatorCommand []string,
+	kmsCallTimeout time.Duration,
+	staticPod bool,
+) kmsPreflightTemplate {
+	operatorCommandQuoted := make([]string, len(operatorCommand))
+	for i, cmd := range operatorCommand {
+		operatorCommandQuoted[i] = fmt.Sprintf("%q", cmd)
+	}
+
+	return kmsPreflightTemplate{
+		PodName:        podName,
+		Namespace:      namespace,
+		ConfigHash:     configHash,
+		OperatorImage:  operatorImage,
+		Command:        strings.Join(operatorCommandQuoted, ","),
+		KMSCallTimeout: kmsCallTimeout.String(),
+		StaticPod:      staticPod,
+	}
 }
 
 // generatePodTemplate renders the KMS preflight pod YAML template.
@@ -32,25 +57,40 @@ func generatePodTemplate(
 	operatorImage string,
 	operatorCommand []string,
 	kmsCallTimeout time.Duration,
-	kubeconfig string,
+) (*corev1.Pod, error) {
+	return renderPreflightPodTemplate(podName, namespace, configHash, operatorImage, operatorCommand, kmsCallTimeout, false)
+}
+
+// generateStaticPodTemplate renders the KMS preflight static pod YAML template.
+func generateStaticPodTemplate(
+	podName string,
+	namespace string,
+	configHash string,
+	operatorImage string,
+	operatorCommand []string,
+	kmsCallTimeout time.Duration,
+) (*corev1.Pod, error) {
+	return renderPreflightPodTemplate(podName, namespace, configHash, operatorImage, operatorCommand, kmsCallTimeout, true)
+}
+
+func renderPreflightPodTemplate(
+	podName string,
+	namespace string,
+	configHash string,
+	operatorImage string,
+	operatorCommand []string,
+	kmsCallTimeout time.Duration,
+	staticPod bool,
 ) (*corev1.Pod, error) {
 	rawManifest := mustAsset("assets/kms-preflight-pod.yaml")
+	tmplVal := newKmsPreflightTemplate(
+		podName, namespace, configHash, operatorImage, operatorCommand, kmsCallTimeout, staticPod,
+	)
+	return renderPodTemplate("kms-preflight", string(rawManifest), tmplVal)
+}
 
-	operatorCommandQuoted := make([]string, len(operatorCommand))
-	for i, cmd := range operatorCommand {
-		operatorCommandQuoted[i] = fmt.Sprintf("%q", cmd)
-	}
-
-	tmplVal := kmsPreflightTemplate{
-		PodName:        podName,
-		Namespace:      namespace,
-		ConfigHash:     configHash,
-		OperatorImage:  operatorImage,
-		Command:        strings.Join(operatorCommandQuoted, ","),
-		KMSCallTimeout: kmsCallTimeout.String(),
-		Kubeconfig:     kubeconfig,
-	}
-	tmpl, err := template.New("kms-preflight").Parse(string(rawManifest))
+func renderPodTemplate(name, rawManifest string, tmplVal any) (*corev1.Pod, error) {
+	tmpl, err := template.New(name).Parse(rawManifest)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operator/encryption/kms/preflight/pod_template_test.go
+++ b/pkg/operator/encryption/kms/preflight/pod_template_test.go
@@ -65,13 +65,94 @@ func TestGeneratePodTemplate(t *testing.T) {
 		"quay.io/openshift/operator:latest",
 		[]string{"operator", "kms-preflight"},
 		10*time.Second,
-		"",
 	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	expectedPod, err := resourceread.ReadPodV1([]byte(expectedPodYAML))
+	if err != nil {
+		t.Fatalf("failed to parse expected pod YAML: %v", err)
+	}
+	if !equality.Semantic.DeepEqual(pod, expectedPod) {
+		t.Fatalf("pod does not match expected:\ngot:  %+v\nwant: %+v", pod, expectedPod)
+	}
+}
+
+var expectedStaticPodYAML = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kms-preflight
+  namespace: test-ns
+  labels:
+    app: openshift-kms-preflight
+  annotations:
+    encryption.apiserver.operator.openshift.io/kms-preflight-config-hash: abc123
+spec:
+  restartPolicy: Never
+  priorityClassName: system-cluster-critical
+  nodeSelector:
+    node-role.kubernetes.io/master: ""
+  tolerations:
+    - key: node-role.kubernetes.io/master
+      operator: Exists
+      effect: NoSchedule
+    - key: node-role.kubernetes.io/master
+      operator: Exists
+      effect: NoExecute
+  hostNetwork: true
+  containers:
+    - name: kms-preflight-check
+      image: quay.io/openshift/operator:latest
+      command: ["operator","kms-preflight"]
+      args:
+        - --kms-call-timeout=10s
+        - --config-hash=$(CONFIG_HASH)
+        - --pod-name=$(POD_NAME)
+        - --pod-namespace=$(POD_NAMESPACE)
+        - --kubeconfig=/etc/kubernetes/static-pod-resources/secrets/kms-preflight-encryption-config/lb-int.kubeconfig
+      env:
+      - name: POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: POD_NAMESPACE
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.namespace
+      - name: CONFIG_HASH
+        value: abc123
+      resources:
+        requests:
+          memory: 50Mi
+          cpu: 5m
+      securityContext:
+        runAsUser: 0
+      volumeMounts:
+        - name: resource-dir
+          mountPath: /etc/kubernetes/static-pod-resources
+          readOnly: true
+  volumes:
+    - name: resource-dir
+      hostPath:
+        path: /etc/kubernetes/manifests
+`
+
+func TestGenerateStaticPodTemplate(t *testing.T) {
+	pod, err := generateStaticPodTemplate(
+		preflightPodName,
+		"test-ns",
+		"abc123",
+		"quay.io/openshift/operator:latest",
+		[]string{"operator", "kms-preflight"},
+		10*time.Second,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expectedPod, err := resourceread.ReadPodV1([]byte(expectedStaticPodYAML))
 	if err != nil {
 		t.Fatalf("failed to parse expected pod YAML: %v", err)
 	}


### PR DESCRIPTION
to facilitate static pods, this is a spin-off from #2345.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for running KMS preflight checks in both standard and static pod modes.
  * Static pod mode now uses host networking and mounts the Kubernetes manifests directory automatically.

* **Bug Fixes**
  * Improved pod configuration so the correct service account and kubeconfig are applied based on the selected mode.
  * Updated pod setup to better match the required runtime permissions for static pod environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->