### PR TITLE
CNTRLPLANE-3237: kms: report preflight results via KMSEncryptionStatus

### DIFF
--- a/pkg/operator/encryption/controllers/kms_preflight_controller.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller.go
@@ -134,9 +134,9 @@ const (
 	// in the condition message.
 	KMSPreflightResultPodCondition corev1.PodConditionType = "KMSPreflightResult"
 
-	// KMSPreflightKEKIDPodCondition carries the current key encryption key (KEK)
-	// ID reported by the KMS plugin during the preflight evaluation.
-	KMSPreflightKEKIDPodCondition corev1.PodConditionType = "KMSPreflightKekID"
+	// KMSPreflightRemoteKeyIDPodCondition carries the remote key ID reported by
+	// the KMS plugin during the preflight evaluation.
+	KMSPreflightRemoteKeyIDPodCondition corev1.PodConditionType = "KMSPreflightRemoteKeyID"
 
 	preflightPodRetention      = 1 * time.Hour
 	preflightPodStartupTimeout = 3 * time.Minute

--- a/pkg/operator/encryption/controllers/kms_preflight_controller.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller.go
@@ -139,7 +139,6 @@ const (
 	// the KMS plugin during the preflight evaluation.
 	KMSPreflightRemoteKeyIDPodCondition corev1.PodConditionType = "KMSPreflightRemoteKeyID"
 
-	preflightPodRetention      = 1 * time.Hour
 	preflightPodStartupTimeout = 3 * time.Minute
 )
 
@@ -369,7 +368,7 @@ func (c *kmsPreflightController) sync(ctx context.Context, syncCtx factory.SyncC
 //     the startup timeout, return an error with the stuck reason.
 //
 //     e) Hash matches, KMSPreflightResult is True — check passed.
-//     Keep the pod for retention (1h), then clean up.
+//     Clean up the pod immediately.
 //
 //     f) Hash matches, KMSPreflightResult is False — check failed. Report
 //     degraded with the failure message. Keep the pod for inspection.
@@ -458,7 +457,7 @@ func (c *kmsPreflightController) runPreflightChecks(ctx context.Context) (requeu
 		}); err != nil {
 			return false, err
 		}
-		return false, c.cleanupAfterRetention(ctx, resultCondition.LastTransitionTime.Time)
+		return false, c.deployer.Cleanup(ctx)
 	}
 
 	// Scenario 3f: check failed. Keep pod for inspection; the admin will
@@ -490,15 +489,6 @@ func (c *kmsPreflightController) ensurePreflightResult(ctx context.Context, exis
 	})
 }
 
