### PR TITLE
OCPBUGS-100060: staticpod: add installer precondition hook

### DIFF
--- a/pkg/operator/staticpod/controller/installer/installer_controller.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller.go
@@ -106,6 +106,11 @@ type InstallerController struct {
 
 	installerPodMutationFns []InstallerPodMutationFunc
 
+	// installerPrecondition, when set, is consulted immediately before an installer pod is created for a node.
+	// When it returns false the installer controller emits an InstallerPreconditionNotMet event and requeues
+	// instead of creating the installer pod (which would restart the operand static pod on that node).
+	installerPrecondition InstallerPreconditionFunc
+
 	startupMonitorEnabled func() (bool, error)
 
 	factory          *factory.Factory
@@ -130,6 +135,24 @@ func (c *InstallerController) WithInstallerPodMutationFn(installerPodMutationFn 
 
 func (c *InstallerController) WithMinReadyDuration(minReadyDuration time.Duration) *InstallerController {
 	c.minReadyDuration = minReadyDuration
+	return c
+}
+
+// installerPreconditionRequeueDuration is how long the installer controller waits before rechecking
+// an unmet installer precondition.
+const installerPreconditionRequeueDuration = 15 * time.Second
+
+// InstallerPreconditionFunc returns true when it is safe to create an installer pod (which will
+// restart the operand static pod) on the given node.  When it returns false with a reason, the
+// installer controller requeues and retries later.  An error makes the sync fail.
+type InstallerPreconditionFunc func(ctx context.Context, nodeName string) (safe bool, reason string, err error)
+
+// WithInstallerPrecondition sets a precondition consulted immediately before creating an installer
+// pod for a node.  Operators can use it to delay operand restarts when doing so would be unsafe,
+// for example when restarting an etcd member while another control plane node is being rebooted
+// would lose quorum.
+func (c *InstallerController) WithInstallerPrecondition(precondition InstallerPreconditionFunc) *InstallerController {
+	c.installerPrecondition = precondition
 	return c
 }
 
@@ -510,6 +533,18 @@ func (c *InstallerController) manageInstallationPods(ctx context.Context, operat
 					if !c.now().After(earliestRetry) {
 						klog.V(4).Infof("Backing off node %s installer retry %d until %v", currNodeState.NodeName, currNodeState.LastFailedCount+1, earliestRetry)
 						return true, earliestRetry.Sub(c.now()), nil, nil, nil
+					}
+				}
+
+				if c.installerPrecondition != nil {
+					safe, reason, err := c.installerPrecondition(ctx, currNodeState.NodeName)
+					if err != nil {
+						return true, 0, nil, nil, err
+					}
+					if !safe {
+						c.eventRecorder.Warningf("InstallerPreconditionNotMet", "Delaying installer pod for revision %d on node %q: %s",
+							currNodeState.TargetRevision, currNodeState.NodeName, reason)
+						return true, installerPreconditionRequeueDuration, nil, nil, nil
 					}
 				}
 

--- a/pkg/operator/staticpod/controller/installer/installer_controller.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller.go
@@ -107,8 +107,7 @@ type InstallerController struct {
 	installerPodMutationFns []InstallerPodMutationFunc
 
 	// installerPrecondition, when set, is consulted immediately before an installer pod is created for a node.
-	// When it returns false the installer controller emits an InstallerPreconditionNotMet event and requeues
-	// instead of creating the installer pod (which would restart the operand static pod on that node).
+	// A positive duration delays pod creation by that amount.
 	installerPrecondition InstallerPreconditionFunc
 
 	startupMonitorEnabled func() (bool, error)
@@ -138,14 +137,10 @@ func (c *InstallerController) WithMinReadyDuration(minReadyDuration time.Duratio
 	return c
 }
 
-// installerPreconditionRequeueDuration is how long the installer controller waits before rechecking
-// an unmet installer precondition.
-const installerPreconditionRequeueDuration = 15 * time.Second
-
-// InstallerPreconditionFunc returns true when it is safe to create an installer pod (which will
-// restart the operand static pod) on the given node.  When it returns false with a reason, the
-// installer controller requeues and retries later.  An error makes the sync fail.
-type InstallerPreconditionFunc func(ctx context.Context, nodeName string) (safe bool, reason string, err error)
+// InstallerPreconditionFunc returns how long the installer controller should delay creating an
+// installer pod (which will restart the operand static pod) on the given node. A positive duration
+// requeues the controller to retry later; zero allows the pod to be created. An error makes the sync fail.
+type InstallerPreconditionFunc func(ctx context.Context, nodeName string) (delay time.Duration, reason string, err error)
 
 // WithInstallerPrecondition sets a precondition consulted immediately before creating an installer
 // pod for a node.  Operators can use it to delay operand restarts when doing so would be unsafe,
@@ -537,14 +532,14 @@ func (c *InstallerController) manageInstallationPods(ctx context.Context, operat
 				}
 
 				if c.installerPrecondition != nil {
-					safe, reason, err := c.installerPrecondition(ctx, currNodeState.NodeName)
+					delay, reason, err := c.installerPrecondition(ctx, currNodeState.NodeName)
 					if err != nil {
 						return true, 0, nil, nil, err
 					}
-					if !safe {
+					if delay > 0 {
 						c.eventRecorder.Warningf("InstallerPreconditionNotMet", "Delaying installer pod for revision %d on node %q: %s",
 							currNodeState.TargetRevision, currNodeState.NodeName, reason)
-						return true, installerPreconditionRequeueDuration, nil, nil, nil
+						return true, delay, nil, nil, nil
 					}
 				}
 

--- a/pkg/operator/staticpod/controller/installer/installer_controller_test.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller_test.go
@@ -2769,3 +2769,97 @@ func TestWaitToObserveWrites(t *testing.T) {
 		t.Fatalf("expected %d status apply, got %d", want, nApplies)
 	}
 }
+
+func TestCreateInstallerPodPrecondition(t *testing.T) {
+	newController := func(precondition InstallerPreconditionFunc) (*InstallerController, *events.Recorder, func() *corev1.Pod) {
+		kubeClient := fake.NewSimpleClientset(
+			&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "test-config"}},
+			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "test-secret"}},
+			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: fmt.Sprintf("%s-%d", "test-secret", 1)}},
+			&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: fmt.Sprintf("%s-%d", "test-config", 1)}},
+		)
+		var installerPod *corev1.Pod
+		kubeClient.PrependReactor("create", "pods", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+			installerPod = action.(ktesting.CreateAction).GetObject().(*corev1.Pod)
+			return false, nil, nil
+		})
+		kubeInformers := informers.NewSharedInformerFactoryWithOptions(kubeClient, 1*time.Minute, informers.WithNamespace("test"))
+		fakeStaticPodOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(
+			&operatorv1.StaticPodOperatorSpec{OperatorSpec: operatorv1.OperatorSpec{ManagementState: operatorv1.Managed}},
+			&operatorv1.StaticPodOperatorStatus{
+				OperatorStatus: operatorv1.OperatorStatus{LatestAvailableRevision: 1},
+				NodeStatuses:   []operatorv1.NodeStatus{{NodeName: "test-node-1"}},
+			},
+			nil, nil,
+		)
+		eventRecorder := events.NewRecorder(kubeClient.CoreV1().Events("test"), "test-operator", &corev1.ObjectReference{}, clocktesting.NewFakePassiveClock(time.Now()))
+		c := NewInstallerController(
+			"unit-test", "test", "test-pod",
+			[]revision.RevisionResource{{Name: "test-config"}},
+			[]revision.RevisionResource{{Name: "test-secret"}},
+			[]string{"/bin/true"},
+			kubeInformers,
+			fakeStaticPodOperatorClient,
+			kubeClient.CoreV1(),
+			kubeClient.CoreV1(),
+			kubeClient.CoreV1(),
+			eventRecorder,
+		).WithInstallerPrecondition(precondition)
+		c.ownerRefsFn = func(ctx context.Context, revision int32) ([]metav1.OwnerReference, error) {
+			return []metav1.OwnerReference{}, nil
+		}
+		c.installerPodImageFn = func() string { return "docker.io/foo/bar" }
+		return c, &eventRecorder, func() *corev1.Pod { return installerPod }
+	}
+
+	t.Run("unmet precondition delays installer pod", func(t *testing.T) {
+		checkedNode := ""
+		c, eventRecorder, getPod := newController(func(ctx context.Context, nodeName string) (bool, string, error) {
+			checkedNode = nodeName
+			return false, "another master is rebooting", nil
+		})
+		for i := 0; i < 3; i++ {
+			if err := c.Sync(context.TODO(), factory.NewSyncContext("InstallerController", *eventRecorder)); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if getPod() != nil {
+			t.Fatalf("expected no installer pod while the precondition is unmet")
+		}
+		if checkedNode != "test-node-1" {
+			t.Fatalf("expected precondition to be consulted for test-node-1, got %q", checkedNode)
+		}
+	})
+
+	t.Run("met precondition allows installer pod", func(t *testing.T) {
+		c, eventRecorder, getPod := newController(func(ctx context.Context, nodeName string) (bool, string, error) {
+			return true, "", nil
+		})
+		for i := 0; i < 3; i++ {
+			if err := c.Sync(context.TODO(), factory.NewSyncContext("InstallerController", *eventRecorder)); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if getPod() == nil {
+			t.Fatalf("expected installer pod to be created when the precondition is met")
+		}
+	})
+
+	t.Run("precondition error fails sync", func(t *testing.T) {
+		c, eventRecorder, getPod := newController(func(ctx context.Context, nodeName string) (bool, string, error) {
+			return false, "", fmt.Errorf("boom")
+		})
+		var syncErr error
+		for i := 0; i < 3; i++ {
+			if syncErr = c.Sync(context.TODO(), factory.NewSyncContext("InstallerController", *eventRecorder)); syncErr != nil {
+				break
+			}
+		}
+		if syncErr == nil {
+			t.Fatalf("expected sync error from precondition")
+		}
+		if getPod() != nil {
+			t.Fatalf("expected no installer pod on precondition error")
+		}
+	})
+}

--- a/pkg/operator/staticpod/controller/installer/installer_controller_test.go
+++ b/pkg/operator/staticpod/controller/installer/installer_controller_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	ktesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/util/workqueue"
 	clocktesting "k8s.io/utils/clock/testing"
 )
 
