### PR TITLE
CNTRLPLANE-3237: kms preflight: introduce kmsConfigHasherResourceProvider interface

### DIFF
--- a/pkg/operator/encryption/controllers/kms_preflight_controller.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller.go
@@ -27,16 +27,46 @@ import (
 	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
 )
 
-type kmsConfigHasher struct {
-	provider   kmsProviderConfig
+// kmsConfigHasherResourceProvider abstracts fetching the Secret and ConfigMap referenced
+// by a KMS provider config.
+type kmsConfigHasherResourceProvider interface {
+	getSecret(ctx context.Context, namespace, name string) (*corev1.Secret, error)
+	getConfigMap(ctx context.Context, namespace, name string) (*corev1.ConfigMap, error)
+}
+
+var _ kmsConfigHasherResourceProvider = &coreClientKMSConfigHasherResourceProvider{}
+
+// coreClientKMSConfigHasherResourceProvider fetches resources from the Kubernetes API.
+type coreClientKMSConfigHasherResourceProvider struct {
 	coreClient corev1client.CoreV1Interface
-	namespace  string
+}
+
+func newCoreClientKMSConfigHasherResourceProvider(coreClient corev1client.CoreV1Interface) *coreClientKMSConfigHasherResourceProvider {
+	return &coreClientKMSConfigHasherResourceProvider{coreClient: coreClient}
+}
+
+func (p *coreClientKMSConfigHasherResourceProvider) getSecret(ctx context.Context, namespace, name string) (*corev1.Secret, error) {
+	return p.coreClient.Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
+}
+
+func (p *coreClientKMSConfigHasherResourceProvider) getConfigMap(ctx context.Context, namespace, name string) (*corev1.ConfigMap, error) {
+	return p.coreClient.ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
+}
+
+type kmsConfigHasher struct {
+	provider                        kmsProviderConfig
+	kmsConfigHasherResourceProvider kmsConfigHasherResourceProvider
+	// namespace is the namespace where the referenced Secrets and ConfigMaps are stored (e.g., openshift-config).
+	namespace string
 }
 
 // newKMSConfigHasher creates a hasher for a KMS provider config and its referenced resources.
 // namespace is the namespace where the referenced Secrets and ConfigMaps are stored (e.g., openshift-config).
-func newKMSConfigHasher(provider kmsProviderConfig, coreClient corev1client.CoreV1Interface, namespace string) *kmsConfigHasher {
-	return &kmsConfigHasher{provider: provider, coreClient: coreClient, namespace: namespace}
+func newKMSConfigHasher(provider kmsProviderConfig, resourceProvider kmsConfigHasherResourceProvider, namespace string) (*kmsConfigHasher, error) {
+	if resourceProvider == nil {
+		return nil, fmt.Errorf("kmsConfigHasherResourceProvider must not be nil")
+	}
+	return &kmsConfigHasher{provider: provider, kmsConfigHasherResourceProvider: resourceProvider, namespace: namespace}, nil
 }
 
 // hash computes a deterministic hash over the provider config and the specific data keys
@@ -68,7 +98,7 @@ func (h *kmsConfigHasher) hashReferencedSecret(ctx context.Context, hasher hash.
 		return nil
 	}
 
-	secret, err := h.coreClient.Secrets(h.namespace).Get(ctx, name, metav1.GetOptions{})
+	secret, err := h.kmsConfigHasherResourceProvider.getSecret(ctx, h.namespace, name)
 	if err != nil {
 		return fmt.Errorf("failed to get secret %s/%s: %w", h.namespace, name, err)
 	}
@@ -101,7 +131,7 @@ func (h *kmsConfigHasher) hashReferencedConfigMap(ctx context.Context, hasher ha
 		return nil
 	}
 
-	cm, err := h.coreClient.ConfigMaps(h.namespace).Get(ctx, name, metav1.GetOptions{})
+	cm, err := h.kmsConfigHasherResourceProvider.getConfigMap(ctx, h.namespace, name)
 	if err != nil {
 		return fmt.Errorf("failed to get configmap %s/%s: %w", h.namespace, name, err)
 	}
@@ -673,7 +703,11 @@ func (c *kmsPreflightController) preflightRequired(ctx context.Context) (string,
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to create KMS provider config: %w", err)
 	}
-	currentHash, err := newKMSConfigHasher(providerCfg, c.coreClient, openshiftConfigNS).hash(ctx)
+	hasher, err := newKMSConfigHasher(providerCfg, newCoreClientKMSConfigHasherResourceProvider(c.coreClient), openshiftConfigNS)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to create KMS config hasher: %w", err)
+	}
+	currentHash, err := hasher.hash(ctx)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to compute KMS config hash: %w", err)
 	}

--- a/pkg/operator/encryption/controllers/kms_preflight_controller_test.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller_test.go
@@ -287,7 +287,11 @@ func TestKMSConfigHasher(t *testing.T) {
 			}
 
 			client := fake.NewSimpleClientset(scenario.resources...).CoreV1()
-			got, err := newKMSConfigHasher(provider, client, "openshift-config").hash(context.Background())
+			hasher, err := newKMSConfigHasher(provider, newCoreClientKMSConfigHasherResourceProvider(client), "openshift-config")
+			if err != nil {
+				t.Fatalf("newKMSConfigHasher: %v", err)
+			}
+			got, err := hasher.hash(context.Background())
 
 			if scenario.expectedError != "" {
 				if err == nil {


### PR DESCRIPTION
splitting https://github.com/openshift/library-go/pull/2392 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved KMS configuration handling for referenced Secrets and ConfigMaps.
  * Preserved existing configuration hashing behavior and error handling.
  * Improved separation of resource retrieval from KMS configuration processing.

* **Tests**
  * Updated coverage to verify resource retrieval during KMS configuration processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->