-func (c *kmsPreflightController) cleanupAfterRetention(ctx context.Context, completedAt time.Time) error {
-	age := time.Since(completedAt)
-	if age < preflightPodRetention {
-		klog.V(4).Infof("Preflight pod completed %s ago, keeping for inspection (retention %s)", age.Truncate(time.Second), preflightPodRetention)
-		return nil
-	}
-	klog.V(2).Infof("Preflight pod retention period elapsed (%s), cleaning up", preflightPodRetention)
-	return c.deployer.Cleanup(ctx)
-}
 
 type preflightError struct {
 	reason  string

--- a/pkg/operator/encryption/controllers/kms_preflight_controller.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller.go
@@ -386,7 +386,7 @@ func (c *kmsPreflightController) sync(ctx context.Context, syncCtx factory.SyncC
 //
 // TODO: in the future we might want to add retries for failed preflights.
 func (c *kmsPreflightController) runPreflightChecks(ctx context.Context) (requeue bool, err error) {
-	requiredHash, err := c.preflightRequired(ctx)
+	requiredHash, existingResult, err := c.preflightRequired(ctx)
 	if err != nil {
 		return false, err
 	}
@@ -451,7 +451,7 @@ func (c *kmsPreflightController) runPreflightChecks(ctx context.Context) (requeu
 
 	// Scenario 3e: check passed.
 	if resultCondition.Status == corev1.ConditionTrue {
-		if err := c.writePreflightResult(ctx, operatorv1.KMSPreflightResult{
+		if err := c.ensurePreflightResult(ctx, existingResult, operatorv1.KMSPreflightResult{
 			Status:      operatorv1.KMSPreflightResultSucceeded,
 			ConfigHash:  requiredHash,
 			RemoteKeyID: remoteKeyID,
@@ -467,7 +467,7 @@ func (c *kmsPreflightController) runPreflightChecks(ctx context.Context) (requeu
 		reason:  "PreflightCheckFailed",
 		message: fmt.Sprintf("preflight check failed for hash %s: %s", requiredHash, resultCondition.Message),
 	}
-	if writeErr := c.writePreflightResult(ctx, operatorv1.KMSPreflightResult{
+	if writeErr := c.ensurePreflightResult(ctx, existingResult, operatorv1.KMSPreflightResult{
 		Status:      operatorv1.KMSPreflightResultFailed,
 		ConfigHash:  requiredHash,
 		RemoteKeyID: remoteKeyID,
@@ -477,7 +477,14 @@ func (c *kmsPreflightController) runPreflightChecks(ctx context.Context) (requeu
 	return false, pe
 }
 
-func (c *kmsPreflightController) writePreflightResult(ctx context.Context, result operatorv1.KMSPreflightResult) error {
+// ensurePreflightResult writes result to KMSEncryptionStatus.Preflight.Result
+// if it has not already been written for this hash. It is a no-op when
+// existingResult is non-nil and its ConfigHash already matches result.ConfigHash,
+// making it safe to call on every sync without overwriting a previously stored outcome.
+func (c *kmsPreflightController) ensurePreflightResult(ctx context.Context, existingResult *operatorv1.KMSPreflightResult, result operatorv1.KMSPreflightResult) error {
+	if existingResult != nil && existingResult.ConfigHash == result.ConfigHash {
+		return nil
+	}
 	return c.encryptionStatusProvider.UpdateKMSEncryptionStatus(ctx, func(s *operatorv1.KMSEncryptionStatus) {
 		s.Preflight.Result = result
 	})
@@ -579,30 +586,31 @@ func FindPodCondition(conditions []corev1.PodCondition, condType corev1.PodCondi
 	return nil
 }
 
-// preflightRequired returns the config hash that needs preflight validation,
-// or an empty string when no preflight is needed.
-func (c *kmsPreflightController) preflightRequired(ctx context.Context) (string, error) {
+// preflightRequired returns the config hash that needs preflight validation
+// and any existing result already recorded for that hash, or an empty string
+// when no preflight is needed.
+func (c *kmsPreflightController) preflightRequired(ctx context.Context) (string, *operatorv1.KMSPreflightResult, error) {
 	encryptionStatus, err := c.encryptionStatusProvider.GetKMSEncryptionStatus(ctx)
 	if err != nil {
-		return "", fmt.Errorf("failed to get KMS encryption status: %w", err)
+		return "", nil, fmt.Errorf("failed to get KMS encryption status: %w", err)
 	}
 	requiredHash := encryptionStatus.Preflight.ObservedConfigHash
 	if requiredHash == "" {
-		return "", nil
+		return "", nil, nil
 	}
 
 	apiServer, err := c.apiServerClient.Get(ctx, "cluster", metav1.GetOptions{})
 	if err != nil {
-		return "", fmt.Errorf("failed to get apiserver config: %w", err)
+		return "", nil, fmt.Errorf("failed to get apiserver config: %w", err)
 	}
 
 	providerCfg, err := newKMSProviderConfig(apiServer.Spec.Encryption.KMS)
 	if err != nil {
-		return "", fmt.Errorf("failed to create KMS provider config: %w", err)
+		return "", nil, fmt.Errorf("failed to create KMS provider config: %w", err)
 	}
 	currentHash, err := newKMSConfigHasher(providerCfg, c.coreClient, openshiftConfigNS).hash(ctx)
 	if err != nil {
-		return "", fmt.Errorf("failed to compute KMS config hash: %w", err)
+		return "", nil, fmt.Errorf("failed to compute KMS config hash: %w", err)
 	}
 
 	// No requeue needed: the key-controller will update ObservedConfigHash when it
@@ -610,8 +618,14 @@ func (c *kmsPreflightController) preflightRequired(ctx context.Context) (string,
 	// operatorClient.Informer(). The minute-based resync is a backstop.
 	if currentHash != requiredHash {
 		klog.V(4).Infof("KMS config hash changed: required=%s, current=%s; waiting for the key-controller to update ObservedConfigHash", requiredHash, currentHash)
-		return "", nil
+		return "", nil, nil
 	}
 
-	return requiredHash, nil
+	var existingResult *operatorv1.KMSPreflightResult
+	if encryptionStatus.Preflight.Result.ConfigHash == requiredHash {
+		r := encryptionStatus.Preflight.Result
+		existingResult = &r
+	}
+
+	return requiredHash, existingResult, nil
 }

--- a/pkg/operator/encryption/controllers/kms_preflight_controller.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller.go
@@ -22,6 +22,7 @@ import (
 	applyoperatorv1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
 
 	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/encryption/kms"
 	"github.com/openshift/library-go/pkg/operator/events"
 	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
 )
@@ -171,9 +172,10 @@ type kmsPreflightController struct {
 	apiServerClient configv1client.APIServerInterface
 	coreClient      corev1client.CoreV1Interface
 
-	deployer                 KMSPreflightDeployer
-	provider                 Provider
-	preconditionsFulfilledFn preconditionsFulfilled
+	deployer                    KMSPreflightDeployer
+	provider                    Provider
+	preconditionsFulfilledFn    preconditionsFulfilled
+	encryptionStatusProvider    kms.EncryptionStatusProvider
 }
 
 // NewKMSPreflightController validates KMS configuration before a key is created.
@@ -258,6 +260,7 @@ func NewKMSPreflightController(
 	// posts a new EncryptionKMSPreflightRequired condition, which triggers this controller
 	// via the operatorClient informer. The minute-based resync covers the rest.
 	coreClient corev1client.CoreV1Interface,
+	encryptionStatusProvider kms.EncryptionStatusProvider,
 	eventRecorder events.Recorder,
 ) factory.Controller {
 	c := &kmsPreflightController{
@@ -270,6 +273,7 @@ func NewKMSPreflightController(
 		deployer:                 deployer,
 		provider:                 provider,
 		preconditionsFulfilledFn: preconditionsFulfilledFn,
+		encryptionStatusProvider: encryptionStatusProvider,
 	}
 
 	return factory.New().
@@ -371,6 +375,14 @@ func (c *kmsPreflightController) sync(ctx context.Context, syncCtx factory.SyncC
 //     The admin fixes the config, which triggers a new hash and cleanup
 //     via scenario (c).
 //
+// KMSEncryptionStatus.Preflight.Result is written only when the checker ran
+// to completion; infrastructure failures are surfaced through the degraded
+// condition only:
+//
+//   - 3e (check passed):  writes Result{Succeeded, configHash, remoteKeyID}
+//   - 3f (check failed):  writes Result{Failed,    configHash, remoteKeyID}; EncryptionKMSPreflightControllerDegraded is also set
+//   - 3a, 3b, 3d (infrastructure failures): no write; EncryptionKMSPreflightControllerDegraded is set instead
+//
 // TODO: in the future we might want to add retries for failed preflights.
 func (c *kmsPreflightController) runPreflightChecks(ctx context.Context) (requeue bool, err error) {
 	requiredHash, err := c.preflightRequired(ctx)
@@ -431,17 +443,43 @@ func (c *kmsPreflightController) runPreflightChecks(ctx context.Context) (requeu
 		return true, nil
 	}
 
+	remoteKeyID := ""
+	if kc := FindPodCondition(podStatus.Conditions, KMSPreflightRemoteKeyIDPodCondition); kc != nil {
+		remoteKeyID = kc.Message
+	}
+
 	// Scenario 3e: check passed.
 	if resultCondition.Status == corev1.ConditionTrue {
+		if err := c.writePreflightResult(ctx, operatorv1.KMSPreflightResult{
+			Status:      operatorv1.KMSPreflightResultSucceeded,
+			ConfigHash:  requiredHash,
+			RemoteKeyID: remoteKeyID,
+		}); err != nil {
+			return false, err
+		}
 		return false, c.cleanupAfterRetention(ctx, resultCondition.LastTransitionTime.Time)
 	}
 
 	// Scenario 3f: check failed. Keep pod for inspection; the admin will
 	// update the config which triggers a new hash and cleanup via scenario 3c.
-	return false, &preflightError{
+	pe := &preflightError{
 		reason:  "PreflightCheckFailed",
 		message: fmt.Sprintf("preflight check failed for hash %s: %s", requiredHash, resultCondition.Message),
 	}
+	if writeErr := c.writePreflightResult(ctx, operatorv1.KMSPreflightResult{
+		Status:      operatorv1.KMSPreflightResultFailed,
+		ConfigHash:  requiredHash,
+		RemoteKeyID: remoteKeyID,
+	}); writeErr != nil {
+		return false, fmt.Errorf("%w; also failed to write preflight result: %v", pe, writeErr)
+	}
+	return false, pe
+}
+
+func (c *kmsPreflightController) writePreflightResult(ctx context.Context, result operatorv1.KMSPreflightResult) error {
+	return c.encryptionStatusProvider.UpdateKMSEncryptionStatus(ctx, func(s *operatorv1.KMSEncryptionStatus) {
+		s.Preflight.Result = result
+	})
 }
 
 func (c *kmsPreflightController) cleanupAfterRetention(ctx context.Context, completedAt time.Time) error {

--- a/pkg/operator/encryption/controllers/kms_preflight_controller.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller.go
@@ -182,11 +182,12 @@ type kmsPreflightController struct {
 //
 // Coordination with the key-controller:
 //
-// The key-controller writes a hash of the current KMS config to operator status
-// as the EncryptionKMSPreflightRequired condition (hash in the message).
-// This controller reads that hash, runs preflight checks, and on success sets
-// the EncryptionKMSPreflightSucceeded condition (same hash in the message).
-// The key-controller waits for the two hashes to match before creating a key.
+// The key-controller writes a hash of the current KMS config to
+// KMSEncryptionStatus.Preflight.ObservedConfigHash.
+// This controller reads that hash, runs preflight checks, and on success writes
+// KMSEncryptionStatus.Preflight.Result.
+// The key-controller waits for Result.ConfigHash to match ObservedConfigHash
+// and Result.Status to be Succeeded before creating a key.
 //
 // This is the same pattern used by the revision and installer controllers:
 // the revision controller writes LatestAvailableRevision, the installer
@@ -201,25 +202,25 @@ type kmsPreflightController struct {
 //     runs preflight for B, overwrites status with hash B.
 //  5. The key created in step 2 was for config A but status now says B.
 //
-// Letting the key-controller own EncryptionKMSPreflightRequired and this
-// controller own EncryptionKMSPreflightSucceeded solves this. If the config
-// changes mid-flight the key-controller posts a new hash and the preflight
-// controller sees the mismatch and waits.
+// Letting the key-controller own ObservedConfigHash and this controller own
+// Result solves this. If the config changes mid-flight the key-controller
+// updates ObservedConfigHash and the preflight controller sees the mismatch
+// and waits.
 //
 // Example 1: config changes before key is created
 //  1. User creates KMS config A.
-//  2. Key-controller computes hash A, writes EncryptionKMSPreflightRequired=A.
-//  3. Preflight controller sees required=A, starts checking A.
+//  2. Key-controller computes hash A, writes ObservedConfigHash=A.
+//  3. Preflight controller sees ObservedConfigHash=A, starts checking A.
 //  4. User changes config to A2 (minor variation, different hash).
-//  5. Key-controller computes hash A2, writes EncryptionKMSPreflightRequired=A2.
-//  6. Preflight controller sees required=A2, starts checking A2.
-//  7. Key-controller does not create a key until succeeded=A2.
+//  5. Key-controller computes hash A2, writes ObservedConfigHash=A2.
+//  6. Preflight controller sees ObservedConfigHash=A2, starts checking A2.
+//  7. Key-controller does not create a key until Result.ConfigHash=A2, Result.Status=Succeeded.
 //
 // Example 2: config changes after key is created
 //  1. User creates KMS config A.
-//  2. Key-controller computes hash A, writes EncryptionKMSPreflightRequired=A.
-//  3. Preflight controller checks A, succeeds, writes EncryptionKMSPreflightSucceeded=A.
-//  4. Key-controller sees required=A matches succeeded=A, creates key for A.
+//  2. Key-controller computes hash A, writes ObservedConfigHash=A.
+//  3. Preflight controller checks A, succeeds, writes Result{Succeeded, A}.
+//  4. Key-controller sees Result.ConfigHash=A matches ObservedConfigHash=A, creates key for A.
 //  5. User changes config to A2 (or B).
 //  6. Key-controller waits until the key for A completes the full cycle
 //     (read, write, migrated) before creating a new key. No preflight done
@@ -257,8 +258,8 @@ func NewKMSPreflightController(
 	apiServerInformer configv1informers.APIServerInformer,
 	// coreClient reads referenced Secrets and ConfigMaps in openshift-config for hash
 	// computation. No informer is needed: the key-controller detects config changes and
-	// posts a new EncryptionKMSPreflightRequired condition, which triggers this controller
-	// via the operatorClient informer. The minute-based resync covers the rest.
+	// updates ObservedConfigHash, which triggers this controller via the operatorClient
+	// informer. The minute-based resync covers the rest.
 	coreClient corev1client.CoreV1Interface,
 	encryptionStatusProvider kms.EncryptionStatusProvider,
 	eventRecorder events.Recorder,
@@ -581,14 +582,15 @@ func FindPodCondition(conditions []corev1.PodCondition, condType corev1.PodCondi
 // preflightRequired returns the config hash that needs preflight validation,
 // or an empty string when no preflight is needed.
 func (c *kmsPreflightController) preflightRequired(ctx context.Context) (string, error) {
-	_, operatorStatus, _, err := c.operatorClient.GetOperatorState()
+	encryptionStatus, err := c.encryptionStatusProvider.GetKMSEncryptionStatus(ctx)
 	if err != nil {
-		return "", fmt.Errorf("failed to get operator state: %w", err)
+		return "", fmt.Errorf("failed to get KMS encryption status: %w", err)
 	}
-	requiredCondition := operatorv1helpers.FindOperatorCondition(operatorStatus.Conditions, "EncryptionKMSPreflightRequired")
-	if requiredCondition == nil || requiredCondition.Status != operatorv1.ConditionTrue {
+	requiredHash := encryptionStatus.Preflight.ObservedConfigHash
+	if requiredHash == "" {
 		return "", nil
 	}
+
 	apiServer, err := c.apiServerClient.Get(ctx, "cluster", metav1.GetOptions{})
 	if err != nil {
 		return "", fmt.Errorf("failed to get apiserver config: %w", err)
@@ -603,12 +605,11 @@ func (c *kmsPreflightController) preflightRequired(ctx context.Context) (string,
 		return "", fmt.Errorf("failed to compute KMS config hash: %w", err)
 	}
 
-	requiredHash := requiredCondition.Message
-	// No requeue needed: the key-controller will post an updated condition when it
+	// No requeue needed: the key-controller will update ObservedConfigHash when it
 	// picks up the config change (via apiServerInformer), which triggers us through
 	// operatorClient.Informer(). The minute-based resync is a backstop.
 	if currentHash != requiredHash {
-		klog.V(4).Infof("KMS config hash changed: required=%s, current=%s; waiting for the key-controller to post an updated condition", requiredHash, currentHash)
+		klog.V(4).Infof("KMS config hash changed: required=%s, current=%s; waiting for the key-controller to update ObservedConfigHash", requiredHash, currentHash)
 		return "", nil
 	}
 

--- a/pkg/operator/encryption/controllers/kms_preflight_controller.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller.go
@@ -171,10 +171,10 @@ type kmsPreflightController struct {
 	apiServerClient configv1client.APIServerInterface
 	coreClient      corev1client.CoreV1Interface
 
-	deployer                    KMSPreflightDeployer
-	provider                    Provider
-	preconditionsFulfilledFn    preconditionsFulfilled
-	encryptionStatusProvider    kms.EncryptionStatusProvider
+	deployer                 KMSPreflightDeployer
+	provider                 Provider
+	preconditionsFulfilledFn preconditionsFulfilled
+	encryptionStatusProvider kms.EncryptionStatusProvider
 }
 
 // NewKMSPreflightController validates KMS configuration before a key is created.
@@ -337,12 +337,17 @@ func (c *kmsPreflightController) sync(ctx context.Context, syncCtx factory.SyncC
 //
 // Scenarios:
 //
-//  1. No preflight required (condition absent, False, or hash mismatch in preflightRequired).
+//  1. No preflight required (ObservedConfigHash empty or hash mismatch).
 //     Cleanup any lingering resources (pod, SA, RBAC) from a previous run.
 //
+//     1a. Result already recorded as Succeeded for this hash.
+//     Cleanup the pod (idempotent) and return. No pod work needed.
+//
 //  2. Preflight required, no pod exists (Status returns NotFound).
-//     Call Deploy. On success, requeue and wait for the pod to report results.
-//     If Deploy fails, report the error.
+//     2a. Result already recorded as Failed and pod is gone: surface the error
+//     without re-deploying. The admin must fix the config (new hash) before
+//     a new check can run.
+//     2b. No result yet: call Deploy. On success, requeue and wait for the pod to report results.
 //
 //  3. Preflight required, pod exists (Status returns a PodStatus).
 //     Evaluate the pod state via conditions and phase:
@@ -395,10 +400,25 @@ func (c *kmsPreflightController) runPreflightChecks(ctx context.Context) (requeu
 		return false, c.deployer.Cleanup(ctx)
 	}
 
+	// Result already recorded for this hash as Succeeded: clean up the pod
+	// (idempotent if already gone) and return — no pod work needed.
+	if isPreflightResultSucceeded(existingResult) {
+		return false, c.deployer.Cleanup(ctx)
+	}
+
 	// Check whether a preflight pod already exists.
 	podStatus, err := c.deployer.Status(ctx)
-	// Scenario 2: no pod exists, deploy a new one.
+	// Scenario 2: no pod exists.
 	if apierrors.IsNotFound(err) {
+		// Result already recorded as Failed and the pod is gone: surface the error
+		// without re-deploying. The admin must fix the config (new hash) before a
+		// new check can run.
+		if isPreflightResultFailed(existingResult) {
+			return false, &preflightError{
+				reason:  "PreflightCheckFailed",
+				message: fmt.Sprintf("preflight check failed for hash %s: pod was removed but failure is recorded in status", requiredHash),
+			}
+		}
 		// TODO: compute the encryption configuration and pass it to the deployer
 		return true, c.deployer.Deploy(ctx, requiredHash, nil)
 	}
@@ -480,6 +500,12 @@ func (c *kmsPreflightController) runPreflightChecks(ctx context.Context) (requeu
 // if it has not already been written for this hash. It is a no-op when
 // existingResult is non-nil and its ConfigHash already matches result.ConfigHash,
 // making it safe to call on every sync without overwriting a previously stored outcome.
+//
+// Idempotency is keyed on ConfigHash only, not Status, because for a given hash
+// the result status is stable: a pod posts its result condition once and does not
+// change it. Success pods are cleaned up immediately; failure pods are retained
+// until the config changes (new hash), so the same hash cannot produce both
+// Succeeded and Failed.
 func (c *kmsPreflightController) ensurePreflightResult(ctx context.Context, existingResult *operatorv1.KMSPreflightResult, result operatorv1.KMSPreflightResult) error {
 	if existingResult != nil && existingResult.ConfigHash == result.ConfigHash {
 		return nil
@@ -489,6 +515,13 @@ func (c *kmsPreflightController) ensurePreflightResult(ctx context.Context, exis
 	})
 }
 
+func isPreflightResultSucceeded(result *operatorv1.KMSPreflightResult) bool {
+	return result != nil && result.Status == operatorv1.KMSPreflightResultSucceeded
+}
+
+func isPreflightResultFailed(result *operatorv1.KMSPreflightResult) bool {
+	return result != nil && result.Status == operatorv1.KMSPreflightResultFailed
+}
 
 type preflightError struct {
 	reason  string
@@ -611,11 +644,9 @@ func (c *kmsPreflightController) preflightRequired(ctx context.Context) (string,
 		return "", nil, nil
 	}
 
-	var existingResult *operatorv1.KMSPreflightResult
 	if encryptionStatus.Preflight.Result.ConfigHash == requiredHash {
 		r := encryptionStatus.Preflight.Result
-		existingResult = &r
+		return requiredHash, &r, nil
 	}
-
-	return requiredHash, existingResult, nil
+	return requiredHash, nil, nil
 }

--- a/pkg/operator/encryption/controllers/kms_preflight_controller_test.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller_test.go
@@ -461,7 +461,7 @@ func TestKMSPreflightController(t *testing.T) {
 			},
 		},
 		{
-			name: "pod succeeded recently, keeps pod for inspection",
+			name: "pod succeeded, cleans up immediately",
 			deployer: &fakeDeployer{podStatus: corev1.PodStatus{
 				Conditions: []corev1.PodCondition{
 					{Type: KMSPreflightConfigHashPodCondition, Message: wellKnownMatchingHashForBaseVaultConfig},
@@ -473,35 +473,14 @@ func TestKMSPreflightController(t *testing.T) {
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
 			preconditionsMet: true,
+			expectedEncryptionStatusProviderUpdateCalls: 1,
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
 			},
-			expectedEncryptionStatusProviderUpdateCalls: 1,
 			expectedKMSPreflightResult: &operatorv1.KMSPreflightResult{
 				Status:      operatorv1.KMSPreflightResultSucceeded,
 				ConfigHash:  wellKnownMatchingHashForBaseVaultConfig,
 				RemoteKeyID: "remote-key-abc",
-			},
-		},
-		{
-			name: "pod succeeded, retention period elapsed, cleans up",
-			deployer: &fakeDeployer{podStatus: corev1.PodStatus{
-				Conditions: []corev1.PodCondition{
-					{Type: KMSPreflightConfigHashPodCondition, Message: wellKnownMatchingHashForBaseVaultConfig},
-					{Type: KMSPreflightResultPodCondition, Status: corev1.ConditionTrue, LastTransitionTime: metav1.NewTime(time.Now().Add(-2 * time.Hour))},
-				},
-			}},
-			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
-			apiServerObjects: []runtime.Object{apiServerWithKMS},
-			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			preconditionsMet: true,
-			expectedConditions: []operatorv1.OperatorCondition{
-				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
-			},
-			expectedEncryptionStatusProviderUpdateCalls: 1,
-			expectedKMSPreflightResult: &operatorv1.KMSPreflightResult{
-				Status:     operatorv1.KMSPreflightResultSucceeded,
-				ConfigHash: wellKnownMatchingHashForBaseVaultConfig,
 			},
 		},
 		{

--- a/pkg/operator/encryption/controllers/kms_preflight_controller_test.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller_test.go
@@ -3,7 +3,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -16,11 +15,13 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	clocktesting "k8s.io/utils/clock/testing"
 
+	"k8s.io/apimachinery/pkg/api/equality"
+
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
-	applyoperatorv1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
 	configv1clientfake "github.com/openshift/client-go/config/clientset/versioned/fake"
 	configv1informers "github.com/openshift/client-go/config/informers/externalversions"
+	applyoperatorv1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
 
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/encryption/kms"
@@ -383,34 +384,78 @@ func TestKMSPreflightController(t *testing.T) {
 	const wellKnownMatchingHashForBaseVaultConfig = "cuZm_g=="
 
 	scenarios := []struct {
-		name                       string
-		deployer                   KMSPreflightDeployer
-		encryptionStatusProvider   *fakeEncryptionStatusProvider
-		apiServerObjects           []runtime.Object
-		coreObjects                []runtime.Object
-		preconditionsMet           bool
-		expectedError              string
-		expectedPreflightPodCleanup            bool
-		expectedConditions         []operatorv1.OperatorCondition
-		expectedKMSPreflightResult *operatorv1.KMSPreflightResult
-		expectedEncryptionStatusProviderUpdateCalls        int
+		name                                        string
+		deployer                                    KMSPreflightDeployer
+		encryptionStatusProvider                    *fakeEncryptionStatusProvider
+		apiServerObjects                            []runtime.Object
+		coreObjects                                 []runtime.Object
+		preconditionsMet                            bool
+		expectedError                               string
+		expectedPreflightPodCleanup                 bool
+		expectedConditions                          []operatorv1.OperatorCondition
+		expectedKMSPreflightResult                  *operatorv1.KMSPreflightResult
+		expectedEncryptionStatusProviderUpdateCalls int
 	}{
 		{
-			name:             "preconditions not met, clears degraded",
+			name:                     "preconditions not met, clears degraded",
 			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
-			apiServerObjects: []runtime.Object{&configv1.APIServer{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}}},
-			preconditionsMet: false,
+			apiServerObjects:         []runtime.Object{&configv1.APIServer{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}}},
+			preconditionsMet:         false,
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
 			},
 		},
 		{
-			name:             "hashes match, no pod exists, deploys and returns",
-			deployer:         &fakeDeployer{statusErr: apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "kms-preflight")},
-			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
+			name:     "result already Succeeded, pod gone — cleanup and return without deploying",
+			deployer: &fakeDeployer{statusErr: apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "kms-preflight")},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{
+				observedConfigHash: wellKnownMatchingHashForBaseVaultConfig,
+				writtenStatus: &operatorv1.KMSPreflightResult{
+					Status:     operatorv1.KMSPreflightResultSucceeded,
+					ConfigHash: wellKnownMatchingHashForBaseVaultConfig,
+				},
+			},
+			apiServerObjects:            []runtime.Object{apiServerWithKMS},
+			coreObjects:                 []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			preconditionsMet:            true,
+			expectedPreflightPodCleanup: true,
+			expectedConditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
+			},
+			expectedKMSPreflightResult: &operatorv1.KMSPreflightResult{
+				Status:     operatorv1.KMSPreflightResultSucceeded,
+				ConfigHash: wellKnownMatchingHashForBaseVaultConfig,
+			},
+		},
+		{
+			name:     "result already Failed, pod manually removed — surface error without re-deploying",
+			deployer: &fakeDeployer{statusErr: apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "kms-preflight")},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{
+				observedConfigHash: wellKnownMatchingHashForBaseVaultConfig,
+				writtenStatus: &operatorv1.KMSPreflightResult{
+					Status:     operatorv1.KMSPreflightResultFailed,
+					ConfigHash: wellKnownMatchingHashForBaseVaultConfig,
+				},
+			},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
 			preconditionsMet: true,
+			expectedError:    "preflight check failed for hash cuZm_g==: pod was removed but failure is recorded in status",
+			expectedConditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "PreflightCheckFailed", Message: "preflight check failed for hash cuZm_g==: pod was removed but failure is recorded in status"},
+			},
+			expectedKMSPreflightResult: &operatorv1.KMSPreflightResult{
+				Status:     operatorv1.KMSPreflightResultFailed,
+				ConfigHash: wellKnownMatchingHashForBaseVaultConfig,
+			},
+		},
+		{
+			name:                     "hashes match, no pod exists, deploys and returns",
+			deployer:                 &fakeDeployer{statusErr: apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "kms-preflight")},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
+			apiServerObjects:         []runtime.Object{apiServerWithKMS},
+			coreObjects:              []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			preconditionsMet:         true,
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
 			},
@@ -423,9 +468,9 @@ func TestKMSPreflightController(t *testing.T) {
 				},
 			}},
 			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
-			apiServerObjects: []runtime.Object{apiServerWithKMS},
-			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			preconditionsMet: true,
+			apiServerObjects:         []runtime.Object{apiServerWithKMS},
+			coreObjects:              []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			preconditionsMet:         true,
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
 			},
@@ -436,10 +481,10 @@ func TestKMSPreflightController(t *testing.T) {
 				Phase: corev1.PodSucceeded,
 			}},
 			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
-			apiServerObjects: []runtime.Object{apiServerWithKMS},
-			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			preconditionsMet: true,
-			expectedError:    "preflight pod completed without reporting result for hash cuZm_g==",
+			apiServerObjects:         []runtime.Object{apiServerWithKMS},
+			coreObjects:              []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			preconditionsMet:         true,
+			expectedError:            "preflight pod completed without reporting result for hash cuZm_g==",
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "PodCompletedWithoutResult", Message: "preflight pod completed without reporting result for hash cuZm_g=="},
 			},
@@ -453,10 +498,10 @@ func TestKMSPreflightController(t *testing.T) {
 				},
 			}},
 			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
-			apiServerObjects: []runtime.Object{apiServerWithKMS},
-			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			preconditionsMet: true,
-			expectedError:    "preflight pod completed without reporting result for hash cuZm_g==",
+			apiServerObjects:         []runtime.Object{apiServerWithKMS},
+			coreObjects:              []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			preconditionsMet:         true,
+			expectedError:            "preflight pod completed without reporting result for hash cuZm_g==",
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "PodCompletedWithoutResult", Message: "preflight pod completed without reporting result for hash cuZm_g=="},
 			},
@@ -470,11 +515,11 @@ func TestKMSPreflightController(t *testing.T) {
 					{Type: KMSPreflightRemoteKeyIDPodCondition, Status: corev1.ConditionTrue, Message: "remote-key-abc"},
 				},
 			}},
-			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
-			apiServerObjects: []runtime.Object{apiServerWithKMS},
-			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			preconditionsMet: true,
-			expectedPreflightPodCleanup:  true,
+			encryptionStatusProvider:                    &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
+			apiServerObjects:                            []runtime.Object{apiServerWithKMS},
+			coreObjects:                                 []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			preconditionsMet:                            true,
+			expectedPreflightPodCleanup:                 true,
 			expectedEncryptionStatusProviderUpdateCalls: 1,
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
@@ -495,10 +540,10 @@ func TestKMSPreflightController(t *testing.T) {
 				},
 			}},
 			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
-			apiServerObjects: []runtime.Object{apiServerWithKMS},
-			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			preconditionsMet: true,
-			expectedError:    "preflight check failed for hash cuZm_g==: encrypt call failed",
+			apiServerObjects:         []runtime.Object{apiServerWithKMS},
+			coreObjects:              []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			preconditionsMet:         true,
+			expectedError:            "preflight check failed for hash cuZm_g==: encrypt call failed",
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "PreflightCheckFailed", Message: "preflight check failed for hash cuZm_g==: encrypt call failed"},
 			},
@@ -524,10 +569,10 @@ func TestKMSPreflightController(t *testing.T) {
 					ConfigHash: wellKnownMatchingHashForBaseVaultConfig,
 				},
 			},
-			apiServerObjects:              []runtime.Object{apiServerWithKMS},
-			coreObjects:                   []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			preconditionsMet:              true,
-			expectedPreflightPodCleanup:   true,
+			apiServerObjects:            []runtime.Object{apiServerWithKMS},
+			coreObjects:                 []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			preconditionsMet:            true,
+			expectedPreflightPodCleanup: true,
 			expectedEncryptionStatusProviderUpdateCalls: 0,
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
@@ -552,17 +597,38 @@ func TestKMSPreflightController(t *testing.T) {
 					ConfigHash: wellKnownMatchingHashForBaseVaultConfig,
 				},
 			},
-			apiServerObjects:    []runtime.Object{apiServerWithKMS},
-			coreObjects:         []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			preconditionsMet:    true,
+			apiServerObjects: []runtime.Object{apiServerWithKMS},
+			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			preconditionsMet: true,
 			expectedEncryptionStatusProviderUpdateCalls: 0,
-			expectedError:       "preflight check failed for hash k6dSVA==: encrypt call failed",
+			expectedError: "preflight check failed for hash cuZm_g==: encrypt call failed",
 			expectedConditions: []operatorv1.OperatorCondition{
-				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "PreflightCheckFailed", Message: "preflight check failed for hash k6dSVA==: encrypt call failed"},
+				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "PreflightCheckFailed", Message: "preflight check failed for hash cuZm_g==: encrypt call failed"},
 			},
 			expectedKMSPreflightResult: &operatorv1.KMSPreflightResult{
 				Status:     operatorv1.KMSPreflightResultFailed,
 				ConfigHash: wellKnownMatchingHashForBaseVaultConfig,
+			},
+		},
+		{
+			name: "UpdateKMSEncryptionStatus returns error, reports error",
+			deployer: &fakeDeployer{podStatus: corev1.PodStatus{
+				Conditions: []corev1.PodCondition{
+					{Type: KMSPreflightConfigHashPodCondition, Message: wellKnownMatchingHashForBaseVaultConfig},
+					{Type: KMSPreflightResultPodCondition, Status: corev1.ConditionTrue, LastTransitionTime: metav1.Now()},
+				},
+			}},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{
+				observedConfigHash: wellKnownMatchingHashForBaseVaultConfig,
+				updateErr:          fmt.Errorf("status update failed"),
+			},
+			apiServerObjects: []runtime.Object{apiServerWithKMS},
+			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			preconditionsMet: true,
+			expectedEncryptionStatusProviderUpdateCalls: 1,
+			expectedError: "status update failed",
+			expectedConditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "Error", Message: "status update failed"},
 			},
 		},
 		{
@@ -573,8 +639,8 @@ func TestKMSPreflightController(t *testing.T) {
 					{Type: KMSPreflightResultPodCondition, Status: corev1.ConditionTrue},
 				},
 			}},
-			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
-			apiServerObjects: []runtime.Object{apiServerWithKMS},
+			encryptionStatusProvider:    &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
+			apiServerObjects:            []runtime.Object{apiServerWithKMS},
 			coreObjects:                 []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
 			preconditionsMet:            true,
 			expectedPreflightPodCleanup: true,
@@ -600,10 +666,10 @@ func TestKMSPreflightController(t *testing.T) {
 				},
 			}},
 			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
