### PR TITLE
[WIP] kms: compute dry-run encryption config secret for preflight pod

### DIFF
--- a/pkg/operator/encryption/controllers/kms_preflight_controller.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/encryption/kms"
+	"github.com/openshift/library-go/pkg/operator/encryption/statemachine"
 	"github.com/openshift/library-go/pkg/operator/events"
 	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
 )
@@ -165,13 +166,17 @@ type KMSPreflightDeployer interface {
 }
 
 type kmsPreflightController struct {
-	controllerInstanceName string
+	controllerInstanceName   string
+	instanceName             string
+	unsupportedConfigPrefix  []string
+	encryptionSecretSelector metav1.ListOptions
 
 	operatorClient  operatorv1helpers.OperatorClient
 	apiServerClient configv1client.APIServerInterface
 	coreClient      corev1client.CoreV1Interface
 
 	deployer                 KMSPreflightDeployer
+	encryptionDeployer       statemachine.Deployer
 	provider                 Provider
 	preconditionsFulfilledFn preconditionsFulfilled
 	encryptionStatusProvider kms.EncryptionStatusProvider
@@ -249,28 +254,39 @@ type kmsPreflightController struct {
 // so that its logs can be inspected, then cleaned up by a subsequent sync.
 func NewKMSPreflightController(
 	instanceName string,
+	unsupportedConfigPrefix []string,
 	provider Provider,
 	preconditionsFulfilledFn preconditionsFulfilled,
 	deployer KMSPreflightDeployer,
+	// encryptionDeployer is the same statemachine.Deployer used by the key and state
+	// controllers. It is consulted once when seeding the dry-run that produces the
+	// encryption-config Secret for the preflight pod.
+	encryptionDeployer statemachine.Deployer,
 	operatorClient operatorv1helpers.OperatorClient,
 	apiServerClient configv1client.APIServerInterface,
 	apiServerInformer configv1informers.APIServerInformer,
 	// coreClient reads referenced Secrets and ConfigMaps in openshift-config for hash
-	// computation. No informer is needed: the key-controller detects config changes and
-	// updates ObservedConfigHash, which triggers this controller via the operatorClient
+	// computation and seeds the key/state dry-run sandbox. No informer is needed for
+	// openshift-config: the key-controller detects config changes and updates
+	// ObservedConfigHash, which triggers this controller via the operatorClient
 	// informer. The minute-based resync covers the rest.
 	coreClient corev1client.CoreV1Interface,
+	encryptionSecretSelector metav1.ListOptions,
 	encryptionStatusProvider kms.EncryptionStatusProvider,
 	eventRecorder events.Recorder,
 ) factory.Controller {
 	c := &kmsPreflightController{
-		controllerInstanceName: factory.ControllerInstanceName(instanceName, "EncryptionKMSPreflight"),
+		controllerInstanceName:   factory.ControllerInstanceName(instanceName, "EncryptionKMSPreflight"),
+		instanceName:             instanceName,
+		unsupportedConfigPrefix:  unsupportedConfigPrefix,
+		encryptionSecretSelector: encryptionSecretSelector,
 
 		operatorClient:  operatorClient,
 		apiServerClient: apiServerClient,
 		coreClient:      coreClient,
 
 		deployer:                 deployer,
+		encryptionDeployer:       encryptionDeployer,
 		provider:                 provider,
 		preconditionsFulfilledFn: preconditionsFulfilledFn,
 		encryptionStatusProvider: encryptionStatusProvider,
@@ -356,7 +372,9 @@ func (c *kmsPreflightController) sync(ctx context.Context, syncCtx factory.SyncC
 //     2a. Result already recorded as Failed and pod is gone: surface the error
 //     without re-deploying. The admin must fix the config (new hash) before
 //     a new check can run.
-//     2b. No result yet: call Deploy. On success, requeue and wait for the pod to report results.
+//     2b. No result yet: compute the encryption-config Secret via dry-run, then
+//     call Deploy. On success, requeue and wait for the pod to report results.
+//     If the encryption deployer has not converged, requeue and wait before Deploy.
 //
 //  3. Preflight required, pod exists (Status returns a PodStatus).
 //     Evaluate the pod state via conditions and phase:
@@ -408,8 +426,8 @@ func (c *kmsPreflightController) sync(ctx context.Context, syncCtx factory.SyncC
 //	1         No preflight required — cleanup                   false    nil   False     False        No
 //	1a        Already Succeeded — cleanup, no pod work          false    nil   False     False        No
 //	2a        No pod, already Failed — surface error            false    *pe   True      False        Yes
-//	2b        No pod, Deploy success                            true     nil   False     True         No
-//	2b        No pod, Deploy error                              true     err   True      False        No
+//	2b        No pod, dry-run / Deploy success                  true     nil   False     True         No
+//	2b        No pod, dry-run / Deploy error                    true     err   True      False        No
 //	3a        Pod Failed — keep for inspection                  false    *pe   True      False        Yes
 //	3b        No hash, pod Running, no timeout                  true     nil   False     True         No
 //	3b        No hash, timeout exceeded                         true     *pe   True      False        Yes
@@ -454,8 +472,28 @@ func (c *kmsPreflightController) runPreflightChecks(ctx context.Context) (requeu
 				message: fmt.Sprintf("preflight check failed for hash %s: pod was removed but failure is recorded in status", requiredHash),
 			}
 		}
-		// TODO: compute the encryption configuration and pass it to the deployer
-		if err := c.deployer.Deploy(ctx, requiredHash, nil); err != nil {
+		requeueForConvergence, encryptionSecret, err := computeEncryptionConfigSecretDryRun(
+			ctx,
+			c.instanceName,
+			c.unsupportedConfigPrefix,
+			c.provider,
+			c.encryptionDeployer,
+			c.operatorClient,
+			c.apiServerClient,
+			c.coreClient,
+			c.encryptionSecretSelector,
+		)
+		if err != nil {
+			return true, "", "", fmt.Errorf("failed to compute encryption config for preflight: %w", err)
+		}
+		// The preflight pod must test the actual encryption config that will be deployed
+		// to the API server. If the deployer hasn't converged (e.g., a new revision is
+		// still rolling out), the dry-run won't produce the correct config. Wait for
+		// convergence before deploying the preflight workload.
+		if requeueForConvergence {
+			return true, "RunningPreflightCheck", "Waiting for encryption deployer to converge before computing preflight encryption config", nil
+		}
+		if err := c.deployer.Deploy(ctx, requiredHash, encryptionSecret); err != nil {
 			return true, "", "", err
 		}
 		return true, "RunningPreflightCheck", fmt.Sprintf("Deploying preflight pod for hash %s", requiredHash), nil

--- a/pkg/operator/encryption/controllers/kms_preflight_controller_test.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller_test.go
@@ -24,6 +24,7 @@ import (
 	applyoperatorv1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
 
 	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
 	"github.com/openshift/library-go/pkg/operator/encryption/kms"
 	encryptiontesting "github.com/openshift/library-go/pkg/operator/encryption/testing"
 	"github.com/openshift/library-go/pkg/operator/events"
@@ -310,16 +311,18 @@ func TestKMSConfigHasher(t *testing.T) {
 }
 
 type fakeDeployer struct {
-	deployed   bool
-	cleaned    bool
-	deployErr  error
-	statusErr  error
-	cleanupErr error
-	podStatus  corev1.PodStatus
+	deployed                   bool
+	cleaned                    bool
+	deployErr                  error
+	statusErr                  error
+	cleanupErr                 error
+	podStatus                  corev1.PodStatus
+	lastEncryptionConfigSecret *corev1.Secret
 }
 
-func (f *fakeDeployer) Deploy(_ context.Context, _ string, _ *corev1.Secret) error {
+func (f *fakeDeployer) Deploy(_ context.Context, _ string, encryptionConfiguration *corev1.Secret) error {
 	f.deployed = true
+	f.lastEncryptionConfigSecret = encryptionConfiguration
 	return f.deployErr
 }
 
@@ -371,6 +374,7 @@ func TestKMSPreflightController(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
 		Spec: configv1.APIServerSpec{
 			Encryption: configv1.APIServerEncryption{
+				Type: "KMS",
 				KMS: configv1.KMSPluginConfig{
 					Type:  configv1.VaultKMSProvider,
 					Vault: wellKnownBaseVaultConfig,
@@ -970,16 +974,20 @@ func TestKMSPreflightController(t *testing.T) {
 			if deployer == nil {
 				deployer = &fakeDeployer{}
 			}
+			encryptionSecretSelector := metav1.ListOptions{LabelSelector: "encryption.apiserver.operator.openshift.io/component=test"}
 
 			target := NewKMSPreflightController(
 				"test",
+				nil,
 				provider,
 				preconditionsFn,
 				deployer,
+				&staticEncryptionDeployer{},
 				fakeOperatorClient,
 				fakeApiServerClient,
 				fakeApiServerInformer,
 				fakeKubeClient.CoreV1(),
+				encryptionSecretSelector,
 				scenario.encryptionStatusProvider,
 				eventRecorder,
 			)
@@ -1010,8 +1018,174 @@ func TestKMSPreflightController(t *testing.T) {
 			if fakeDeployerInstance.cleaned != scenario.expectedPreflightPodCleanup {
 				t.Errorf("deployer.Cleanup called: got %v, want %v", fakeDeployerInstance.cleaned, scenario.expectedPreflightPodCleanup)
 			}
+			if fakeDeployerInstance.deployed {
+				if fakeDeployerInstance.lastEncryptionConfigSecret == nil {
+					t.Fatalf("expected Deploy to receive a non-nil encryption config secret")
+				}
+				if fakeDeployerInstance.lastEncryptionConfigSecret.Data["encryption-config"] == nil {
+					t.Fatalf("expected encryption config secret to contain encryption-config data")
+				}
+			}
 
 			encryptiontesting.ValidateOperatorClientConditions(t, fakeOperatorClient, scenario.expectedConditions)
 		})
+	}
+}
+
+func TestKMSPreflightController_DeployUsesDryRunEncryptionConfig(t *testing.T) {
+	apiServer := apiServerWithWellKnownVaultKMS()
+	const matchingHash = "cuZm_g=="
+
+	fakeOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(
+		&operatorv1.StaticPodOperatorSpec{OperatorSpec: operatorv1.OperatorSpec{ManagementState: operatorv1.Managed}},
+		&operatorv1.StaticPodOperatorStatus{OperatorStatus: operatorv1.OperatorStatus{
+			Conditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
+				{Type: "EncryptionKMSPreflightControllerProgressing", Status: "False"},
+			},
+		}},
+		nil,
+		nil,
+	)
+	fakeKubeClient := fake.NewSimpleClientset(&wellKnownBaseSecret, &wellKnownBaseConfigMap)
+	eventRecorder := events.NewRecorder(fakeKubeClient.CoreV1().Events("test"), "test-kmsPreflightController", &corev1.ObjectReference{}, clocktesting.NewFakePassiveClock(time.Now()))
+	fakeConfigClient := configv1clientfake.NewSimpleClientset(apiServer)
+	fakeApiServerInformer := configv1informers.NewSharedInformerFactory(fakeConfigClient, time.Minute).Config().V1().APIServers()
+	deployer := &fakeDeployer{statusErr: apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "kms-preflight")}
+
+	target := NewKMSPreflightController(
+		"test",
+		nil,
+		newTestProvider([]schema.GroupResource{{Group: "", Resource: "secrets"}}),
+		alwaysFulfilledPreconditions,
+		deployer,
+		&staticEncryptionDeployer{},
+		fakeOperatorClient,
+		fakeConfigClient.ConfigV1().APIServers(),
+		fakeApiServerInformer,
+		fakeKubeClient.CoreV1(),
+		metav1.ListOptions{LabelSelector: "encryption.apiserver.operator.openshift.io/component=test"},
+		&fakeEncryptionStatusProvider{observedConfigHash: matchingHash},
+		eventRecorder,
+	)
+
+	if err := target.Sync(context.TODO(), factory.NewSyncContext("test", eventRecorder)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !deployer.deployed {
+		t.Fatal("expected Deploy to be called")
+	}
+	assertDeployedPreflightEncryptionConfig(t, deployer.lastEncryptionConfigSecret)
+
+	encryptiontesting.ValidateOperatorClientConditions(t, fakeOperatorClient, []operatorv1.OperatorCondition{
+		{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
+		{Type: "EncryptionKMSPreflightControllerProgressing", Status: "True", Reason: "RunningPreflightCheck", Message: "Deploying preflight pod for hash cuZm_g=="},
+	})
+}
+
+func TestKMSPreflightController_WaitsWhenEncryptionDeployerNotConverged(t *testing.T) {
+	apiServer := apiServerWithWellKnownVaultKMS()
+	const matchingHash = "cuZm_g=="
+
+	fakeOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(
+		&operatorv1.StaticPodOperatorSpec{OperatorSpec: operatorv1.OperatorSpec{ManagementState: operatorv1.Managed}},
+		&operatorv1.StaticPodOperatorStatus{OperatorStatus: operatorv1.OperatorStatus{
+			Conditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
+				{Type: "EncryptionKMSPreflightControllerProgressing", Status: "False"},
+			},
+		}},
+		nil,
+		nil,
+	)
+	fakeKubeClient := fake.NewSimpleClientset(&wellKnownBaseSecret, &wellKnownBaseConfigMap)
+	eventRecorder := events.NewRecorder(fakeKubeClient.CoreV1().Events("test"), "test-kmsPreflightController", &corev1.ObjectReference{}, clocktesting.NewFakePassiveClock(time.Now()))
+	fakeConfigClient := configv1clientfake.NewSimpleClientset(apiServer)
+	fakeApiServerInformer := configv1informers.NewSharedInformerFactory(fakeConfigClient, time.Minute).Config().V1().APIServers()
+	deployer := &fakeDeployer{statusErr: apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "kms-preflight")}
+
+	target := NewKMSPreflightController(
+		"test",
+		nil,
+		newTestProvider([]schema.GroupResource{{Group: "", Resource: "secrets"}}),
+		alwaysFulfilledPreconditions,
+		deployer,
+		&staticEncryptionDeployerNotConverged{},
+		fakeOperatorClient,
+		fakeConfigClient.ConfigV1().APIServers(),
+		fakeApiServerInformer,
+		fakeKubeClient.CoreV1(),
+		metav1.ListOptions{LabelSelector: "encryption.apiserver.operator.openshift.io/component=test"},
+		&fakeEncryptionStatusProvider{observedConfigHash: matchingHash},
+		eventRecorder,
+	)
+
+	if err := target.Sync(context.TODO(), factory.NewSyncContext("test", eventRecorder)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if deployer.deployed {
+		t.Fatal("expected Deploy not to be called while encryption deployer is not converged")
+	}
+	if deployer.lastEncryptionConfigSecret != nil {
+		t.Fatal("expected no encryption config secret to be passed to Deploy")
+	}
+
+	encryptiontesting.ValidateOperatorClientConditions(t, fakeOperatorClient, []operatorv1.OperatorCondition{
+		{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
+		{Type: "EncryptionKMSPreflightControllerProgressing", Status: "True", Reason: "RunningPreflightCheck", Message: "Waiting for encryption deployer to converge before computing preflight encryption config"},
+	})
+}
+
+func apiServerWithWellKnownVaultKMS() *configv1.APIServer {
+	return &configv1.APIServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Spec: configv1.APIServerSpec{
+			Encryption: configv1.APIServerEncryption{
+				Type: "KMS",
+				KMS: configv1.KMSPluginConfig{
+					Type:  configv1.VaultKMSProvider,
+					Vault: wellKnownBaseVaultConfig,
+				},
+			},
+		},
+	}
+}
+
+func assertDeployedPreflightEncryptionConfig(t *testing.T, secret *corev1.Secret) {
+	t.Helper()
+	if secret == nil {
+		t.Fatal("expected Deploy to receive a non-nil encryption config secret")
+	}
+	if secret.Data["encryption-config"] == nil {
+		t.Fatal("expected encryption config secret to contain encryption-config data")
+	}
+
+	cfg, err := encryptiondata.FromSecret(secret)
+	if err != nil {
+		t.Fatalf("failed to parse encryption config secret: %v", err)
+	}
+	if cfg == nil || cfg.Encryption == nil {
+		t.Fatal("expected non-empty encryption configuration")
+	}
+	if _, ok := cfg.KMSPlugins["1"]; !ok {
+		t.Fatalf("expected KMS plugin for key ID 1, got %#v", cfg.KMSPlugins)
+	}
+
+	foundPreflightEndpoint := false
+	for _, resource := range cfg.Encryption.Resources {
+		for _, providerCfg := range resource.Providers {
+			if providerCfg.KMS == nil {
+				continue
+			}
+			if providerCfg.KMS.Endpoint == preflightKMSSocketEndpoint {
+				foundPreflightEndpoint = true
+			}
+			if strings.Contains(providerCfg.KMS.Endpoint, "kms-1.sock") {
+				t.Fatalf("expected write-key endpoint to be rewritten away from per-key socket, got %q", providerCfg.KMS.Endpoint)
+			}
+		}
+	}
+	if !foundPreflightEndpoint {
+		t.Fatalf("expected write-key KMS endpoint rewritten to %s", preflightKMSSocketEndpoint)
 	}
 }

--- a/pkg/operator/encryption/controllers/kms_preflight_overlay.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_overlay.go
@@ -1,0 +1,153 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	applyconfigurationscorev1 "k8s.io/client-go/applyconfigurations/core/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+// dryRunSecretsGetter wraps a live SecretsGetter for preflight dry-runs:
+// reads hit the live API (plus an in-memory overlay of prior writes);
+// Create/Update are recorded in memory and never reach the API.
+type dryRunSecretsGetter struct {
+	real    corev1client.SecretsGetter
+	written map[string]map[string]*corev1.Secret // namespace → name → recorded secret
+}
+
+var _ corev1client.SecretsGetter = (*dryRunSecretsGetter)(nil)
+
+func newDryRunSecretsGetter(real corev1client.SecretsGetter) (*dryRunSecretsGetter, error) {
+	if real == nil {
+		return nil, fmt.Errorf("dry-run secrets getter requires a non-nil SecretsGetter")
+	}
+	return &dryRunSecretsGetter{
+		real:    real,
+		written: map[string]map[string]*corev1.Secret{},
+	}, nil
+}
+
+func (g *dryRunSecretsGetter) Secrets(ns string) corev1client.SecretInterface {
+	return &dryRunSecretClient{
+		parent: g,
+		ns:     ns,
+	}
+}
+
+// Recorded returns a deep copy of the secret recorded by Create/Update during this
+// dry-run, if any. Live secrets that were only read are not returned. The bool
+// return value indicates whether the secret was found in the overlay.
+func (g *dryRunSecretsGetter) Recorded(namespace, name string) (*corev1.Secret, bool) {
+	s, ok := g.written[namespace][name]
+	if !ok {
+		return nil, false
+	}
+	return s.DeepCopy(), true
+}
+
+// dryRunSecretClient implements corev1client.SecretInterface.
+// Get/List read the live API and overlay prior writes; Create/Update record writes in memory.
+// Other mutating methods and Watch return an error and never hit the live API.
+type dryRunSecretClient struct {
+	parent *dryRunSecretsGetter
+	ns     string
+}
+
+var _ corev1client.SecretInterface = (*dryRunSecretClient)(nil)
+
+func (c *dryRunSecretClient) Get(ctx context.Context, name string, opts metav1.GetOptions) (*corev1.Secret, error) {
+	if s, ok := c.parent.written[c.ns][name]; ok {
+		return s.DeepCopy(), nil
+	}
+	return c.parent.real.Secrets(c.ns).Get(ctx, name, opts)
+}
+
+func (c *dryRunSecretClient) List(ctx context.Context, opts metav1.ListOptions) (*corev1.SecretList, error) {
+	selector, err := labels.Parse(opts.LabelSelector)
+	if err != nil {
+		return nil, err
+	}
+	list, err := c.parent.real.Secrets(c.ns).List(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	written := c.parent.written[c.ns]
+	filtered := make([]corev1.Secret, 0, len(list.Items))
+	seen := make(map[string]struct{}, len(list.Items))
+
+	// Replace or drop live entries that have an overlay write.
+	for i := range list.Items {
+		name := list.Items[i].Name
+		seen[name] = struct{}{}
+		if s, ok := written[name]; ok {
+			if !selector.Matches(labels.Set(s.Labels)) {
+				continue
+			}
+			filtered = append(filtered, *s.DeepCopy())
+			continue
+		}
+		filtered = append(filtered, list.Items[i])
+	}
+
+	// Insert overlay-only secrets that match the selector.
+	for _, s := range written {
+		if _, ok := seen[s.Name]; ok {
+			continue
+		}
+		if !selector.Matches(labels.Set(s.Labels)) {
+			continue
+		}
+		filtered = append(filtered, *s.DeepCopy())
+	}
+	list.Items = filtered
+	return list, nil
+}
+
+func (c *dryRunSecretClient) Create(_ context.Context, secret *corev1.Secret, _ metav1.CreateOptions) (*corev1.Secret, error) {
+	return c.record(secret), nil
+}
+
+func (c *dryRunSecretClient) Update(_ context.Context, secret *corev1.Secret, _ metav1.UpdateOptions) (*corev1.Secret, error) {
+	return c.record(secret), nil
+}
+
+func (c *dryRunSecretClient) Delete(_ context.Context, _ string, _ metav1.DeleteOptions) error {
+	return fmt.Errorf("dry-run secrets client does not support Delete")
+}
+
+func (c *dryRunSecretClient) DeleteCollection(_ context.Context, _ metav1.DeleteOptions, _ metav1.ListOptions) error {
+	return fmt.Errorf("dry-run secrets client does not support DeleteCollection")
+}
+
+func (c *dryRunSecretClient) Watch(_ context.Context, _ metav1.ListOptions) (watch.Interface, error) {
+	return nil, fmt.Errorf("dry-run secrets client does not support Watch")
+}
+
+func (c *dryRunSecretClient) Patch(_ context.Context, _ string, _ types.PatchType, _ []byte, _ metav1.PatchOptions, _ ...string) (*corev1.Secret, error) {
+	return nil, fmt.Errorf("dry-run secrets client does not support Patch")
+}
+
+func (c *dryRunSecretClient) Apply(_ context.Context, _ *applyconfigurationscorev1.SecretApplyConfiguration, _ metav1.ApplyOptions) (*corev1.Secret, error) {
+	return nil, fmt.Errorf("dry-run secrets client does not support Apply")
+}
+
+func (c *dryRunSecretClient) record(secret *corev1.Secret) *corev1.Secret {
+	cp := secret.DeepCopy()
+	// Scope to client namespace before storing, matching real client-go behavior.
+	cp.Namespace = c.ns
+	byName, ok := c.parent.written[c.ns]
+	if !ok {
+		byName = map[string]*corev1.Secret{}
+		c.parent.written[c.ns] = byName
+	}
+	byName[cp.Name] = cp
+	// Return a copy so caller mutations don't affect the stored version.
+	return cp.DeepCopy()
+}

--- a/pkg/operator/encryption/controllers/kms_preflight_overlay_test.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_overlay_test.go
@@ -1,0 +1,254 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestNewDryRunSecretsGetter_NilReal(t *testing.T) {
+	overlay, err := newDryRunSecretsGetter(nil)
+	require.Error(t, err)
+	require.Nil(t, overlay)
+	require.Contains(t, err.Error(), "non-nil SecretsGetter")
+}
+
+func TestDryRunSecretsOverlay_CreateThenGet(t *testing.T) {
+	fakeClient := fake.NewSimpleClientset()
+	overlay, err := newDryRunSecretsGetter(fakeClient.CoreV1())
+	require.NoError(t, err)
+
+	created, err := overlay.Secrets("ns").Create(context.Background(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-secret", Namespace: "ns"},
+		Data:       map[string][]byte{"k": []byte("v")},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+	require.Equal(t, "my-secret", created.Name)
+
+	got, err := overlay.Secrets("ns").Get(context.Background(), "my-secret", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, []byte("v"), got.Data["k"])
+
+	for _, action := range fakeClient.Actions() {
+		if action.GetVerb() == "create" || action.GetVerb() == "update" {
+			t.Fatalf("live client must not be mutated, got action %#v", action)
+		}
+	}
+}
+
+func TestDryRunSecretsOverlay_GetFallsThrough(t *testing.T) {
+	live := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "live-secret", Namespace: "ns"},
+		Data:       map[string][]byte{"from": []byte("live")},
+	}
+	fakeClient := fake.NewSimpleClientset(live)
+	overlay, err := newDryRunSecretsGetter(fakeClient.CoreV1())
+	require.NoError(t, err)
+
+	got, err := overlay.Secrets("ns").Get(context.Background(), "live-secret", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, []byte("live"), got.Data["from"])
+}
+
+func TestDryRunSecretsOverlay_ListMergesNewName(t *testing.T) {
+	live := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "existing",
+			Namespace: "ns",
+			Labels:    map[string]string{"comp": "test"},
+		},
+	}
+	fakeClient := fake.NewSimpleClientset(live)
+	overlay, err := newDryRunSecretsGetter(fakeClient.CoreV1())
+	require.NoError(t, err)
+
+	_, err = overlay.Secrets("ns").Create(context.Background(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "new-key",
+			Namespace: "ns",
+			Labels:    map[string]string{"comp": "test"},
+		},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	list, err := overlay.Secrets("ns").List(context.Background(), metav1.ListOptions{
+		LabelSelector: "comp=test",
+	})
+	require.NoError(t, err)
+	require.Len(t, list.Items, 2)
+
+	names := map[string]bool{}
+	for _, s := range list.Items {
+		names[s.Name] = true
+	}
+	require.True(t, names["existing"])
+	require.True(t, names["new-key"])
+}
+
+func TestDryRunSecretsOverlay_ListReplacesSameName(t *testing.T) {
+	live := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "shared",
+			Namespace: "ns",
+			Labels:    map[string]string{"comp": "test"},
+		},
+		Data: map[string][]byte{"v": []byte("live")},
+	}
+	fakeClient := fake.NewSimpleClientset(live)
+	overlay, err := newDryRunSecretsGetter(fakeClient.CoreV1())
+	require.NoError(t, err)
+
+	_, err = overlay.Secrets("ns").Update(context.Background(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "shared",
+			Namespace: "ns",
+			Labels:    map[string]string{"comp": "test"},
+		},
+		Data: map[string][]byte{"v": []byte("overlay")},
+	}, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	list, err := overlay.Secrets("ns").List(context.Background(), metav1.ListOptions{
+		LabelSelector: "comp=test",
+	})
+	require.NoError(t, err)
+	require.Len(t, list.Items, 1)
+	require.Equal(t, "shared", list.Items[0].Name)
+	require.Equal(t, []byte("overlay"), list.Items[0].Data["v"])
+}
+
+func TestDryRunSecretsOverlay_CreateUsesClientNamespace(t *testing.T) {
+	fakeClient := fake.NewSimpleClientset()
+	overlay, err := newDryRunSecretsGetter(fakeClient.CoreV1())
+	require.NoError(t, err)
+
+	created, err := overlay.Secrets("ns").Create(context.Background(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-secret",
+			Namespace: "other-ns", // mismatched; client namespace must win
+		},
+		Data: map[string][]byte{"k": []byte("v")},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+	require.Equal(t, "ns", created.Namespace)
+
+	got, err := overlay.Secrets("ns").Get(context.Background(), "my-secret", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, "ns", got.Namespace)
+	require.Equal(t, []byte("v"), got.Data["k"])
+
+	_, err = overlay.Secrets("other-ns").Get(context.Background(), "my-secret", metav1.GetOptions{})
+	require.Error(t, err, "must not be stored under the object Namespace")
+
+	recorded, ok := overlay.Recorded("ns", "my-secret")
+	require.True(t, ok)
+	require.Equal(t, "ns", recorded.Namespace)
+	_, ok = overlay.Recorded("other-ns", "my-secret")
+	require.False(t, ok)
+}
+
+func TestDryRunSecretsOverlay_ListDropsWhenLabelsNoLongerMatch(t *testing.T) {
+	live := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "shared",
+			Namespace: "ns",
+			Labels:    map[string]string{"comp": "test"},
+		},
+		Data: map[string][]byte{"v": []byte("live")},
+	}
+	fakeClient := fake.NewSimpleClientset(live)
+	overlay, err := newDryRunSecretsGetter(fakeClient.CoreV1())
+	require.NoError(t, err)
+
+	_, err = overlay.Secrets("ns").Update(context.Background(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "shared",
+			Namespace: "ns",
+			Labels:    map[string]string{"comp": "other"},
+		},
+		Data: map[string][]byte{"v": []byte("overlay")},
+	}, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	list, err := overlay.Secrets("ns").List(context.Background(), metav1.ListOptions{
+		LabelSelector: "comp=test",
+	})
+	require.NoError(t, err)
+	require.Empty(t, list.Items, "overlay write that demotes labels must remove the live list entry")
+}
+
+func TestDryRunSecretsOverlay_MutatorsFailClosed(t *testing.T) {
+	fakeClient := fake.NewSimpleClientset()
+	overlay, err := newDryRunSecretsGetter(fakeClient.CoreV1())
+	require.NoError(t, err)
+	client := overlay.Secrets("ns")
+	ctx := context.Background()
+
+	err = client.Delete(ctx, "x", metav1.DeleteOptions{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not support Delete")
+
+	err = client.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not support DeleteCollection")
+
+	_, err = client.Patch(ctx, "x", types.MergePatchType, []byte("{}"), metav1.PatchOptions{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not support Patch")
+
+	_, err = client.Watch(ctx, metav1.ListOptions{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not support Watch")
+
+	_, err = client.Apply(ctx, nil, metav1.ApplyOptions{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not support Apply")
+
+	for _, action := range fakeClient.Actions() {
+		t.Fatalf("live client must not be called for unsupported mutators, got action %#v", action)
+	}
+}
+
+func TestDryRunSecretsOverlay_Recorded(t *testing.T) {
+	live := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "live-only", Namespace: "ns"},
+	}
+	fakeClient := fake.NewSimpleClientset(live)
+	overlay, err := newDryRunSecretsGetter(fakeClient.CoreV1())
+	require.NoError(t, err)
+
+	_, ok := overlay.Recorded("ns", "live-only")
+	require.False(t, ok, "live-only reads must not appear in recorded writes")
+
+	_, err = overlay.Secrets("ns").Create(context.Background(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "written-a", Namespace: "ns"},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+	_, err = overlay.Secrets("ns").Update(context.Background(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "written-b", Namespace: "ns"},
+		Data:       map[string][]byte{"k": []byte("v")},
+	}, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	gotA, ok := overlay.Recorded("ns", "written-a")
+	require.True(t, ok)
+	require.Equal(t, "ns", gotA.Namespace)
+
+	gotB, ok := overlay.Recorded("ns", "written-b")
+	require.True(t, ok)
+	require.Equal(t, []byte("v"), gotB.Data["k"])
+
+	_, ok = overlay.Recorded("ns", "live-only")
+	require.False(t, ok, "live-only reads must not appear in recorded writes")
+
+	// Mutating the returned object must not affect the overlay store.
+	gotA.Data = map[string][]byte{"mutated": []byte("x")}
+	reread, ok := overlay.Recorded("ns", "written-a")
+	require.True(t, ok)
+	require.NotEqual(t, []byte("x"), reread.Data["mutated"])
+}

--- a/pkg/operator/encryption/controllers/kms_preflight_sandbox.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_sandbox.go
@@ -1,0 +1,229 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/utils/clock"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
+	"github.com/openshift/library-go/pkg/operator/encryption/secrets"
+	"github.com/openshift/library-go/pkg/operator/encryption/state"
+	"github.com/openshift/library-go/pkg/operator/encryption/statemachine"
+	"github.com/openshift/library-go/pkg/operator/events"
+	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+const (
+	openshiftConfigManagedNS   = "openshift-config-managed"
+	preflightKMSSocketEndpoint = "unix:///var/run/kmsplugin/kms.sock"
+)
+
+// computeEncryptionConfigSecretDryRun runs keyController.sync then stateController.sync against the
+// live cluster with an in-memory write overlay, returning the encryption-config Secret those controllers
+// would have applied without persisting the key or encryption-config Secrets to the real API.
+// If the live encryption deployer reports !converged, requeue is true and secret is nil.
+func computeEncryptionConfigSecretDryRun(
+	ctx context.Context,
+	instanceName string,
+	unsupportedConfigPrefix []string,
+	provider Provider,
+	encryptionDeployer statemachine.Deployer,
+	operatorClient operatorv1helpers.OperatorClient,
+	apiServerClient configv1client.APIServerInterface,
+	coreClient corev1client.CoreV1Interface,
+	encryptionSecretSelector metav1.ListOptions,
+) (requeue bool, secret *corev1.Secret, err error) {
+	_, converged, err := encryptionDeployer.DeployedEncryptionConfigSecret(ctx)
+	if err != nil {
+		return false, nil, fmt.Errorf("failed to get deployed encryption config: %w", err)
+	}
+	if !converged {
+		return true, nil, nil
+	}
+
+	// overlay is shared between both dry-run runs so the key secret created by
+	// the key controller is visible to the state controller's List call.
+	overlay, err := newDryRunSecretsGetter(coreClient)
+	if err != nil {
+		return false, nil, err
+	}
+
+	if err := dryRunKeyController(ctx, overlay, instanceName, unsupportedConfigPrefix, provider, encryptionDeployer, operatorClient, apiServerClient, coreClient, encryptionSecretSelector); err != nil {
+		return false, nil, err
+	}
+
+	encryptionSecret, err := dryRunStateController(ctx, overlay, instanceName, provider, encryptionDeployer, operatorClient, encryptionSecretSelector)
+	if err != nil {
+		return false, nil, err
+	}
+
+	// The write key is the highest key ID among live + dry-run overlay secrets.
+	keySecrets, err := secrets.ListKeySecrets(ctx, overlay, encryptionSecretSelector)
+	if err != nil {
+		return false, nil, err
+	}
+	var latestKeyID uint64
+	foundKey := false
+	for _, s := range keySecrets {
+		id, ok := state.NameToKeyID(s.Name)
+		if !ok {
+			continue
+		}
+		if !foundKey || id > latestKeyID {
+			latestKeyID = id
+			foundKey = true
+		}
+	}
+	if !foundKey {
+		return false, nil, fmt.Errorf("no encryption key secrets found after key controller dry-run")
+	}
+
+	rewritten, err := rewritePreflightWriteKeyEndpoint(encryptionSecret, latestKeyID)
+	if err != nil {
+		return false, nil, fmt.Errorf("failed to rewrite preflight KMS endpoint: %w", err)
+	}
+	return false, rewritten, nil
+}
+
+func dryRunKeyController(
+	ctx context.Context,
+	overlay *dryRunSecretsGetter,
+	instanceName string,
+	unsupportedConfigPrefix []string,
+	provider Provider,
+	encryptionDeployer statemachine.Deployer,
+	operatorClient operatorv1helpers.OperatorClient,
+	apiServerClient configv1client.APIServerInterface,
+	coreClient corev1client.CoreV1Interface,
+	encryptionSecretSelector metav1.ListOptions,
+) error {
+	dryRunOperatorClient, err := operatorClientForDryRun(operatorClient)
+	if err != nil {
+		return err
+	}
+
+	c := &keyController{
+		operatorClient:           dryRunOperatorClient,
+		apiServerClient:          apiServerClient,
+		instanceName:             instanceName,
+		controllerInstanceName:   factory.ControllerInstanceName(instanceName, "EncryptionKey"),
+		unsupportedConfigPrefix:  unsupportedConfigPrefix,
+		encryptionSecretSelector: encryptionSecretSelector,
+		deployer:                 encryptionDeployer,
+		provider:                 provider,
+		preconditionsFulfilledFn: func() (bool, error) { return true, nil },
+		secretClient:             overlay,
+		configMapClient:          coreClient,
+	}
+
+	recorder := events.NewInMemoryRecorder("kms-preflight-key-dry-run", clock.RealClock{})
+	syncCtx := factory.NewSyncContext("kms-preflight-key-dry-run", recorder)
+	if err := c.sync(ctx, syncCtx); err != nil {
+		return fmt.Errorf("key controller dry-run failed: %w", err)
+	}
+	return nil
+}
+
+func dryRunStateController(
+	ctx context.Context,
+	overlay *dryRunSecretsGetter,
+	instanceName string,
+	provider Provider,
+	encryptionDeployer statemachine.Deployer,
+	operatorClient operatorv1helpers.OperatorClient,
+	encryptionSecretSelector metav1.ListOptions,
+) (*corev1.Secret, error) {
+	dryRunOperatorClient, err := operatorClientForDryRun(operatorClient)
+	if err != nil {
+		return nil, err
+	}
+
+	c := &stateController{
+		instanceName:             instanceName,
+		controllerInstanceName:   factory.ControllerInstanceName(instanceName, "EncryptionState"),
+		encryptionSecretSelector: encryptionSecretSelector,
+		operatorClient:           dryRunOperatorClient,
+		secretClient:             overlay,
+		deployer:                 encryptionDeployer,
+		provider:                 provider,
+		preconditionsFulfilledFn: func() (bool, error) { return true, nil },
+	}
+
+	recorder := events.NewInMemoryRecorder("kms-preflight-state-dry-run", clock.RealClock{})
+	syncCtx := factory.NewSyncContext("kms-preflight-state-dry-run", recorder)
+	if err := c.sync(ctx, syncCtx); err != nil {
+		return nil, fmt.Errorf("state controller dry-run failed: %w", err)
+	}
+
+	expectedName := fmt.Sprintf("%s-%s", encryptiondata.EncryptionConfSecretName, instanceName)
+	ecSecret, ok := overlay.Recorded(openshiftConfigManagedNS, expectedName)
+	if !ok {
+		return nil, fmt.Errorf("state controller dry-run did not create or update encryption config secret %q", expectedName)
+	}
+	return ecSecret, nil
+}
+
+// operatorClientForDryRun snapshots the live operator spec/status into a fake client so Sync can
+// read management state and unsupported config without writing degraded conditions to the cluster.
+func operatorClientForDryRun(live operatorv1helpers.OperatorClient) (operatorv1helpers.OperatorClient, error) {
+	spec, status, _, err := live.GetOperatorState()
+	if err != nil {
+		return nil, fmt.Errorf("failed to snapshot operator state for dry-run: %w", err)
+	}
+	var specCopy *operatorv1.OperatorSpec
+	var statusCopy *operatorv1.OperatorStatus
+	if spec != nil {
+		specCopy = spec.DeepCopy()
+	}
+	if status != nil {
+		statusCopy = status.DeepCopy()
+	}
+	return operatorv1helpers.NewFakeOperatorClient(specCopy, statusCopy, nil), nil
+}
+
+// rewritePreflightWriteKeyEndpoint rewrites the write-key KMS endpoint from the
+// per-key production socket (kms-{id}.sock) to the fixed preflight socket
+// (kms.sock). Today's preflight checker dials that fixed path, while the plugin
+// builder uses each provider's Endpoint as -listen-address, so the dry-run
+// secret must agree with the checker.
+//
+// TODO: once preflight dials the write-key socket (kms-{id}.sock) directly,
+// this rewrite can be removed and the dry-run secret can be used as-is.
+func rewritePreflightWriteKeyEndpoint(secret *corev1.Secret, keyID uint64) (*corev1.Secret, error) {
+	cfg, err := encryptiondata.FromSecret(secret)
+	if err != nil {
+		return nil, err
+	}
+	if cfg == nil || cfg.Encryption == nil {
+		return nil, fmt.Errorf("encryption configuration is empty")
+	}
+
+	// Provider names are "{keyID}_{resource}" (e.g. "2_secrets"). Match on name
+	// rather than endpoint so we identify the write key by its stable identity.
+	wantNamePrefix := fmt.Sprintf("%d_", keyID)
+	rewrote := false
+	for i := range cfg.Encryption.Resources {
+		for j := range cfg.Encryption.Resources[i].Providers {
+			kms := cfg.Encryption.Resources[i].Providers[j].KMS
+			if kms == nil || !strings.HasPrefix(kms.Name, wantNamePrefix) {
+				continue
+			}
+			kms.Endpoint = preflightKMSSocketEndpoint
+			rewrote = true
+		}
+	}
+	if !rewrote {
+		return nil, fmt.Errorf("write-key KMS provider with name prefix %q not found in encryption config", wantNamePrefix)
+	}
+
+	return encryptiondata.ToSecret(secret.Namespace, secret.Name, cfg)
+}

--- a/pkg/operator/encryption/controllers/kms_preflight_sandbox_test.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_sandbox_test.go
@@ -1,0 +1,326 @@
+package controllers
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	configv1clientfake "github.com/openshift/client-go/config/clientset/versioned/fake"
+
+	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
+	encryptiontesting "github.com/openshift/library-go/pkg/operator/encryption/testing"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+func TestComputeEncryptionConfigSecretDryRun_FirstKMSKey(t *testing.T) {
+	instanceName := "test"
+	apiServer := &configv1.APIServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Spec: configv1.APIServerSpec{
+			Encryption: configv1.APIServerEncryption{
+				Type: "KMS",
+				KMS: configv1.KMSPluginConfig{
+					Type:  configv1.VaultKMSProvider,
+					Vault: wellKnownBaseVaultConfig,
+				},
+			},
+		},
+	}
+
+	fakeKubeClient := fake.NewSimpleClientset(&wellKnownBaseSecret, &wellKnownBaseConfigMap)
+	fakeConfigClient := configv1clientfake.NewSimpleClientset(apiServer)
+	fakeOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(
+		&operatorv1.StaticPodOperatorSpec{OperatorSpec: operatorv1.OperatorSpec{ManagementState: operatorv1.Managed}},
+		&operatorv1.StaticPodOperatorStatus{},
+		nil,
+		nil,
+	)
+	provider := newTestProvider([]schema.GroupResource{{Group: "", Resource: "secrets"}})
+	selector := metav1.ListOptions{LabelSelector: "encryption.apiserver.operator.openshift.io/component=" + instanceName}
+
+	requeue, secret, err := computeEncryptionConfigSecretDryRun(
+		context.Background(),
+		instanceName,
+		nil,
+		provider,
+		&staticEncryptionDeployer{},
+		fakeOperatorClient,
+		fakeConfigClient.ConfigV1().APIServers(),
+		fakeKubeClient.CoreV1(),
+		selector,
+	)
+	require.NoError(t, err)
+	require.False(t, requeue)
+	require.NotNil(t, secret)
+	require.Equal(t, "encryption-config-"+instanceName, secret.Name)
+	require.Equal(t, openshiftConfigManagedNS, secret.Namespace)
+
+	cfg, err := encryptiondata.FromSecret(secret)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	require.NotNil(t, cfg.Encryption)
+	require.Contains(t, cfg.KMSPlugins, "1")
+
+	foundPreflightEndpoint := false
+	for _, resource := range cfg.Encryption.Resources {
+		for _, providerCfg := range resource.Providers {
+			if providerCfg.KMS == nil {
+				continue
+			}
+			if providerCfg.KMS.Endpoint == preflightKMSSocketEndpoint {
+				foundPreflightEndpoint = true
+			}
+		}
+	}
+	require.True(t, foundPreflightEndpoint, "expected write-key KMS endpoint rewritten to %s", preflightKMSSocketEndpoint)
+
+	for _, action := range fakeKubeClient.Actions() {
+		if action.GetVerb() == "create" || action.GetVerb() == "update" {
+			t.Fatalf("live client must not be mutated, got action %#v", action)
+		}
+	}
+}
+
+func TestComputeEncryptionConfigSecretDryRun_RequeueWhenNotConverged(t *testing.T) {
+	instanceName := "test"
+	apiServer := &configv1.APIServer{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}}
+	fakeKubeClient := fake.NewSimpleClientset()
+	fakeConfigClient := configv1clientfake.NewSimpleClientset(apiServer)
+	fakeOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(
+		&operatorv1.StaticPodOperatorSpec{OperatorSpec: operatorv1.OperatorSpec{ManagementState: operatorv1.Managed}},
+		&operatorv1.StaticPodOperatorStatus{},
+		nil,
+		nil,
+	)
+	provider := newTestProvider([]schema.GroupResource{{Group: "", Resource: "secrets"}})
+
+	requeue, secret, err := computeEncryptionConfigSecretDryRun(
+		context.Background(),
+		instanceName,
+		nil,
+		provider,
+		&staticEncryptionDeployerNotConverged{},
+		fakeOperatorClient,
+		fakeConfigClient.ConfigV1().APIServers(),
+		fakeKubeClient.CoreV1(),
+		metav1.ListOptions{},
+	)
+	require.NoError(t, err)
+	require.True(t, requeue)
+	require.Nil(t, secret)
+}
+
+func TestComputeEncryptionConfigSecretDryRun_ExistingKeysPlusProviderChange(t *testing.T) {
+	instanceName := "test"
+	grs := []schema.GroupResource{{Group: "", Resource: "secrets"}}
+	existingKey := encryptiontesting.CreateMigratedEncryptionKeySecretWithKMSPluginConfig(instanceName, grs, 1, metav1.Now().Time)
+
+	changedPlugin := encryptiontesting.DefaultKMSPluginConfig
+	changedPlugin.Vault.VaultAddress = "https://other-vault.example.com"
+
+	apiServer := &configv1.APIServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Spec: configv1.APIServerSpec{
+			Encryption: configv1.APIServerEncryption{
+				Type: "KMS",
+				KMS:  changedPlugin,
+			},
+		},
+	}
+
+	vaultSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "vault-approle-secret", Namespace: "openshift-config"},
+		Data: map[string][]byte{
+			"role-id":   []byte("role"),
+			"secret-id": []byte("secret"),
+		},
+	}
+	vaultCA := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "vault-ca-bundle", Namespace: "openshift-config"},
+		Data:       map[string]string{"ca-bundle.crt": "ca"},
+	}
+
+	fakeKubeClient := fake.NewSimpleClientset(existingKey, vaultSecret, vaultCA)
+	fakeConfigClient := configv1clientfake.NewSimpleClientset(apiServer)
+	fakeOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(
+		&operatorv1.StaticPodOperatorSpec{OperatorSpec: operatorv1.OperatorSpec{ManagementState: operatorv1.Managed}},
+		&operatorv1.StaticPodOperatorStatus{},
+		nil,
+		nil,
+	)
+	provider := newTestProvider(grs)
+	selector := metav1.ListOptions{LabelSelector: "encryption.apiserver.operator.openshift.io/component=" + instanceName}
+
+	requeue, secret, err := computeEncryptionConfigSecretDryRun(
+		context.Background(),
+		instanceName,
+		nil,
+		provider,
+		&staticEncryptionDeployer{},
+		fakeOperatorClient,
+		fakeConfigClient.ConfigV1().APIServers(),
+		fakeKubeClient.CoreV1(),
+		selector,
+	)
+	require.NoError(t, err)
+	require.False(t, requeue)
+	require.NotNil(t, secret)
+
+	cfg, err := encryptiondata.FromSecret(secret)
+	require.NoError(t, err)
+	require.Contains(t, cfg.KMSPlugins, "2")
+
+	var sawWriteKey, sawOldKey bool
+	for _, resource := range cfg.Encryption.Resources {
+		for _, providerCfg := range resource.Providers {
+			if providerCfg.KMS == nil {
+				continue
+			}
+			switch providerCfg.KMS.Endpoint {
+			case preflightKMSSocketEndpoint:
+				sawWriteKey = true
+			case "unix:///var/run/kmsplugin/kms-1.sock":
+				sawOldKey = true
+			case "unix:///var/run/kmsplugin/kms-2.sock":
+				t.Fatalf("write-key endpoint must be rewritten away from per-key socket, got %q", providerCfg.KMS.Endpoint)
+			}
+		}
+	}
+	require.True(t, sawWriteKey, "expected write-key endpoint rewritten to %s", preflightKMSSocketEndpoint)
+	require.True(t, sawOldKey, "expected old key endpoint left on per-key socket")
+}
+
+func TestRewritePreflightWriteKeyEndpoint(t *testing.T) {
+	secret, err := encryptiondata.ToSecret(openshiftConfigManagedNS, "encryption-config-test", &encryptiondata.Config{
+		Encryption: &apiserverconfigv1.EncryptionConfiguration{
+			Resources: []apiserverconfigv1.ResourceConfiguration{{
+				Resources: []string{"secrets"},
+				Providers: []apiserverconfigv1.ProviderConfiguration{
+					{KMS: &apiserverconfigv1.KMSConfiguration{Name: "2_secrets", Endpoint: "unix:///var/run/kmsplugin/kms-2.sock"}},
+					{KMS: &apiserverconfigv1.KMSConfiguration{Name: "1_secrets", Endpoint: "unix:///var/run/kmsplugin/kms-1.sock"}},
+				},
+			}},
+		},
+	})
+	require.NoError(t, err)
+
+	rewritten, err := rewritePreflightWriteKeyEndpoint(secret, 2)
+	require.NoError(t, err)
+	cfg, err := encryptiondata.FromSecret(rewritten)
+	require.NoError(t, err)
+	require.Equal(t, preflightKMSSocketEndpoint, cfg.Encryption.Resources[0].Providers[0].KMS.Endpoint)
+	require.Equal(t, "unix:///var/run/kmsplugin/kms-1.sock", cfg.Encryption.Resources[0].Providers[1].KMS.Endpoint)
+
+	_, err = rewritePreflightWriteKeyEndpoint(secret, 99)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `write-key KMS provider with name prefix "99_" not found`)
+}
+
+func TestComputeEncryptionConfigSecretDryRun_KeyNotNeeded(t *testing.T) {
+	instanceName := "test"
+	grs := []schema.GroupResource{{Group: "", Resource: "secrets"}}
+	existingKey := encryptiontesting.CreateEncryptionKeySecretWithKMSPluginConfig(instanceName, grs, 1)
+
+	apiServer := &configv1.APIServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Spec: configv1.APIServerSpec{
+			Encryption: configv1.APIServerEncryption{
+				Type: "KMS",
+				KMS:  encryptiontesting.DefaultKMSPluginConfig,
+			},
+		},
+	}
+	vaultSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "vault-approle-secret", Namespace: "openshift-config"},
+		Data: map[string][]byte{
+			"role-id":   []byte("role"),
+			"secret-id": []byte("secret"),
+		},
+	}
+	vaultCA := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "vault-ca-bundle", Namespace: "openshift-config"},
+		Data:       map[string]string{"ca-bundle.crt": "ca"},
+	}
+
+	fakeKubeClient := fake.NewSimpleClientset(existingKey, vaultSecret, vaultCA)
+	fakeConfigClient := configv1clientfake.NewSimpleClientset(apiServer)
+	fakeOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(
+		&operatorv1.StaticPodOperatorSpec{OperatorSpec: operatorv1.OperatorSpec{ManagementState: operatorv1.Managed}},
+		&operatorv1.StaticPodOperatorStatus{},
+		nil,
+		nil,
+	)
+	provider := newTestProvider(grs)
+	selector := metav1.ListOptions{LabelSelector: "encryption.apiserver.operator.openshift.io/component=" + instanceName}
+
+	requeue, secret, err := computeEncryptionConfigSecretDryRun(
+		context.Background(),
+		instanceName,
+		nil,
+		provider,
+		&staticEncryptionDeployer{},
+		fakeOperatorClient,
+		fakeConfigClient.ConfigV1().APIServers(),
+		fakeKubeClient.CoreV1(),
+		selector,
+	)
+	require.NoError(t, err)
+	require.False(t, requeue)
+	require.NotNil(t, secret)
+
+	cfg, err := encryptiondata.FromSecret(secret)
+	require.NoError(t, err)
+	require.Contains(t, cfg.KMSPlugins, "1")
+
+	foundPreflightEndpoint := false
+	for _, resource := range cfg.Encryption.Resources {
+		for _, providerCfg := range resource.Providers {
+			if providerCfg.KMS == nil {
+				continue
+			}
+			if providerCfg.KMS.Endpoint == preflightKMSSocketEndpoint {
+				foundPreflightEndpoint = true
+			}
+			if strings.Contains(providerCfg.KMS.Endpoint, "kms-1.sock") {
+				t.Fatalf("existing write-key endpoint must be rewritten, got %q", providerCfg.KMS.Endpoint)
+			}
+		}
+	}
+	require.True(t, foundPreflightEndpoint, "expected write-key KMS endpoint rewritten to %s", preflightKMSSocketEndpoint)
+}
+
+type staticEncryptionDeployer struct {
+	secret *corev1.Secret
+}
+
+func (d *staticEncryptionDeployer) DeployedEncryptionConfigSecret(_ context.Context) (*corev1.Secret, bool, error) {
+	return d.secret, true, nil
+}
+
+func (d *staticEncryptionDeployer) AddEventHandler(_ cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
+	return nil, nil
+}
+
+func (d *staticEncryptionDeployer) HasSynced() bool { return true }
+
+type staticEncryptionDeployerNotConverged struct{}
+
+func (d *staticEncryptionDeployerNotConverged) DeployedEncryptionConfigSecret(context.Context) (*corev1.Secret, bool, error) {
+	return nil, false, nil
+}
+
+func (d *staticEncryptionDeployerNotConverged) AddEventHandler(cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
+	return nil, nil
+}
+
+func (d *staticEncryptionDeployerNotConverged) HasSynced() bool { return true }


### PR DESCRIPTION
When deploying a new KMS preflight pod, the preflight controller now computes the required encryption configuration Secret using a dry-run sandbox.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * KMS preflight now computes the managed `encryption-config` via a dry-run and deploys the preflight workload using the computed, validated result.
  * Preflight reconciles until encryption state converges while continuing to rewrite KMS provider endpoints to the preflight socket.
* **Bug Fixes**
  * Prevents deploying the preflight workload with a missing/`nil` `encryption-config` when no preflight pod exists.
* **Tests**
  * Added unit tests for dry-run `encryption-config` generation and for the dry-run secrets overlay.
  * Updated controller tests to verify the generated `encryption-config` is passed to the deployer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->