### PR TITLE
NO-JIRA: Runs state controller even if there is a transition

### DIFF
--- a/pkg/operator/encryption/controllers/state_controller.go
+++ b/pkg/operator/encryption/controllers/state_controller.go
@@ -23,8 +23,6 @@ import (
 	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
 )
 
-const stateWorkKey = "key"
-
 // stateController is responsible for creating a single secret in
 // openshift-config-managed with the name destName.  This single secret
 // contains the complete EncryptionConfiguration that is consumed by the API
@@ -127,13 +125,9 @@ type eventWithReason struct {
 }
 
 func (c *stateController) generateAndApplyCurrentEncryptionConfigSecret(ctx context.Context, queue workqueue.RateLimitingInterface, recorder events.Recorder, encryptedGRs []schema.GroupResource) error {
-	currentConfig, desiredEncryptionState, encryptionSecrets, transitioningReason, err := statemachine.GetEncryptionConfigAndState(ctx, c.deployer, c.secretClient, c.encryptionSecretSelector, encryptedGRs)
+	currentConfig, desiredEncryptionState, encryptionSecrets, _, err := statemachine.GetEncryptionConfigAndState(ctx, c.deployer, c.secretClient, c.encryptionSecretSelector, encryptedGRs)
 	if err != nil {
 		return err
-	}
-	if len(transitioningReason) > 0 {
-		queue.AddAfter(stateWorkKey, 2*time.Minute)
-		return nil
 	}
 
 	if currentConfig == nil && len(encryptionSecrets) == 0 {


### PR DESCRIPTION
Key controller may propagate data, even if there isn't any convergence. So from that point, state controller should run even if there is an active transition.

This is the full implementation https://github.com/openshift/library-go/pull/2241/ to demonstrate the purpose.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved encryption configuration reconciliation by removing unnecessary delays during transitions.
  * Encryption configuration secrets are now generated and applied directly when reconciliation occurs.
  * Updated event reporting to reflect changes to the applied encryption configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->