-			apiServerObjects: []runtime.Object{apiServerWithKMS},
-			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			preconditionsMet: true,
-			expectedError:    "preflight pod failed for hash cuZm_g==: at least one container kms-preflight-check exited with 1 (Unknown): connection refused",
+			apiServerObjects:         []runtime.Object{apiServerWithKMS},
+			coreObjects:              []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			preconditionsMet:         true,
+			expectedError:            "preflight pod failed for hash cuZm_g==: at least one container kms-preflight-check exited with 1 (Unknown): connection refused",
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "Unknown", Message: "preflight pod failed for hash cuZm_g==: at least one container kms-preflight-check exited with 1 (Unknown): connection refused"},
 			},
@@ -614,9 +680,9 @@ func TestKMSPreflightController(t *testing.T) {
 				Phase: corev1.PodRunning,
 			}},
 			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
-			apiServerObjects: []runtime.Object{apiServerWithKMS},
-			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			preconditionsMet: true,
+			apiServerObjects:         []runtime.Object{apiServerWithKMS},
+			coreObjects:              []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			preconditionsMet:         true,
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
 			},
@@ -630,10 +696,10 @@ func TestKMSPreflightController(t *testing.T) {
 				},
 			}},
 			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
-			apiServerObjects: []runtime.Object{apiServerWithKMS},
-			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			preconditionsMet: true,
-			expectedError:    "preflight pod has not reported config hash after 3m0s: pod is in Pending phase",
+			apiServerObjects:         []runtime.Object{apiServerWithKMS},
+			coreObjects:              []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			preconditionsMet:         true,
+			expectedError:            "preflight pod has not reported config hash after 3m0s: pod is in Pending phase",
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "Unknown", Message: "preflight pod has not reported config hash after 3m0s: pod is in Pending phase"},
 			},
