### PR TITLE
CNTRLPLANE-3237: Add inParallel helper for running encryption test steps concurrently

### DIFF
--- a/test/library/encryption/helpers.go
+++ b/test/library/encryption/helpers.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -473,5 +474,37 @@ func WaitForCurrentKeyMigrated(t testing.TB, kubeClient kubernetes.Interface, pr
 	}); err != nil {
 		newErr := fmt.Errorf("timed out waiting for key %q to complete migration of %v: %v", prevKeyMeta.Name, targetGRs, err)
 		require.NoError(t, newErr)
+	}
+}
+
+// inParallel returns a single testStep that runs the given steps
+// concurrently and waits for all to finish before returning.
+// Panics are caught and reported via t.Errorf. Failures from
+// t.FailNow/require (runtime.Goexit) are handled naturally since
+// the testing framework already records the error on t.
+func inParallel(steps ...testStep) testStep {
+	if len(steps) == 1 {
+		return steps[0]
+	}
+	names := make([]string, len(steps))
+	for i, s := range steps {
+		names[i] = s.name
+	}
+	return testStep{
+		name: strings.Join(names, " | "),
+		testFunc: func(t testing.TB) {
+			var wg sync.WaitGroup
+			for _, s := range steps {
+				wg.Go(func() {
+					defer func() {
+						if r := recover(); r != nil {
+							t.Errorf("step %q panicked: %v", s.name, r)
+						}
+					}()
+					s.testFunc(t)
+				})
+			}
+			wg.Wait()
+		},
 	}
 }

--- a/test/library/encryption/helpers_test.go
+++ b/test/library/encryption/helpers_test.go
@@ -1,0 +1,136 @@
+package encryption
+
+import (
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// recordingTB intercepts failure methods so we can check Failed()
+// without actually failing the real test.
+type recordingTB struct {
+	*testing.T
+	failed atomic.Bool
+}
+
+func (r *recordingTB) Errorf(format string, args ...interface{}) {
+	r.failed.Store(true)
+	r.T.Logf("recorded error: "+format, args...)
+}
+
+func (r *recordingTB) FailNow() {
+	r.failed.Store(true)
+	runtime.Goexit()
+}
+
+func (r *recordingTB) Failed() bool { return r.failed.Load() }
+
+func countCompletions(steps []testStep, completed *atomic.Int32) []testStep {
+	wrapped := make([]testStep, len(steps))
+	for i, s := range steps {
+		wrapped[i] = testStep{name: s.name, testFunc: wrapWithCounter(s.testFunc, completed)}
+	}
+	return wrapped
+}
+
+func wrapWithCounter(fn func(testing.TB), completed *atomic.Int32) func(testing.TB) {
+	return func(t testing.TB) {
+		fn(t)
+		completed.Add(1)
+	}
+}
+
+func TestInParallel(t *testing.T) {
+	noop := func(t testing.TB) {}
+
+	tests := []struct {
+		name            string
+		steps           []testStep
+		expectName      string
+		expectFailed    bool
+		expectCompleted int32
+	}{
+		{
+			name:            "single step passes through",
+			steps:           []testStep{{name: "only", testFunc: noop}},
+			expectName:      "only",
+			expectCompleted: 1,
+		},
+		{
+			name: "all succeed",
+			steps: []testStep{
+				{name: "a", testFunc: noop},
+				{name: "b", testFunc: noop},
+			},
+			expectName:      "a | b",
+			expectCompleted: 2,
+		},
+		{
+			name: "panic fails test and other steps complete",
+			steps: []testStep{
+				{name: "ok-1", testFunc: noop},
+				{name: "panicker", testFunc: func(t testing.TB) { panic("boom") }},
+				{name: "ok-2", testFunc: noop},
+			},
+			expectName:      "ok-1 | panicker | ok-2",
+			expectFailed:    true,
+			expectCompleted: 2,
+		},
+		{
+			name: "FailNow fails test and other steps complete",
+			steps: []testStep{
+				{name: "ok", testFunc: noop},
+				{name: "failnow", testFunc: func(t testing.TB) { t.FailNow() }},
+			},
+			expectName:      "ok | failnow",
+			expectFailed:    true,
+			expectCompleted: 1,
+		},
+		{
+			name: "Errorf fails test and other steps complete",
+			steps: []testStep{
+				{name: "ok", testFunc: noop},
+				{name: "errorer", testFunc: func(t testing.TB) { t.Errorf("broke") }},
+			},
+			expectName:      "ok | errorer",
+			expectFailed:    true,
+			expectCompleted: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var completed atomic.Int32
+			rec := &recordingTB{T: t}
+			combined := inParallel(countCompletions(tt.steps, &completed)...)
+			combined.testFunc(rec)
+
+			if combined.name != tt.expectName {
+				t.Errorf("expected name %q, actual %q", tt.expectName, combined.name)
+			}
+			if rec.Failed() != tt.expectFailed {
+				t.Errorf("expected Failed()=%v, actual %v", tt.expectFailed, rec.Failed())
+			}
+			if actual := completed.Load(); actual != tt.expectCompleted {
+				t.Errorf("expected %d completed, actual %d", tt.expectCompleted, actual)
+			}
+		})
+	}
+}
+
+func TestInParallelRunsConcurrently(t *testing.T) {
+	sleep := func(t testing.TB) { time.Sleep(500 * time.Millisecond) }
+
+	start := time.Now()
+	inParallel(
+		testStep{name: "a", testFunc: sleep},
+		testStep{name: "b", testFunc: sleep},
+		testStep{name: "c", testFunc: sleep},
+	).testFunc(t)
+	elapsed := time.Since(start)
+
+	if elapsed >= 1*time.Second {
+		t.Errorf("expected ~500ms (parallel), actual %v (sequential would be ~1.5s)", elapsed)
+	}
+}


### PR DESCRIPTION
could be used as a more generic mechanism to run arbitrary scenarios for https://github.com/openshift/library-go/pull/2349

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added new unit tests covering the parallel execution behavior of encryption test steps.
  * Improved validation of composed step naming and failure handling (including panics and immediate failure).
  * Added a concurrency timing check to confirm multiple steps run concurrently rather than sequentially.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->