### PR TITLE
CNTRLPLANE-3237: kms preflight: add AlwaysSucceedKMSPreflightDeployer

### DIFF
--- a/pkg/operator/encryption/kms/preflight/always_succeed_deployer.go
+++ b/pkg/operator/encryption/kms/preflight/always_succeed_deployer.go
@@ -1,0 +1,62 @@
+package preflight
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/openshift/library-go/pkg/operator/encryption/controllers"
+)
+
+// NewAlwaysSucceedKMSPreflightDeployer returns a KMSPreflightDeployer that
+// always reports a successful preflight without running any real check.
+// Use as a temporary stand-in until a real pod-based deployer is available.
+func NewAlwaysSucceedKMSPreflightDeployer() *AlwaysSucceedKMSPreflightDeployer {
+	return &AlwaysSucceedKMSPreflightDeployer{}
+}
+
+// AlwaysSucceedKMSPreflightDeployer is a KMSPreflightDeployer that immediately
+// reports a successful preflight result without deploying any workload.
+type AlwaysSucceedKMSPreflightDeployer struct {
+	configHash string
+	deployed   bool
+}
+
+func (d *AlwaysSucceedKMSPreflightDeployer) Deploy(_ context.Context, configHash string, _ *corev1.Secret) error {
+	d.configHash = configHash
+	d.deployed = true
+	return nil
+}
+
+func (d *AlwaysSucceedKMSPreflightDeployer) Status(_ context.Context) (corev1.PodStatus, error) {
+	if !d.deployed {
+		return corev1.PodStatus{}, apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "kms-preflight")
+	}
+	return corev1.PodStatus{
+		Phase: corev1.PodSucceeded,
+		Conditions: []corev1.PodCondition{
+			{
+				Type:    controllers.KMSPreflightConfigHashPodCondition,
+				Status:  corev1.ConditionTrue,
+				Message: d.configHash,
+			},
+			{
+				Type:   controllers.KMSPreflightResultPodCondition,
+				Status: corev1.ConditionTrue,
+			},
+			{
+				Type:    controllers.KMSPreflightRemoteKeyIDPodCondition,
+				Status:  corev1.ConditionTrue,
+				Message: "always-succeed",
+			},
+		},
+	}, nil
+}
+
+func (d *AlwaysSucceedKMSPreflightDeployer) Cleanup(_ context.Context) error {
+	d.configHash = ""
+	d.deployed = false
+	return nil
+}

--- a/pkg/operator/encryption/kms/preflight/always_succeed_deployer_test.go
+++ b/pkg/operator/encryption/kms/preflight/always_succeed_deployer_test.go
@@ -1,0 +1,67 @@
+package preflight
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/openshift/library-go/pkg/operator/encryption/controllers"
+)
+
+func TestAlwaysSucceedKMSPreflightDeployer(t *testing.T) {
+	const hash = "abc123=="
+	d := NewAlwaysSucceedKMSPreflightDeployer()
+
+	// Before Deploy: Status returns NotFound.
+	_, err := d.Status(context.Background())
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("expected NotFound before Deploy, got %v", err)
+	}
+
+	// After Deploy: Status returns a succeeded pod with the hash in conditions.
+	if err := d.Deploy(context.Background(), hash, nil); err != nil {
+		t.Fatalf("Deploy: %v", err)
+	}
+	podStatus, err := d.Status(context.Background())
+	if err != nil {
+		t.Fatalf("Status after Deploy: %v", err)
+	}
+	if podStatus.Phase != corev1.PodSucceeded {
+		t.Errorf("expected PodSucceeded, got %s", podStatus.Phase)
+	}
+	hashCond := controllers.FindPodCondition(podStatus.Conditions, controllers.KMSPreflightConfigHashPodCondition)
+	if hashCond == nil || hashCond.Message != hash {
+		t.Errorf("expected hash condition with message %q, got %v", hash, hashCond)
+	}
+	resultCond := controllers.FindPodCondition(podStatus.Conditions, controllers.KMSPreflightResultPodCondition)
+	if resultCond == nil || resultCond.Status != corev1.ConditionTrue {
+		t.Errorf("expected result condition True, got %v", resultCond)
+	}
+	remoteKeyIDCond := controllers.FindPodCondition(podStatus.Conditions, controllers.KMSPreflightRemoteKeyIDPodCondition)
+	if remoteKeyIDCond == nil || remoteKeyIDCond.Message == "" {
+		t.Errorf("expected non-empty remoteKeyID condition, got %v", remoteKeyIDCond)
+	}
+
+	// After Cleanup: Status returns NotFound again.
+	if err := d.Cleanup(context.Background()); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+	_, err = d.Status(context.Background())
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("expected NotFound after Cleanup, got %v", err)
+	}
+
+	// Deploy with an empty hash: Status must still report success, not NotFound.
+	if err := d.Deploy(context.Background(), "", nil); err != nil {
+		t.Fatalf("Deploy with empty hash: %v", err)
+	}
+	podStatus, err = d.Status(context.Background())
+	if err != nil {
+		t.Fatalf("Status after Deploy with empty hash: %v", err)
+	}
+	if podStatus.Phase != corev1.PodSucceeded {
+		t.Errorf("expected PodSucceeded after Deploy with empty hash, got %s", podStatus.Phase)
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a KMS preflight deployment option that records configuration, reports successful readiness conditions, and supports cleanup.
  * Status now clearly indicates when a preflight deployment has not yet been created or has been removed.
  * Preflight status reports success even when configuration details are empty.

* **Tests**
  * Added coverage for deployment, status reporting, required KMS conditions, empty configuration, and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->