### PR TITLE
kms: add EnsureKMSPluginSidecar* to prune stale sidecars

### DIFF
--- a/pkg/operator/encryption/kms/pluginlifecycle/builder.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/builder.go
@@ -107,6 +107,10 @@ func (b *KMSPluginBuilder) Apply(ctx context.Context, podSpec *corev1.PodSpec, c
 	if err != nil {
 		return fmt.Errorf("failed to get KMS configurations: %w", err)
 	}
+
+	// Strip all existing KMS-related resources before re-adding exactly what the current encryption config requires.
+	removeAllKMSManagedResources(podSpec, containerName)
+
 	if len(kmsConfigurations) == 0 {
 		klog.V(4).Infof("skipping KMS sidecar injection: no KMS plugins found in EncryptionConfiguration")
 		return nil

--- a/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
@@ -3,10 +3,12 @@ package pluginlifecycle
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/api/features"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
+	"github.com/openshift/library-go/pkg/operator/encryption/kms/health"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -25,6 +27,11 @@ const (
 	kmsPluginSocketMountPath  = "/var/run/kmsplugin"
 )
 
+const (
+	vaultSidecarPrefix = "vault-kms-plugin"
+	healthReporterName = "kms-health-reporter"
+)
+
 // sidecarProvider abstracts the construction of a KMS plugin sidecar container for a specific provider (e.g. Vault).
 type sidecarProvider interface {
 	// Name returns the identifier used to name the sidecar container and locate its volume mounts.
@@ -38,13 +45,15 @@ type sidecarProvider interface {
 func newSidecarProvider(keyID string, udsPath string, pluginConfig configv1.KMSPluginConfig, refData *referenceDataResolver) (sidecarProvider, error) {
 	switch pluginConfig.Type {
 	case configv1.VaultKMSProvider:
-		return newVaultSidecarProvider("vault-kms-plugin", keyID, udsPath, pluginConfig.Vault, refData)
+		return newVaultSidecarProvider(vaultSidecarPrefix, keyID, udsPath, pluginConfig.Vault, refData)
 	default:
 		return nil, fmt.Errorf("unsupported KMS plugin configuration")
 	}
 }
 
-// AddKMSPluginSidecarToStaticPodSpec injects KMS plugin sidecar containers into a kube-apiserver static pod spec.
+// EnsureKMSPluginSidecarInStaticPodSpec reconciles KMS plugin sidecar containers in a kube-apiserver static pod spec.
+// It removes all KMS-managed resources (sidecars, volumes, volume mounts) and then re-adds exactly what the
+// current encryption config requires, ensuring stale resources from a previous configuration are pruned.
 //
 // Static pods access KMS plugin data through the resource-dir volume, which the static pod revision controller
 // populates on disk from the encryption-config Secret. Because those files are owned by root, each sidecar
@@ -52,7 +61,7 @@ func newSidecarProvider(keyID string, udsPath string, pluginConfig configv1.KMSP
 //
 // It is a no-op when the KMSEncryption feature gate is not enabled or the encryption-config secret does not exist.
 // The secretClient should be uncached to avoid injecting sidecars based on a stale encryption configuration.
-func AddKMSPluginSidecarToStaticPodSpec(ctx context.Context, podSpec *corev1.PodSpec, containerName string, encryptionConfigNamespace string, encryptionConfigSecretName string, diskSecretName string, operatorBinary string, operatorImage string, secretClient corev1client.SecretsGetter, featureGateAccessor featuregates.FeatureGateAccess) error {
+func EnsureKMSPluginSidecarInStaticPodSpec(ctx context.Context, podSpec *corev1.PodSpec, containerName string, encryptionConfigNamespace string, encryptionConfigSecretName string, diskSecretName string, operatorBinary string, operatorImage string, secretClient corev1client.SecretsGetter, featureGateAccessor featuregates.FeatureGateAccess) error {
 	if !featureGateAccessor.AreInitialFeatureGatesObserved() {
 		return nil
 	}
@@ -72,11 +81,13 @@ func AddKMSPluginSidecarToStaticPodSpec(ctx context.Context, podSpec *corev1.Pod
 		Apply(ctx, podSpec, containerName)
 }
 
-// AddKMSPluginSidecarToPodSpec injects KMS plugin sidecar containers into an aggregated API server pod spec (e.g., openshift-apiserver, oauth-apiserver).
+// EnsureKMSPluginSidecarInPodSpec reconciles KMS plugin sidecar containers in an aggregated API server pod spec (e.g., openshift-apiserver, oauth-apiserver).
+// It removes all KMS-managed resources (sidecars, volumes, volume mounts) and then re-adds exactly what the
+// current encryption config requires, ensuring stale resources from a previous configuration are pruned.
 //
 // It is a no-op when the KMSEncryption feature gate is not enabled or the encryption-config secret does not exist.
 // The secretClient should be uncached to avoid injecting sidecars based on a stale encryption configuration.
-func AddKMSPluginSidecarToPodSpec(ctx context.Context, podSpec *corev1.PodSpec, containerName string, encryptionConfigNamespace string, encryptionConfigSecretName string, operatorBinary string, operatorImage string, secretClient corev1client.SecretsGetter, featureGateAccessor featuregates.FeatureGateAccess) error {
+func EnsureKMSPluginSidecarInPodSpec(ctx context.Context, podSpec *corev1.PodSpec, containerName string, encryptionConfigNamespace string, encryptionConfigSecretName string, operatorBinary string, operatorImage string, secretClient corev1client.SecretsGetter, featureGateAccessor featuregates.FeatureGateAccess) error {
 	if !featureGateAccessor.AreInitialFeatureGatesObserved() {
 		return nil
 	}
@@ -170,6 +181,57 @@ func ensureReferenceDataVolume(podSpec *corev1.PodSpec, secretName string) error
 		},
 	}
 	return ensureVolume(podSpec, volume)
+}
+
+func isKMSManagedContainer(name string) bool {
+	// Check if this is the KMS health reporter sidecar
+	if name == health.Subcommand {
+		return true
+	}
+	// Check if this is a Vault KMS plugin sidecar
+	if strings.HasPrefix(name, vaultSidecarPrefix+"-") {
+		return true
+	}
+	return false
+}
+
+func isKMSManagedVolume(name string) bool {
+	return name == kmsPluginSocketVolumeName || name == referenceDataVolumeName
+}
+
+// removeAllKMSManagedResources removes all KMS-managed initContainers, volumes, and volume mounts from the pod spec.
+// IMPORTANT: When adding new KMS resource types (e.g., ephemeral containers, config maps), update this function
+// and the corresponding isKMSManaged* helper functions. Failure to do so breaks the pre-ready revision checks
+// that rely on this Ensure function to achieve the desired state.
+func removeAllKMSManagedResources(podSpec *corev1.PodSpec, containerName string) {
+	filtered := podSpec.InitContainers[:0]
+	for _, c := range podSpec.InitContainers {
+		if !isKMSManagedContainer(c.Name) {
+			filtered = append(filtered, c)
+		}
+	}
+	podSpec.InitContainers = filtered
+
+	filteredVolumes := podSpec.Volumes[:0]
+	for _, v := range podSpec.Volumes {
+		if !isKMSManagedVolume(v.Name) {
+			filteredVolumes = append(filteredVolumes, v)
+		}
+	}
+	podSpec.Volumes = filteredVolumes
+
+	for i, c := range podSpec.Containers {
+		if c.Name == containerName {
+			mounts := c.VolumeMounts[:0]
+			for _, m := range c.VolumeMounts {
+				if m.Name != kmsPluginSocketVolumeName {
+					mounts = append(mounts, m)
+				}
+			}
+			podSpec.Containers[i].VolumeMounts = mounts
+			break
+		}
+	}
 }
 
 // setRunAsRoot sets RunAsUser=0 on the named container.

--- a/pkg/operator/encryption/kms/pluginlifecycle/sidecar_test.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/sidecar_test.go
@@ -1036,3 +1036,81 @@ func TestEnsureKMSPluginSidecarInStaticPodSpec(t *testing.T) {
 		})
 	}
 }
+
+// TestRemoveAllKMSManagedResourcesDrift verifies that removeAllKMSManagedResources cleans
+// up every resource type that Apply can create. If a new resource type is added to the ensure
+// path without a corresponding update to removeAllKMSManagedResources, this test will fail.
+func TestRemoveAllKMSManagedResourcesDrift(t *testing.T) {
+	f := newSidecarTestFixtures(t)
+	fga := featuregates.NewHardcodedFeatureGateAccess(
+		[]configv1.FeatureGateName{features.FeatureGateKMSEncryption}, nil,
+	)
+
+	noKMSConfig := &apiserverv1.EncryptionConfiguration{
+		Resources: []apiserverv1.ResourceConfiguration{
+			{
+				Resources: []string{"secrets"},
+				Providers: []apiserverv1.ProviderConfiguration{
+					{AESCBC: &apiserverv1.AESConfiguration{}},
+				},
+			},
+		},
+	}
+	noKMSBytes, err := encoding.EncodeEncryptionConfiguration(noKMSConfig)
+	require.NoError(t, err)
+
+	secretName := f.encryptionConfigSecret.Name
+	secretNamespace := f.encryptionConfigSecret.Namespace
+	noKMSSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: secretNamespace,
+		},
+		Data: map[string][]byte{"encryption-config": noKMSBytes},
+	}
+
+	tests := []struct {
+		name          string
+		containerName string
+		ensure        func(*corev1.PodSpec, string, corev1client.SecretsGetter) error
+	}{
+		{
+			name:          "deployment mode",
+			containerName: "openshift-apiserver",
+			ensure: func(podSpec *corev1.PodSpec, containerName string, sc corev1client.SecretsGetter) error {
+				return EnsureKMSPluginSidecarInPodSpec(context.Background(), podSpec, containerName, secretNamespace, secretName, "cluster-openshift-apiserver-operator", "quay.io/test/operator:latest", sc, fga)
+			},
+		},
+		{
+			name:          "static pod mode",
+			containerName: "kube-apiserver",
+			ensure: func(podSpec *corev1.PodSpec, containerName string, sc corev1client.SecretsGetter) error {
+				return EnsureKMSPluginSidecarInStaticPodSpec(context.Background(), podSpec, containerName, secretNamespace, secretName, "", "cluster-kube-apiserver-operator", "quay.io/test/operator:latest", sc, fga)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			podSpec := &corev1.PodSpec{
+				Containers: []corev1.Container{{Name: tt.containerName}},
+				Volumes:    []corev1.Volume{f.resourceDirVolume},
+			}
+
+			err := tt.ensure(podSpec, tt.containerName, fake.NewClientset(f.encryptionConfigSecret).CoreV1())
+			require.NoError(t, err)
+			require.NotEmpty(t, podSpec.InitContainers, "sanity: KMS sidecars should have been added")
+
+			err = tt.ensure(podSpec, tt.containerName, fake.NewClientset(noKMSSecret).CoreV1())
+			require.NoError(t, err)
+
+			require.Empty(t, podSpec.InitContainers, "all KMS init containers must be removed")
+			require.Equal(t, []corev1.Volume{f.resourceDirVolume}, podSpec.Volumes, "all KMS volumes must be removed")
+			for _, c := range podSpec.Containers {
+				if c.Name == tt.containerName {
+					require.Empty(t, c.VolumeMounts, "all KMS volume mounts must be removed")
+				}
+			}
+		})
+	}
+}

--- a/pkg/operator/encryption/kms/pluginlifecycle/sidecar_test.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/sidecar_test.go
@@ -106,7 +106,7 @@ func newSidecarTestFixtures(t *testing.T) sidecarTestFixtures {
 	}
 }
 
