### PR TITLE
resourceapply: make resourceCache thread-safe

### DIFF
--- a/pkg/operator/resource/resourceapply/resource_cache.go
+++ b/pkg/operator/resource/resourceapply/resource_cache.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"sync"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -26,6 +27,7 @@ type cachedResource struct {
 }
 
 type resourceCache struct {
+	mu    sync.RWMutex
 	cache map[cachedVersionKey]cachedResource
 }
 
@@ -114,7 +116,9 @@ func (c *resourceCache) UpdateCachedResourceMetadata(required runtime.Object, ac
 		return
 	}
 
+	c.mu.Lock()
 	c.cache[cacheKey] = cachedResource{resourceHash, resourceVersion}
+	c.mu.Unlock()
 	klog.V(7).Infof("updated resourceVersion of %s:%s:%s %s", name, kind, namespace, resourceVersion)
 }
 
@@ -144,14 +148,13 @@ func (c *resourceCache) SafeToSkipApply(required runtime.Object, existing runtim
 		return false
 	}
 
-	var versionMatch, hashMatch bool
-	if cached, exists := c.cache[cacheKey]; exists {
-		versionMatch = cached.resourceVersion == resourceVersion
-		hashMatch = cached.resourceHash == resourceHash
-		if versionMatch && hashMatch {
-			klog.V(4).Infof("found matching resourceVersion & manifest hash")
-			return true
-		}
+	c.mu.RLock()
+	cached, exists := c.cache[cacheKey]
+	c.mu.RUnlock()
+
+	if exists && cached.resourceVersion == resourceVersion && cached.resourceHash == resourceHash {
+		klog.V(4).Infof("found matching resourceVersion & manifest hash")
+		return true
 	}
 
 	return false

--- a/pkg/operator/resource/resourceapply/resource_cache_test.go
+++ b/pkg/operator/resource/resourceapply/resource_cache_test.go
@@ -1,8 +1,10 @@
 package resourceapply
 
 import (
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sync"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func TestHashOfResourceStructUnstructured(t *testing.T) {
@@ -33,4 +35,39 @@ func TestHashOfResourceStructUnstructured(t *testing.T) {
 	if hashOfResourceStruct(&unstructuredObject) == hash {
 		t.Errorf("expected a different hash after modifying the object")
 	}
+}
+
+func TestResourceCacheConcurrentAccess(t *testing.T) {
+	cache := NewResourceCache()
+
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind":       "ConfigMap",
+			"apiVersion": "v1",
+			"metadata": map[string]interface{}{
+				"name":            "test-obj",
+				"namespace":       "test-ns",
+				"resourceVersion": "1",
+			},
+		},
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			cache.UpdateCachedResourceMetadata(obj, obj)
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			cache.SafeToSkipApply(obj, obj)
+		}
+	}()
+
+	wg.Wait()
 }

--- a/pkg/operator/resource/resourceapply/resource_cache_test.go
+++ b/pkg/operator/resource/resourceapply/resource_cache_test.go
@@ -37,6 +37,8 @@ func TestHashOfResourceStructUnstructured(t *testing.T) {
 	}
 }
 