@@ -645,10 +711,10 @@ func TestKMSPreflightController(t *testing.T) {
 				StartTime: &metav1.Time{Time: time.Now().Add(-5 * time.Minute)},
 			}},
 			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
-			apiServerObjects: []runtime.Object{apiServerWithKMS},
-			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			preconditionsMet: true,
-			expectedError:    "preflight pod has not reported config hash after 3m0s: pod is in Pending phase",
+			apiServerObjects:         []runtime.Object{apiServerWithKMS},
+			coreObjects:              []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			preconditionsMet:         true,
+			expectedError:            "preflight pod has not reported config hash after 3m0s: pod is in Pending phase",
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "Unknown", Message: "preflight pod has not reported config hash after 3m0s: pod is in Pending phase"},
 			},
@@ -671,10 +737,10 @@ func TestKMSPreflightController(t *testing.T) {
 				},
 			}},
 			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
-			apiServerObjects: []runtime.Object{apiServerWithKMS},
-			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			preconditionsMet: true,
-			expectedError:    "preflight pod has not reported config hash after 3m0s: at least one container kms-preflight-check is waiting: ImagePullBackOff: back-off pulling image",
+			apiServerObjects:         []runtime.Object{apiServerWithKMS},
+			coreObjects:              []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			preconditionsMet:         true,
+			expectedError:            "preflight pod has not reported config hash after 3m0s: at least one container kms-preflight-check is waiting: ImagePullBackOff: back-off pulling image",
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "ImagePullBackOff", Message: "preflight pod has not reported config hash after 3m0s: at least one container kms-preflight-check is waiting: ImagePullBackOff: back-off pulling image"},
 			},
@@ -689,34 +755,34 @@ func TestKMSPreflightController(t *testing.T) {
 				},
 			}},
 			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
-			apiServerObjects: []runtime.Object{apiServerWithKMS},
-			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			preconditionsMet: true,
-			expectedError:    "preflight pod has not reported result after 3m0s: pod is in Running phase",
+			apiServerObjects:         []runtime.Object{apiServerWithKMS},
+			coreObjects:              []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			preconditionsMet:         true,
+			expectedError:            "preflight pod has not reported result after 3m0s: pod is in Running phase",
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "Unknown", Message: "preflight pod has not reported result after 3m0s: pod is in Running phase"},
 			},
 		},
 		{
-			name:             "deploy fails, reports error",
-			deployer:         &fakeDeployer{statusErr: apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "kms-preflight"), deployErr: fmt.Errorf("quota exceeded")},
+			name:                     "deploy fails, reports error",
+			deployer:                 &fakeDeployer{statusErr: apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "kms-preflight"), deployErr: fmt.Errorf("quota exceeded")},
 			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
-			apiServerObjects: []runtime.Object{apiServerWithKMS},
-			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			preconditionsMet: true,
-			expectedError:    "quota exceeded",
+			apiServerObjects:         []runtime.Object{apiServerWithKMS},
+			coreObjects:              []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			preconditionsMet:         true,
+			expectedError:            "quota exceeded",
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "Error", Message: "quota exceeded"},
 			},
 		},
 		{
-			name:             "status returns unexpected error",
-			deployer:         &fakeDeployer{statusErr: fmt.Errorf("connection refused")},
+			name:                     "status returns unexpected error",
+			deployer:                 &fakeDeployer{statusErr: fmt.Errorf("connection refused")},
 			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
-			apiServerObjects: []runtime.Object{apiServerWithKMS},
-			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			preconditionsMet: true,
-			expectedError:    "failed to get preflight pod status",
+			apiServerObjects:         []runtime.Object{apiServerWithKMS},
+			coreObjects:              []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			preconditionsMet:         true,
+			expectedError:            "failed to get preflight pod status",
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "Error", Message: "failed to get preflight pod status: connection refused"},
 			},
@@ -731,9 +797,9 @@ func TestKMSPreflightController(t *testing.T) {
 					},
 				},
 			},
-			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
-			apiServerObjects: []runtime.Object{apiServerWithKMS},
-			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			encryptionStatusProvider:    &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
+			apiServerObjects:            []runtime.Object{apiServerWithKMS},
+			coreObjects:                 []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
 			preconditionsMet:            true,
 			expectedPreflightPodCleanup: true,
 			expectedError:               "delete forbidden",