@@ -2770,8 +2771,40 @@ func TestWaitToObserveWrites(t *testing.T) {
 	}
 }
 
+type addAfterCall struct {
+	item  interface{}
+	delay time.Duration
+}
+
+type recordingRateLimitingQueue struct {
+	workqueue.RateLimitingInterface
+	addAfterCalls []addAfterCall
+}
+
+func (q *recordingRateLimitingQueue) AddAfter(item interface{}, delay time.Duration) {
+	q.addAfterCalls = append(q.addAfterCalls, addAfterCall{item: item, delay: delay})
+}
+
+type recordingSyncContext struct {
+	recorder events.Recorder
+	queue    workqueue.RateLimitingInterface
+	queueKey string
+}
+
+func (c recordingSyncContext) Recorder() events.Recorder {
+	return c.recorder
+}
+
+func (c recordingSyncContext) Queue() workqueue.RateLimitingInterface {
+	return c.queue
+}
+
+func (c recordingSyncContext) QueueKey() string {
+	return c.queueKey
+}
+
 func TestCreateInstallerPodPrecondition(t *testing.T) {
-	newController := func(precondition InstallerPreconditionFunc) (*InstallerController, *events.Recorder, func() *corev1.Pod) {
+	newController := func(precondition InstallerPreconditionFunc) (*InstallerController, events.InMemoryRecorder, func() *corev1.Pod) {
 		kubeClient := fake.NewSimpleClientset(
 			&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "test-config"}},
 			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "test-secret"}},