+// This test relies on -race to deterministically detect concurrent map access.
+// See https://github.com/openshift/library-go/pull/2380.
 func TestResourceCacheConcurrentAccess(t *testing.T) {
 	cache := NewResourceCache()
 

--- a/pkg/operator/resource/resourceapply/resource_cache_test.go
+++ b/pkg/operator/resource/resourceapply/resource_cache_test.go
@@ -1,6 +1,7 @@
 package resourceapply
 
 import (
+	"fmt"
 	"sync"
 	"testing"
 
@@ -42,34 +43,37 @@ func TestHashOfResourceStructUnstructured(t *testing.T) {
 func TestResourceCacheConcurrentAccess(t *testing.T) {
 	cache := NewResourceCache()
 
-	obj := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"kind":       "ConfigMap",
-			"apiVersion": "v1",
-			"metadata": map[string]interface{}{
-				"name":            "test-obj",
-				"namespace":       "test-ns",
-				"resourceVersion": "1",
+	makeObj := func(i int, rv string) *unstructured.Unstructured {
+		return &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"kind":       "ConfigMap",
+				"apiVersion": "v1",
+				"metadata": map[string]interface{}{
+					"name":            fmt.Sprintf("obj-%d", i),
+					"namespace":       "test-ns",
+					"resourceVersion": rv,
+				},
 			},
-		},
+		}
 	}
 
 	var wg sync.WaitGroup
-	wg.Add(2)
 
-	go func() {
-		defer wg.Done()
-		for i := 0; i < 100; i++ {
-			cache.UpdateCachedResourceMetadata(obj, obj)
-		}
-	}()
+	for range 10 {
+		wg.Go(func() {
+			for i := range 10 {
+				cache.UpdateCachedResourceMetadata(makeObj(i, ""), makeObj(i, "1"))
+			}
+		})
+	}
 
-	go func() {
-		defer wg.Done()
-		for i := 0; i < 100; i++ {
-			cache.SafeToSkipApply(obj, obj)
-		}
-	}()
+	for range 10 {
+		wg.Go(func() {
+			for i := range 10 {
+				cache.SafeToSkipApply(makeObj(i, ""), makeObj(i, "1"))
+			}
+		})
+	}
 
 	wg.Wait()
 }


### PR DESCRIPTION
resourceCache uses a plain map with no synchronization. Callers that share a single ResourceCache across goroutines (e.g. CMO that runs ~15 reconciliation tasks concurrently, see https://redhat.atlassian.net/browse/OCPBUGS-99769) hit "concurrent map writes" panics .

Add a sync.RWMutex to protect map access and a test that reproduces the race.

without the patch:
```
==================
WARNING: DATA RACE
Read at 0x00c0004790e0 by goroutine 32:
  internal/runtime/maps.(*table).Print()
      /Users/XXX/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.0.darwin-arm64/src/internal/runtime/maps/table_debug.go:83 +0x36c
  github.com/openshift/library-go/pkg/operator/resource/resourceapply.(*resourceCache).SafeToSkipApply()
      /tmp/library-go-pr2380/pkg/operator/resource/resourceapply/resource_cache.go:148 +0xb8
  github.com/openshift/library-go/pkg/operator/resource/resourceapply.TestResourceCacheConcurrentAccess.func2()
      /tmp/library-go-pr2380/pkg/operator/resource/resourceapply/resource_cache_test.go:68 +0xa8

Previous write at 0x00c0004790e0 by goroutine 31:
  runtime.mapaccess2()
      /Users/XXX/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.0.darwin-arm64/src/internal/runtime/maps/runtime.go:131 +0x2fc
  github.com/openshift/library-go/pkg/operator/resource/resourceapply.(*resourceCache).UpdateCachedResourceMetadata()
      /tmp/library-go-pr2380/pkg/operator/resource/resourceapply/resource_cache.go:117 +0x2e0
  github.com/openshift/library-go/pkg/operator/resource/resourceapply.TestResourceCacheConcurrentAccess.func1()
      /tmp/library-go-pr2380/pkg/operator/resource/resourceapply/resource_cache_test.go:61 +0xa8

Goroutine 32 (running) created at:
  github.com/openshift/library-go/pkg/operator/resource/resourceapply.TestResourceCacheConcurrentAccess()
      /tmp/library-go-pr2380/pkg/operator/resource/resourceapply/resource_cache_test.go:65 +0x4bc
  testing.tRunner()
      /Users/XXX/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.0.darwin-arm64/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /Users/XXX/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.0.darwin-arm64/src/testing/testing.go:2101 +0x34

Goroutine 31 (running) created at:
  github.com/openshift/library-go/pkg/operator/resource/resourceapply.TestResourceCacheConcurrentAccess()
      /tmp/library-go-pr2380/pkg/operator/resource/resourceapply/resource_cache_test.go:58 +0x3ec
  testing.tRunner()
      /Users/XXX/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.0.darwin-arm64/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /Users/XXX/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.0.darwin-arm64/src/testing/testing.go:2101 +0x34
==================
==================
WARNING: DATA RACE
Read at 0x00c0006e58d0 by goroutine 32:
  github.com/openshift/library-go/pkg/operator/resource/resourceapply.(*resourceCache).SafeToSkipApply()
      /tmp/library-go-pr2380/pkg/operator/resource/resourceapply/resource_cache.go:148 +0xc8
  github.com/openshift/library-go/pkg/operator/resource/resourceapply.TestResourceCacheConcurrentAccess.func2()
      /tmp/library-go-pr2380/pkg/operator/resource/resourceapply/resource_cache_test.go:68 +0xa8

Previous write at 0x00c0006e58d0 by goroutine 31:
  github.com/openshift/library-go/pkg/operator/resource/resourceapply.(*resourceCache).UpdateCachedResourceMetadata()
      /tmp/library-go-pr2380/pkg/operator/resource/resourceapply/resource_cache.go:117 +0x2f0
  github.com/openshift/library-go/pkg/operator/resource/resourceapply.TestResourceCacheConcurrentAccess.func1()
      /tmp/library-go-pr2380/pkg/operator/resource/resourceapply/resource_cache_test.go:61 +0xa8

Goroutine 32 (running) created at:
  github.com/openshift/library-go/pkg/operator/resource/resourceapply.TestResourceCacheConcurrentAccess()
      /tmp/library-go-pr2380/pkg/operator/resource/resourceapply/resource_cache_test.go:65 +0x4bc
  testing.tRunner()
      /Users/XXX/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.0.darwin-arm64/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /Users/XXX/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.0.darwin-arm64/src/testing/testing.go:2101 +0x34

Goroutine 31 (running) created at:
  github.com/openshift/library-go/pkg/operator/resource/resourceapply.TestResourceCacheConcurrentAccess()
      /tmp/library-go-pr2380/pkg/operator/resource/resourceapply/resource_cache_test.go:58 +0x3ec
  testing.tRunner()
      /Users/XXX/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.0.darwin-arm64/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /Users/XXX/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.0.darwin-arm64/src/testing/testing.go:2101 +0x34
==================
--- FAIL: TestResourceCacheConcurrentAccess (0.01s)
    testing.go:1712: race detected during execution of test
FAIL
FAIL	github.com/openshift/library-go/pkg/operator/resource/resourceapply	1.057s
FAIL

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource cache reliability during concurrent operations.
  * Prevented potential data races when updating or checking cached resource metadata.

* **Tests**
  * Added a concurrency-focused test covering simultaneous cache updates and skip-apply checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->