@@ -748,10 +814,10 @@ func TestKMSPreflightController(t *testing.T) {
 				Message: "node lost",
 			}},
 			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
-			apiServerObjects: []runtime.Object{apiServerWithKMS},
-			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			preconditionsMet: true,
-			expectedError:    "preflight pod failed for hash cuZm_g==: node lost",
+			apiServerObjects:         []runtime.Object{apiServerWithKMS},
+			coreObjects:              []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			preconditionsMet:         true,
+			expectedError:            "preflight pod failed for hash cuZm_g==: node lost",
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "Unknown", Message: "preflight pod failed for hash cuZm_g==: node lost"},
 			},
@@ -772,16 +838,16 @@ func TestKMSPreflightController(t *testing.T) {
 				},
 			}},
 			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
-			apiServerObjects: []runtime.Object{apiServerWithKMS},
-			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			preconditionsMet: true,
-			expectedError:    "preflight pod failed for hash cuZm_g==: at least one container kms-preflight-check exited with 137 (Unknown)",
+			apiServerObjects:         []runtime.Object{apiServerWithKMS},
+			coreObjects:              []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			preconditionsMet:         true,
+			expectedError:            "preflight pod failed for hash cuZm_g==: at least one container kms-preflight-check exited with 137 (Unknown)",
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "Unknown", Message: "preflight pod failed for hash cuZm_g==: at least one container kms-preflight-check exited with 137 (Unknown)"},
 			},
 		},
 		{
-			name:             "hashes differ, config changed since ObservedConfigHash was written, cleans up",
+			name:                        "hashes differ, config changed since ObservedConfigHash was written, cleans up",
 			encryptionStatusProvider:    &fakeEncryptionStatusProvider{observedConfigHash: "stale-hash"},
 			apiServerObjects:            []runtime.Object{apiServerWithKMS},
 			coreObjects:                 []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
@@ -792,18 +858,18 @@ func TestKMSPreflightController(t *testing.T) {
 			},
 		},
 		{
-			name:             "hash computation fails due to missing secret",
+			name:                     "hash computation fails due to missing secret",
 			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
-			apiServerObjects: []runtime.Object{apiServerWithKMS},
-			coreObjects:      []runtime.Object{&wellKnownBaseConfigMap},
-			preconditionsMet: true,
-			expectedError:    "failed to compute KMS config hash",
+			apiServerObjects:         []runtime.Object{apiServerWithKMS},
+			coreObjects:              []runtime.Object{&wellKnownBaseConfigMap},
+			preconditionsMet:         true,
+			expectedError:            "failed to compute KMS config hash",
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "Error", Message: `failed to compute KMS config hash: failed to get secret openshift-config/vault-approle: secrets "vault-approle" not found`},
 			},
 		},
 		{
-			name:             "empty ObservedConfigHash, cleans up",
+			name:                        "empty ObservedConfigHash, cleans up",
 			encryptionStatusProvider:    &fakeEncryptionStatusProvider{observedConfigHash: ""},
 			apiServerObjects:            []runtime.Object{apiServerWithKMS},
 			coreObjects:                 []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
@@ -877,7 +943,7 @@ func TestKMSPreflightController(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			if !reflect.DeepEqual(scenario.encryptionStatusProvider.writtenStatus, scenario.expectedKMSPreflightResult) {
+			if !equality.Semantic.DeepEqual(scenario.encryptionStatusProvider.writtenStatus, scenario.expectedKMSPreflightResult) {
 				t.Errorf("written KMS preflight result: got %v, want %v", scenario.encryptionStatusProvider.writtenStatus, scenario.expectedKMSPreflightResult)
 			}
 			if got := scenario.encryptionStatusProvider.updateCallCount; got != scenario.expectedEncryptionStatusProviderUpdateCalls {

--- a/pkg/operator/encryption/controllers/kms_preflight_controller_test.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller_test.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -17,10 +18,12 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
+	applyoperatorv1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
 	configv1clientfake "github.com/openshift/client-go/config/clientset/versioned/fake"
 	configv1informers "github.com/openshift/client-go/config/informers/externalversions"
 
 	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/encryption/kms"
 	encryptiontesting "github.com/openshift/library-go/pkg/operator/encryption/testing"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
@@ -328,6 +331,36 @@ func (f *fakeDeployer) Cleanup(_ context.Context) error {
 	return f.cleanupErr
 }
 
+type fakeEncryptionStatusProvider struct {
+	writtenStatus *operatorv1.KMSPreflightResult
+	updateErr     error
+}
+
+func (f *fakeEncryptionStatusProvider) GetKMSEncryptionStatus(_ context.Context) (*operatorv1.KMSEncryptionStatus, error) {
+	s := &operatorv1.KMSEncryptionStatus{}
+	if f.writtenStatus != nil {
+		s.Preflight.Result = *f.writtenStatus
+	}
+	return s, nil
+}
+
+func (f *fakeEncryptionStatusProvider) ApplyKMSEncryptionStatus(_ context.Context, _ string, _ *applyoperatorv1.KMSEncryptionStatusApplyConfiguration) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (f *fakeEncryptionStatusProvider) UpdateKMSEncryptionStatus(_ context.Context, mutateFn func(*operatorv1.KMSEncryptionStatus)) error {
+	if f.updateErr != nil {
+		return f.updateErr
+	}
+	s := &operatorv1.KMSEncryptionStatus{}
+	mutateFn(s)
+	result := s.Preflight.Result
+	f.writtenStatus = &result
+	return nil
+}
+
+var _ kms.EncryptionStatusProvider = &fakeEncryptionStatusProvider{}
+
 func TestKMSPreflightController(t *testing.T) {
 	apiServerWithKMS := &configv1.APIServer{
 		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
@@ -346,17 +379,20 @@ func TestKMSPreflightController(t *testing.T) {
 	const wellKnownMatchingHashForBaseVaultConfig = "cuZm_g=="
 
 	scenarios := []struct {
-		name               string
-		deployer           KMSPreflightDeployer
-		apiServerObjects   []runtime.Object
-		coreObjects        []runtime.Object
-		operatorConditions []operatorv1.OperatorCondition
-		preconditionsMet   bool
-		expectedError      string
-		expectedConditions []operatorv1.OperatorCondition
+		name                       string
+		deployer                   KMSPreflightDeployer
+		encryptionStatusProvider   *fakeEncryptionStatusProvider
+		apiServerObjects           []runtime.Object
+		coreObjects                []runtime.Object
+		operatorConditions         []operatorv1.OperatorCondition
+		preconditionsMet           bool
+		expectedError              string
+		expectedConditions         []operatorv1.OperatorCondition
+		expectedKMSPreflightResult *operatorv1.KMSPreflightResult
 	}{
 		{
 			name:             "preconditions not met, clears degraded",
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
 			apiServerObjects: []runtime.Object{&configv1.APIServer{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}}},
 			preconditionsMet: false,
 			expectedConditions: []operatorv1.OperatorCondition{
@@ -365,6 +401,7 @@ func TestKMSPreflightController(t *testing.T) {
 		},
 		{
 			name:             "no EncryptionKMSPreflightRequired condition, cleans up",
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
 			preconditionsMet: true,
@@ -374,6 +411,7 @@ func TestKMSPreflightController(t *testing.T) {
 		},
 		{
 			name:             "EncryptionKMSPreflightRequired condition is False, cleans up",
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
 			operatorConditions: []operatorv1.OperatorCondition{
@@ -388,6 +426,7 @@ func TestKMSPreflightController(t *testing.T) {
 		{
 			name:             "hashes match, no pod exists, deploys and returns",
 			deployer:         &fakeDeployer{statusErr: apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "kms-preflight")},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
 			operatorConditions: []operatorv1.OperatorCondition{
@@ -406,6 +445,7 @@ func TestKMSPreflightController(t *testing.T) {
 					{Type: KMSPreflightConfigHashPodCondition, Message: wellKnownMatchingHashForBaseVaultConfig},
 				},
 			}},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
 			operatorConditions: []operatorv1.OperatorCondition{
@@ -422,6 +462,7 @@ func TestKMSPreflightController(t *testing.T) {
 			deployer: &fakeDeployer{podStatus: corev1.PodStatus{
 				Phase: corev1.PodSucceeded,
 			}},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
 			operatorConditions: []operatorv1.OperatorCondition{
@@ -442,6 +483,7 @@ func TestKMSPreflightController(t *testing.T) {
 					{Type: KMSPreflightConfigHashPodCondition, Message: wellKnownMatchingHashForBaseVaultConfig},
 				},
 			}},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
 			operatorConditions: []operatorv1.OperatorCondition{
@@ -460,10 +502,12 @@ func TestKMSPreflightController(t *testing.T) {
 				Conditions: []corev1.PodCondition{
 					{Type: KMSPreflightConfigHashPodCondition, Message: wellKnownMatchingHashForBaseVaultConfig},
 					{Type: KMSPreflightResultPodCondition, Status: corev1.ConditionTrue, LastTransitionTime: metav1.Now()},
+					{Type: KMSPreflightRemoteKeyIDPodCondition, Status: corev1.ConditionTrue, Message: "remote-key-abc"},
 				},
 			}},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
-			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			coreObjects:              []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
 			operatorConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
 			},
@@ -471,6 +515,11 @@ func TestKMSPreflightController(t *testing.T) {
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
 				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
+			},
+			expectedKMSPreflightResult: &operatorv1.KMSPreflightResult{
+				Status:      operatorv1.KMSPreflightResultSucceeded,
+				ConfigHash:  wellKnownMatchingHashForBaseVaultConfig,
+				RemoteKeyID: "remote-key-abc",
 			},
 		},
 		{
@@ -481,8 +530,9 @@ func TestKMSPreflightController(t *testing.T) {
 					{Type: KMSPreflightResultPodCondition, Status: corev1.ConditionTrue, LastTransitionTime: metav1.NewTime(time.Now().Add(-2 * time.Hour))},
 				},
 			}},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
-			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			coreObjects:              []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
 			operatorConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
 			},
@@ -491,6 +541,10 @@ func TestKMSPreflightController(t *testing.T) {
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
 				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
 			},
+			expectedKMSPreflightResult: &operatorv1.KMSPreflightResult{
+				Status:     operatorv1.KMSPreflightResultSucceeded,
+				ConfigHash: wellKnownMatchingHashForBaseVaultConfig,
+			},
 		},
 		{
 			name: "pod exists, hash matches, result is False, reports error",
@@ -498,10 +552,12 @@ func TestKMSPreflightController(t *testing.T) {
 				Conditions: []corev1.PodCondition{
 					{Type: KMSPreflightConfigHashPodCondition, Message: wellKnownMatchingHashForBaseVaultConfig},
 					{Type: KMSPreflightResultPodCondition, Status: corev1.ConditionFalse, Message: "encrypt call failed", LastTransitionTime: metav1.Now()},
+					{Type: KMSPreflightRemoteKeyIDPodCondition, Status: corev1.ConditionTrue, Message: "remote-key-xyz"},
 				},
 			}},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
-			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			coreObjects:              []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
 			operatorConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
 			},
@@ -510,6 +566,11 @@ func TestKMSPreflightController(t *testing.T) {
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "PreflightCheckFailed", Message: "preflight check failed for hash cuZm_g==: encrypt call failed"},
 				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
+			},
+			expectedKMSPreflightResult: &operatorv1.KMSPreflightResult{
+				Status:      operatorv1.KMSPreflightResultFailed,
+				ConfigHash:  wellKnownMatchingHashForBaseVaultConfig,
+				RemoteKeyID: "remote-key-xyz",
 			},
 		},
 		{
@@ -520,6 +581,7 @@ func TestKMSPreflightController(t *testing.T) {
 					{Type: KMSPreflightResultPodCondition, Status: corev1.ConditionTrue},
 				},
 			}},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
 			operatorConditions: []operatorv1.OperatorCondition{
@@ -548,6 +610,7 @@ func TestKMSPreflightController(t *testing.T) {
 					},
 				},
 			}},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
 			operatorConditions: []operatorv1.OperatorCondition{
@@ -565,6 +628,7 @@ func TestKMSPreflightController(t *testing.T) {
 			deployer: &fakeDeployer{podStatus: corev1.PodStatus{
 				Phase: corev1.PodRunning,
 			}},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
 			operatorConditions: []operatorv1.OperatorCondition{
@@ -584,6 +648,7 @@ func TestKMSPreflightController(t *testing.T) {
 					{Type: corev1.PodScheduled, Status: corev1.ConditionTrue, LastTransitionTime: metav1.Time{Time: time.Now().Add(-5 * time.Minute)}},
 				},
 			}},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
 			operatorConditions: []operatorv1.OperatorCondition{
@@ -602,6 +667,7 @@ func TestKMSPreflightController(t *testing.T) {
 				Phase:     corev1.PodPending,
 				StartTime: &metav1.Time{Time: time.Now().Add(-5 * time.Minute)},
 			}},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
 			operatorConditions: []operatorv1.OperatorCondition{
@@ -631,6 +697,7 @@ func TestKMSPreflightController(t *testing.T) {
 					},
 				},
 			}},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
 			operatorConditions: []operatorv1.OperatorCondition{
@@ -652,6 +719,7 @@ func TestKMSPreflightController(t *testing.T) {
 					{Type: KMSPreflightConfigHashPodCondition, Message: wellKnownMatchingHashForBaseVaultConfig},
 				},
 			}},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
 			operatorConditions: []operatorv1.OperatorCondition{
@@ -667,6 +735,7 @@ func TestKMSPreflightController(t *testing.T) {
 		{
 			name:             "deploy fails, reports error",
 			deployer:         &fakeDeployer{statusErr: apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "kms-preflight"), deployErr: fmt.Errorf("quota exceeded")},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
 			operatorConditions: []operatorv1.OperatorCondition{
@@ -682,6 +751,7 @@ func TestKMSPreflightController(t *testing.T) {
 		{
 			name:             "status returns unexpected error",
 			deployer:         &fakeDeployer{statusErr: fmt.Errorf("connection refused")},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
 			operatorConditions: []operatorv1.OperatorCondition{
@@ -704,6 +774,7 @@ func TestKMSPreflightController(t *testing.T) {
 					},
 				},
 			},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
 			operatorConditions: []operatorv1.OperatorCondition{
@@ -722,6 +793,7 @@ func TestKMSPreflightController(t *testing.T) {
 				Phase:   corev1.PodFailed,
 				Message: "node lost",
 			}},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
 			operatorConditions: []operatorv1.OperatorCondition{
@@ -749,6 +821,7 @@ func TestKMSPreflightController(t *testing.T) {
 					},
 				},
 			}},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
 			operatorConditions: []operatorv1.OperatorCondition{
@@ -763,6 +836,7 @@ func TestKMSPreflightController(t *testing.T) {
 		},
 		{
 			name:             "hashes differ, config changed since condition was posted, cleans up",
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
 			operatorConditions: []operatorv1.OperatorCondition{
@@ -776,6 +850,7 @@ func TestKMSPreflightController(t *testing.T) {
 		},
 		{
 			name:             "hash computation fails due to missing secret",
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseConfigMap},
 			operatorConditions: []operatorv1.OperatorCondition{
@@ -790,6 +865,7 @@ func TestKMSPreflightController(t *testing.T) {
 		},
 		{
 			name:             "EncryptionKMSPreflightRequired condition is True but has empty message, treated as hash mismatch",
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
 			operatorConditions: []operatorv1.OperatorCondition{
@@ -849,6 +925,7 @@ func TestKMSPreflightController(t *testing.T) {
 				fakeApiServerClient,
 				fakeApiServerInformer,
 				fakeKubeClient.CoreV1(),
+				scenario.encryptionStatusProvider,
 				eventRecorder,
 			)
 
@@ -863,6 +940,10 @@ func TestKMSPreflightController(t *testing.T) {
 				}
 			} else if err != nil {
 				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if !reflect.DeepEqual(scenario.encryptionStatusProvider.writtenStatus, scenario.expectedKMSPreflightResult) {
+				t.Errorf("written KMS preflight result: got %v, want %v", scenario.encryptionStatusProvider.writtenStatus, scenario.expectedKMSPreflightResult)
 			}
 
 			encryptiontesting.ValidateOperatorClientConditions(t, fakeOperatorClient, scenario.expectedConditions)

--- a/pkg/operator/encryption/controllers/kms_preflight_controller_test.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller_test.go
@@ -334,6 +334,7 @@ func (f *fakeDeployer) Cleanup(_ context.Context) error {
 type fakeEncryptionStatusProvider struct {
 	observedConfigHash string
 	writtenStatus      *operatorv1.KMSPreflightResult
+	updateCallCount    int
 	updateErr          error
 }
 
@@ -351,6 +352,7 @@ func (f *fakeEncryptionStatusProvider) ApplyKMSEncryptionStatus(_ context.Contex
 }
 
 func (f *fakeEncryptionStatusProvider) UpdateKMSEncryptionStatus(_ context.Context, mutateFn func(*operatorv1.KMSEncryptionStatus)) error {
+	f.updateCallCount++
 	if f.updateErr != nil {
 		return f.updateErr
 	}
@@ -390,6 +392,7 @@ func TestKMSPreflightController(t *testing.T) {
 		expectedError              string
 		expectedConditions         []operatorv1.OperatorCondition
 		expectedKMSPreflightResult *operatorv1.KMSPreflightResult
+		expectedEncryptionStatusProviderUpdateCalls        int
 	}{
 		{
 			name:             "preconditions not met, clears degraded",
@@ -473,6 +476,7 @@ func TestKMSPreflightController(t *testing.T) {
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
 			},
+			expectedEncryptionStatusProviderUpdateCalls: 1,
 			expectedKMSPreflightResult: &operatorv1.KMSPreflightResult{
 				Status:      operatorv1.KMSPreflightResultSucceeded,
 				ConfigHash:  wellKnownMatchingHashForBaseVaultConfig,
@@ -494,6 +498,7 @@ func TestKMSPreflightController(t *testing.T) {
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
 			},
+			expectedEncryptionStatusProviderUpdateCalls: 1,
 			expectedKMSPreflightResult: &operatorv1.KMSPreflightResult{
 				Status:     operatorv1.KMSPreflightResultSucceeded,
 				ConfigHash: wellKnownMatchingHashForBaseVaultConfig,
@@ -516,10 +521,66 @@ func TestKMSPreflightController(t *testing.T) {
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "PreflightCheckFailed", Message: "preflight check failed for hash cuZm_g==: encrypt call failed"},
 			},
+			expectedEncryptionStatusProviderUpdateCalls: 1,
 			expectedKMSPreflightResult: &operatorv1.KMSPreflightResult{
 				Status:      operatorv1.KMSPreflightResultFailed,
 				ConfigHash:  wellKnownMatchingHashForBaseVaultConfig,
 				RemoteKeyID: "remote-key-xyz",
+			},
+		},
+		{
+			name: "result already written for this hash (succeeded), ensurePreflightResult is a no-op",
+			deployer: &fakeDeployer{podStatus: corev1.PodStatus{
+				Conditions: []corev1.PodCondition{
+					{Type: KMSPreflightConfigHashPodCondition, Message: wellKnownMatchingHashForBaseVaultConfig},
+					{Type: KMSPreflightResultPodCondition, Status: corev1.ConditionTrue, LastTransitionTime: metav1.Now()},
+				},
+			}},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{
+				observedConfigHash: wellKnownMatchingHashForBaseVaultConfig,
+				writtenStatus: &operatorv1.KMSPreflightResult{
+					Status:     operatorv1.KMSPreflightResultSucceeded,
+					ConfigHash: wellKnownMatchingHashForBaseVaultConfig,
+				},
+			},
+			apiServerObjects:    []runtime.Object{apiServerWithKMS},
+			coreObjects:         []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			preconditionsMet:    true,
+			expectedEncryptionStatusProviderUpdateCalls: 0,
+			expectedConditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
+			},
+			expectedKMSPreflightResult: &operatorv1.KMSPreflightResult{
+				Status:     operatorv1.KMSPreflightResultSucceeded,
+				ConfigHash: wellKnownMatchingHashForBaseVaultConfig,
+			},
+		},
+		{
+			name: "result already written for this hash (failed), ensurePreflightResult is a no-op",
+			deployer: &fakeDeployer{podStatus: corev1.PodStatus{
+				Conditions: []corev1.PodCondition{
+					{Type: KMSPreflightConfigHashPodCondition, Message: wellKnownMatchingHashForBaseVaultConfig},
+					{Type: KMSPreflightResultPodCondition, Status: corev1.ConditionFalse, Message: "encrypt call failed", LastTransitionTime: metav1.Now()},
+				},
+			}},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{
+				observedConfigHash: wellKnownMatchingHashForBaseVaultConfig,
+				writtenStatus: &operatorv1.KMSPreflightResult{
+					Status:     operatorv1.KMSPreflightResultFailed,
+					ConfigHash: wellKnownMatchingHashForBaseVaultConfig,
+				},
+			},
+			apiServerObjects:    []runtime.Object{apiServerWithKMS},
+			coreObjects:         []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			preconditionsMet:    true,
+			expectedEncryptionStatusProviderUpdateCalls: 0,
+			expectedError:       "preflight check failed for hash k6dSVA==: encrypt call failed",
+			expectedConditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "PreflightCheckFailed", Message: "preflight check failed for hash k6dSVA==: encrypt call failed"},
+			},
+			expectedKMSPreflightResult: &operatorv1.KMSPreflightResult{
+				Status:     operatorv1.KMSPreflightResultFailed,
+				ConfigHash: wellKnownMatchingHashForBaseVaultConfig,
 			},
 		},
 		{
@@ -832,6 +893,9 @@ func TestKMSPreflightController(t *testing.T) {
 
 			if !reflect.DeepEqual(scenario.encryptionStatusProvider.writtenStatus, scenario.expectedKMSPreflightResult) {
 				t.Errorf("written KMS preflight result: got %v, want %v", scenario.encryptionStatusProvider.writtenStatus, scenario.expectedKMSPreflightResult)
+			}
+			if got := scenario.encryptionStatusProvider.updateCallCount; got != scenario.expectedEncryptionStatusProviderUpdateCalls {
+				t.Errorf("UpdateKMSEncryptionStatus call count: got %d, want %d", got, scenario.expectedEncryptionStatusProviderUpdateCalls)
 			}
 
 			encryptiontesting.ValidateOperatorClientConditions(t, fakeOperatorClient, scenario.expectedConditions)

--- a/pkg/operator/encryption/controllers/kms_preflight_controller_test.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller_test.go
@@ -332,12 +332,14 @@ func (f *fakeDeployer) Cleanup(_ context.Context) error {
 }
 
 type fakeEncryptionStatusProvider struct {
-	writtenStatus *operatorv1.KMSPreflightResult
-	updateErr     error
+	observedConfigHash string
+	writtenStatus      *operatorv1.KMSPreflightResult
+	updateErr          error
 }
 
 func (f *fakeEncryptionStatusProvider) GetKMSEncryptionStatus(_ context.Context) (*operatorv1.KMSEncryptionStatus, error) {
 	s := &operatorv1.KMSEncryptionStatus{}
+	s.Preflight.ObservedConfigHash = f.observedConfigHash
 	if f.writtenStatus != nil {
 		s.Preflight.Result = *f.writtenStatus
 	}
@@ -384,7 +386,6 @@ func TestKMSPreflightController(t *testing.T) {
 		encryptionStatusProvider   *fakeEncryptionStatusProvider
 		apiServerObjects           []runtime.Object
 		coreObjects                []runtime.Object
-		operatorConditions         []operatorv1.OperatorCondition
 		preconditionsMet           bool
 		expectedError              string
 		expectedConditions         []operatorv1.OperatorCondition
@@ -400,42 +401,14 @@ func TestKMSPreflightController(t *testing.T) {
 			},
 		},
 		{
-			name:             "no EncryptionKMSPreflightRequired condition, cleans up",
-			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
-			apiServerObjects: []runtime.Object{apiServerWithKMS},
-			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			preconditionsMet: true,
-			expectedConditions: []operatorv1.OperatorCondition{
-				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
-			},
-		},
-		{
-			name:             "EncryptionKMSPreflightRequired condition is False, cleans up",
-			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
-			apiServerObjects: []runtime.Object{apiServerWithKMS},
-			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			operatorConditions: []operatorv1.OperatorCondition{
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionFalse, Message: wellKnownMatchingHashForBaseVaultConfig},
-			},
-			preconditionsMet: true,
-			expectedConditions: []operatorv1.OperatorCondition{
-				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionFalse, Message: wellKnownMatchingHashForBaseVaultConfig},
-			},
-		},
-		{
 			name:             "hashes match, no pod exists, deploys and returns",
 			deployer:         &fakeDeployer{statusErr: apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "kms-preflight")},
-			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			operatorConditions: []operatorv1.OperatorCondition{
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
-			},
 			preconditionsMet: true,
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
 			},
 		},
 		{
@@ -445,16 +418,12 @@ func TestKMSPreflightController(t *testing.T) {
 					{Type: KMSPreflightConfigHashPodCondition, Message: wellKnownMatchingHashForBaseVaultConfig},
 				},
 			}},
-			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			operatorConditions: []operatorv1.OperatorCondition{
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
-			},
 			preconditionsMet: true,
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
 			},
 		},
 		{
@@ -462,17 +431,13 @@ func TestKMSPreflightController(t *testing.T) {
 			deployer: &fakeDeployer{podStatus: corev1.PodStatus{
 				Phase: corev1.PodSucceeded,
 			}},
-			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			operatorConditions: []operatorv1.OperatorCondition{
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
-			},
 			preconditionsMet: true,
 			expectedError:    "preflight pod completed without reporting result for hash cuZm_g==",
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "PodCompletedWithoutResult", Message: "preflight pod completed without reporting result for hash cuZm_g=="},
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
 			},
 		},
 		{
@@ -483,17 +448,13 @@ func TestKMSPreflightController(t *testing.T) {
 					{Type: KMSPreflightConfigHashPodCondition, Message: wellKnownMatchingHashForBaseVaultConfig},
 				},
 			}},
-			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			operatorConditions: []operatorv1.OperatorCondition{
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
-			},
 			preconditionsMet: true,
 			expectedError:    "preflight pod completed without reporting result for hash cuZm_g==",
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "PodCompletedWithoutResult", Message: "preflight pod completed without reporting result for hash cuZm_g=="},
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
 			},
 		},
 		{
@@ -505,16 +466,12 @@ func TestKMSPreflightController(t *testing.T) {
 					{Type: KMSPreflightRemoteKeyIDPodCondition, Status: corev1.ConditionTrue, Message: "remote-key-abc"},
 				},
 			}},
