### PR TITLE
NO-JIRA: kms preflight: add reflection based drift detection

### DIFF
--- a/test/library/encryption/preflight_deploy.go
+++ b/test/library/encryption/preflight_deploy.go
@@ -31,8 +31,8 @@ const (
 // PreflightDeployScenario configures a real-cluster Deploy() check against a live
 // operand namespace. The operand namespace must already have preflight RBAC.
 //
-// BasicScenario.Namespace is the operand namespace (Deploy target).
-// BasicScenario.LabelSelector is reserved for a follow-up operand pod drift check.
+// BasicScenario.Namespace is the operand namespace (Deploy target and pod lookup).
+// BasicScenario.LabelSelector selects an operand pod for AssertNoPreflightConfigDrift.
 type PreflightDeployScenario struct {
 	BasicScenario
 	// CreateDeployerFunc builds the deployer (image, command, static-pod mode).
@@ -48,10 +48,11 @@ type PreflightDeployScenario struct {
 }
 
 // TestPreflightDeployAndPodMatchesOperand deploys a preflight pod into the operand
-// namespace and runs AssertDeployFunc against it.
+// namespace, runs AssertDeployFunc, then AssertNoPreflightConfigDrift.
 func TestPreflightDeployAndPodMatchesOperand(ctx context.Context, t testing.TB, scenario PreflightDeployScenario) {
 	t.Helper()
 	require.NotEmpty(t, scenario.Namespace)
+	require.NotEmpty(t, scenario.LabelSelector)
 	require.NotNil(t, scenario.CreateDeployerFunc)
 	require.NotNil(t, scenario.CreateEncryptionConfigFunc)
 	require.NotNil(t, scenario.AssertDeployFunc)
@@ -77,10 +78,12 @@ func TestPreflightDeployAndPodMatchesOperand(ctx context.Context, t testing.TB, 
 
 	require.NoError(t, deployer.Deploy(ctx, preflightDeployConfigHash, secret))
 	scenario.AssertDeployFunc(ctx, t, clientSet, scenario.Namespace, deployer)
+	AssertNoPreflightConfigDrift(ctx, t, clientSet, scenario.Namespace, scenario.LabelSelector)
 }
 
 // AssertPreflightDeploy waits for checker pod conditions and validates Deploy side effects
-// (check container, plugin init container, config-hash / result / KEK-ID conditions).
+// (check container, plugin init container, config-hash / result / remote-key-ID conditions).
+// PodSpec drift vs the operand is AssertNoPreflightConfigDrift — call that separately.
 func AssertPreflightDeploy(ctx context.Context, t testing.TB, clientSet ClientSet, namespace string, deployer *preflight.PodPreflightDeployer) {
 	t.Helper()
 	require.NotNil(t, deployer)

--- a/test/library/encryption/preflight_drift.go
+++ b/test/library/encryption/preflight_drift.go
@@ -1,0 +1,91 @@
+package encryption
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/library-go/pkg/operator/encryption/kms/preflight"
+)
+
+// DefaultPreflightPodSpecDriftIgnore lists PodSpec field names skipped by
+// AssertNoPreflightConfigDrift via cmpopts.IgnoreFields. Unknown diffs outside
+// this list fail the drift check.
+//
+// Keep entries as exported Go field names (e.g. "HostNetwork"), not JSON tags.
+// Prefer a short list: fields that are nil/zero on both sides already compare equal, so
+// only ignore fields we know differ by design between preflight and the operand.
+var DefaultPreflightPodSpecDriftIgnore = []string{
+	// --- Workload-owned: preflight is a one-shot checker, not the apiserver ---
+	// Preflight runs kms-preflight-check (+ KMS plugin init/sidecar); operands run apiserver containers.
+	"Containers",
+	"InitContainers",
+	"EphemeralContainers",
+	// Volume mounts follow the containers above (encryption-config, sockets, etc.).
+	"Volumes",
+	// Preflight uses RestartPolicy=Never; operands typically Always.
+	"RestartPolicy",
+	// Preflight uses its own SA (kms-preflight) vs the operand service account.
+	"ServiceAccountName",
+	"DeprecatedServiceAccount",
+	"AutomountServiceAccountToken",
+	// OpenShift injects the SA dockercfg onto the preflight pod; static KAS pods typically have none.
+	"ImagePullSecrets",
+	// One-shot job semantics; operands are long-running.
+	"ActiveDeadlineSeconds",
+	"TerminationGracePeriodSeconds",
+
+	// Filled by the scheduler on Running pods; preflight and operand will always share a control plane node one way or another.
+	"NodeName",
+	// Preflight sets master nodeSelector; static KAS pods are placed differently.
+	"NodeSelector",
+	// Toleration sets differ (preflight: two master tolerations; KAS: Exists; oauth: master+unreachable+not-ready).
+	"Tolerations",
+	// oauth-apiserver injects anti-affinity in code; preflight has none.
+	"Affinity",
+	// Preflight template still uses system-cluster-critical; operands use system-node-critical.
+	"PriorityClassName",
+	// KAS sets an explicit numeric priority; preflight leaves it to the PriorityClass.
+	"Priority",
+}
+
+// AssertNoPreflightConfigDrift fetches the preflight pod and a Running operand pod matching
+// labelSelector, then fails if cmp.Diff reports unexpected PodSpec drift.
+// Call this separately from AssertPreflightDeploy (e.g. from TestPreflightDeployAndPodMatchesOperand).
+func AssertNoPreflightConfigDrift(ctx context.Context, t testing.TB, clientSet ClientSet, namespace, labelSelector string) {
+	t.Helper()
+	require.NotEmpty(t, namespace)
+	require.NotEmpty(t, labelSelector)
+
+	preflightPod, err := clientSet.Kube.CoreV1().Pods(namespace).Get(ctx, preflight.PodName, metav1.GetOptions{})
+	require.NoError(t, err, "preflight pod %s/%s", namespace, preflight.PodName)
+
+	targetPod := findAnyOperandPod(ctx, t, clientSet, namespace, labelSelector)
+	require.NotNil(t, targetPod, "no Running pod in %s matching %q", namespace, labelSelector)
+
+	diff := cmp.Diff(&targetPod.Spec, &preflightPod.Spec,
+		cmpopts.IgnoreFields(corev1.PodSpec{}, DefaultPreflightPodSpecDriftIgnore...),
+		cmpopts.EquateEmpty(),
+	)
+	require.Empty(t, diff, "preflight pod %s/%s drifted from target %s/%s:\n%s",
+		preflightPod.Namespace, preflightPod.Name, targetPod.Namespace, targetPod.Name, diff)
+}
+
+// findAnyOperandPod returns any Running pod matching labelSelector.
+// Which replica is fine: control-plane operand PodSpecs should match across replicas for fields we compare.
+func findAnyOperandPod(ctx context.Context, t testing.TB, clientSet ClientSet, namespace, labelSelector string) *corev1.Pod {
+	t.Helper()
+	pods, err := clientSet.Kube.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+	require.NoError(t, err)
+	for i := range pods.Items {
+		if pods.Items[i].Status.Phase == corev1.PodRunning {
+			return &pods.Items[i]
+		}
+	}
+	return nil
+}

--- a/test/library/encryption/preflight_drift_test.go
+++ b/test/library/encryption/preflight_drift_test.go
@@ -1,0 +1,81 @@
+package encryption
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestDefaultPreflightPodSpecDriftIgnore(t *testing.T) {
+	base := &corev1.PodSpec{
+		HostNetwork:       true,
+		PriorityClassName: "system-cluster-critical",
+		RestartPolicy:     corev1.RestartPolicyAlways,
+		Containers: []corev1.Container{{
+			Name:  "apiserver",
+			Image: "kas:latest",
+		}},
+	}
+	opts := []cmp.Option{
+		cmpopts.IgnoreFields(corev1.PodSpec{}, DefaultPreflightPodSpecDriftIgnore...),
+		cmpopts.EquateEmpty(),
+	}
+
+	t.Run("ignore list names are PodSpec fields", func(t *testing.T) {
+		typ := reflect.TypeOf(corev1.PodSpec{})
+		for _, name := range DefaultPreflightPodSpecDriftIgnore {
+			if _, ok := typ.FieldByName(name); !ok {
+				t.Errorf("DefaultPreflightPodSpecDriftIgnore entry %q is not a PodSpec field", name)
+			}
+		}
+	})
+
+	t.Run("identical specs", func(t *testing.T) {
+		other := base.DeepCopy()
+		if diff := cmp.Diff(base, other, opts...); diff != "" {
+			t.Fatalf("expected no drift, got:\n%s", diff)
+		}
+	})
+
+	t.Run("ignored workload fields do not fail", func(t *testing.T) {
+		preflightSpec := base.DeepCopy()
+		preflightSpec.Containers = []corev1.Container{{Name: "kms-preflight-check", Image: "op:latest"}}
+		preflightSpec.InitContainers = []corev1.Container{{Name: "plugin", Image: "plugin:latest"}}
+		preflightSpec.RestartPolicy = corev1.RestartPolicyNever
+		preflightSpec.ServiceAccountName = "kms-preflight"
+		preflightSpec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: "kms-preflight-dockercfg"}}
+		if diff := cmp.Diff(base, preflightSpec, opts...); diff != "" {
+			t.Fatalf("expected ignored fields to be skipped, got:\n%s", diff)
+		}
+	})
+
+	t.Run("unexpected HostNetwork drift fails", func(t *testing.T) {
+		preflightSpec := base.DeepCopy()
+		preflightSpec.HostNetwork = false
+		diff := cmp.Diff(base, preflightSpec, opts...)
+		if diff == "" {
+			t.Fatal("expected HostNetwork drift")
+		}
+		if !strings.Contains(diff, "HostNetwork") {
+			t.Fatalf("expected HostNetwork in diff, got:\n%s", diff)
+		}
+	})
+
+	t.Run("custom ignore suppresses field", func(t *testing.T) {
+		preflightSpec := base.DeepCopy()
+		preflightSpec.HostNetwork = false
+		ignore := append([]string{}, DefaultPreflightPodSpecDriftIgnore...)
+		ignore = append(ignore, "HostNetwork")
+		diff := cmp.Diff(base, preflightSpec,
+			cmpopts.IgnoreFields(corev1.PodSpec{}, ignore...),
+			cmpopts.EquateEmpty(),
+		)
+		if diff != "" {
+			t.Fatalf("expected HostNetwork to be ignored, got:\n%s", diff)
+		}
+	})
+}


### PR DESCRIPTION
This adds a basic diff between the preflight pod and the respective apiserver pod. We do this via reflection to avoid constantly changing the logic when new fields are added. There's also an ignore list where we can tag things we want to allow to diverge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved encryption preflight checks by comparing the preflight pod spec against the matching currently running operand pod, selected via an explicit label selector.
  * Strengthened PodSpec drift detection with semantic comparison that tolerates known, intentional differences through a configurable ignore list.

* **Tests**
  * Added test coverage for the default ignored fields, custom ignore overrides, detection of unexpected PodSpec changes (such as host networking), and validation behavior when pods/specs don’t match.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->