### PR TITLE
Add encryption config Secret generation with in-memory Key Secret in preflight controller

### DIFF
--- a/pkg/operator/encryption/controllers/key_controller.go
+++ b/pkg/operator/encryption/controllers/key_controller.go
@@ -278,6 +278,10 @@ func (c *keyController) validateExistingSecret(ctx context.Context, keySecret *c
 }
 
 func (c *keyController) generateKeySecret(ctx context.Context, keyID uint64, currentMode state.Mode, apiServerEncryption configv1.APIServerEncryption, desiredProviderCfg kmsProviderConfig, internalReason, externalReason string) (*corev1.Secret, error) {
+	return generateKeySecret(ctx, c.instanceName, keyID, currentMode, apiServerEncryption, desiredProviderCfg, c.secretClient, c.configMapClient, internalReason, externalReason)
+}
+
+func generateKeySecret(ctx context.Context, instanceName string, keyID uint64, currentMode state.Mode, apiServerEncryption configv1.APIServerEncryption, desiredProviderCfg kmsProviderConfig, secretClient corev1client.SecretsGetter, configMapClient corev1client.ConfigMapsGetter, internalReason, externalReason string) (*corev1.Secret, error) {
 	bs := crypto.ModeToNewKeyFunc[currentMode]()
 	ks := state.KeyState{
 		Key: apiserverv1.Key{
@@ -302,7 +306,7 @@ func (c *keyController) generateKeySecret(ctx context.Context, keyID uint64, cur
 		if secretName, expectedKeys, err := desiredProviderCfg.referencedSecretName(); err != nil {
 			return nil, err
 		} else if len(secretName) > 0 {
-			refSecret, err := c.secretClient.Secrets(openshiftConfigNS).Get(ctx, secretName, metav1.GetOptions{})
+			refSecret, err := secretClient.Secrets(openshiftConfigNS).Get(ctx, secretName, metav1.GetOptions{})
 			if err != nil {
 				return nil, fmt.Errorf("failed to get secret %s in %s: %w", secretName, openshiftConfigNS, err)
 			}
@@ -320,7 +324,7 @@ func (c *keyController) generateKeySecret(ctx context.Context, keyID uint64, cur
 		if cmName, expectedKeys, err := desiredProviderCfg.referencedConfigMapName(); err != nil {
 			return nil, err
 		} else if len(cmName) > 0 {
-			refCM, err := c.configMapClient.ConfigMaps(openshiftConfigNS).Get(ctx, cmName, metav1.GetOptions{})
+			refCM, err := configMapClient.ConfigMaps(openshiftConfigNS).Get(ctx, cmName, metav1.GetOptions{})
 			if err != nil {
 				return nil, fmt.Errorf("failed to get configmap %s in %s: %w", cmName, openshiftConfigNS, err)
 			}
@@ -335,21 +339,25 @@ func (c *keyController) generateKeySecret(ctx context.Context, keyID uint64, cur
 			}
 		}
 	}
-	return secrets.FromKeyState(c.instanceName, ks)
+	return secrets.FromKeyState(instanceName, ks)
 }
 
 func (c *keyController) getCurrentModeReasonAndEncryptionConfig(ctx context.Context) (state.Mode, string, configv1.APIServerEncryption, error) {
-	apiServer, err := c.apiServerClient.Get(ctx, "cluster", metav1.GetOptions{})
+	return getCurrentModeReasonAndEncryptionConfig(ctx, c.apiServerClient, c.operatorClient, c.unsupportedConfigPrefix)
+}
+
+func getCurrentModeReasonAndEncryptionConfig(ctx context.Context, apiServerClient configv1client.APIServerInterface, operatorClient operatorv1helpers.OperatorClient, unsupportedConfigPrefix []string) (state.Mode, string, configv1.APIServerEncryption, error) {
+	apiServer, err := apiServerClient.Get(ctx, "cluster", metav1.GetOptions{})
 	if err != nil {
 		return "", "", configv1.APIServerEncryption{}, err
 	}
 
-	operatorSpec, _, _, err := c.operatorClient.GetOperatorState()
+	operatorSpec, _, _, err := operatorClient.GetOperatorState()
 	if err != nil {
 		return "", "", configv1.APIServerEncryption{}, err
 	}
 
-	encryptionConfig, err := structuredUnsupportedConfigFrom(operatorSpec.UnsupportedConfigOverrides.Raw, c.unsupportedConfigPrefix)
+	encryptionConfig, err := structuredUnsupportedConfigFrom(operatorSpec.UnsupportedConfigOverrides.Raw, unsupportedConfigPrefix)
 	if err != nil {
 		return "", "", configv1.APIServerEncryption{}, err
 	}

--- a/pkg/operator/encryption/controllers/kms_preflight_controller.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"hash"
 	"hash/fnv"
+	"math"
 	"sort"
 	"time"
 
@@ -22,6 +23,10 @@ import (
 	applyoperatorv1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
 
 	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
+	"github.com/openshift/library-go/pkg/operator/encryption/secrets"
+	"github.com/openshift/library-go/pkg/operator/encryption/state"
+	"github.com/openshift/library-go/pkg/operator/encryption/statemachine"
 	"github.com/openshift/library-go/pkg/operator/events"
 	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
 )
@@ -165,13 +170,17 @@ type KMSPreflightDeployer interface {
 }
 
 type kmsPreflightController struct {
-	controllerInstanceName string
+	controllerInstanceName  string
+	instanceName            string
+	unsupportedConfigPrefix []string
 
 	operatorClient  operatorv1helpers.OperatorClient
 	apiServerClient configv1client.APIServerInterface
 	coreClient      corev1client.CoreV1Interface
 
 	deployer                 KMSPreflightDeployer
+	encryptionDeployer       statemachine.Deployer
+	encryptionSecretSelector metav1.ListOptions
 	provider                 Provider
 	preconditionsFulfilledFn preconditionsFulfilled
 }
@@ -247,9 +256,11 @@ type kmsPreflightController struct {
 // so that its logs can be inspected, then cleaned up by a subsequent sync.
 func NewKMSPreflightController(
 	instanceName string,
+	unsupportedConfigPrefix []string,
 	provider Provider,
 	preconditionsFulfilledFn preconditionsFulfilled,
 	deployer KMSPreflightDeployer,
+	encryptionDeployer statemachine.Deployer,
 	operatorClient operatorv1helpers.OperatorClient,
 	apiServerClient configv1client.APIServerInterface,
 	apiServerInformer configv1informers.APIServerInformer,
@@ -258,16 +269,21 @@ func NewKMSPreflightController(
 	// posts a new EncryptionKMSPreflightRequired condition, which triggers this controller
 	// via the operatorClient informer. The minute-based resync covers the rest.
 	coreClient corev1client.CoreV1Interface,
+	encryptionSecretSelector metav1.ListOptions,
 	eventRecorder events.Recorder,
 ) factory.Controller {
 	c := &kmsPreflightController{
-		controllerInstanceName: factory.ControllerInstanceName(instanceName, "EncryptionKMSPreflight"),
+		controllerInstanceName:  factory.ControllerInstanceName(instanceName, "EncryptionKMSPreflight"),
+		instanceName:            instanceName,
+		unsupportedConfigPrefix: unsupportedConfigPrefix,
 
 		operatorClient:  operatorClient,
 		apiServerClient: apiServerClient,
 		coreClient:      coreClient,
 
 		deployer:                 deployer,
+		encryptionDeployer:       encryptionDeployer,
+		encryptionSecretSelector: encryptionSecretSelector,
 		provider:                 provider,
 		preconditionsFulfilledFn: preconditionsFulfilledFn,
 	}
@@ -387,8 +403,11 @@ func (c *kmsPreflightController) runPreflightChecks(ctx context.Context) (requeu
 	podStatus, err := c.deployer.Status(ctx)
 	// Scenario 2: no pod exists, deploy a new one.
 	if apierrors.IsNotFound(err) {
-		// TODO: compute the encryption configuration and pass it to the deployer
-		return true, c.deployer.Deploy(ctx, requiredHash, nil)
+		encryptionSecret, computeErr := c.computeEncryptionConfigSecret(ctx)
+		if computeErr != nil {
+			return false, fmt.Errorf("failed to compute encryption config for preflight: %w", computeErr)
+		}
+		return true, c.deployer.Deploy(ctx, requiredHash, encryptionSecret)
 	}
 	if err != nil {
 		return false, fmt.Errorf("failed to get preflight pod status: %w", err)
@@ -443,6 +462,56 @@ func (c *kmsPreflightController) runPreflightChecks(ctx context.Context) (requeu
 		message: fmt.Sprintf("preflight check failed for hash %s: %s", requiredHash, resultCondition.Message),
 	}
 }
+
+// computeEncryptionConfigSecret builds the encryption-config secret that the
+// preflight pod will use. It simulates what the state controller will produce
+// once the key controller creates the new key: existing KMS plugins from their
+// backed key secrets, plus a simulated key for the candidate KMS plugin.
+func (c *kmsPreflightController) computeEncryptionConfigSecret(ctx context.Context) (*corev1.Secret, error) {
+	currentMode, _, apiEncryptionConfiguration, err := getCurrentModeReasonAndEncryptionConfig(ctx, c.apiServerClient, c.operatorClient, c.unsupportedConfigPrefix)
+	if err != nil {
+		return nil, err
+	}
+	if currentMode != state.KMS {
+		return nil, fmt.Errorf("preflight is only supported in KMS mode, current mode is %q", currentMode)
+	}
+
+	providerCfg, err := newKMSProviderConfig(apiEncryptionConfiguration.KMS)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create KMS provider config: %w", err)
+	}
+
+	simulatedKeySecret, err := generateKeySecret(ctx, c.instanceName, preflightKeyID, state.KMS, apiEncryptionConfiguration, providerCfg, c.coreClient, c.coreClient, "", "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create simulated key secret: %w", err)
+	}
+	ks, err := secrets.ToKeyState(simulatedKeySecret)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse simulated key secret: %w", err)
+	}
+	ks.KMS.Encryption.Endpoint = "unix:///var/run/kmsplugin/kms.sock"
+	simulatedKeySecret, err = secrets.FromKeyState(c.instanceName, ks)
+	if err != nil {
+		return nil, fmt.Errorf("failed to rebuild simulated key secret: %w", err)
+	}
+
+	desiredState, err := statemachine.ComputeDesiredEncryptionStateWithAdditionalKey(
+		ctx, c.encryptionDeployer, c.coreClient, c.encryptionSecretSelector,
+		c.provider.EncryptedGRs(), simulatedKeySecret,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg, err := encryptiondata.FromEncryptionState(desiredState)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build encryption config: %w", err)
+	}
+	secretName := fmt.Sprintf("%s-%s", encryptiondata.EncryptionConfSecretName, c.instanceName)
+	return encryptiondata.ToSecret("openshift-config-managed", secretName, cfg)
+}
+
+const preflightKeyID = math.MaxInt32
 
 func (c *kmsPreflightController) cleanupAfterRetention(ctx context.Context, completedAt time.Time) error {
 	age := time.Since(completedAt)

--- a/pkg/operator/encryption/controllers/kms_preflight_controller_test.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller_test.go
@@ -20,7 +20,10 @@ import (
 	configv1clientfake "github.com/openshift/client-go/config/clientset/versioned/fake"
 	configv1informers "github.com/openshift/client-go/config/informers/externalversions"
 
+	"k8s.io/client-go/tools/cache"
+
 	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/encryption/statemachine"
 	encryptiontesting "github.com/openshift/library-go/pkg/operator/encryption/testing"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
@@ -329,11 +332,28 @@ func (f *fakeDeployer) Cleanup(_ context.Context) error {
 	return f.cleanupErr
 }
 
+type fakeEncryptionDeployer struct {
+	secret    *corev1.Secret
+	converged bool
+	err       error
+}
+
+func (f *fakeEncryptionDeployer) DeployedEncryptionConfigSecret(_ context.Context) (*corev1.Secret, bool, error) {
+	return f.secret, f.converged, f.err
+}
+func (f *fakeEncryptionDeployer) AddEventHandler(_ cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
+	return nil, nil
+}
+func (f *fakeEncryptionDeployer) HasSynced() bool { return true }
+
+var _ statemachine.Deployer = &fakeEncryptionDeployer{}
+
 func TestKMSPreflightController(t *testing.T) {
 	apiServerWithKMS := &configv1.APIServer{
 		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
 		Spec: configv1.APIServerSpec{
 			Encryption: configv1.APIServerEncryption{
+				Type: "KMS",
 				KMS: configv1.KMSPluginConfig{
 					Type:  configv1.VaultKMSProvider,
 					Vault: wellKnownBaseVaultConfig,
@@ -843,13 +863,16 @@ func TestKMSPreflightController(t *testing.T) {
 
 			target := NewKMSPreflightController(
 				"test",
+				nil,
 				provider,
 				preconditionsFn,
 				deployer,
+				&fakeEncryptionDeployer{converged: true},
 				fakeOperatorClient,
 				fakeApiServerClient,
 				fakeApiServerInformer,
 				fakeKubeClient.CoreV1(),
+				metav1.ListOptions{},
 				eventRecorder,
 			)
 

--- a/pkg/operator/encryption/statemachine/transition.go
+++ b/pkg/operator/encryption/statemachine/transition.go
@@ -61,6 +61,44 @@ func GetEncryptionConfigAndState(
 	return secretData, desiredEncryptionState, encryptionSecrets, "", nil
 }
 
+// ComputeDesiredEncryptionStateWithAdditionalKey computes the desired encryption
+// state as if additionalKeySecret already existed alongside the real key secrets.
+// This lets the preflight controller simulate the encryption config that will
+// result once the key controller creates a new key, without actually creating it.
+//
+// Unlike GetEncryptionConfigAndState, this function does not require API server
+// revisions to have converged. The preflight controller needs to validate a new
+// KMS plugin even when a previous rollout is stuck — for example, when the admin
+// updates the apiserver config to fix a broken KMS configuration.
+func ComputeDesiredEncryptionStateWithAdditionalKey(
+	ctx context.Context,
+	deployer Deployer,
+	secretClient corev1client.SecretsGetter,
+	encryptionSecretSelector metav1.ListOptions,
+	encryptedGRs []schema.GroupResource,
+	additionalKeySecret *corev1.Secret,
+) (map[schema.GroupResource]state.GroupResourceState, error) {
+	encryptionConfigSecret, _, err := deployer.DeployedEncryptionConfigSecret(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var current *encryptiondata.Config
+	if encryptionConfigSecret != nil {
+		current, err = encryptiondata.FromSecret(encryptionConfigSecret)
+		if err != nil {
+			return nil, fmt.Errorf("invalid encryption config %s/%s: %v", encryptionConfigSecret.Namespace, encryptionConfigSecret.Name, err)
+		}
+	}
+
+	encryptionSecrets, err := secrets.ListKeySecrets(ctx, secretClient, encryptionSecretSelector)
+	if err != nil {
+		return nil, err
+	}
+
+	allSecrets := append(encryptionSecrets, additionalKeySecret)
+	return getDesiredEncryptionState(current, allSecrets, encryptedGRs), nil
+}
+
 // getDesiredEncryptionState returns the desired state of encryption for all resources.
 // To do this it compares the current state against the available secrets and to-be-encrypted resources.
 // oldEncryptionConfig can be nil if there is no config yet.


### PR DESCRIPTION
This PR experiments the encryption controllers to find an elegant way for the preflight controller to reuse the encryption config Secret generation mechanism.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Improvements**
  * KMS preflight checks now generate a fully computed `encryption-config` Secret and provide it to the preflight workload, including when no preflight pod exists.
  * Encryption state planning now accounts for an additional (simulated) key to ensure correct transition behavior.
  * Added stronger validation/error handling when the current encryption mode isn’t KMS or when encryption configuration can’t be computed.

* **Tests**
  * Updated KMS preflight controller tests to cover the new computed Secret flow and the expanded deployer behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->