### PR TITLE
kms: don't resync preflight controller when apiserver changes

### DIFF
--- a/pkg/operator/encryption/controllers/kms_preflight_controller.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller.go
@@ -281,7 +281,6 @@ func NewKMSPreflightController(
 		WithControllerInstanceName(c.controllerInstanceName).
 		ResyncEvery(time.Minute).
 		WithInformers(
-			apiServerInformer.Informer(),
 			operatorClient.Informer(),
 		).ToController(
 		c.controllerInstanceName,


### PR DESCRIPTION
When the user changes `apiserver/cluster`, the preflight controller currently resyncs. However, the controller will only be able to run the checks if the `ObservedConfigHash` field was set accordingly by the key controller. In that case, it's better to just rely operator client for that status update instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved KMS preflight synchronization behavior by preventing unnecessary syncs from API server events.
  * KMS preflight checks continue to update based on operator status changes and periodic refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->