### PR TITLE
NO-JIRA: Move inProgress check lower levels to allow in-place updates

### DIFF
--- a/pkg/operator/encryption/controllers/key_controller.go
+++ b/pkg/operator/encryption/controllers/key_controller.go
@@ -185,10 +185,6 @@ func (c *keyController) checkAndCreateKeys(ctx context.Context, syncContext fact
 	if err != nil {
 		return err
 	}
-	if len(isProgressingReason) > 0 {
-		syncContext.Queue().AddAfter(syncContext.QueueKey(), 2*time.Minute)
-		return nil
-	}
 
 	// avoid intended start of encryption
 	hasBeenOnBefore := currentConfig != nil || len(secrets) > 0
@@ -239,6 +235,11 @@ func (c *keyController) checkAndCreateKeys(ctx context.Context, syncContext fact
 		reasons = append(reasons, fmt.Sprintf("%s-%s", gr.Resource, internalReason))
 	}
 	if !newKeyRequired {
+		return nil
+	}
+	// We must not create new key, if there is active progress
+	if len(isProgressingReason) > 0 {
+		syncContext.Queue().AddAfter(syncContext.QueueKey(), 2*time.Minute)
 		return nil
 	}
 	if commonReason != nil && len(*commonReason) > 0 && len(reasons) > 1 {


### PR DESCRIPTION
This PR moves the location of convergence check to allow in-place field updates will be effective, even if there is new rollout in progress. 

This is the full implementation https://github.com/openshift/library-go/pull/2241/ to demonstrate the purpose.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved encryption key management while an encryption update is in progress.
  * The system now completes key requirement checks before deferring further processing, allowing configuration issues to be detected earlier.
  * New encryption keys are still not created until the active update has finished.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->