### PR TITLE
NO-JIRA: Add documentation about we don't add informers for openshift-config namespace

### DIFF
--- a/pkg/operator/encryption/controllers/key_controller.go
+++ b/pkg/operator/encryption/controllers/key_controller.go
@@ -116,12 +116,19 @@ func NewKeyController(
 	return factory.New().
 		WithSync(c.sync).
 		WithControllerInstanceName(c.controllerInstanceName).
+		// Keep the resync interval short: openshift-config secrets/configmaps are not
+		// watched directly, so credential and CA bundle rotations are only detected on
+		// resync. Increasing this significantly delays in-place config propagation.
 		ResyncEvery(time.Minute).
 		WithInformers(
 			apiServerInformer.Informer(),
 			operatorClient.Informer(),
 			kubeInformersForNamespaces.InformersFor("openshift-config-managed").Core().V1().Secrets().Informer(),
-			// TODO: add informers for openshift-config namespace to watch referenced Secrets and ConfigMaps for KMS plugin data changes
+			// openshift-config secrets/configmaps are not watched directly. While we could
+			// build a mechanism to watch only the referenced resources, creating and
+			// maintaining it is not free, and watching all resources in the namespace
+			// would create excessive API server load. Instead, changes are picked up
+			// on the next periodic resync.
 			deployer,
 		).ToController(
 		c.controllerInstanceName,


### PR DESCRIPTION
This PR adds documentation about why we decided to not add informers for openshift-config namespace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that Secrets and ConfigMaps in the configuration namespace are intentionally not continuously watched, and that updates are picked up during the next periodic resync cycle.
* **Bug Fixes**
  * No functional behavior changes were introduced in this update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->