### PR TITLE
CNTRLPLANE-3237: encryption/kms/health/cmd: creates the provider from the operator client.

### DIFF
--- a/pkg/operator/encryption/kms/health/cmd.go
+++ b/pkg/operator/encryption/kms/health/cmd.go
@@ -11,8 +11,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/server"
 	k8senvelopekmsv2 "k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2"
-	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
+
+	operatorclient "github.com/openshift/client-go/operator/clientset/versioned"
 
 	"github.com/openshift/library-go/pkg/operator/encryption/kms"
 )
@@ -26,9 +27,8 @@ const (
 var kmsSocketPattern = regexp.MustCompile(`^unix:///var/run/kmsplugin/kms-(\d+)\.sock$`)
 
 // NewEncryptionStatusProviderFunc builds the EncryptionStatusProvider for a
-// target apiserver operator status CR. The factory lets sidecar binaries defer
-// REST client creation until startup when the in-cluster config is available.
-type NewEncryptionStatusProviderFunc func(restConfig *rest.Config) (kms.EncryptionStatusProvider, error)
+// target apiserver operator status CR.
+type NewEncryptionStatusProviderFunc func(client operatorclient.Interface) (kms.EncryptionStatusProvider, error)
 
 type Config struct {
 	provider     kms.EncryptionStatusProvider

--- a/pkg/operator/encryption/kms/health/options.go
+++ b/pkg/operator/encryption/kms/health/options.go
@@ -10,6 +10,8 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/clientcmd"
+
+	operatorclient "github.com/openshift/client-go/operator/clientset/versioned"
 )
 
 // options' flag-bound fields are exported so the struct can be logged as a
@@ -81,7 +83,12 @@ func (o *options) Config(ctx context.Context) (*Config, error) {
 		return nil, fmt.Errorf("build rest config: %w", err)
 	}
 
-	provider, err := o.newProvider(restCfg)
+	opClient, err := operatorclient.NewForConfig(restCfg)
+	if err != nil {
+		return nil, fmt.Errorf("build operator client: %w", err)
+	}
+
+	provider, err := o.newProvider(opClient)
 	if err != nil {
 		return nil, fmt.Errorf("build encryption status provider: %w", err)
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved KMS encryption health status initialization.
  * Added clearer handling when the operator client cannot be created, helping surface configuration issues more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->