### PR TITLE
kms: remove TODO comment about resource requests in kms-preflight pod manifest

### DIFF
--- a/pkg/operator/encryption/kms/preflight/assets/kms-preflight-pod.yaml
+++ b/pkg/operator/encryption/kms/preflight/assets/kms-preflight-pod.yaml
@@ -52,7 +52,6 @@ spec:
         valueFrom: { fieldRef: { fieldPath: metadata.namespace } }
       - name: CONFIG_HASH
         value: {{.ConfigHash}}
-      # TODO: figure out good resource request values.
       resources:
         requests:
           memory: 50Mi


### PR DESCRIPTION
The current values should be good enough for a one shot pod. These values are also used for pods that use the same binary, but different commands in KASO.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an outdated note from the preflight pod template. No functional behavior or user-facing configuration changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->