-func TestAddKMSPluginSidecarToPodSpec(t *testing.T) {
+func TestEnsureKMSPluginSidecarInPodSpec(t *testing.T) {
 	f := newSidecarTestFixtures(t)
 
 	secretClient := func(objs ...runtime.Object) corev1client.SecretsGetter {
@@ -556,7 +556,7 @@ func TestAddKMSPluginSidecarToPodSpec(t *testing.T) {
 			featureGateAccessor: featuregates.NewHardcodedFeatureGateAccess([]configv1.FeatureGateName{features.FeatureGateKMSEncryption}, nil),
 		},
 		{
-			name: "conflicting volume mount on API server container",
+			name: "conflicting volume mount on API server container is replaced",
 			actualPodSpec: &corev1.PodSpec{
 				Containers: []corev1.Container{
 					{
@@ -568,15 +568,164 @@ func TestAddKMSPluginSidecarToPodSpec(t *testing.T) {
 				},
 				Volumes: []corev1.Volume{f.resourceDirVolume},
 			},
+			expectedPodSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:         "kube-apiserver",
+						VolumeMounts: []corev1.VolumeMount{socketMount},
+					},
+				},
+				InitContainers: []corev1.Container{
+					{
+						Name:                     "vault-kms-plugin-555",
+						Image:                    "quay.io/test/vault:v1",
+						Args:                     sidecarArgs,
+						ImagePullPolicy:          corev1.PullIfNotPresent,
+						RestartPolicy:            ptr.To(corev1.ContainerRestartPolicyAlways),
+						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("64Mi"),
+								corev1.ResourceCPU:    resource.MustParse("10m"),
+							},
+						},
+						SecurityContext: &corev1.SecurityContext{
+							ReadOnlyRootFilesystem:   ptr.To(true),
+							AllowPrivilegeEscalation: ptr.To(false),
+							Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+							SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+						},
+						VolumeMounts: []corev1.VolumeMount{socketMount, refDataMount},
+					},
+					expectedHealthReporter("unix:///var/run/kmsplugin/kms-555.sock"),
+				},
+				Volumes: []corev1.Volume{f.resourceDirVolume, socketVolume, refDataVolume},
+			},
 			secretClient:        secretClient(f.encryptionConfigSecret),
 			featureGateAccessor: featuregates.NewHardcodedFeatureGateAccess([]configv1.FeatureGateName{features.FeatureGateKMSEncryption}, nil),
-			wantErr:             "already has volume mount kms-plugin-socket with different settings",
+		},
+		{
+			name: "stale sidecar from removed provider is pruned",
+			actualPodSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:         "kube-apiserver",
+						VolumeMounts: []corev1.VolumeMount{socketMount},
+					},
+				},
+				InitContainers: []corev1.Container{
+					{
+						Name:  "vault-kms-plugin-777",
+						Image: "quay.io/test/vault:v2",
+						Args:  []string{"-old-arg"},
+					},
+					{
+						Name:  "vault-kms-plugin-555",
+						Image: "quay.io/test/vault:v1",
+						Args:  []string{"-old-arg"},
+					},
+					{
+						Name:  "kms-health-reporter",
+						Image: "quay.io/test/operator:latest",
+					},
+				},
+				Volumes: []corev1.Volume{f.resourceDirVolume, socketVolume, refDataVolume},
+			},
+			expectedPodSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:         "kube-apiserver",
+						VolumeMounts: []corev1.VolumeMount{socketMount},
+					},
+				},
+				InitContainers: []corev1.Container{
+					{
+						Name:                     "vault-kms-plugin-555",
+						Image:                    "quay.io/test/vault:v1",
+						Args:                     sidecarArgs,
+						ImagePullPolicy:          corev1.PullIfNotPresent,
+						RestartPolicy:            ptr.To(corev1.ContainerRestartPolicyAlways),
+						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("64Mi"),
+								corev1.ResourceCPU:    resource.MustParse("10m"),
+							},
+						},
+						SecurityContext: &corev1.SecurityContext{
+							ReadOnlyRootFilesystem:   ptr.To(true),
+							AllowPrivilegeEscalation: ptr.To(false),
+							Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+							SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+						},
+						VolumeMounts: []corev1.VolumeMount{socketMount, refDataMount},
+					},
+					expectedHealthReporter("unix:///var/run/kmsplugin/kms-555.sock"),
+				},
+				Volumes: []corev1.Volume{f.resourceDirVolume, socketVolume, refDataVolume},
+			},
+			secretClient:        secretClient(f.encryptionConfigSecret),
+			featureGateAccessor: featuregates.NewHardcodedFeatureGateAccess([]configv1.FeatureGateName{features.FeatureGateKMSEncryption}, nil),
+		},
+		{
+			name: "all KMS resources removed when no KMS plugins in config",
+			actualPodSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:         "kube-apiserver",
+						VolumeMounts: []corev1.VolumeMount{socketMount},
+					},
+				},
+				InitContainers: []corev1.Container{
+					{
+						Name:  "vault-kms-plugin-555",
+						Image: "quay.io/test/vault:v1",
+					},
+					{
+						Name:  "kms-health-reporter",
+						Image: "quay.io/test/operator:latest",
+					},
+				},
+				Volumes: []corev1.Volume{f.resourceDirVolume, socketVolume, refDataVolume},
+			},
+			expectedPodSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:         "kube-apiserver",
+						VolumeMounts: []corev1.VolumeMount{},
+					},
+				},
+				InitContainers: []corev1.Container{},
+				Volumes:        []corev1.Volume{f.resourceDirVolume},
+			},
+			secretClient: func() corev1client.SecretsGetter {
+				noKMSConfig := &apiserverv1.EncryptionConfiguration{
+					Resources: []apiserverv1.ResourceConfiguration{
+						{
+							Resources: []string{"secrets"},
+							Providers: []apiserverv1.ProviderConfiguration{
+								{AESCBC: &apiserverv1.AESConfiguration{}},
+							},
+						},
+					},
+				}
+				noKMSBytes, err := encoding.EncodeEncryptionConfiguration(noKMSConfig)
+				require.NoError(t, err)
+				return secretClient(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "encryption-config",
+						Namespace: "openshift-kube-apiserver",
+					},
+					Data: map[string][]byte{"encryption-config": noKMSBytes},
+				})
+			}(),
+			featureGateAccessor: featuregates.NewHardcodedFeatureGateAccess([]configv1.FeatureGateName{features.FeatureGateKMSEncryption}, nil),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := AddKMSPluginSidecarToPodSpec(context.Background(), tt.actualPodSpec, "kube-apiserver", "openshift-kube-apiserver", "encryption-config", "cluster-kube-apiserver-operator", "quay.io/test/operator:latest", tt.secretClient, tt.featureGateAccessor)
+			err := EnsureKMSPluginSidecarInPodSpec(context.Background(), tt.actualPodSpec, "kube-apiserver", "openshift-kube-apiserver", "encryption-config", "cluster-kube-apiserver-operator", "quay.io/test/operator:latest", tt.secretClient, tt.featureGateAccessor)
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
 				return