-			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
-			coreObjects:              []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			operatorConditions: []operatorv1.OperatorCondition{
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
-			},
+			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
 			preconditionsMet: true,
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
 			},
 			expectedKMSPreflightResult: &operatorv1.KMSPreflightResult{
 				Status:      operatorv1.KMSPreflightResultSucceeded,
@@ -530,16 +487,12 @@ func TestKMSPreflightController(t *testing.T) {
 					{Type: KMSPreflightResultPodCondition, Status: corev1.ConditionTrue, LastTransitionTime: metav1.NewTime(time.Now().Add(-2 * time.Hour))},
 				},
 			}},
-			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
-			coreObjects:              []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			operatorConditions: []operatorv1.OperatorCondition{
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
-			},
+			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
 			preconditionsMet: true,
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
 			},
 			expectedKMSPreflightResult: &operatorv1.KMSPreflightResult{
 				Status:     operatorv1.KMSPreflightResultSucceeded,
@@ -555,17 +508,13 @@ func TestKMSPreflightController(t *testing.T) {
 					{Type: KMSPreflightRemoteKeyIDPodCondition, Status: corev1.ConditionTrue, Message: "remote-key-xyz"},
 				},
 			}},
-			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
-			coreObjects:              []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			operatorConditions: []operatorv1.OperatorCondition{
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
-			},
+			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
 			preconditionsMet: true,
 			expectedError:    "preflight check failed for hash cuZm_g==: encrypt call failed",
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "PreflightCheckFailed", Message: "preflight check failed for hash cuZm_g==: encrypt call failed"},
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
 			},
 			expectedKMSPreflightResult: &operatorv1.KMSPreflightResult{
 				Status:      operatorv1.KMSPreflightResultFailed,
@@ -581,16 +530,12 @@ func TestKMSPreflightController(t *testing.T) {
 					{Type: KMSPreflightResultPodCondition, Status: corev1.ConditionTrue},
 				},
 			}},