@@ -2792,7 +2825,7 @@ func TestCreateInstallerPodPrecondition(t *testing.T) {
 			},
 			nil, nil,
 		)
-		eventRecorder := events.NewRecorder(kubeClient.CoreV1().Events("test"), "test-operator", &corev1.ObjectReference{}, clocktesting.NewFakePassiveClock(time.Now()))
+		eventRecorder := events.NewInMemoryRecorder("test-operator", clocktesting.NewFakePassiveClock(time.Now()))
 		c := NewInstallerController(
 			"unit-test", "test", "test-pod",
 			[]revision.RevisionResource{{Name: "test-config"}},
@@ -2809,49 +2842,72 @@ func TestCreateInstallerPodPrecondition(t *testing.T) {
 			return []metav1.OwnerReference{}, nil
 		}
 		c.installerPodImageFn = func() string { return "docker.io/foo/bar" }
-		return c, &eventRecorder, func() *corev1.Pod { return installerPod }
+		return c, eventRecorder, func() *corev1.Pod { return installerPod }
 	}
 
-	t.Run("unmet precondition delays installer pod", func(t *testing.T) {
+	t.Run("positive delay postpones installer pod", func(t *testing.T) {
+		const requestedDelay = 37 * time.Second
 		checkedNode := ""
-		c, eventRecorder, getPod := newController(func(ctx context.Context, nodeName string) (bool, string, error) {
+		c, eventRecorder, getPod := newController(func(ctx context.Context, nodeName string) (time.Duration, string, error) {
 			checkedNode = nodeName
-			return false, "another master is rebooting", nil
+			return requestedDelay, "another master is rebooting", nil
 		})
-		for i := 0; i < 3; i++ {
-			if err := c.Sync(context.TODO(), factory.NewSyncContext("InstallerController", *eventRecorder)); err != nil {
+		queue := &recordingRateLimitingQueue{RateLimitingInterface: workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())}
+		defer queue.ShutDown()
+		syncCtx := recordingSyncContext{recorder: eventRecorder, queue: queue, queueKey: "test-key"}
+		for i := 0; i < 3 && len(queue.addAfterCalls) == 0; i++ {
+			if err := c.Sync(context.TODO(), syncCtx); err != nil {
 				t.Fatal(err)
 			}
 		}
 		if getPod() != nil {
-			t.Fatalf("expected no installer pod while the precondition is unmet")
+			t.Fatalf("expected no installer pod while the precondition requests a delay")
 		}
 		if checkedNode != "test-node-1" {
 			t.Fatalf("expected precondition to be consulted for test-node-1, got %q", checkedNode)
 		}
+		if len(queue.addAfterCalls) != 1 {
+			t.Fatalf("expected one delayed requeue, got %d", len(queue.addAfterCalls))
+		}
+		if got := queue.addAfterCalls[0]; got.item != "test-key" || got.delay != requestedDelay {
+			t.Fatalf("expected test-key to be requeued after %s, got item %q after %s", requestedDelay, got.item, got.delay)
+		}
+		var preconditionEvent *corev1.Event
+		for _, event := range eventRecorder.Events() {
+			if event.Reason == "InstallerPreconditionNotMet" {
+				preconditionEvent = event
+				break
+			}
+		}
+		if preconditionEvent == nil {
+			t.Fatal("expected InstallerPreconditionNotMet event")
+		}
+		if preconditionEvent.Type != corev1.EventTypeWarning {
+			t.Fatalf("expected warning event, got type %q", preconditionEvent.Type)
+		}
 	})
 
-	t.Run("met precondition allows installer pod", func(t *testing.T) {
-		c, eventRecorder, getPod := newController(func(ctx context.Context, nodeName string) (bool, string, error) {
-			return true, "", nil
+	t.Run("zero delay allows installer pod", func(t *testing.T) {
+		c, eventRecorder, getPod := newController(func(ctx context.Context, nodeName string) (time.Duration, string, error) {
+			return 0, "", nil
 		})
 		for i := 0; i < 3; i++ {
-			if err := c.Sync(context.TODO(), factory.NewSyncContext("InstallerController", *eventRecorder)); err != nil {
+			if err := c.Sync(context.TODO(), factory.NewSyncContext("InstallerController", eventRecorder)); err != nil {
 				t.Fatal(err)
 			}
 		}
 		if getPod() == nil {
-			t.Fatalf("expected installer pod to be created when the precondition is met")
+			t.Fatalf("expected installer pod to be created when the precondition requests no delay")
 		}
 	})
 
 	t.Run("precondition error fails sync", func(t *testing.T) {
-		c, eventRecorder, getPod := newController(func(ctx context.Context, nodeName string) (bool, string, error) {
-			return false, "", fmt.Errorf("boom")
+		c, eventRecorder, getPod := newController(func(ctx context.Context, nodeName string) (time.Duration, string, error) {
+			return 0, "", fmt.Errorf("boom")
 		})
 		var syncErr error
 		for i := 0; i < 3; i++ {
-			if syncErr = c.Sync(context.TODO(), factory.NewSyncContext("InstallerController", *eventRecorder)); syncErr != nil {
+			if syncErr = c.Sync(context.TODO(), factory.NewSyncContext("InstallerController", eventRecorder)); syncErr != nil {
 				break
 			}
 		}

--- a/pkg/operator/staticpod/controllers.go
+++ b/pkg/operator/staticpod/controllers.go
@@ -66,6 +66,7 @@ type staticPodOperatorControllerBuilder struct {
 	installCommand           []string
 	installerPodMutationFunc installer.InstallerPodMutationFunc
 	minReadyDuration         time.Duration
+	installerPrecondition    installer.InstallerPreconditionFunc
 	enableStartMonitor       func() (bool, error)
 
 	// pruning information
@@ -114,6 +115,9 @@ type Builder interface {
 	WithUnrevisionedCerts(certDir string, certConfigMaps, certSecrets []installer.UnrevisionedResource) Builder
 	WithInstaller(command []string) Builder
 	WithMinReadyDuration(minReadyDuration time.Duration) Builder
+	// WithInstallerPrecondition sets a precondition consulted immediately before an installer pod is
+	// created for a node; see installer.InstallerPreconditionFunc.
+	WithInstallerPrecondition(precondition installer.InstallerPreconditionFunc) Builder
 	WithStartupMonitor(enabledStartupMonitor func() (bool, error)) Builder
 
 	// WithExtraNodeSelector Informs controllers to handle extra nodes as well as master nodes.
@@ -182,6 +186,11 @@ func (b *staticPodOperatorControllerBuilder) WithInstaller(command []string) Bui
 
 func (b *staticPodOperatorControllerBuilder) WithMinReadyDuration(minReadyDuration time.Duration) Builder {
 	b.minReadyDuration = minReadyDuration
+	return b
+}
+
+func (b *staticPodOperatorControllerBuilder) WithInstallerPrecondition(precondition installer.InstallerPreconditionFunc) Builder {
+	b.installerPrecondition = precondition
 	return b
 }
 
@@ -296,6 +305,8 @@ func (b *staticPodOperatorControllerBuilder) ToControllers() (manager.Controller
 			b.installerPodMutationFunc,
 		).WithMinReadyDuration(
 			b.minReadyDuration,
+		).WithInstallerPrecondition(
+			b.installerPrecondition,
 		), 1)
 
 		manager.WithController(installerstate.NewInstallerStateController(


### PR DESCRIPTION
## Summary

First of two PRs for [OCPBUGS-100060](https://issues.redhat.com/browse/OCPBUGS-100060): etcd quorum loss during upgrades when the etcd-operator's revision installer restarts an etcd member while MCO is simultaneously rebooting another master (2/3 members down, ~2min leaderless, cluster-wide API outage returning `429 storage is (re)initializing`).

- The installer controller creates installer pods unconditionally once a node has a pending target revision; the installer pod replaces the operand static-pod manifest, restarting the operand. The etcd-operator's `QuorumChecker` gates only **revision creation** (`WithRevisionControllerPrecondition`), so per-node installs of an existing revision proceed with no safety check. Evidence: in both incident runs the installer killed master-1's etcd 150–156s before master-0 finished its MCO reboot ([run 2075907197388197888](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-main-nightly-5.0-e2e-metal-ipi-ovn-upgrade/2075907197388197888), [run 2077192709163978752](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-main-nightly-5.0-e2e-metal-ipi-ovn-upgrade-runc/2077192709163978752)).
- Adds `WithInstallerPrecondition(func(ctx, nodeName) (safe bool, reason string, err error))` to `InstallerController` and the static-pod controllers `Builder`. Consulted immediately before `ensureInstallerPod`; when unmet, emits `InstallerPreconditionNotMet` and requeues (15s) instead of restarting the operand. `nil` precondition preserves existing behavior for all other operators.
- Companion PR in cluster-etcd-operator wires this to a quorum/cordon safety check (`IsSafeToRestartMember`).

## Test plan

- [x] `gofmt`, `go vet`, `go build ./pkg/operator/staticpod/...`
- [x] `go test ./pkg/operator/staticpod/controller/installer/` — new `TestCreateInstallerPodPrecondition` (unmet delays pod + consults correct node; met allows; error fails sync); existing tests pass (`internal/atomicdir TestSwap` fails identically on pristine master in my environment — pre-existing, unrelated)

---
This PR was generated using AI. Please verify before acting on it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional precondition check before creating installer pods.
  * Installer pod creation can now be delayed by a requested duration when conditions are not ready.
  * Added warning events and automatic retries using the specified delay.
  * A zero delay allows pod creation to proceed immediately.
  * Errors from the precondition check stop synchronization and prevent pod creation.
  * Added support for configuring the installer precondition through the static pod operator builder.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->