### PR TITLE
NO-JIRA: add foundation for a basic KMS preflight drift test

### DIFF
--- a/pkg/operator/encryption/controllers/kms_preflight_controller.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller.go
@@ -403,7 +403,7 @@ func (c *kmsPreflightController) runPreflightChecks(ctx context.Context) (requeu
 	}
 
 	// Scenario 3b: pod has not reported its config hash yet.
-	hashCondition := findPodCondition(podStatus.Conditions, KMSPreflightConfigHashPodCondition)
+	hashCondition := FindPodCondition(podStatus.Conditions, KMSPreflightConfigHashPodCondition)
 	if hashCondition == nil {
 		if podStatus.Phase == corev1.PodSucceeded {
 			return false, &preflightError{reason: "PodCompletedWithoutResult", message: fmt.Sprintf("preflight pod completed without reporting result for hash %s", requiredHash)}
@@ -420,7 +420,7 @@ func (c *kmsPreflightController) runPreflightChecks(ctx context.Context) (requeu
 	}
 
 	// Scenario 3d: hash matches, waiting for result.
-	resultCondition := findPodCondition(podStatus.Conditions, KMSPreflightResultPodCondition)
+	resultCondition := FindPodCondition(podStatus.Conditions, KMSPreflightResultPodCondition)
 	if resultCondition == nil {
 		if podStatus.Phase == corev1.PodSucceeded {
 			return false, &preflightError{reason: "PodCompletedWithoutResult", message: fmt.Sprintf("preflight pod completed without reporting result for hash %s", requiredHash)}
@@ -505,7 +505,7 @@ func podStartupTimestamp(podStatus corev1.PodStatus) *metav1.Time {
 	if podStatus.StartTime != nil {
 		return podStatus.StartTime
 	}
-	if c := findPodCondition(podStatus.Conditions, corev1.PodScheduled); c != nil {
+	if c := FindPodCondition(podStatus.Conditions, corev1.PodScheduled); c != nil {
 		return &c.LastTransitionTime
 	}
 	return nil
@@ -531,7 +531,7 @@ func podStuckReasonAndMessage(podStatus corev1.PodStatus) (string, string) {
 	return reason, fmt.Sprintf("pod is in %s phase", podStatus.Phase)
 }
 
-func findPodCondition(conditions []corev1.PodCondition, condType corev1.PodConditionType) *corev1.PodCondition {
+func FindPodCondition(conditions []corev1.PodCondition, condType corev1.PodConditionType) *corev1.PodCondition {
 	for i := range conditions {
 		if conditions[i].Type == condType {
 			return &conditions[i]

--- a/pkg/operator/encryption/kms/preflight/deployer.go
+++ b/pkg/operator/encryption/kms/preflight/deployer.go
@@ -19,11 +19,15 @@ import (
 )
 
 const (
-	preflightPodName                    = "kms-preflight"
-	preflightCheckContainerName         = "kms-preflight-check"
-	preflightEncryptionConfigSecretName = "kms-preflight-encryption-config"
-	preflightRBACName                   = "kms-preflight"
-	preflightAppLabel                   = "openshift-kms-preflight"
+	// PodName is the fixed name of the preflight pod created by Deploy.
+	PodName = "kms-preflight"
+	// CheckContainerName is the container that runs the preflight checker command.
+	CheckContainerName = "kms-preflight-check"
+	// EncryptionConfigSecretName is the secret Deploy creates for the preflight pod.
+	EncryptionConfigSecretName = "kms-preflight-encryption-config"
+
+	preflightRBACName = "kms-preflight"
+	preflightAppLabel = "openshift-kms-preflight"
 )
 
 var (
@@ -64,14 +68,14 @@ func (d *PodPreflightDeployer) Deploy(ctx context.Context, configHash string, en
 
 	encryptionConfigSecret = encryptionConfigSecret.DeepCopy()
 	// rewrite the entire ObjectMeta to avoid copying resource versions or managed fields
-	encryptionConfigSecret.ObjectMeta = metav1.ObjectMeta{Namespace: d.namespace, Name: preflightEncryptionConfigSecretName, Labels: labels}
+	encryptionConfigSecret.ObjectMeta = metav1.ObjectMeta{Namespace: d.namespace, Name: EncryptionConfigSecretName, Labels: labels}
 	_, err := d.coreClient.Secrets(d.namespace).Create(ctx, encryptionConfigSecret, metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to create preflight encryption config secret: %w", err)
 	}
 
 	pod, err := renderPreflightPodTemplate(
-		preflightPodName,
+		PodName,
 		d.namespace,
 		configHash,
 		d.operatorImage,
@@ -85,8 +89,8 @@ func (d *PodPreflightDeployer) Deploy(ctx context.Context, configHash string, en
 
 	err = pluginlifecycle.NewKMSPluginBuilder().
 		WithSecretRequired().
-		FromEncryptionConfigSecret(d.namespace, preflightEncryptionConfigSecretName, d.coreClient).
-		Apply(ctx, &pod.Spec, preflightCheckContainerName)
+		FromEncryptionConfigSecret(d.namespace, EncryptionConfigSecretName, d.coreClient).
+		Apply(ctx, &pod.Spec, CheckContainerName)
 	if err != nil {
 		return fmt.Errorf("failed to apply preflight plugin: %w", err)
 	}
@@ -108,9 +112,9 @@ func (d *PodPreflightDeployer) Deploy(ctx context.Context, configHash string, en
 
 func (d *PodPreflightDeployer) Status(ctx context.Context) (corev1.PodStatus, error) {
 	// preflight status checks are not very frequent, so we use the live client instead of a cached lister
-	pod, err := d.coreClient.Pods(d.namespace).Get(ctx, preflightPodName, metav1.GetOptions{})
+	pod, err := d.coreClient.Pods(d.namespace).Get(ctx, PodName, metav1.GetOptions{})
 	if err != nil {
-		return corev1.PodStatus{}, fmt.Errorf("failed to get pod for preflight %s/%s: %w", d.namespace, preflightPodName, err)
+		return corev1.PodStatus{}, fmt.Errorf("failed to get pod for preflight %s/%s: %w", d.namespace, PodName, err)
 	}
 
 	return pod.Status, nil
@@ -120,14 +124,14 @@ func (d *PodPreflightDeployer) Cleanup(ctx context.Context) error {
 	// See Deploy: preflight RBAC is intentionally not deleted here.
 	var errs []error
 
-	err := d.coreClient.Pods(d.namespace).Delete(ctx, preflightPodName, metav1.DeleteOptions{})
+	err := d.coreClient.Pods(d.namespace).Delete(ctx, PodName, metav1.DeleteOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
-		errs = append(errs, fmt.Errorf("failed to delete pod %s/%s: %w", d.namespace, preflightPodName, err))
+		errs = append(errs, fmt.Errorf("failed to delete pod %s/%s: %w", d.namespace, PodName, err))
 	}
 
-	err = d.coreClient.Secrets(d.namespace).Delete(ctx, preflightEncryptionConfigSecretName, metav1.DeleteOptions{})
+	err = d.coreClient.Secrets(d.namespace).Delete(ctx, EncryptionConfigSecretName, metav1.DeleteOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
-		errs = append(errs, fmt.Errorf("failed to delete secret %s/%s: %w", d.namespace, preflightEncryptionConfigSecretName, err))
+		errs = append(errs, fmt.Errorf("failed to delete secret %s/%s: %w", d.namespace, EncryptionConfigSecretName, err))
 	}
 
 	return errors.Join(errs...)

--- a/pkg/operator/encryption/kms/preflight/deployer_test.go
+++ b/pkg/operator/encryption/kms/preflight/deployer_test.go
@@ -259,7 +259,7 @@ func testPreflightEncryptionConfigSecret(t *testing.T) *corev1.Secret {
 	}
 
 	config := testPreflightEncryptionConfigFromData(t, secretData, configMapData)
-	secret, err := encryptiondata.ToSecret(testNamespace, preflightEncryptionConfigSecretName, config)
+	secret, err := encryptiondata.ToSecret(testNamespace, EncryptionConfigSecretName, config)
 	if err != nil {
 		t.Fatalf("failed to build encryption config secret: %v", err)
 	}
@@ -474,7 +474,7 @@ func TestPodPreflightDeployer_Deploy_nilEncryptionConfigSecret(t *testing.T) {
 func TestPodPreflightDeployer_Deploy_secretCreateFailure(t *testing.T) {
 	deployer, kubeClient := newTestDeployer(t)
 	kubeClient.PrependReactor("create", "secrets", func(action clienttesting.Action) (bool, runtime.Object, error) {
-		return true, nil, apierrors.NewForbidden(corev1.Resource("secrets"), preflightEncryptionConfigSecretName, nil)
+		return true, nil, apierrors.NewForbidden(corev1.Resource("secrets"), EncryptionConfigSecretName, nil)
 	})
 
 	err := deployer.Deploy(context.Background(), testConfigHash, testPreflightEncryptionConfigSecret(t))
@@ -543,7 +543,7 @@ func TestPodPreflightDeployer_Deploy_pluginApplyFailure(t *testing.T) {
 func TestPodPreflightDeployer_Deploy_podCreateFailure(t *testing.T) {
 	deployer, kubeClient := newTestDeployer(t)
 	kubeClient.PrependReactor("create", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
-		return true, nil, apierrors.NewForbidden(corev1.Resource("pods"), preflightPodName, nil)
+		return true, nil, apierrors.NewForbidden(corev1.Resource("pods"), PodName, nil)
 	})
 
 	err := deployer.Deploy(context.Background(), testConfigHash, testPreflightEncryptionConfigSecret(t))
@@ -595,13 +595,13 @@ func TestPodPreflightDeployer_Deploy_podCreateFailure(t *testing.T) {
 func TestPodPreflightDeployer_Deploy_cleanupFailure(t *testing.T) {
 	existingPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      preflightPodName,
+			Name:      PodName,
 			Namespace: testNamespace,
 		},
 	}
 	deployer, kubeClient := newTestDeployer(t, existingPod)
 	kubeClient.PrependReactor("delete", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
-		return true, nil, apierrors.NewForbidden(corev1.Resource("pods"), preflightPodName, nil)
+		return true, nil, apierrors.NewForbidden(corev1.Resource("pods"), PodName, nil)
 	})
 
 	err := deployer.Deploy(context.Background(), testConfigHash, testPreflightEncryptionConfigSecret(t))
@@ -627,7 +627,7 @@ func TestPodPreflightDeployer_Deploy_deletesStaleResources(t *testing.T) {
 	ctx := context.Background()
 	stalePod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      preflightPodName,
+			Name:      PodName,
 			Namespace: testNamespace,
 		},
 	}
@@ -695,7 +695,7 @@ func TestPodPreflightDeployer_Status(t *testing.T) {
 			objects: []runtime.Object{
 				&corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      preflightPodName,
+						Name:      PodName,
 						Namespace: testNamespace,
 					},
 					Status: corev1.PodStatus{Phase: corev1.PodRunning},
@@ -729,7 +729,7 @@ func TestPodPreflightDeployer_Status(t *testing.T) {
 func TestPodPreflightDeployer_Cleanup(t *testing.T) {
 	existingPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      preflightPodName,
+			Name:      PodName,
 			Namespace: testNamespace,
 			Annotations: map[string]string{
 				configHashAnnotationKey: testConfigHash,
@@ -760,7 +760,7 @@ func TestPodPreflightDeployer_Cleanup(t *testing.T) {
 				if !ok {
 					t.Fatalf("expected DeleteAction, got %T", actions[0])
 				}
-				if deleteAction.GetName() != preflightPodName {
+				if deleteAction.GetName() != PodName {
 					t.Fatalf("unexpected pod name %q", deleteAction.GetName())
 				}
 				if deleteAction.GetNamespace() != testNamespace {
@@ -790,7 +790,7 @@ func TestPodPreflightDeployer_Cleanup(t *testing.T) {
 			objects: []runtime.Object{existingPod},
 			setupClient: func(kubeClient *fake.Clientset) {
 				kubeClient.PrependReactor("delete", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
-					return true, nil, apierrors.NewForbidden(corev1.Resource("pods"), preflightPodName, nil)
+					return true, nil, apierrors.NewForbidden(corev1.Resource("pods"), PodName, nil)
 				})
 			},
 			expectErr: "failed to delete pod",
@@ -811,7 +811,7 @@ func TestPodPreflightDeployer_Cleanup(t *testing.T) {
 			objects: []runtime.Object{existingSecret},
 			setupClient: func(kubeClient *fake.Clientset) {
 				kubeClient.PrependReactor("delete", "secrets", func(action clienttesting.Action) (bool, runtime.Object, error) {
-					return true, nil, apierrors.NewForbidden(corev1.Resource("secrets"), preflightEncryptionConfigSecretName, nil)
+					return true, nil, apierrors.NewForbidden(corev1.Resource("secrets"), EncryptionConfigSecretName, nil)
 				})
 			},
 			expectErr: "failed to delete secret",
@@ -834,10 +834,10 @@ func TestPodPreflightDeployer_Cleanup(t *testing.T) {
 			objects: []runtime.Object{existingPod, existingSecret},
 			setupClient: func(kubeClient *fake.Clientset) {
 				kubeClient.PrependReactor("delete", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
-					return true, nil, apierrors.NewForbidden(corev1.Resource("pods"), preflightPodName, nil)
+					return true, nil, apierrors.NewForbidden(corev1.Resource("pods"), PodName, nil)
 				})
 				kubeClient.PrependReactor("delete", "secrets", func(action clienttesting.Action) (bool, runtime.Object, error) {
-					return true, nil, apierrors.NewForbidden(corev1.Resource("secrets"), preflightEncryptionConfigSecretName, nil)
+					return true, nil, apierrors.NewForbidden(corev1.Resource("secrets"), EncryptionConfigSecretName, nil)
 				})
 			},
 			expectErrContains: []string{"failed to delete pod", "failed to delete secret"},

--- a/pkg/operator/encryption/kms/preflight/pod_template_test.go
+++ b/pkg/operator/encryption/kms/preflight/pod_template_test.go
@@ -59,7 +59,7 @@ spec:
 
 func TestGeneratePodTemplate(t *testing.T) {
 	pod, err := renderPreflightPodTemplate(
-		preflightPodName,
+		PodName,
 		"test-ns",
 		"abc123",
 		"quay.io/openshift/operator:latest",
@@ -132,7 +132,7 @@ spec:
 
 func TestGenerateStaticPodTemplate(t *testing.T) {
 	pod, err := renderPreflightPodTemplate(
-		preflightPodName,
+		PodName,
 		"test-ns",
 		"abc123",
 		"quay.io/openshift/operator:latest",

--- a/test/library/encryption/preflight_deploy.go
+++ b/test/library/encryption/preflight_deploy.go
@@ -1,0 +1,198 @@
+package encryption
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/library-go/pkg/operator/encryption/controllers"
+	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
+	"github.com/openshift/library-go/pkg/operator/encryption/kms/preflight"
+)
+
+const (
+	preflightDeployConfigHash = "e2e-preflight-drift"
+	// PreflightDeployCallTimeout is the KMS gRPC call timeout used by preflight e2e Deploy.
+	PreflightDeployCallTimeout  = 10 * time.Second
+	preflightKMSSocketEndpoint  = "unix:///var/run/kmsplugin/kms.sock"
+	preflightStatusPollInterval = 5 * time.Second
+	preflightStatusPollTimeout  = 5 * time.Minute
+	openshiftConfigNS           = "openshift-config"
+)
+
+// PreflightDeployScenario configures a real-cluster Deploy() check against a live
+// operand namespace. The operand namespace must already have preflight RBAC.
+//
+// BasicScenario.Namespace is the operand namespace (Deploy target).
+// BasicScenario.LabelSelector is reserved for a follow-up operand pod drift check.
+type PreflightDeployScenario struct {
+	BasicScenario
+	// CreateDeployerFunc builds the deployer (image, command, static-pod mode).
+	CreateDeployerFunc func(ctx context.Context, t testing.TB, clientSet ClientSet) *preflight.PodPreflightDeployer
+	// CreateEncryptionConfigFunc builds the encryption-config Secret Deploy mounts.
+	// Use VaultPreflightEncryptionConfigSecret for Vault.
+	CreateEncryptionConfigFunc func(ctx context.Context, t testing.TB, clientSet ClientSet, namespace string, plugin configv1.KMSPluginConfig) *corev1.Secret
+	// AssertDeployFunc validates the deployed preflight pod. Use AssertPreflightDeploy.
+	AssertDeployFunc func(ctx context.Context, t testing.TB, clientSet ClientSet, namespace string, deployer *preflight.PodPreflightDeployer)
+	// EncryptionProvider supplies KMS plugin config and optional Setup (e.g. AppRole
+	// secret). Prefer kms.DefaultVaultEncryptionProvider so references resolve.
+	EncryptionProvider EncryptionProvider
+}
+
+// TestPreflightDeployAndPodMatchesOperand deploys a preflight pod into the operand
+// namespace and runs AssertDeployFunc against it.
+func TestPreflightDeployAndPodMatchesOperand(ctx context.Context, t testing.TB, scenario PreflightDeployScenario) {
+	t.Helper()
+	require.NotEmpty(t, scenario.Namespace)
+	require.NotNil(t, scenario.CreateDeployerFunc)
+	require.NotNil(t, scenario.CreateEncryptionConfigFunc)
+	require.NotNil(t, scenario.AssertDeployFunc)
+	require.Equal(t, configv1.EncryptionTypeKMS, scenario.EncryptionProvider.Type)
+	require.NotEmpty(t, scenario.EncryptionProvider.KMS.Type)
+
+	if scenario.EncryptionProvider.Setup != nil {
+		scenario.EncryptionProvider.Setup(ctx, t)
+	}
+
+	clientSet := GetClients(t)
+	deployer := scenario.CreateDeployerFunc(ctx, t, clientSet)
+	require.NotNil(t, deployer)
+
+	secret := scenario.CreateEncryptionConfigFunc(ctx, t, clientSet, scenario.Namespace, scenario.EncryptionProvider.KMS)
+	require.NotNil(t, secret)
+
+	t.Cleanup(func() {
+		if err := deployer.Cleanup(context.Background()); err != nil {
+			t.Errorf("preflight Cleanup: %v", err)
+		}
+	})
+
+	require.NoError(t, deployer.Deploy(ctx, preflightDeployConfigHash, secret))
+	scenario.AssertDeployFunc(ctx, t, clientSet, scenario.Namespace, deployer)
+}
+
+// AssertPreflightDeploy waits for checker pod conditions and validates Deploy side effects
+// (check container, plugin init container, config-hash / result / KEK-ID conditions).
+func AssertPreflightDeploy(ctx context.Context, t testing.TB, clientSet ClientSet, namespace string, deployer *preflight.PodPreflightDeployer) {
+	t.Helper()
+	require.NotNil(t, deployer)
+	require.NotEmpty(t, namespace)
+
+	preflightPod, err := clientSet.Kube.CoreV1().Pods(namespace).Get(ctx, preflight.PodName, metav1.GetOptions{})
+	require.NoError(t, err, "preflight pod %s/%s", namespace, preflight.PodName)
+
+	require.Len(t, preflightPod.Spec.Containers, 1)
+	require.Equal(t, preflight.CheckContainerName, preflightPod.Spec.Containers[0].Name)
+	require.NotEmpty(t, preflightPod.Spec.InitContainers, "expected KMS plugin init container")
+
+	var status corev1.PodStatus
+	err = wait.PollUntilContextTimeout(ctx, preflightStatusPollInterval, preflightStatusPollTimeout, true, func(ctx context.Context) (bool, error) {
+		var statusErr error
+		status, statusErr = deployer.Status(ctx)
+		if statusErr != nil {
+			return false, statusErr
+		}
+		if status.Phase == corev1.PodFailed {
+			return false, fmt.Errorf("preflight pod failed: reason=%q message=%q", status.Reason, status.Message)
+		}
+		return controllers.FindPodCondition(status.Conditions, controllers.KMSPreflightResultPodCondition) != nil, nil
+	})
+	require.NoError(t, err, "waiting for KMSPreflightResult condition")
+
+	hashCond := requirePodCondition(t, status.Conditions, controllers.KMSPreflightConfigHashPodCondition, corev1.ConditionTrue)
+	require.Equal(t, preflightDeployConfigHash, hashCond.Message)
+
+	resultCond := requirePodCondition(t, status.Conditions, controllers.KMSPreflightResultPodCondition, corev1.ConditionTrue)
+	require.Equal(t, "Succeeded", resultCond.Reason)
+
+	kekCond := requirePodCondition(t, status.Conditions, controllers.KMSPreflightKEKIDPodCondition, corev1.ConditionTrue)
+	require.NotEmpty(t, kekCond.Message, "KEK ID")
+}
+
+func requirePodCondition(t testing.TB, conditions []corev1.PodCondition, condType corev1.PodConditionType, wantStatus corev1.ConditionStatus) *corev1.PodCondition {
+	t.Helper()
+	cond := controllers.FindPodCondition(conditions, condType)
+	require.NotNil(t, cond, "missing %s condition", condType)
+	require.Equal(t, wantStatus, cond.Status, "condition %s: %s", condType, cond.Message)
+	return cond
+}
+
+// OperatorImageFromDeployment returns the image of containerName from the named
+// Deployment. Used by preflight e2e to run the same operator binary the cluster
+// is already running, without requiring OPERATOR_IMAGE.
+func OperatorImageFromDeployment(ctx context.Context, t testing.TB, namespace, deploymentName, containerName string) string {
+	t.Helper()
+	clientSet := GetClients(t)
+	deploy, err := clientSet.Kube.AppsV1().Deployments(namespace).Get(ctx, deploymentName, metav1.GetOptions{})
+	require.NoError(t, err, "get operator deployment %s/%s", namespace, deploymentName)
+	for _, c := range deploy.Spec.Template.Spec.Containers {
+		if c.Name == containerName {
+			require.NotEmpty(t, c.Image, "operator container %q image must not be empty", containerName)
+			return c.Image
+		}
+	}
+	require.FailNow(t, fmt.Sprintf("container %q not found in deployment %s/%s", containerName, namespace, deploymentName))
+	return ""
+}
+
+// TODO(thomas): this should go away once we have an official mapping function between plugin config and transient encryption config
+func VaultPreflightEncryptionConfigSecret(ctx context.Context, t testing.TB, clientSet ClientSet, namespace string, plugin configv1.KMSPluginConfig) *corev1.Secret {
+	t.Helper()
+	require.Equal(t, configv1.VaultKMSProvider, plugin.Type, "preflight deploy e2e currently supports Vault only")
+	require.Equal(t, configv1.VaultAuthenticationTypeAppRole, plugin.Vault.Authentication.Type)
+
+	secretName := plugin.Vault.Authentication.AppRole.Secret.Name
+	require.NotEmpty(t, secretName, "Vault AppRole secret name")
+	refSecret, err := clientSet.Kube.CoreV1().Secrets(openshiftConfigNS).Get(ctx, secretName, metav1.GetOptions{})
+	require.NoError(t, err, "referenced AppRole secret %s/%s", openshiftConfigNS, secretName)
+
+	var secretData encryptiondata.KMSPluginsReferenceData
+	for _, key := range []string{"role-id", "secret-id"} {
+		v, ok := refSecret.Data[key]
+		require.True(t, ok, "secret %s/%s missing key %q", openshiftConfigNS, secretName, key)
+		require.NoError(t, secretData.SetFromRawKey("1", secretName+"_"+key, v))
+	}
+
+	var configMapData encryptiondata.KMSPluginsReferenceData
+	if cmName := plugin.Vault.TLS.CABundle.Name; cmName != "" {
+		refCM, err := clientSet.Kube.CoreV1().ConfigMaps(openshiftConfigNS).Get(ctx, cmName, metav1.GetOptions{})
+		require.NoError(t, err, "referenced CA ConfigMap %s/%s", openshiftConfigNS, cmName)
+		v, ok := refCM.Data["ca-bundle.crt"]
+		require.True(t, ok, "configmap %s/%s missing key ca-bundle.crt", openshiftConfigNS, cmName)
+		require.NoError(t, configMapData.SetFromRawKey("1", cmName+"_ca-bundle.crt", []byte(v)))
+	}
+
+	config := &encryptiondata.Config{
+		Encryption: &apiserverconfigv1.EncryptionConfiguration{
+			TypeMeta: metav1.TypeMeta{Kind: "EncryptionConfiguration", APIVersion: "apiserver.config.k8s.io/v1"},
+			Resources: []apiserverconfigv1.ResourceConfiguration{{
+				Resources: []string{"secrets"},
+				Providers: []apiserverconfigv1.ProviderConfiguration{
+					{KMS: &apiserverconfigv1.KMSConfiguration{
+						APIVersion: "v2",
+						Name:       "1_secrets",
+						Endpoint:   preflightKMSSocketEndpoint,
+						Timeout:    &metav1.Duration{Duration: PreflightDeployCallTimeout},
+					}},
+					{Identity: &apiserverconfigv1.IdentityConfiguration{}},
+				},
+			}},
+		},
+		KMSPlugins: map[string]configv1.KMSPluginConfig{
+			"1": plugin,
+		},
+		KMSPluginsSecretData:    secretData,
+		KMSPluginsConfigMapData: configMapData,
+	}
+	secret, err := encryptiondata.ToSecret(namespace, preflight.EncryptionConfigSecretName, config)
+	require.NoError(t, err)
+	return secret
+}


### PR DESCRIPTION
This PR exposes constants for the test to consume, adds an e2e test for the preflight deployer, which in turn will assert the drift between the operand pod and the preflight pod it deployed.

Fake bump PR: https://github.com/openshift/cluster-kube-apiserver-operator/pull/2233


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes / Improvements**
  * Standardized KMS encryption preflight resource identifiers (pod name, check container, encryption-config secret) so deploy, status, and cleanup consistently target the correct objects.

* **Tests**
  * Added end-to-end validation for KMS encryption preflight deployments, including secret/pod configuration checks and controller-reported results.
  * Updated and strengthened preflight deployment test utilities and pod/secret assertions to match canonical naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->