### PR TITLE
CNTRLPLANE-3237: key controller schedules a preflight check

### DIFF
--- a/pkg/operator/apiserver/controllerset/apiservercontrollerset.go
+++ b/pkg/operator/apiserver/controllerset/apiservercontrollerset.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/encryption"
 	"github.com/openshift/library-go/pkg/operator/encryption/controllers"
 	"github.com/openshift/library-go/pkg/operator/encryption/controllers/migrators"
+	"github.com/openshift/library-go/pkg/operator/encryption/kms"
 	"github.com/openshift/library-go/pkg/operator/encryption/statemachine"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/loglevel"
@@ -368,7 +369,9 @@ func (cs *APIServerControllerSet) WithEncryptionControllers(
 	apiServerClient configv1client.APIServerInterface,
 	apiServerInformer configv1informers.APIServerInformer,
 	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
-	resourceSyncer *resourcesynccontroller.ResourceSyncController,
+	resourceSyncer           *resourcesynccontroller.ResourceSyncController,
+	encryptionStatusProvider kms.EncryptionStatusProvider,
+	preflightDeployer        controllers.KMSPreflightDeployer,
 ) *APIServerControllerSet {
 
 	cs.encryptionControllers = encryptionControllerBuilder{
@@ -385,6 +388,8 @@ func (cs *APIServerControllerSet) WithEncryptionControllers(
 		secretsClient:              secretsClient,
 		configMapClient:            configMapClient,
 		resourceSyncer:             resourceSyncer,
+		encryptionStatusProvider:   encryptionStatusProvider,
+		preflightDeployer:          preflightDeployer,
 	}
 
 	return cs
@@ -394,6 +399,7 @@ func (cs *APIServerControllerSet) WithUnsupportedConfigPrefixForEncryptionContro
 	cs.encryptionControllers.unsupportedConfigPrefix = prefix
 	return cs
 }
+
 
 func (cs *APIServerControllerSet) WithoutEncryptionControllers() *APIServerControllerSet {
 	cs.encryptionControllers.controller = nil
@@ -492,6 +498,8 @@ type encryptionControllerBuilder struct {
 	apiServerInformer          configv1informers.APIServerInformer
 	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces
 	resourceSyncer             *resourcesynccontroller.ResourceSyncController
+	encryptionStatusProvider   kms.EncryptionStatusProvider
+	preflightDeployer          controllers.KMSPreflightDeployer
 
 	unsupportedConfigPrefix []string
 }
@@ -515,6 +523,8 @@ func (e *encryptionControllerBuilder) build() []controllerWrapper {
 		e.configMapClient,
 		e.eventRecorder,
 		e.resourceSyncer,
+		e.encryptionStatusProvider,
+		e.preflightDeployer,
 	)
 	if err != nil {
 		e.creationError = err

--- a/pkg/operator/apiserver/controllerset/apiservercontrollerset.go
+++ b/pkg/operator/apiserver/controllerset/apiservercontrollerset.go
@@ -369,9 +369,9 @@ func (cs *APIServerControllerSet) WithEncryptionControllers(
 	apiServerClient configv1client.APIServerInterface,
 	apiServerInformer configv1informers.APIServerInformer,
 	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
-	resourceSyncer           *resourcesynccontroller.ResourceSyncController,
+	resourceSyncer *resourcesynccontroller.ResourceSyncController,
 	encryptionStatusProvider kms.EncryptionStatusProvider,
-	preflightDeployer        controllers.KMSPreflightDeployer,
+	preflightDeployer controllers.KMSPreflightDeployer,
 ) *APIServerControllerSet {
 
 	cs.encryptionControllers = encryptionControllerBuilder{
@@ -399,7 +399,6 @@ func (cs *APIServerControllerSet) WithUnsupportedConfigPrefixForEncryptionContro
 	cs.encryptionControllers.unsupportedConfigPrefix = prefix
 	return cs
 }
-
 
 func (cs *APIServerControllerSet) WithoutEncryptionControllers() *APIServerControllerSet {
 	cs.encryptionControllers.controller = nil

--- a/pkg/operator/encryption/controllers.go
+++ b/pkg/operator/encryption/controllers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/encryption/controllers/migrators"
 	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
+	"github.com/openshift/library-go/pkg/operator/encryption/kms"
 	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
 
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
@@ -37,6 +38,8 @@ func NewControllers(
 	configMapClient corev1.ConfigMapsGetter,
 	eventRecorder events.Recorder,
 	resourceSyncer *resourcesynccontroller.ResourceSyncController,
+	encryptionStatusProvider kms.EncryptionStatusProvider,
+	preflightDeployer controllers.KMSPreflightDeployer,
 ) (Controllers, error) {
 	// avoid using the CachedSecretGetter as we need strong guarantees that our encryptionSecretSelector works
 	// otherwise we could see secrets from a different component (which will break our keyID invariants)
@@ -60,7 +63,7 @@ func NewControllers(
 		}
 	}
 
-	return []factory.Controller{
+	encryptionControllers := []factory.Controller{
 		controllers.NewKeyController(
 			component,
 			unsupportedConfigPrefix,
@@ -75,6 +78,7 @@ func NewControllers(
 			configMapClient,
 			encryptionSecretSelector,
 			eventRecorder,
+			encryptionStatusProvider,
 		),
 		controllers.NewStateController(
 			component,
@@ -125,7 +129,23 @@ func NewControllers(
 			encryptionSecretSelector,
 			eventRecorder,
 		),
-	}, nil
+	}
+
+	encryptionControllers = append(encryptionControllers, controllers.NewKMSPreflightController(
+		component,
+		provider,
+		encryptionEnabledChecker.PreconditionFulfilled,
+		preflightDeployer,
+		operatorClient,
+		apiServerClient,
+		apiServerInformer,
+		secretsClient,
+		configMapClient,
+		encryptionStatusProvider,
+		eventRecorder,
+	))
+
+	return encryptionControllers, nil
 }
 
 type Controllers []factory.Controller

--- a/pkg/operator/encryption/controllers/key_controller.go
+++ b/pkg/operator/encryption/controllers/key_controller.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/encryption/crypto"
+	"github.com/openshift/library-go/pkg/operator/encryption/kms"
 	"github.com/openshift/library-go/pkg/operator/encryption/secrets"
 	"github.com/openshift/library-go/pkg/operator/encryption/state"
 	"github.com/openshift/library-go/pkg/operator/encryption/statemachine"
@@ -79,6 +80,9 @@ type keyController struct {
 	provider                 Provider
 	preconditionsFulfilledFn preconditionsFulfilled
 
+	// encryptionStatusProvider gates KMS key creation on a preflight check.
+	encryptionStatusProvider kms.EncryptionStatusProvider
+
 	unsupportedConfigPrefix []string
 }
 
@@ -96,6 +100,8 @@ func NewKeyController(
 	configMapClient corev1client.ConfigMapsGetter,
 	encryptionSecretSelector metav1.ListOptions,
 	eventRecorder events.Recorder,
+	// encryptionStatusProvider is required for KMS operators; it gates key creation on a preflight check.
+	encryptionStatusProvider kms.EncryptionStatusProvider,
 ) factory.Controller {
 	c := &keyController{
 		operatorClient:  operatorClient,
@@ -111,6 +117,8 @@ func NewKeyController(
 		preconditionsFulfilledFn: preconditionsFulfilledFn,
 		secretClient:             secretClient,
 		configMapClient:          configMapClient,
+
+		encryptionStatusProvider: encryptionStatusProvider,
 	}
 
 	return factory.New().
@@ -241,15 +249,20 @@ func (c *keyController) checkAndCreateKeys(ctx context.Context, syncContext fact
 	if !newKeyRequired {
 		return nil
 	}
+
 	if commonReason != nil && len(*commonReason) > 0 && len(reasons) > 1 {
 		reasons = []string{*commonReason} // don't repeat reasons
 	}
 
 	sort.Sort(sort.StringSlice(reasons))
 	internalReason := strings.Join(reasons, ", ")
-	keySecret, err := c.generateKeySecret(ctx, newKeyID, currentMode, apiEncryptionConfiguration, desiredProviderCfg, internalReason, externalReason)
+	keySecret, preconditionMet, err := c.generateKeySecret(ctx, newKeyID, currentMode, apiEncryptionConfiguration, desiredProviderCfg, internalReason, externalReason)
 	if err != nil {
 		return fmt.Errorf("failed to create key: %v", err)
+	}
+	if !preconditionMet {
+		syncContext.Queue().AddAfter(syncContext.QueueKey(), 30*time.Second)
+		return nil
 	}
 	_, createErr := c.secretClient.Secrets("openshift-config-managed").Create(ctx, keySecret, metav1.CreateOptions{})
 	if errors.IsAlreadyExists(createErr) {
@@ -284,7 +297,16 @@ func (c *keyController) validateExistingSecret(ctx context.Context, keySecret *c
 	return nil // we made this key earlier
 }
 
-func (c *keyController) generateKeySecret(ctx context.Context, keyID uint64, currentMode state.Mode, apiServerEncryption configv1.APIServerEncryption, desiredProviderCfg kmsProviderConfig, internalReason, externalReason string) (*corev1.Secret, error) {
+// generateKeySecret builds the key secret for the given key ID and mode.
+//
+// For KMS mode it also computes the config hash (from the referenced Secret and
+// ConfigMap it already reads) and gates on the KMS preflight check. The boolean
+// return value signals the outcome:
+//
+//   - (secret, true,  nil) — preflight passed; caller should persist the key.
+//   - (nil,   false, nil) — preflight still in progress; caller should back off.
+//   - (nil,   false, err) — preflight failed or transient error; caller should surface it.
+func (c *keyController) generateKeySecret(ctx context.Context, keyID uint64, currentMode state.Mode, apiServerEncryption configv1.APIServerEncryption, desiredProviderCfg kmsProviderConfig, internalReason, externalReason string) (*corev1.Secret, bool, error) {
 	bs := crypto.ModeToNewKeyFunc[currentMode]()
 	ks := state.KeyState{
 		Key: apiserverv1.Key{
@@ -306,43 +328,70 @@ func (c *keyController) generateKeySecret(ctx context.Context, keyID uint64, cur
 			Plugin: apiServerEncryption.KMS,
 		}
 
+		// Fetch the referenced Secret and ConfigMap, copying their data into the
+		// key state. The fetched objects are reused by prefetchedKMSConfigHasherResourceProvider
+		// to compute the config hash without a second API round-trip.
+		var refSecret *corev1.Secret
 		if secretName, expectedKeys, err := desiredProviderCfg.referencedSecretName(); err != nil {
-			return nil, err
+			return nil, false, err
 		} else if len(secretName) > 0 {
-			refSecret, err := c.secretClient.Secrets(openshiftConfigNS).Get(ctx, secretName, metav1.GetOptions{})
+			refSecret, err = c.secretClient.Secrets(openshiftConfigNS).Get(ctx, secretName, metav1.GetOptions{})
 			if err != nil {
-				return nil, fmt.Errorf("failed to get secret %s in %s: %w", secretName, openshiftConfigNS, err)
+				return nil, false, fmt.Errorf("failed to get secret %s in %s: %w", secretName, openshiftConfigNS, err)
 			}
 			for _, key := range expectedKeys {
 				v, ok := refSecret.Data[key]
 				if !ok {
-					return nil, fmt.Errorf("secret %s in %s is missing required key %q", secretName, openshiftConfigNS, key)
+					return nil, false, fmt.Errorf("secret %s in %s is missing required key %q", secretName, openshiftConfigNS, key)
 				}
 				if err := ks.KMS.PluginSecretData.Set(secretName, key, v); err != nil {
-					return nil, err
+					return nil, false, err
 				}
 			}
 		}
 
+		var refCM *corev1.ConfigMap
 		if cmName, expectedKeys, err := desiredProviderCfg.referencedConfigMapName(); err != nil {
-			return nil, err
+			return nil, false, err
 		} else if len(cmName) > 0 {
-			refCM, err := c.configMapClient.ConfigMaps(openshiftConfigNS).Get(ctx, cmName, metav1.GetOptions{})
+			refCM, err = c.configMapClient.ConfigMaps(openshiftConfigNS).Get(ctx, cmName, metav1.GetOptions{})
 			if err != nil {
-				return nil, fmt.Errorf("failed to get configmap %s in %s: %w", cmName, openshiftConfigNS, err)
+				return nil, false, fmt.Errorf("failed to get configmap %s in %s: %w", cmName, openshiftConfigNS, err)
 			}
 			for _, key := range expectedKeys {
 				v, ok := refCM.Data[key]
 				if !ok {
-					return nil, fmt.Errorf("configmap %s in %s is missing required key %q", cmName, openshiftConfigNS, key)
+					return nil, false, fmt.Errorf("configmap %s in %s is missing required key %q", cmName, openshiftConfigNS, key)
 				}
 				if err := ks.KMS.PluginConfigMapData.Set(cmName, key, []byte(v)); err != nil {
-					return nil, err
+					return nil, false, err
 				}
 			}
 		}
+
+		resources := &prefetchedKMSConfigHasherResourceProvider{secret: refSecret, configMap: refCM}
+		hasher, err := newKMSConfigHasher(desiredProviderCfg, resources, openshiftConfigNS)
+		if err != nil {
+			return nil, false, fmt.Errorf("failed to create KMS config hasher: %w", err)
+		}
+		configHash, err := hasher.hash(ctx)
+		if err != nil {
+			return nil, false, fmt.Errorf("failed to compute KMS config hash: %w", err)
+		}
+		preflightPassed, err := c.ensureKMSPreflightPassed(ctx, configHash)
+		if err != nil {
+			return nil, false, err
+		}
+		if !preflightPassed {
+			return nil, false, nil
+		}
 	}
-	return secrets.FromKeyState(c.instanceName, ks)
+
+	secret, err := secrets.FromKeyState(c.instanceName, ks)
+	if err != nil {
+		return nil, false, err
+	}
+	return secret, true, nil
 }
 
 func (c *keyController) getCurrentModeReasonAndEncryptionConfig(ctx context.Context) (state.Mode, string, configv1.APIServerEncryption, error) {
@@ -373,6 +422,78 @@ func (c *keyController) getCurrentModeReasonAndEncryptionConfig(ctx context.Cont
 	default:
 		return "", "", configv1.APIServerEncryption{}, fmt.Errorf("unknown encryption mode configured: %s", currentMode)
 	}
+}
+
+var _ kmsConfigHasherResourceProvider = &prefetchedKMSConfigHasherResourceProvider{}
+
+// prefetchedKMSConfigHasherResourceProvider implements kmsConfigHasherResourceProvider using Secret and
+// ConfigMap objects already fetched by the key controller while building the key
+// secret, avoiding a second API round-trip for hash computation.
+type prefetchedKMSConfigHasherResourceProvider struct {
+	secret    *corev1.Secret
+	configMap *corev1.ConfigMap
+}
+
+func (p *prefetchedKMSConfigHasherResourceProvider) getSecret(_ context.Context, namespace, name string) (*corev1.Secret, error) {
+	if p.secret == nil || p.secret.Namespace != namespace || p.secret.Name != name {
+		return nil, fmt.Errorf("prefetched secret does not match requested %s/%s", namespace, name)
+	}
+	return p.secret, nil
+}
+
+func (p *prefetchedKMSConfigHasherResourceProvider) getConfigMap(_ context.Context, namespace, name string) (*corev1.ConfigMap, error) {
+	if p.configMap == nil || p.configMap.Namespace != namespace || p.configMap.Name != name {
+		return nil, fmt.Errorf("prefetched configmap does not match requested %s/%s", namespace, name)
+	}
+	return p.configMap, nil
+}
+
+// ensureKMSPreflightPassed checks whether the KMS preflight has passed for the
+// given config hash. It writes ObservedConfigHash when not yet set (which triggers
+// the preflight controller to run the check), then inspects the Result.
+//
+// Scenarios:
+//
+//  1. ObservedConfigHash does not match configHash — write it and back off.
+//     The preflight controller will pick up the new hash and start the check.
+//
+//  2. ObservedConfigHash matches, Result.Status is Succeeded — proceed.
+//
+//  3. ObservedConfigHash matches, Result.Status is Failed — surface the error.
+//     The admin must fix the KMS configuration (which produces a new hash)
+//     before the key controller can proceed.
+//
+//  4. ObservedConfigHash matches, no result yet — preflight still in progress,
+//     back off.
+//
+// Callers are responsible for requeuing when this returns (false, nil).
+func (c *keyController) ensureKMSPreflightPassed(ctx context.Context, configHash string) (bool, error) {
+	encryptionStatus, err := c.encryptionStatusProvider.GetKMSEncryptionStatus(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to get KMS encryption status: %w", err)
+	}
+
+	// Scenario 1: ObservedConfigHash outdated — schedule the preflight check.
+	if encryptionStatus.Preflight.ObservedConfigHash != configHash {
+		if err := c.encryptionStatusProvider.UpdateKMSEncryptionStatus(ctx, func(s *operatorv1.KMSEncryptionStatus) {
+			s.Preflight.ObservedConfigHash = configHash
+		}); err != nil {
+			return false, fmt.Errorf("failed to write preflight observed config hash: %w", err)
+		}
+		// Scenario 1: back off: wait for the preflight controller to pick up the new hash.
+		return false, nil
+	}
+
+	// Scenario 2: preflight passed — proceed.
+	if encryptionStatus.Preflight.Result.ConfigHash == configHash && isPreflightResultSucceeded(&encryptionStatus.Preflight.Result) {
+		return true, nil
+	}
+	// Scenario 3: preflight failed — surface the error.
+	if encryptionStatus.Preflight.Result.ConfigHash == configHash && isPreflightResultFailed(&encryptionStatus.Preflight.Result) {
+		return false, fmt.Errorf("KMS preflight check failed for config hash %s; fix the KMS configuration to proceed", configHash)
+	}
+	// Scenario 4: back off: preflight check is still in progress.
+	return false, nil
 }
 
 // needsNewKey checks whether a new key must be created for the given resource. If true, it also returns the latest

--- a/pkg/operator/encryption/controllers/key_controller_test.go
+++ b/pkg/operator/encryption/controllers/key_controller_test.go
@@ -50,9 +50,6 @@ func TestKeyController(t *testing.T) {
 	apiServerWithKMS := simpleAPIServer.DeepCopy()
 	apiServerWithKMS.Spec.Encryption = configv1.APIServerEncryption{Type: "KMS", KMS: encryptiontesting.DefaultKMSPluginConfig}
 
-	// Pre-compute the preflight hash for KMS scenarios that create a key.
-	// All three scenarios share the same DefaultKMSPluginConfig and the same
-	// vault-approle-secret / vault-ca-bundle data, so one provider covers all.
 	kmsCreateKeyStatusProvider := newPreflightSucceededProvider(t, encryptiontesting.DefaultKMSPluginConfig,
 		encryptiontesting.CreateVaultAppRoleSecret("vault-approle-secret", "test-role-id", "test-secret-id"),
 		encryptiontesting.CreateVaultCABundleConfigMap("vault-ca-bundle", "test-ca-cert"),
@@ -550,7 +547,7 @@ func TestKeyController(t *testing.T) {
 			apiServerObjects:         []runtime.Object{apiServerWithKMS},
 			targetNamespace:          "kms",
 			encryptionStatusProvider: kmsCreateKeyStatusProvider,
-			expectedActions:  []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config", "get:configmaps:openshift-config", "create:secrets:openshift-config-managed", "create:events:kms"},
+			expectedActions:          []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config", "get:configmaps:openshift-config", "create:secrets:openshift-config-managed", "create:events:kms"},
 			validateFunc: func(ts *testing.T, actions []clientgotesting.Action, targetNamespace string, targetGRs []schema.GroupResource) {
 				wasSecretValidated := false
 				for _, action := range actions {
@@ -622,7 +619,8 @@ func TestKeyController(t *testing.T) {
 			targetNamespace:          "kms",
 			encryptionStatusProvider: &fakeKMSStatusProvider{},
 			expectedActions:          []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config", "get:configmaps:openshift-config"},
-			validateFunc:             func(ts *testing.T, actions []clientgotesting.Action, targetNamespace string, targetGRs []schema.GroupResource) {},
+			validateFunc: func(ts *testing.T, actions []clientgotesting.Action, targetNamespace string, targetGRs []schema.GroupResource) {
+			},
 		},
 
 		{
@@ -1039,6 +1037,18 @@ type fakeKMSStatusProvider struct {
 	updateErr   error
 }
 
+// preflightSucceededForHash returns a fakeKMSStatusProvider pre-seeded with a
+// Succeeded result for a known config hash.
+func preflightSucceededForHash(configHash string) *fakeKMSStatusProvider {
+	p := &fakeKMSStatusProvider{}
+	p.status.Preflight.ObservedConfigHash = configHash
+	p.status.Preflight.Result = operatorv1.KMSPreflightResult{
+		Status:     operatorv1.KMSPreflightResultSucceeded,
+		ConfigHash: configHash,
+	}
+	return p
+}
+
 // newPreflightSucceededProvider builds a fakeKMSStatusProvider pre-seeded with a
 // Succeeded preflight result for the given KMS plugin config and referenced objects.
 // It uses a scratch client so the reads do not pollute any test's action log.
@@ -1051,13 +1061,7 @@ func newPreflightSucceededProvider(t *testing.T, pluginConfig configv1.KMSPlugin
 	require.NoError(t, err)
 	hash, err := hasher.hash(context.Background())
 	require.NoError(t, err)
-	p := &fakeKMSStatusProvider{}
-	p.status.Preflight.ObservedConfigHash = hash
-	p.status.Preflight.Result = operatorv1.KMSPreflightResult{
-		Status:     operatorv1.KMSPreflightResultSucceeded,
-		ConfigHash: hash,
-	}
-	return p
+	return preflightSucceededForHash(hash)
 }
 
 func (f *fakeKMSStatusProvider) GetKMSEncryptionStatus(_ context.Context) (*operatorv1.KMSEncryptionStatus, error) {

--- a/pkg/operator/encryption/controllers/key_controller_test.go
+++ b/pkg/operator/encryption/controllers/key_controller_test.go
@@ -26,11 +26,13 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	configv1clientfake "github.com/openshift/client-go/config/clientset/versioned/fake"
 	configv1informers "github.com/openshift/client-go/config/informers/externalversions"
+	applyoperatorv1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
 
 	"github.com/openshift/library-go/pkg/controller/factory"
 	encryptiondeployer "github.com/openshift/library-go/pkg/operator/encryption/deployer"
 	"github.com/openshift/library-go/pkg/operator/encryption/encoding"
 	encryptiondatatesting "github.com/openshift/library-go/pkg/operator/encryption/encryptiondata/testing"
+	"github.com/openshift/library-go/pkg/operator/encryption/kms"
 	encryptiontesting "github.com/openshift/library-go/pkg/operator/encryption/testing"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
@@ -48,6 +50,14 @@ func TestKeyController(t *testing.T) {
 	apiServerWithKMS := simpleAPIServer.DeepCopy()
 	apiServerWithKMS.Spec.Encryption = configv1.APIServerEncryption{Type: "KMS", KMS: encryptiontesting.DefaultKMSPluginConfig}
 
+	// Pre-compute the preflight hash for KMS scenarios that create a key.
+	// All three scenarios share the same DefaultKMSPluginConfig and the same
+	// vault-approle-secret / vault-ca-bundle data, so one provider covers all.
+	kmsCreateKeyStatusProvider := newPreflightSucceededProvider(t, encryptiontesting.DefaultKMSPluginConfig,
+		encryptiontesting.CreateVaultAppRoleSecret("vault-approle-secret", "test-role-id", "test-secret-id"),
+		encryptiontesting.CreateVaultCABundleConfigMap("vault-ca-bundle", "test-ca-cert"),
+	)
+
 	scenarios := []struct {
 		name                     string
 		initialObjects           []runtime.Object
@@ -55,6 +65,7 @@ func TestKeyController(t *testing.T) {
 		encryptionSecretSelector metav1.ListOptions
 		targetNamespace          string
 		targetGRs                []schema.GroupResource
+		encryptionStatusProvider kms.EncryptionStatusProvider
 		// expectedActions holds actions to be verified in the form of "verb:resource:namespace"
 		expectedActions            []string
 		validateFunc               func(ts *testing.T, actions []clientgotesting.Action, targetNamespace string, targetGRs []schema.GroupResource)
@@ -337,8 +348,9 @@ func TestKeyController(t *testing.T) {
 			targetGRs: []schema.GroupResource{
 				{Group: "", Resource: "secrets"},
 			},
-			targetNamespace: "kms",
-			expectedActions: []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config", "get:configmaps:openshift-config", "create:secrets:openshift-config-managed", "create:events:kms"},
+			targetNamespace:          "kms",
+			encryptionStatusProvider: kmsCreateKeyStatusProvider,
+			expectedActions:          []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config", "get:configmaps:openshift-config", "create:secrets:openshift-config-managed", "create:events:kms"},
 			initialObjects: []runtime.Object{
 				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
 				encryptiontesting.CreateVaultAppRoleSecret("vault-approle-secret", "test-role-id", "test-secret-id"),
@@ -438,9 +450,10 @@ func TestKeyController(t *testing.T) {
 				encryptiontesting.CreateVaultAppRoleSecret("vault-approle-secret", "test-role-id", "test-secret-id"),
 				encryptiontesting.CreateVaultCABundleConfigMap("vault-ca-bundle", "test-ca-cert"),
 			},
-			apiServerObjects: []runtime.Object{apiServerWithKMS},
-			targetNamespace:  "kms",
-			expectedActions:  []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config", "get:configmaps:openshift-config", "create:secrets:openshift-config-managed", "create:events:kms"},
+			apiServerObjects:         []runtime.Object{apiServerWithKMS},
+			targetNamespace:          "kms",
+			encryptionStatusProvider: kmsCreateKeyStatusProvider,
+			expectedActions:          []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config", "get:configmaps:openshift-config", "create:secrets:openshift-config-managed", "create:events:kms"},
 			validateFunc: func(ts *testing.T, actions []clientgotesting.Action, targetNamespace string, targetGRs []schema.GroupResource) {
 				wasSecretValidated := false
 				for _, action := range actions {
@@ -534,8 +547,9 @@ func TestKeyController(t *testing.T) {
 				encryptiontesting.CreateVaultAppRoleSecret("vault-approle-secret", "test-role-id", "test-secret-id"),
 				encryptiontesting.CreateVaultCABundleConfigMap("vault-ca-bundle", "test-ca-cert"),
 			},
-			apiServerObjects: []runtime.Object{apiServerWithKMS},
-			targetNamespace:  "kms",
+			apiServerObjects:         []runtime.Object{apiServerWithKMS},
+			targetNamespace:          "kms",
+			encryptionStatusProvider: kmsCreateKeyStatusProvider,
 			expectedActions:  []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config", "get:configmaps:openshift-config", "create:secrets:openshift-config-managed", "create:events:kms"},
 			validateFunc: func(ts *testing.T, actions []clientgotesting.Action, targetNamespace string, targetGRs []schema.GroupResource) {
 				wasSecretValidated := false
@@ -592,6 +606,23 @@ func TestKeyController(t *testing.T) {
 					ts.Errorf("the secret wasn't created and validated")
 				}
 			},
+		},
+
+		{
+			name: "KMS key not created when preflight has not run",
+			targetGRs: []schema.GroupResource{
+				{Group: "", Resource: "secrets"},
+			},
+			initialObjects: []runtime.Object{
+				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
+				encryptiontesting.CreateVaultAppRoleSecret("vault-approle-secret", "test-role-id", "test-secret-id"),
+				encryptiontesting.CreateVaultCABundleConfigMap("vault-ca-bundle", "test-ca-cert"),
+			},
+			apiServerObjects:         []runtime.Object{apiServerWithKMS},
+			targetNamespace:          "kms",
+			encryptionStatusProvider: &fakeKMSStatusProvider{},
+			expectedActions:          []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config", "get:configmaps:openshift-config"},
+			validateFunc:             func(ts *testing.T, actions []clientgotesting.Action, targetNamespace string, targetGRs []schema.GroupResource) {},
 		},
 
 		{
@@ -881,7 +912,7 @@ func TestKeyController(t *testing.T) {
 			}
 			provider := newTestProvider(scenario.targetGRs)
 
-			target := NewKeyController(scenario.targetNamespace, nil, provider, deployer, alwaysFulfilledPreconditions, fakeOperatorClient, fakeApiServerClient, fakeApiServerInformer, kubeInformers, fakeSecretClient, fakeConfigMapClient, scenario.encryptionSecretSelector, eventRecorder)
+			target := NewKeyController(scenario.targetNamespace, nil, provider, deployer, alwaysFulfilledPreconditions, fakeOperatorClient, fakeApiServerClient, fakeApiServerInformer, kubeInformers, fakeSecretClient, fakeConfigMapClient, scenario.encryptionSecretSelector, eventRecorder, scenario.encryptionStatusProvider)
 
 			// act
 			err = target.Sync(context.TODO(), factory.NewSyncContext("test", eventRecorder))
@@ -974,7 +1005,9 @@ func TestKMSMigrationTriggeredFields(t *testing.T) {
 			require.NoError(t, err)
 
 			provider := newTestProvider([]schema.GroupResource{{Group: "", Resource: "secrets"}})
-			target := NewKeyController("kms", nil, provider, deployer, alwaysFulfilledPreconditions, fakeOperatorClient, fakeApiServerClient, fakeApiServerInformer, kubeInformers, fakeSecretClient, fakeConfigMapClient, metav1.ListOptions{}, eventRecorder)
+			sp := newPreflightSucceededProvider(t, *changedConfig, initialObjects...)
+
+			target := NewKeyController("kms", nil, provider, deployer, alwaysFulfilledPreconditions, fakeOperatorClient, fakeApiServerClient, fakeApiServerInformer, kubeInformers, fakeSecretClient, fakeConfigMapClient, metav1.ListOptions{}, eventRecorder, sp)
 
 			err = target.Sync(context.TODO(), factory.NewSyncContext("test", eventRecorder))
 			require.NoError(t, err)
@@ -997,6 +1030,53 @@ func TestKMSMigrationTriggeredFields(t *testing.T) {
 	}
 }
 
+// fakeKMSStatusProvider is a simple in-memory EncryptionStatusProvider for
+// key-controller tests. UpdateKMSEncryptionStatus applies the full mutation to
+// the backing store so ObservedConfigHash writes are visible on the next Get.
+type fakeKMSStatusProvider struct {
+	status      operatorv1.KMSEncryptionStatus
+	updateCount int
+	updateErr   error
+}
+
+// newPreflightSucceededProvider builds a fakeKMSStatusProvider pre-seeded with a
+// Succeeded preflight result for the given KMS plugin config and referenced objects.
+// It uses a scratch client so the reads do not pollute any test's action log.
+func newPreflightSucceededProvider(t *testing.T, pluginConfig configv1.KMSPluginConfig, objects ...runtime.Object) *fakeKMSStatusProvider {
+	t.Helper()
+	scratch := fake.NewSimpleClientset(objects...)
+	providerCfg, err := newKMSProviderConfig(pluginConfig)
+	require.NoError(t, err)
+	hasher, err := newKMSConfigHasher(providerCfg, newCoreClientKMSConfigHasherResourceProvider(scratch.CoreV1(), scratch.CoreV1()), openshiftConfigNS)
+	require.NoError(t, err)
+	hash, err := hasher.hash(context.Background())
+	require.NoError(t, err)
+	p := &fakeKMSStatusProvider{}
+	p.status.Preflight.ObservedConfigHash = hash
+	p.status.Preflight.Result = operatorv1.KMSPreflightResult{
+		Status:     operatorv1.KMSPreflightResultSucceeded,
+		ConfigHash: hash,
+	}
+	return p
+}
+
+func (f *fakeKMSStatusProvider) GetKMSEncryptionStatus(_ context.Context) (*operatorv1.KMSEncryptionStatus, error) {
+	cp := f.status.DeepCopy()
+	return cp, nil
+}
+
+func (f *fakeKMSStatusProvider) ApplyKMSEncryptionStatus(_ context.Context, _ string, _ *applyoperatorv1.KMSEncryptionStatusApplyConfiguration) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (f *fakeKMSStatusProvider) UpdateKMSEncryptionStatus(_ context.Context, mutateFn func(*operatorv1.KMSEncryptionStatus)) error {
+	f.updateCount++
+	if f.updateErr != nil {
+		return f.updateErr
+	}
+	mutateFn(&f.status)
+	return nil
+}
 func TestReferencedSecretName(t *testing.T) {
 	scenarios := []struct {
 		name             string

--- a/pkg/operator/encryption/kms/preflight/deployer.go
+++ b/pkg/operator/encryption/kms/preflight/deployer.go
@@ -121,6 +121,9 @@ func (d *PodPreflightDeployer) Status(ctx context.Context) (corev1.PodStatus, er
 }
 
 func (d *PodPreflightDeployer) Cleanup(ctx context.Context) error {
+	// TODO: Cleanup is called on every controller sync, including syncs where
+	// Deploy was never called. Track whether resources were deployed and make
+	// this a no-op when there is nothing to remove.
 	// See Deploy: preflight RBAC is intentionally not deleted here.
 	var errs []error
 

--- a/test/e2e-encryption/encryption_test.go
+++ b/test/e2e-encryption/encryption_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -40,7 +41,6 @@ import (
 	"github.com/openshift/library-go/pkg/operator/encryption/encoding"
 	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
 	"github.com/openshift/library-go/pkg/operator/encryption/kms"
-	kmspreflight "github.com/openshift/library-go/pkg/operator/encryption/kms/preflight"
 	"github.com/openshift/library-go/pkg/operator/encryption/secrets"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/genericoperatorclient"
@@ -148,6 +148,7 @@ func TestEncryptionIntegration(tt *testing.T) {
 	// create controllers
 	eventRecorder := events.NewLoggingEventRecorder(component, clk)
 	deployer := NewInstantDeployer(t, stopCh, kubeClient.CoreV1(), fmt.Sprintf("encryption-config-%s", component))
+	kmsPreflightDeployer := &configurableKMSPreflightDeployer{}
 	migrator := migrators.NewInProcessMigrator(dynamicClient, kubeClient.DiscoveryClient)
 	provider := newProvider([]schema.GroupResource{
 		// some random low-cardinality GVRs:
@@ -169,8 +170,8 @@ func TestEncryptionIntegration(tt *testing.T) {
 		kubeClient.CoreV1(),
 		eventRecorder,
 		nil, // resourceSyncer
-		&noopKMSEncryptionStatusProvider{},
-		kmspreflight.NewAlwaysSucceedKMSPreflightDeployer(),
+		&dynamicKMSEncryptionStatusProvider{client: dynamicClient.Resource(operatorGVR)},
+		kmsPreflightDeployer,
 	)
 	if err != nil {
 		t.Fatalf("failed to initialize controllers: %v", err)
@@ -669,6 +670,23 @@ func TestEncryptionIntegration(tt *testing.T) {
 	waitForKeys(12)
 	waitForConditionStatus("Encrypted", operatorv1.ConditionTrue)
 
+	t.Logf("KMS preflight failure: key must not be created when preflight fails")
+	kmsPreflightDeployer.fail.Store(true)
+	_, err = fakeApiServerClient.Patch(ctx, "cluster", types.MergePatchType, []byte(`{"spec":{"encryption":{"type":"KMS","kms":{"type":"Vault","vault":{"kmsPluginImage":"registry.example.com/kms-plugin@sha256:0000000000000000000000000000000000000000000000000000000000000000","vaultAddress":"https://vault-failing.example.com","authentication":{"type":"AppRole","appRole":{"secret":{"name":"vault-approle-secret"}}},"vaultKeyPath":"transit/keys/test-transit-key"}}}}}`), metav1.PatchOptions{})
+	require.NoError(t, err)
+	time.Sleep(5 * time.Second)
+	waitForKeys(12) // key count must not advance
+	waitForConditionStatus("EncryptionKeyControllerDegraded", operatorv1.ConditionTrue)
+	// Revert to the previous config (kms13 already exists for vault-new) and fix the deployer.
+	// The key controller will find an existing key for vault-new and skip creation,
+	// keeping the total at 12.
+	kmsPreflightDeployer.fail.Store(false)
+	_, err = fakeApiServerClient.Patch(ctx, "cluster", types.MergePatchType, []byte(`{"spec":{"encryption":{"type":"KMS","kms":{"type":"Vault","vault":{"kmsPluginImage":"registry.example.com/kms-plugin@sha256:0000000000000000000000000000000000000000000000000000000000000000","vaultAddress":"https://vault-new.example.com","authentication":{"type":"AppRole","appRole":{"secret":{"name":"vault-approle-secret"}}},"vaultKeyPath":"transit/keys/test-transit-key"}}}}}`), metav1.PatchOptions{})
+	require.NoError(t, err)
+	waitForConditionStatus("EncryptionKeyControllerDegraded", operatorv1.ConditionFalse)
+	time.Sleep(5 * time.Second)
+	waitForKeys(12) // still 12 — no new key needed, config reverted to one that already has kms13
+
 	t.Logf("Delete the encryption-config while in KMS mode")
 	_, err = kubeClient.CoreV1().Secrets("openshift-config-managed").Patch(ctx, fmt.Sprintf("encryption-config-%s", component), types.JSONPatchType, []byte(`[{"op":"remove","path":"/metadata/finalizers"}]`), metav1.PatchOptions{})
 	require.NoError(t, err)
@@ -746,6 +764,7 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
           status:
             type: object
+            x-kubernetes-preserve-unknown-fields: true
             properties:
               conditions:
                 type: array
@@ -1039,21 +1058,94 @@ func kmsPluginName(resource, keyID string) string {
 	return fmt.Sprintf("%s_%s", keyID, resource)
 }
 
-// noopKMSEncryptionStatusProvider is a minimal kms.EncryptionStatusProvider for
-// the e2e test, which uses AESCBC and never writes ObservedConfigHash. The
-// preflight controller reads it on every sync and does nothing (empty hash).
-type noopKMSEncryptionStatusProvider struct{}
-
-func (p *noopKMSEncryptionStatusProvider) GetKMSEncryptionStatus(_ context.Context) (*operatorv1.KMSEncryptionStatus, error) {
-	return &operatorv1.KMSEncryptionStatus{}, nil
+// dynamicKMSEncryptionStatusProvider implements kms.EncryptionStatusProvider
+// by storing the KMSEncryptionStatus as a JSON field in the encryptiontests/cluster
+// resource status on the real cluster.
+type dynamicKMSEncryptionStatusProvider struct {
+	client dynamic.ResourceInterface
 }
 
-func (p *noopKMSEncryptionStatusProvider) ApplyKMSEncryptionStatus(_ context.Context, _ string, _ *applyoperatorv1.KMSEncryptionStatusApplyConfiguration) error {
+const kmsStatusField = "kmsEncryptionStatus"
+
+func (p *dynamicKMSEncryptionStatusProvider) get(ctx context.Context) (*unstructured.Unstructured, *operatorv1.KMSEncryptionStatus, error) {
+	obj, err := p.client.Get(ctx, "cluster", metav1.GetOptions{}, "status")
+	if err != nil {
+		return nil, nil, err
+	}
+	raw, _, err := unstructured.NestedMap(obj.Object, "status", kmsStatusField)
+	if err != nil {
+		return nil, nil, err
+	}
+	var status operatorv1.KMSEncryptionStatus
+	return obj, &status, runtime.DefaultUnstructuredConverter.FromUnstructured(raw, &status)
+}
+
+func (p *dynamicKMSEncryptionStatusProvider) GetKMSEncryptionStatus(ctx context.Context) (*operatorv1.KMSEncryptionStatus, error) {
+	_, status, err := p.get(ctx)
+	return status, err
+}
+
+func (p *dynamicKMSEncryptionStatusProvider) ApplyKMSEncryptionStatus(_ context.Context, _ string, _ *applyoperatorv1.KMSEncryptionStatusApplyConfiguration) error {
+	return fmt.Errorf("ApplyKMSEncryptionStatus not implemented")
+}
+
+func (p *dynamicKMSEncryptionStatusProvider) UpdateKMSEncryptionStatus(ctx context.Context, mutateFn func(*operatorv1.KMSEncryptionStatus)) error {
+	obj, status, err := p.get(ctx)
+	if err != nil {
+		return err
+	}
+	mutateFn(status)
+	rawNew, err := runtime.DefaultUnstructuredConverter.ToUnstructured(status)
+	if err != nil {
+		return err
+	}
+	if err := unstructured.SetNestedField(obj.Object, rawNew, "status", kmsStatusField); err != nil {
+		return err
+	}
+	_, err = p.client.Update(ctx, obj, metav1.UpdateOptions{}, "status")
+	return err
+}
+
+var _ kms.EncryptionStatusProvider = &dynamicKMSEncryptionStatusProvider{}
+
+// configurableKMSPreflightDeployer is a test deployer based on
+// AlwaysSucceedKMSPreflightDeployer that can be switched to report a failed
+// preflight result via the fail flag.
+type configurableKMSPreflightDeployer struct {
+	configHash string
+	deployed   bool
+	// fail is set by the test goroutine and read by the controller goroutine in Status.
+	fail atomic.Bool
+}
+
+func (d *configurableKMSPreflightDeployer) Deploy(_ context.Context, configHash string, _ *corev1.Secret) error {
+	d.configHash = configHash
+	d.deployed = true
 	return nil
 }
 
-func (p *noopKMSEncryptionStatusProvider) UpdateKMSEncryptionStatus(_ context.Context, _ func(*operatorv1.KMSEncryptionStatus)) error {
+func (d *configurableKMSPreflightDeployer) Status(_ context.Context) (corev1.PodStatus, error) {
+	if !d.deployed {
+		return corev1.PodStatus{}, errors.NewNotFound(schema.GroupResource{Resource: "pods"}, "kms-preflight")
+	}
+	resultStatus, resultMessage := corev1.ConditionTrue, ""
+	if d.fail.Load() {
+		resultStatus, resultMessage = corev1.ConditionFalse, "intentional failure for testing"
+	}
+	return corev1.PodStatus{
+		Phase: corev1.PodSucceeded,
+		Conditions: []corev1.PodCondition{
+			{Type: controllers.KMSPreflightConfigHashPodCondition, Status: corev1.ConditionTrue, Message: d.configHash},
+			{Type: controllers.KMSPreflightResultPodCondition, Status: resultStatus, Message: resultMessage},
+			{Type: controllers.KMSPreflightRemoteKeyIDPodCondition, Status: corev1.ConditionTrue, Message: "configurable"},
+		},
+	}, nil
+}
+
+func (d *configurableKMSPreflightDeployer) Cleanup(_ context.Context) error {
+	d.configHash = ""
+	d.deployed = false
 	return nil
 }
 
-var _ kms.EncryptionStatusProvider = &noopKMSEncryptionStatusProvider{}
+var _ controllers.KMSPreflightDeployer = &configurableKMSPreflightDeployer{}

--- a/test/e2e-encryption/encryption_test.go
+++ b/test/e2e-encryption/encryption_test.go
@@ -39,6 +39,8 @@ import (
 	"github.com/openshift/library-go/pkg/operator/encryption/controllers/migrators"
 	"github.com/openshift/library-go/pkg/operator/encryption/encoding"
 	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
+	"github.com/openshift/library-go/pkg/operator/encryption/kms"
+	kmspreflight "github.com/openshift/library-go/pkg/operator/encryption/kms/preflight"
 	"github.com/openshift/library-go/pkg/operator/encryption/secrets"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/genericoperatorclient"
@@ -166,7 +168,9 @@ func TestEncryptionIntegration(tt *testing.T) {
 		deployer, // secret client wrapping kubeClient with encryption-config revision counting
 		kubeClient.CoreV1(),
 		eventRecorder,
-		nil,
+		nil, // resourceSyncer
+		&noopKMSEncryptionStatusProvider{},
+		kmspreflight.NewAlwaysSucceedKMSPreflightDeployer(),
 	)
 	if err != nil {
 		t.Fatalf("failed to initialize controllers: %v", err)
@@ -1034,3 +1038,22 @@ func (p *provider) ShouldRunEncryptionControllers() (bool, error) {
 func kmsPluginName(resource, keyID string) string {
 	return fmt.Sprintf("%s_%s", keyID, resource)
 }
+
+// noopKMSEncryptionStatusProvider is a minimal kms.EncryptionStatusProvider for
+// the e2e test, which uses AESCBC and never writes ObservedConfigHash. The
+// preflight controller reads it on every sync and does nothing (empty hash).
+type noopKMSEncryptionStatusProvider struct{}
+
+func (p *noopKMSEncryptionStatusProvider) GetKMSEncryptionStatus(_ context.Context) (*operatorv1.KMSEncryptionStatus, error) {
+	return &operatorv1.KMSEncryptionStatus{}, nil
+}
+
+func (p *noopKMSEncryptionStatusProvider) ApplyKMSEncryptionStatus(_ context.Context, _ string, _ *applyoperatorv1.KMSEncryptionStatusApplyConfiguration) error {
+	return nil
+}
+
+func (p *noopKMSEncryptionStatusProvider) UpdateKMSEncryptionStatus(_ context.Context, _ func(*operatorv1.KMSEncryptionStatus)) error {
+	return nil
+}
+
+var _ kms.EncryptionStatusProvider = &noopKMSEncryptionStatusProvider{}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added KMS preflight validation before encryption keys are created or persisted.
  * Encryption configuration changes now use referenced Secret and ConfigMap data to verify readiness.
  * Added automatic retry behavior while preflight checks are pending.
* **Bug Fixes**
  * Prevented key creation when KMS preflight validation fails.
  * Improved reporting of KMS preflight failures and status changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->