@@ -587,7 +736,7 @@ func TestAddKMSPluginSidecarToPodSpec(t *testing.T) {
 	}
 }
 
-func TestAddKMSPluginSidecarToPodSpecIdempotency(t *testing.T) {
+func TestEnsureKMSPluginSidecarInPodSpecIdempotency(t *testing.T) {
 	f := newSidecarTestFixtures(t)
 	sc := fake.NewClientset(f.encryptionConfigSecret).CoreV1()
 	fga := featuregates.NewHardcodedFeatureGateAccess(
@@ -601,7 +750,7 @@ func TestAddKMSPluginSidecarToPodSpecIdempotency(t *testing.T) {
 
 	call := func() {
 		t.Helper()
-		err := AddKMSPluginSidecarToPodSpec(context.Background(), podSpec, "kube-apiserver", "openshift-kube-apiserver", "encryption-config", "cluster-kube-apiserver-operator", "quay.io/test/operator:latest", sc, fga)
+		err := EnsureKMSPluginSidecarInPodSpec(context.Background(), podSpec, "kube-apiserver", "openshift-kube-apiserver", "encryption-config", "cluster-kube-apiserver-operator", "quay.io/test/operator:latest", sc, fga)
 		require.NoError(t, err)
 	}
 
@@ -612,10 +761,10 @@ func TestAddKMSPluginSidecarToPodSpecIdempotency(t *testing.T) {
 	require.Equal(t, afterFirstCall, podSpec)
 }
 
-// TestAddKMSPluginSidecarToStaticPodSpec focuses on static-pod-specific behavior (resource-dir
-// paths, diskSecretName override). Error and edge cases are covered by TestAddKMSPluginSidecarToPodSpec
+// TestEnsureKMSPluginSidecarInStaticPodSpec focuses on static-pod-specific behavior (resource-dir
+// paths, diskSecretName override). Error and edge cases are covered by TestEnsureKMSPluginSidecarInPodSpec
 // since both functions share the same underlying KMSPluginBuilder.Apply logic.
-func TestAddKMSPluginSidecarToStaticPodSpec(t *testing.T) {
+func TestEnsureKMSPluginSidecarInStaticPodSpec(t *testing.T) {
 	f := newSidecarTestFixtures(t)
 
 	secretClient := func(objs ...runtime.Object) corev1client.SecretsGetter {
@@ -750,6 +899,50 @@ func TestAddKMSPluginSidecarToStaticPodSpec(t *testing.T) {
 			featureGateAccessor: featuregates.NewHardcodedFeatureGateAccess([]configv1.FeatureGateName{features.FeatureGateKMSEncryption}, nil),
 		},
 		{
+			name:           "stale sidecar from removed provider is pruned",
+			diskSecretName: "",
+			actualPodSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:         "kube-apiserver",
+						VolumeMounts: []corev1.VolumeMount{socketMount},
+					},
+				},
+				InitContainers: []corev1.Container{
+					{
+						Name:  "vault-kms-plugin-777",
+						Image: "quay.io/test/vault:v2",
+						Args:  []string{"-old-arg"},
+					},
+					{
+						Name:  "vault-kms-plugin-555",
+						Image: "quay.io/test/vault:v1",
+						Args:  []string{"-old-arg"},
+					},
+					{
+						Name:  "kms-health-reporter",
+						Image: "quay.io/test/operator:latest",
+					},
+				},
+				Volumes: []corev1.Volume{f.resourceDirVolume, socketVolume},
+			},
+			expectedPodSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:         "kube-apiserver",
+						VolumeMounts: []corev1.VolumeMount{socketMount},
+					},
+				},
+				InitContainers: []corev1.Container{
+					expectedSidecar("encryption-config"),
+					expectedHealthReporter("unix:///var/run/kmsplugin/kms-555.sock"),
+				},
+				Volumes: []corev1.Volume{f.resourceDirVolume, socketVolume},
+			},
+			secretClient:        secretClient(f.encryptionConfigSecret),
+			featureGateAccessor: featuregates.NewHardcodedFeatureGateAccess([]configv1.FeatureGateName{features.FeatureGateKMSEncryption}, nil),
+		},
+		{
 			name:           "diskSecretName overrides on-disk path",
 			diskSecretName: "custom-disk-secret",
 			actualPodSpec: &corev1.PodSpec{
@@ -774,11 +967,66 @@ func TestAddKMSPluginSidecarToStaticPodSpec(t *testing.T) {
 			secretClient:        secretClient(f.encryptionConfigSecret),
 			featureGateAccessor: featuregates.NewHardcodedFeatureGateAccess([]configv1.FeatureGateName{features.FeatureGateKMSEncryption}, nil),
 		},
+		{
+			name:           "all KMS resources removed when no KMS plugins in config",
+			diskSecretName: "",
+			actualPodSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:         "kube-apiserver",
+						VolumeMounts: []corev1.VolumeMount{socketMount},
+					},
+				},
+				InitContainers: []corev1.Container{
+					{
+						Name:  "vault-kms-plugin-555",
+						Image: "quay.io/test/vault:v1",
+					},
+					{
+						Name:  "kms-health-reporter",
+						Image: "quay.io/test/operator:latest",
+					},
+				},
+				Volumes: []corev1.Volume{f.resourceDirVolume, socketVolume},
+			},
+			expectedPodSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:         "kube-apiserver",
+						VolumeMounts: []corev1.VolumeMount{},
+					},
+				},
+				InitContainers: []corev1.Container{},
+				Volumes:        []corev1.Volume{f.resourceDirVolume},
+			},
+			secretClient: func() corev1client.SecretsGetter {
+				noKMSConfig := &apiserverv1.EncryptionConfiguration{
+					Resources: []apiserverv1.ResourceConfiguration{
+						{
+							Resources: []string{"secrets"},
+							Providers: []apiserverv1.ProviderConfiguration{
+								{AESCBC: &apiserverv1.AESConfiguration{}},
+							},
+						},
+					},
+				}
+				noKMSBytes, err := encoding.EncodeEncryptionConfiguration(noKMSConfig)
+				require.NoError(t, err)
+				return secretClient(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "encryption-config",
+						Namespace: "openshift-kube-apiserver",
+					},
+					Data: map[string][]byte{"encryption-config": noKMSBytes},
+				})
+			}(),
+			featureGateAccessor: featuregates.NewHardcodedFeatureGateAccess([]configv1.FeatureGateName{features.FeatureGateKMSEncryption}, nil),
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := AddKMSPluginSidecarToStaticPodSpec(context.Background(), tt.actualPodSpec, "kube-apiserver", "openshift-kube-apiserver", "encryption-config", tt.diskSecretName, "cluster-kube-apiserver-operator", "quay.io/test/operator:latest", tt.secretClient, tt.featureGateAccessor)
+			err := EnsureKMSPluginSidecarInStaticPodSpec(context.Background(), tt.actualPodSpec, "kube-apiserver", "openshift-kube-apiserver", "encryption-config", tt.diskSecretName, "cluster-kube-apiserver-operator", "quay.io/test/operator:latest", tt.secretClient, tt.featureGateAccessor)
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
 				return


### PR DESCRIPTION
The existing Add* functions use upsert semantics, which leaves orphaned KMS sidecar containers, health reporters, and volumes when a provider is removed from the encryption configuration.

This PR adds EnsureKMSPluginSidecarInStaticPodSpec, which removes all KMS-managed resources before re-adding exactly what the current config requires.

Proofs:

* https://github.com/openshift/cluster-kube-apiserver-operator/pull/2231
* https://github.com/openshift/cluster-openshift-apiserver-operator/pull/733

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - KMS encryption resources are now reconciled more reliably when encryption settings change.
  - Stale KMS sidecars, initialization containers, volume mounts, and related volumes are automatically removed.
  - All KMS-managed resources are cleaned up when no KMS plugins are configured.
  - Conflicting socket mounts are corrected instead of causing pod specification errors.
- **Improvements**
  - KMS sidecar detection is more consistent across deployment and static-pod configurations.
  - Existing resources are updated to match current encryption requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->