### PR TITLE
NO-JIRA: csr: fix RequestCommonNameFilter and the self-signing denial path

### DIFF
--- a/pkg/operator/csr/csr_approver.go
+++ b/pkg/operator/csr/csr_approver.go
@@ -113,7 +113,7 @@ func (c *csrApproverController) sync(ctx context.Context, syncCtx factory.SyncCo
 	}
 
 	if x509CSR.Subject.CommonName == csr.Spec.Username {
-		c.denyCSR(ctx, csrCopy, "IllegitimateRequester", "requester cannot request certificates for themselves", syncCtx.Recorder())
+		return c.denyCSR(ctx, csrCopy, "IllegitimateRequester", "requester cannot request certificates for themselves", syncCtx.Recorder())
 	}
 
 	csrDecision, denyReason, err := c.csrApprover.Approve(csr, x509CSR)
@@ -283,8 +283,14 @@ func NewRequestCommonNameFilter(commonNames ...string) *RequestCommonNameFilter 
 	return &RequestCommonNameFilter{sets.New(commonNames...)}
 }
 
-func (f *RequestCommonNameFilter) Match(csr *certapiv1.CertificateSigningRequest) bool {
-	x509CSR, err := x509.ParseCertificateRequest(csr.Spec.Request)
+func (f *RequestCommonNameFilter) Matches(csr *certapiv1.CertificateSigningRequest) bool {
+	csrPEM, _ := pem.Decode(csr.Spec.Request)
+	if csrPEM == nil {
+		klog.V(4).Infof("failed to PEM-parse the CSR block in .spec.request of %q: no CSRs were found", csr.Name)
+		return false
+	}
+
+	x509CSR, err := x509.ParseCertificateRequest(csrPEM.Bytes)
 	if err != nil {
 		klog.V(4).Infof("failed to parse the CSR .spec.request of %q: %v", csr.Name, err)
 		return false

--- a/pkg/operator/csr/csr_approver_test.go
+++ b/pkg/operator/csr/csr_approver_test.go
@@ -399,3 +399,53 @@ func (c fakeSyncContext) QueueKey() string {
 func (c fakeSyncContext) Recorder() events.Recorder {
 	return c.eventRecorder
 }
+
+func TestRequestCommonNameFilter(t *testing.T) {
+	// the filter has to satisfy CSRFilter to be usable in a filter chain
+	var _ CSRFilter = NewRequestCommonNameFilter("whatever")
+
+	tests := []struct {
+		name        string
+		commonNames []string
+		request     []byte
+		want        bool
+	}{
+		{
+			name:        "PEM-armored CSR with a listed CN",
+			commonNames: []string{"someone-else", "therealyou"},
+			request:     genCSR(t, "therealyou"),
+			want:        true,
+		},
+		{
+			name:        "PEM-armored CSR with an unlisted CN",
+			commonNames: []string{"therealyou"},
+			request:     genCSR(t, "someone-else"),
+			want:        false,
+		},
+		{
+			name:        "no PEM block at all",
+			commonNames: []string{"therealyou"},
+			request:     []byte("this is not a PEM block"),
+			want:        false,
+		},
+		{
+			name:        "empty request",
+			commonNames: []string{"therealyou"},
+			request:     nil,
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := NewRequestCommonNameFilter(tt.commonNames...)
+			got := f.Matches(&certapiv1.CertificateSigningRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-csr"},
+				Spec:       certapiv1.CertificateSigningRequestSpec{Request: tt.request},
+			})
+			if got != tt.want {
+				t.Errorf("Matches() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Three small fixes in `pkg/operator/csr/csr_approver.go`. All of them are correctness issues, not security issues, since every one of the broken paths fails closed. Details below.

### `RequestCommonNameFilter` doesn't satisfy `CSRFilter`

The method is declared as `Match`, but the interface wants `Matches`. `AndFilter`, `OrFilter`, `LabelFilter` and `NamesFilter` all declare `Matches`, so this one is the odd one out and the type can't actually be passed to `NewCSRApproverController`. Renamed it.

This is technically a rename of an exported method, but since the type never satisfied the interface it was meant for, there's no working filter-chain usage to break. Nothing in the tree calls it.

### `RequestCommonNameFilter` parses PEM as DER

`.spec.request` is PEM-armored, and the filter handed it straight to `x509.ParseCertificateRequest`. That parse always fails, so the filter logged at V(4) and returned false for everything. `sync()` a bit further up gets this right: it runs `pem.Decode` first and bails if the block is nil. Did the same here, returning false on a nil block rather than erroring, which matches how the other filters behave.

Fail-closed, so the worst case was a filter that silently matched nothing.

### Self-signing denial falls through to approval

In `sync()`, the `x509CSR.Subject.CommonName == csr.Spec.Username` branch called `denyCSR` but threw away the error and had no `return`, so it kept going and ran the approver. The two other `denyCSR` calls right below it (the `CSRApprovingFailed` and `CSRDenied` cases) both return. Added the `return`.

Worth being clear about the impact: this is not a bypass. The API server enforces mutual exclusion between Approved and Denied conditions, so the follow-up approval update doesn't land on an already-denied CSR. The real bug is that a failed denial got swallowed instead of surfacing, and the sync did extra work it shouldn't have.

### Testing

Added `TestRequestCommonNameFilter` covering a PEM CSR with a listed CN, one with an unlisted CN, a non-PEM request, and an empty request, plus a `var _ CSRFilter = ...` assertion.

Checked it fails before the fix, both parts. With the method renamed back to `Match`:

```
pkg/operator/csr/csr_approver_test.go:405:20: cannot use NewRequestCommonNameFilter("whatever") (value of type *RequestCommonNameFilter) as CSRFilter value in variable declaration: *RequestCommonNameFilter does not implement CSRFilter (missing method Matches)
```

And with only the `pem.Decode` reverted (keeping the rename so it compiles):

```
--- FAIL: TestRequestCommonNameFilter (0.02s)
    --- FAIL: TestRequestCommonNameFilter/PEM-armored_CSR_with_a_listed_CN (0.00s)
        csr_approver_test.go:447: Matches() = false, want true
```

After the fix, `go build ./...` is clean and `go test -count=1 ./pkg/operator/csr/...` passes:

```
ok  	github.com/openshift/library-go/pkg/operator/csr	3.645s
```

The existing `Test_csrApproverController_sync` cases still pass with the added `return`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Self-requested certificate signing requests are now denied immediately, preventing further approval processing.
  * Common Name filtering now correctly handles PEM-encoded certificate requests.
  * Invalid or empty certificate requests are safely rejected instead of causing processing errors.

* **Tests**
  * Added coverage for matching and non-matching Common Names, malformed requests, and empty requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->