-			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			operatorConditions: []operatorv1.OperatorCondition{
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
-			},
 			preconditionsMet: true,
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
 			},
 		},
 		{
@@ -610,17 +555,13 @@ func TestKMSPreflightController(t *testing.T) {
 					},
 				},
 			}},
-			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			operatorConditions: []operatorv1.OperatorCondition{
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
-			},
 			preconditionsMet: true,
 			expectedError:    "preflight pod failed for hash cuZm_g==: at least one container kms-preflight-check exited with 1 (Unknown): connection refused",
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "Unknown", Message: "preflight pod failed for hash cuZm_g==: at least one container kms-preflight-check exited with 1 (Unknown): connection refused"},
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
 			},
 		},
 		{
@@ -628,16 +569,12 @@ func TestKMSPreflightController(t *testing.T) {
 			deployer: &fakeDeployer{podStatus: corev1.PodStatus{
 				Phase: corev1.PodRunning,
 			}},
-			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			operatorConditions: []operatorv1.OperatorCondition{
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
-			},
 			preconditionsMet: true,
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
 			},
 		},
 		{
@@ -648,17 +585,13 @@ func TestKMSPreflightController(t *testing.T) {
 					{Type: corev1.PodScheduled, Status: corev1.ConditionTrue, LastTransitionTime: metav1.Time{Time: time.Now().Add(-5 * time.Minute)}},
 				},
 			}},
-			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			operatorConditions: []operatorv1.OperatorCondition{
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
-			},
 			preconditionsMet: true,
 			expectedError:    "preflight pod has not reported config hash after 3m0s: pod is in Pending phase",
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "Unknown", Message: "preflight pod has not reported config hash after 3m0s: pod is in Pending phase"},
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
 			},
 		},
 		{
@@ -667,17 +600,13 @@ func TestKMSPreflightController(t *testing.T) {
 				Phase:     corev1.PodPending,
 				StartTime: &metav1.Time{Time: time.Now().Add(-5 * time.Minute)},
 			}},
-			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			operatorConditions: []operatorv1.OperatorCondition{
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
-			},
 			preconditionsMet: true,
 			expectedError:    "preflight pod has not reported config hash after 3m0s: pod is in Pending phase",
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "Unknown", Message: "preflight pod has not reported config hash after 3m0s: pod is in Pending phase"},
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
 			},
 		},
 		{
@@ -697,17 +626,13 @@ func TestKMSPreflightController(t *testing.T) {
 					},
 				},
 			}},
-			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			operatorConditions: []operatorv1.OperatorCondition{
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
-			},
 			preconditionsMet: true,
 			expectedError:    "preflight pod has not reported config hash after 3m0s: at least one container kms-preflight-check is waiting: ImagePullBackOff: back-off pulling image",
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "ImagePullBackOff", Message: "preflight pod has not reported config hash after 3m0s: at least one container kms-preflight-check is waiting: ImagePullBackOff: back-off pulling image"},
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
 			},
 		},
 		{
@@ -719,49 +644,37 @@ func TestKMSPreflightController(t *testing.T) {
 					{Type: KMSPreflightConfigHashPodCondition, Message: wellKnownMatchingHashForBaseVaultConfig},
 				},
 			}},
-			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			operatorConditions: []operatorv1.OperatorCondition{
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
-			},
 			preconditionsMet: true,
 			expectedError:    "preflight pod has not reported result after 3m0s: pod is in Running phase",
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "Unknown", Message: "preflight pod has not reported result after 3m0s: pod is in Running phase"},
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
 			},
 		},
 		{
 			name:             "deploy fails, reports error",
 			deployer:         &fakeDeployer{statusErr: apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "kms-preflight"), deployErr: fmt.Errorf("quota exceeded")},
-			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			operatorConditions: []operatorv1.OperatorCondition{
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
-			},
 			preconditionsMet: true,
 			expectedError:    "quota exceeded",
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "Error", Message: "quota exceeded"},
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
 			},
 		},
 		{
 			name:             "status returns unexpected error",
 			deployer:         &fakeDeployer{statusErr: fmt.Errorf("connection refused")},
-			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			operatorConditions: []operatorv1.OperatorCondition{
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
-			},
 			preconditionsMet: true,
 			expectedError:    "failed to get preflight pod status",
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "Error", Message: "failed to get preflight pod status: connection refused"},
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
 			},
 		},
 		{
@@ -774,17 +687,13 @@ func TestKMSPreflightController(t *testing.T) {
 					},
 				},
 			},
