### PR TITLE
CNTRLPLANE-3237: kms preflight: don't degrade when encryption is disabled

### DIFF
--- a/pkg/operator/encryption/controllers/kms_preflight_controller.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller.go
@@ -16,6 +16,7 @@ import (
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/klog/v2"
 
+	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
@@ -684,6 +685,17 @@ func FindPodCondition(conditions []corev1.PodCondition, condType corev1.PodCondi
 // and any existing result already recorded for that hash, or an empty string
 // when no preflight is needed.
 func (c *kmsPreflightController) preflightRequired(ctx context.Context) (string, *operatorv1.KMSPreflightResult, error) {
+	apiServer, err := c.apiServerClient.Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to get apiserver config: %w", err)
+	}
+	if apiServer.Spec.Encryption.Type != configv1.EncryptionTypeKMS {
+		// Encryption is not KMS — nothing to preflight. A stale ObservedConfigHash
+		// (written when KMS was active) is irrelevant; the key controller will
+		// overwrite it when/if KMS is re-enabled.
+		return "", nil, nil
+	}
+
 	encryptionStatus, err := c.encryptionStatusProvider.GetKMSEncryptionStatus(ctx)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to get KMS encryption status: %w", err)
@@ -691,11 +703,6 @@ func (c *kmsPreflightController) preflightRequired(ctx context.Context) (string,
 	requiredHash := encryptionStatus.Preflight.ObservedConfigHash
 	if requiredHash == "" {
 		return "", nil, nil
-	}
-
-	apiServer, err := c.apiServerClient.Get(ctx, "cluster", metav1.GetOptions{})
-	if err != nil {
-		return "", nil, fmt.Errorf("failed to get apiserver config: %w", err)
 	}
 
 	providerCfg, err := newKMSProviderConfig(apiServer.Spec.Encryption.KMS)

--- a/pkg/operator/encryption/controllers/kms_preflight_controller_test.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller_test.go
@@ -375,6 +375,7 @@ func TestKMSPreflightController(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
 		Spec: configv1.APIServerSpec{
 			Encryption: configv1.APIServerEncryption{
+				Type: configv1.EncryptionTypeKMS,
 				KMS: configv1.KMSPluginConfig{
 					Type:  configv1.VaultKMSProvider,
 					Vault: wellKnownBaseVaultConfig,
@@ -929,6 +930,30 @@ func TestKMSPreflightController(t *testing.T) {
 			encryptionStatusProvider:    &fakeEncryptionStatusProvider{observedConfigHash: ""},
 			apiServerObjects:            []runtime.Object{apiServerWithKMS},
 			coreObjects:                 []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			preconditionsMet:            true,
+			expectedPreflightPodCleanup: true,
+			expectedConditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
+				{Type: "EncryptionKMSPreflightControllerProgressing", Status: "False"},
+			},
+		},
+		{
+			// ObservedConfigHash is non-empty (set when KMS was active) but the
+			// cluster has since reverted to identity encryption. The controller
+			// must not degrade — the stale hash is irrelevant until KMS is
+			// re-enabled and the key controller overwrites it.
+			name: "ObservedConfigHash set but encryption reverted to identity — no preflight, not degraded",
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{
+				observedConfigHash: wellKnownMatchingHashForBaseVaultConfig,
+			},
+			apiServerObjects: []runtime.Object{&configv1.APIServer{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.APIServerSpec{
+					Encryption: configv1.APIServerEncryption{
+						Type: configv1.EncryptionTypeIdentity,
+					},
+				},
+			}},
 			preconditionsMet:            true,
 			expectedPreflightPodCleanup: true,
 			expectedConditions: []operatorv1.OperatorCondition{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved encryption preflight handling when the cluster is no longer configured for KMS.
  * Prevented stale KMS configuration data from triggering incorrect preflight behavior.
  * Ensured cleanup completes correctly without incorrectly reporting degraded or progressing status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->