### PR TITLE
CNTRLPLANE-3237  test/encryption: fix inParallel crashing when a step fails under Ginkgo

### DIFF
--- a/test/library/encryption/helpers.go
+++ b/test/library/encryption/helpers.go
@@ -553,17 +553,27 @@ func inParallel(steps ...testStep) testStep {
 		name: strings.Join(names, " | "),
 		testFunc: func(t testing.TB) {
 			var wg sync.WaitGroup
+			var mu sync.Mutex
+			var panicMsgs []string
 			for _, s := range steps {
 				wg.Go(func() {
 					defer func() {
 						if r := recover(); r != nil {
-							t.Errorf("step %q panicked: %v", s.name, r)
+							// don't call t.Errorf here: in Ginkgo, t.Errorf panics,
+							// and a panic inside recover crashes the goroutine.
+							mu.Lock()
+							panicMsgs = append(panicMsgs, fmt.Sprintf("step %q panicked: %v", s.name, r))
+							mu.Unlock()
 						}
 					}()
 					s.testFunc(t)
 				})
 			}
 			wg.Wait()
+			// report all panics at once from the outer goroutine, where t.Errorf is safe.
+			if len(panicMsgs) > 0 {
+				t.Errorf("%s", strings.Join(panicMsgs, "\n"))
+			}
 		},
 	}
 }


### PR DESCRIPTION
In Ginkgo t.Errorf panics (via Ginkgo's Fail()) instead of just recording an error. inParallel was calling t.Errorf inside a goroutine's recover(), which caused a second unrecovered panic that crashed the test binary.


xref: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_cluster-kube-apiserver-operator/2229/pull-ci-openshift-cluster-kube-apiserver-operator-main-e2e-aws-operator-encryption-kms/2077767303990087680

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for concurrent test execution.
  * Ensured panics from parallel test steps are collected and reported safely after all steps finish.
  * Consolidated multiple panic messages into a single test failure report.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->