-			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			operatorConditions: []operatorv1.OperatorCondition{
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
-			},
 			preconditionsMet: true,
 			expectedError:    "delete forbidden",
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "Error", Message: "delete forbidden"},
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
 			},
 		},
 		{
@@ -793,17 +702,13 @@ func TestKMSPreflightController(t *testing.T) {
 				Phase:   corev1.PodFailed,
 				Message: "node lost",
 			}},
-			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			operatorConditions: []operatorv1.OperatorCondition{
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
-			},
 			preconditionsMet: true,
 			expectedError:    "preflight pod failed for hash cuZm_g==: node lost",
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "Unknown", Message: "preflight pod failed for hash cuZm_g==: node lost"},
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
 			},
 		},
 		{
@@ -821,60 +726,44 @@ func TestKMSPreflightController(t *testing.T) {
 					},
 				},
 			}},
-			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			operatorConditions: []operatorv1.OperatorCondition{
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
-			},
 			preconditionsMet: true,
 			expectedError:    "preflight pod failed for hash cuZm_g==: at least one container kms-preflight-check exited with 137 (Unknown)",
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "Unknown", Message: "preflight pod failed for hash cuZm_g==: at least one container kms-preflight-check exited with 137 (Unknown)"},
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
 			},
 		},
 		{
-			name:             "hashes differ, config changed since condition was posted, cleans up",
-			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
+			name:             "hashes differ, config changed since ObservedConfigHash was written, cleans up",
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: "stale-hash"},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			operatorConditions: []operatorv1.OperatorCondition{
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: "stale-hash"},
-			},
 			preconditionsMet: true,
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: "stale-hash"},
 			},
 		},
 		{
 			name:             "hash computation fails due to missing secret",
-			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseConfigMap},
-			operatorConditions: []operatorv1.OperatorCondition{
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
-			},
 			preconditionsMet: true,
 			expectedError:    "failed to compute KMS config hash",
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "Error", Message: `failed to compute KMS config hash: failed to get secret openshift-config/vault-approle: secrets "vault-approle" not found`},
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: wellKnownMatchingHashForBaseVaultConfig},
 			},
 		},
 		{
-			name:             "EncryptionKMSPreflightRequired condition is True but has empty message, treated as hash mismatch",
-			encryptionStatusProvider: &fakeEncryptionStatusProvider{},
+			name:             "empty ObservedConfigHash, cleans up",
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: ""},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			operatorConditions: []operatorv1.OperatorCondition{
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: ""},
-			},
 			preconditionsMet: true,
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
-				{Type: "EncryptionKMSPreflightRequired", Status: operatorv1.ConditionTrue, Message: ""},
 			},
 		},
 	}
@@ -884,7 +773,6 @@ func TestKMSPreflightController(t *testing.T) {
 			conditions := []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
 			}
-			conditions = append(conditions, scenario.operatorConditions...)
 
 			fakeOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(
 				&operatorv1.StaticPodOperatorSpec{

--- a/pkg/operator/encryption/controllers/kms_preflight_controller_test.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller_test.go
@@ -390,6 +390,7 @@ func TestKMSPreflightController(t *testing.T) {
 		coreObjects                []runtime.Object
 		preconditionsMet           bool
 		expectedError              string
+		expectedPreflightPodCleanup            bool
 		expectedConditions         []operatorv1.OperatorCondition
 		expectedKMSPreflightResult *operatorv1.KMSPreflightResult
 		expectedEncryptionStatusProviderUpdateCalls        int
@@ -473,6 +474,7 @@ func TestKMSPreflightController(t *testing.T) {
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
 			preconditionsMet: true,
+			expectedPreflightPodCleanup:  true,
 			expectedEncryptionStatusProviderUpdateCalls: 1,
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
@@ -522,9 +524,10 @@ func TestKMSPreflightController(t *testing.T) {
 					ConfigHash: wellKnownMatchingHashForBaseVaultConfig,
 				},
 			},
-			apiServerObjects:    []runtime.Object{apiServerWithKMS},
-			coreObjects:         []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			preconditionsMet:    true,
+			apiServerObjects:              []runtime.Object{apiServerWithKMS},
+			coreObjects:                   []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			preconditionsMet:              true,
+			expectedPreflightPodCleanup:   true,
 			expectedEncryptionStatusProviderUpdateCalls: 0,
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
@@ -572,8 +575,9 @@ func TestKMSPreflightController(t *testing.T) {
 			}},
 			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
-			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			preconditionsMet: true,
+			coreObjects:                 []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			preconditionsMet:            true,
+			expectedPreflightPodCleanup: true,
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
 			},
@@ -730,8 +734,9 @@ func TestKMSPreflightController(t *testing.T) {
 			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
 			apiServerObjects: []runtime.Object{apiServerWithKMS},
 			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			preconditionsMet: true,
-			expectedError:    "delete forbidden",
+			preconditionsMet:            true,
+			expectedPreflightPodCleanup: true,
+			expectedError:               "delete forbidden",
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "Error", Message: "delete forbidden"},
 			},
@@ -777,10 +782,11 @@ func TestKMSPreflightController(t *testing.T) {
 		},
 		{
 			name:             "hashes differ, config changed since ObservedConfigHash was written, cleans up",
-			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: "stale-hash"},
-			apiServerObjects: []runtime.Object{apiServerWithKMS},
-			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			preconditionsMet: true,
+			encryptionStatusProvider:    &fakeEncryptionStatusProvider{observedConfigHash: "stale-hash"},
+			apiServerObjects:            []runtime.Object{apiServerWithKMS},
+			coreObjects:                 []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			preconditionsMet:            true,
+			expectedPreflightPodCleanup: true,
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
 			},
@@ -798,10 +804,11 @@ func TestKMSPreflightController(t *testing.T) {
 		},
 		{
 			name:             "empty ObservedConfigHash, cleans up",
-			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: ""},
-			apiServerObjects: []runtime.Object{apiServerWithKMS},
-			coreObjects:      []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			preconditionsMet: true,
+			encryptionStatusProvider:    &fakeEncryptionStatusProvider{observedConfigHash: ""},
+			apiServerObjects:            []runtime.Object{apiServerWithKMS},
+			coreObjects:                 []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			preconditionsMet:            true,
+			expectedPreflightPodCleanup: true,
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
 			},
@@ -875,6 +882,13 @@ func TestKMSPreflightController(t *testing.T) {
 			}
 			if got := scenario.encryptionStatusProvider.updateCallCount; got != scenario.expectedEncryptionStatusProviderUpdateCalls {
 				t.Errorf("UpdateKMSEncryptionStatus call count: got %d, want %d", got, scenario.expectedEncryptionStatusProviderUpdateCalls)
+			}
+			fakeDeployerInstance, ok := deployer.(*fakeDeployer)
+			if !ok {
+				t.Fatalf("deployer is not *fakeDeployer")
+			}
+			if fakeDeployerInstance.cleaned != scenario.expectedPreflightPodCleanup {
+				t.Errorf("deployer.Cleanup called: got %v, want %v", fakeDeployerInstance.cleaned, scenario.expectedPreflightPodCleanup)
 			}
 
 			encryptiontesting.ValidateOperatorClientConditions(t, fakeOperatorClient, scenario.expectedConditions)

--- a/pkg/operator/encryption/kms/preflight/pod_status.go
+++ b/pkg/operator/encryption/kms/preflight/pod_status.go
@@ -72,7 +72,7 @@ func podCheckConditions(configHash string, status *kmsservice.StatusResponse, ch
 
 	if status != nil {
 		conditions = append(conditions, corev1.PodCondition{
-			Type:               controllers.KMSPreflightKEKIDPodCondition,
+			Type:               controllers.KMSPreflightRemoteKeyIDPodCondition,
 			Status:             corev1.ConditionTrue,
 			Message:            status.KeyID,
 			LastTransitionTime: now,

--- a/pkg/operator/encryption/kms/preflight/pod_status_test.go
+++ b/pkg/operator/encryption/kms/preflight/pod_status_test.go
@@ -39,8 +39,8 @@ func TestPodCheckConditions(t *testing.T) {
 	}
 
 	kekId := conditions[2]
-	if kekId.Type != controllers.KMSPreflightKEKIDPodCondition || kekId.Message != "key-1" {
-		t.Fatalf("unexpected kekID condition: %#v", kekId)
+	if kekId.Type != controllers.KMSPreflightRemoteKeyIDPodCondition || kekId.Message != "key-1" {
+		t.Fatalf("unexpected remoteKeyID condition: %#v", kekId)
 	}
 
 	failed := podCheckConditions(configHash, status, fmt.Errorf("encrypt call failed"))

--- a/pkg/operator/encryption/kms/preflight/pod_status_test.go
+++ b/pkg/operator/encryption/kms/preflight/pod_status_test.go
@@ -38,9 +38,9 @@ func TestPodCheckConditions(t *testing.T) {
 		t.Fatalf("unexpected config hash condition: %#v", configHashCondition)
 	}
 
-	kekId := conditions[2]
-	if kekId.Type != controllers.KMSPreflightRemoteKeyIDPodCondition || kekId.Message != "key-1" {
-		t.Fatalf("unexpected remoteKeyID condition: %#v", kekId)
+	remoteKeyID := conditions[2]
+	if remoteKeyID.Type != controllers.KMSPreflightRemoteKeyIDPodCondition || remoteKeyID.Message != "key-1" {
+		t.Fatalf("unexpected remoteKeyID condition: %#v", remoteKeyID)
 	}
 
 	failed := podCheckConditions(configHash, status, fmt.Errorf("encrypt call failed"))

--- a/test/library/encryption/preflight_deploy.go
+++ b/test/library/encryption/preflight_deploy.go
@@ -113,8 +113,8 @@ func AssertPreflightDeploy(ctx context.Context, t testing.TB, clientSet ClientSe
 	resultCond := requirePodCondition(t, status.Conditions, controllers.KMSPreflightResultPodCondition, corev1.ConditionTrue)
 	require.Equal(t, "Succeeded", resultCond.Reason)
 
-	kekCond := requirePodCondition(t, status.Conditions, controllers.KMSPreflightKEKIDPodCondition, corev1.ConditionTrue)
-	require.NotEmpty(t, kekCond.Message, "KEK ID")
+	kekCond := requirePodCondition(t, status.Conditions, controllers.KMSPreflightRemoteKeyIDPodCondition, corev1.ConditionTrue)
+	require.NotEmpty(t, kekCond.Message, "remote key ID")
 }
 
 func requirePodCondition(t testing.TB, conditions []corev1.PodCondition, condType corev1.PodConditionType, wantStatus corev1.ConditionStatus) *corev1.PodCondition {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * KMS preflight checks now persist the remote key ID in encryption status.
  * Completed preflight checks are reused when the KMS configuration hash hasn’t changed, reducing unnecessary pod activity.
* **Bug Fixes**
  * Preflight results are now more authoritative across retries, failures, and configuration changes.
  * Preflight pods are cleaned up immediately after successful completion; stale or mismatched preflight states are handled more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->