### PR TITLE
NO-JIRA: Add WithOptions constructor and StripManagedFieldsTransform for KubeInformersForNamespaces

### DIFF
--- a/pkg/operator/v1helpers/informers.go
+++ b/pkg/operator/v1helpers/informers.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/informers"
@@ -51,6 +52,19 @@ func NewKubeInformersForNamespacesWithOptions(kubeClient kubernetes.Interface, r
 		ret[namespace] = informers.NewSharedInformerFactoryWithOptions(kubeClient, resyncInterval, factoryOpts...)
 	}
 	return ret
+}
+
+// StripManagedFieldsTransform is a cache.TransformFunc that removes
+// ManagedFields from objects before they are stored in the informer cache.
+func StripManagedFieldsTransform(obj interface{}) (interface{}, error) {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return obj, nil
+	}
+	if accessor.GetManagedFields() != nil {
+		accessor.SetManagedFields(nil)
+	}
+	return obj, nil
 }
 
 type kubeInformersForNamespaces map[string]informers.SharedInformerFactory

--- a/pkg/operator/v1helpers/informers.go
+++ b/pkg/operator/v1helpers/informers.go
@@ -33,20 +33,24 @@ type KubeInformersForNamespaces interface {
 var _ KubeInformersForNamespaces = kubeInformersForNamespaces{}
 
 func NewKubeInformersForNamespacesWithResyncPeriod(kubeClient kubernetes.Interface, resyncInterval time.Duration, namespaces ...string) KubeInformersForNamespaces {
-	ret := kubeInformersForNamespaces{}
-	for _, namespace := range namespaces {
-		if len(namespace) == 0 {
-			ret[""] = informers.NewSharedInformerFactory(kubeClient, resyncInterval)
-			continue
-		}
-		ret[namespace] = informers.NewSharedInformerFactoryWithOptions(kubeClient, resyncInterval, informers.WithNamespace(namespace))
-	}
-
-	return ret
+	return NewKubeInformersForNamespacesWithOptions(kubeClient, resyncInterval, namespaces)
 }
 
 func NewKubeInformersForNamespaces(kubeClient kubernetes.Interface, namespaces ...string) KubeInformersForNamespaces {
-	return NewKubeInformersForNamespacesWithResyncPeriod(kubeClient, 10*time.Minute, namespaces...)
+	return NewKubeInformersForNamespacesWithOptions(kubeClient, 10*time.Minute, namespaces)
+}
+
+func NewKubeInformersForNamespacesWithOptions(kubeClient kubernetes.Interface, resyncInterval time.Duration, namespaces []string, opts ...informers.SharedInformerOption) KubeInformersForNamespaces {
+	ret := kubeInformersForNamespaces{}
+	for _, namespace := range namespaces {
+		factoryOpts := make([]informers.SharedInformerOption, 0, len(opts)+1)
+		factoryOpts = append(factoryOpts, opts...)
+		if len(namespace) != 0 {
+			factoryOpts = append(factoryOpts, informers.WithNamespace(namespace))
+		}
+		ret[namespace] = informers.NewSharedInformerFactoryWithOptions(kubeClient, resyncInterval, factoryOpts...)
+	}
+	return ret
 }
 
 type kubeInformersForNamespaces map[string]informers.SharedInformerFactory

--- a/pkg/operator/v1helpers/informers_test.go
+++ b/pkg/operator/v1helpers/informers_test.go
@@ -1,0 +1,48 @@
+package v1helpers
+
+import (
+	"testing"
+	"time"
+
+	fakekube "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestNewKubeInformersForNamespacesWithOptions(t *testing.T) {
+	kubeClient := fakekube.NewSimpleClientset()
+
+	testCases := []struct {
+		name       string
+		namespaces []string
+	}{
+		{
+			name:       "single namespace",
+			namespaces: []string{"openshift-config"},
+		},
+		{
+			name:       "multiple namespaces",
+			namespaces: []string{"openshift-config", "openshift-config-managed"},
+		},
+		{
+			name:       "cluster-wide",
+			namespaces: []string{""},
+		},
+		{
+			name:       "cluster-wide and namespaced",
+			namespaces: []string{"", "openshift-config"},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ki := NewKubeInformersForNamespacesWithOptions(kubeClient, 10*time.Minute, tc.namespaces)
+
+			for _, ns := range tc.namespaces {
+				if ki.InformersFor(ns) == nil {
+					t.Errorf("expected informers for namespace %q", ns)
+				}
+			}
+			if ki.InformersFor("not-registered") != nil {
+				t.Error("expected no informers for unregistered namespace")
+			}
+		})
+	}
+}

--- a/pkg/operator/v1helpers/informers_test.go
+++ b/pkg/operator/v1helpers/informers_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakekube "k8s.io/client-go/kubernetes/fake"
 )
 
@@ -42,6 +43,61 @@ func TestNewKubeInformersForNamespacesWithOptions(t *testing.T) {
 			}
 			if ki.InformersFor("not-registered") != nil {
 				t.Error("expected no informers for unregistered namespace")
+			}
+		})
+	}
+}
+
+func TestStripManagedFieldsTransform(t *testing.T) {
+	testCases := []struct {
+		name              string
+		obj               interface{}
+		expectManagedNil  bool
+		expectPassThrough bool
+	}{
+		{
+			name: "strips managed fields from object that has them",
+			obj: &metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "default",
+				ManagedFields: []metav1.ManagedFieldsEntry{
+					{Manager: "kubectl", Operation: metav1.ManagedFieldsOperationApply},
+				},
+			},
+			expectManagedNil: true,
+		},
+		{
+			name: "passes through object without managed fields",
+			obj: &metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "default",
+			},
+			expectManagedNil: true,
+		},
+		{
+			name:              "passes through non-Object types without error",
+			obj:               "not-an-object",
+			expectPassThrough: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := StripManagedFieldsTransform(tc.obj)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.expectPassThrough {
+				if result != tc.obj {
+					t.Fatal("expected pass-through for non-Object type")
+				}
+				return
+			}
+			accessor, ok := result.(metav1.Object)
+			if !ok {
+				t.Fatal("expected result to implement metav1.Object")
+			}
+			if tc.expectManagedNil && accessor.GetManagedFields() != nil {
+				t.Fatal("expected ManagedFields to be nil")
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Add `NewKubeInformersForNamespacesWithOptions`, a constructor that accepts `SharedInformerOption` arguments and forwards them to each per-namespace factory. This allows callers to use `WithTransform` and other informer options uniformly across all namespaces.
- Add `StripManagedFieldsTransform`, a `cache.TransformFunc` that removes `ManagedFields` from objects before they are stored in the informer cache. ManagedFields can be 50-80% of serialized object size for server-side apply managed resources. Inspired by the pattern in the lister wrappers in `informers.go` and the inline transform used by upstream Kubernetes in `pkg/controlplane/apiserver/config.go`, which is not exported.

## Test plan

- [x] `go test ./pkg/operator/v1helpers/...` passes
- [x] `make verify` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable Kubernetes informer creation across multiple namespaces, including cluster-wide and mixed scopes.
  * Added a cache transform to strip managed fields from cached Kubernetes objects.
* **Refactor**
  * Updated existing namespace informer helpers to route through the new configurable informer-creation path for consistent behavior.
* **Tests**
  * Added unit tests covering informer namespace registration and managed-field transform passthrough/removal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->