### PR TITLE
NO-JIRA: Guard nil dereference in CachedConfigMapGetter and CachedSecretGetter

### DIFF
--- a/pkg/operator/v1helpers/core_getters.go
+++ b/pkg/operator/v1helpers/core_getters.go
@@ -36,9 +36,13 @@ type combinedConfigMapInterface struct {
 }
 
 func (g combinedConfigMapGetter) ConfigMaps(namespace string) corev1client.ConfigMapInterface {
+	informer := g.listers.InformersFor(namespace)
+	if informer == nil {
+		panic(fmt.Sprintf("namespace %q is missing", namespace))
+	}
 	return combinedConfigMapInterface{
 		ConfigMapInterface: g.client.ConfigMaps(namespace),
-		lister:             g.listers.InformersFor(namespace).Core().V1().ConfigMaps().Lister().ConfigMaps(namespace),
+		lister:             informer.Core().V1().ConfigMaps().Lister().ConfigMaps(namespace),
 		namespace:          namespace,
 	}
 }
@@ -90,9 +94,13 @@ type combinedSecretInterface struct {
 }
 
 func (g combinedSecretGetter) Secrets(namespace string) corev1client.SecretInterface {
+	informer := g.listers.InformersFor(namespace)
+	if informer == nil {
+		panic(fmt.Sprintf("namespace %q is missing", namespace))
+	}
 	return combinedSecretInterface{
 		SecretInterface: g.client.Secrets(namespace),
-		lister:          g.listers.InformersFor(namespace).Core().V1().Secrets().Lister().Secrets(namespace),
+		lister:          informer.Core().V1().Secrets().Lister().Secrets(namespace),
 		namespace:       namespace,
 	}
 }

--- a/pkg/operator/v1helpers/core_getters_test.go
+++ b/pkg/operator/v1helpers/core_getters_test.go
@@ -1,0 +1,109 @@
+package v1helpers
+
+import (
+	"fmt"
+	"testing"
+
+	"k8s.io/client-go/informers"
+	fakekube "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestCachedConfigMapGetterPanicsForMissingNamespace(t *testing.T) {
+	kubeClient := fakekube.NewSimpleClientset()
+	kubeInformers := NewKubeInformersForNamespaces(kubeClient, "openshift-config")
+
+	getter := CachedConfigMapGetter(kubeClient.CoreV1(), kubeInformers)
+
+	assertPanicsWith(t, fmt.Sprintf("namespace %q is missing", "unregistered"), func() {
+		getter.ConfigMaps("unregistered")
+	})
+}
+
+func TestCachedSecretGetterPanicsForMissingNamespace(t *testing.T) {
+	kubeClient := fakekube.NewSimpleClientset()
+	kubeInformers := NewKubeInformersForNamespaces(kubeClient, "openshift-config")
+
+	getter := CachedSecretGetter(kubeClient.CoreV1(), kubeInformers)
+
+	assertPanicsWith(t, fmt.Sprintf("namespace %q is missing", "unregistered"), func() {
+		getter.Secrets("unregistered")
+	})
+}
+
+func TestCachedConfigMapGetterSucceedsForRegisteredNamespace(t *testing.T) {
+	kubeClient := fakekube.NewSimpleClientset()
+	kubeInformers := NewKubeInformersForNamespaces(kubeClient, "openshift-config")
+
+	getter := CachedConfigMapGetter(kubeClient.CoreV1(), kubeInformers)
+
+	// Should not panic for a registered namespace
+	_ = getter.ConfigMaps("openshift-config")
+}
+
+func TestCachedSecretGetterSucceedsForRegisteredNamespace(t *testing.T) {
+	kubeClient := fakekube.NewSimpleClientset()
+	kubeInformers := NewKubeInformersForNamespaces(kubeClient, "openshift-config")
+
+	getter := CachedSecretGetter(kubeClient.CoreV1(), kubeInformers)
+
+	// Should not panic for a registered namespace
+	_ = getter.Secrets("openshift-config")
+}
+
+func TestCachedGetterWithFakeInformers(t *testing.T) {
+	kubeClient := fakekube.NewSimpleClientset()
+	fakeInformers := NewFakeKubeInformersForNamespaces(map[string]informers.SharedInformerFactory{
+		"test-ns": informers.NewSharedInformerFactory(kubeClient, 0),
+	})
+
+	testCases := []struct {
+		name      string
+		namespace string
+		panics    bool
+	}{
+		{
+			name:      "registered namespace succeeds",
+			namespace: "test-ns",
+			panics:    false,
+		},
+		{
+			name:      "unregistered namespace panics",
+			namespace: "missing-ns",
+			panics:    true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			configMapGetter := CachedConfigMapGetter(kubeClient.CoreV1(), fakeInformers)
+			secretGetter := CachedSecretGetter(kubeClient.CoreV1(), fakeInformers)
+
+			if tc.panics {
+				expectedMsg := fmt.Sprintf("namespace %q is missing", tc.namespace)
+				assertPanicsWith(t, expectedMsg, func() {
+					configMapGetter.ConfigMaps(tc.namespace)
+				})
+				assertPanicsWith(t, expectedMsg, func() {
+					secretGetter.Secrets(tc.namespace)
+				})
+			} else {
+				_ = configMapGetter.ConfigMaps(tc.namespace)
+				_ = secretGetter.Secrets(tc.namespace)
+			}
+		})
+	}
+}
+
+func assertPanicsWith(t *testing.T, expectedMessage string, f func()) {
+	t.Helper()
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic, but none occurred")
+		}
+		got := fmt.Sprintf("%v", r)
+		if got != expectedMessage {
+			t.Fatalf("expected panic message %q, got %q", expectedMessage, got)
+		}
+	}()
+	f()
+}


### PR DESCRIPTION
## Summary

- `CachedConfigMapGetter.ConfigMaps()` and `CachedSecretGetter.Secrets()` chain method calls on the return value of `InformersFor()`, which returns `nil` for unregistered namespaces. This produces an unhelpful nil-pointer panic with no diagnostic context.
- Added a nil check before chaining, matching the pattern already used by the lister wrappers in `informers.go` (`configMapLister.ConfigMaps`, `secretLister.Secrets`, `podLister.Pods`) which panic with a message identifying the missing namespace.
- Added unit tests for the new behavior.

## Test plan

- [x] `go test ./pkg/operator/v1helpers/...` passes
- [x] `make verify` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of configuration and secret lookups for namespaces that are not registered.
  * Missing namespaces now produce a clear, actionable error instead of an ambiguous failure.
  * Registered namespaces continue to retrieve configuration and secret data as expected.

* **Tests**
  * Added coverage for missing and registered namespace scenarios, including multiple namespace configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->