### PR TITLE
CNTRLPLANE-3237 kms: add UpdateKMSEncryptionStatus to EncryptionStatusProvider

### DIFF
--- a/pkg/operator/encryption/kms/encryption_status_provider.go
+++ b/pkg/operator/encryption/kms/encryption_status_provider.go
@@ -15,4 +15,13 @@ type EncryptionStatusProvider interface {
 	// ApplyKMSEncryptionStatus uses Server-Side Apply. Each caller owns only
 	// the fields it explicitly sets, identified by fieldManager.
 	ApplyKMSEncryptionStatus(ctx context.Context, fieldManager string, status *applyoperatorv1.KMSEncryptionStatusApplyConfiguration) error
+
+	// UpdateKMSEncryptionStatus reads the current status, applies the mutation,
+	// and writes it back. A conflict (409) is returned as-is.
+	//
+	// Note: use this instead of ApplyKMSEncryptionStatus when the controller is
+	// the sole owner of a field. Apply requires re-sending every owned field on
+	// every sync, omitting one causes the server to remove it, which is
+	// cumbersome for a controller that only writes a field once.
+	UpdateKMSEncryptionStatus(ctx context.Context, mutate func(*operatorv1.KMSEncryptionStatus)) error
 }

--- a/pkg/operator/encryption/kms/health/cmd_test.go
+++ b/pkg/operator/encryption/kms/health/cmd_test.go
@@ -27,6 +27,10 @@ func (f *fakeProvider) ApplyKMSEncryptionStatus(ctx context.Context, fieldManage
 	return f.applyFn(ctx, fieldManager, status)
 }
 
+func (f *fakeProvider) UpdateKMSEncryptionStatus(_ context.Context, _ func(*operatorv1.KMSEncryptionStatus)) error {
+	return fmt.Errorf("not implemented")
+}
+
 var _ kms.EncryptionStatusProvider = &fakeProvider{}
 
 // TestRunReportsOnce checks the loop wiring: Run probes, builds the status, and


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for safely updating KMS encryption status via a mutation callback.
  * KMS encryption status update conflicts (HTTP 409) are preserved to enable correct downstream handling.
* **Tests**
  * Updated the KMS health test fake to include the new encryption status update capability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->