### PR TITLE
WIP: compute encryption-config secret (isolated namespace approach)

### DIFF
--- a/pkg/operator/encryption/controllers/key_controller.go
+++ b/pkg/operator/encryption/controllers/key_controller.go
@@ -136,13 +136,28 @@ func NewKeyController(
 	)
 }
 
-func (c *keyController) sync(ctx context.Context, syncCtx factory.SyncContext) (err error) {
+func (c *keyController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	return c.syncInternal(ctx, syncCtx, keySyncOptions{
+		keysNamespace: secrets.EncryptionKeysNamespace,
+		writeStatus:   true,
+	})
+}
+
+// keySyncOptions controls where key secrets are written and whether operator
+// status conditions are updated. Preflight callers use a temporary namespace
+// and writeStatus=false so degraded conditions are not written to the live operator.
+type keySyncOptions struct {
+	keysNamespace string
+	writeStatus   bool
+}
+
+func (c *keyController) syncInternal(ctx context.Context, syncCtx factory.SyncContext, opts keySyncOptions) (err error) {
 	// The status for this condition is intentionally omitted to ensure it's correctly set in each branch
 	degradedCondition := applyoperatorv1.OperatorCondition().
 		WithType("EncryptionKeyControllerDegraded")
 
 	defer func() {
-		if degradedCondition == nil {
+		if !opts.writeStatus || degradedCondition == nil {
 			return
 		}
 		status := applyoperatorv1.OperatorStatus().WithConditions(degradedCondition)
@@ -161,7 +176,7 @@ func (c *keyController) sync(ctx context.Context, syncCtx factory.SyncContext) (
 		return err // we will get re-kicked when the operator status updates
 	}
 
-	err = c.checkAndCreateKeys(ctx, syncCtx, c.provider.EncryptedGRs())
+	err = c.checkAndCreateKeys(ctx, syncCtx, c.provider.EncryptedGRs(), opts.keysNamespace)
 	if err != nil {
 		degradedCondition = degradedCondition.
 			WithStatus(operatorv1.ConditionTrue).
@@ -175,13 +190,13 @@ func (c *keyController) sync(ctx context.Context, syncCtx factory.SyncContext) (
 	return err
 }
 
-func (c *keyController) checkAndCreateKeys(ctx context.Context, syncContext factory.SyncContext, encryptedGRs []schema.GroupResource) error {
+func (c *keyController) checkAndCreateKeys(ctx context.Context, syncContext factory.SyncContext, encryptedGRs []schema.GroupResource, keysNamespace string) error {
 	currentMode, externalReason, apiEncryptionConfiguration, err := c.getCurrentModeReasonAndEncryptionConfig(ctx)
 	if err != nil {
 		return err
 	}
 
-	currentConfig, desiredEncryptionState, secrets, isProgressingReason, err := statemachine.GetEncryptionConfigAndState(ctx, c.deployer, c.secretClient, c.encryptionSecretSelector, encryptedGRs)
+	currentConfig, desiredEncryptionState, secrets, isProgressingReason, err := statemachine.GetEncryptionConfigAndStateInNamespace(ctx, c.deployer, c.secretClient, keysNamespace, c.encryptionSecretSelector, encryptedGRs)
 	if err != nil {
 		return err
 	}
@@ -251,9 +266,10 @@ func (c *keyController) checkAndCreateKeys(ctx context.Context, syncContext fact
 	if err != nil {
 		return fmt.Errorf("failed to create key: %v", err)
 	}
-	_, createErr := c.secretClient.Secrets("openshift-config-managed").Create(ctx, keySecret, metav1.CreateOptions{})
+	keySecret.Namespace = keysNamespace
+	_, createErr := c.secretClient.Secrets(keysNamespace).Create(ctx, keySecret, metav1.CreateOptions{})
 	if errors.IsAlreadyExists(createErr) {
-		return c.validateExistingSecret(ctx, keySecret, newKeyID)
+		return c.validateExistingSecret(ctx, keySecret, newKeyID, keysNamespace)
 	}
 	if createErr != nil {
 		syncContext.Recorder().Warningf("EncryptionKeyCreateFailed", "Secret %q failed to create: %v", keySecret.Name, err)
@@ -265,8 +281,8 @@ func (c *keyController) checkAndCreateKeys(ctx context.Context, syncContext fact
 	return nil
 }
 
-func (c *keyController) validateExistingSecret(ctx context.Context, keySecret *corev1.Secret, keyID uint64) error {
-	actualKeySecret, err := c.secretClient.Secrets("openshift-config-managed").Get(ctx, keySecret.Name, metav1.GetOptions{})
+func (c *keyController) validateExistingSecret(ctx context.Context, keySecret *corev1.Secret, keyID uint64, keysNamespace string) error {
+	actualKeySecret, err := c.secretClient.Secrets(keysNamespace).Get(ctx, keySecret.Name, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/encryption/controllers/kms_preflight_controller.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller.go
@@ -482,12 +482,18 @@ func (c *kmsPreflightController) runPreflightChecks(ctx context.Context) (requeu
 
 	// Scenario 1: no preflight required, cleanup lingering resources.
 	if requiredHash == "" {
+		if err := cleanupPreflightTempNamespaces(ctx, c.coreClient); err != nil {
+			klog.Warningf("failed to clean up leftover preflight temp namespaces: %v", err)
+		}
 		return false, "", "", c.deployer.Cleanup(ctx)
 	}
 
 	// Result already recorded for this hash as Succeeded: clean up the pod
 	// (idempotent if already gone) and return — no pod work needed.
 	if isPreflightResultSucceeded(existingResult) {
+		if err := deletePreflightTempNamespace(ctx, c.coreClient, preflightTempNamespaceName(requiredHash)); err != nil {
+			klog.Warningf("failed to delete preflight temp namespace for hash %s: %v", requiredHash, err)
+		}
 		return false, "", "", c.deployer.Cleanup(ctx)
 	}
 

--- a/pkg/operator/encryption/controllers/kms_preflight_controller.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/encryption/kms"
+	"github.com/openshift/library-go/pkg/operator/encryption/statemachine"
 	"github.com/openshift/library-go/pkg/operator/events"
 	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
 )
@@ -196,13 +197,17 @@ type KMSPreflightDeployer interface {
 }
 
 type kmsPreflightController struct {
-	controllerInstanceName string
+	controllerInstanceName   string
+	instanceName             string
+	unsupportedConfigPrefix  []string
+	encryptionSecretSelector metav1.ListOptions
 
 	operatorClient  operatorv1helpers.OperatorClient
 	apiServerClient configv1client.APIServerInterface
 	coreClient      corev1client.CoreV1Interface
 
 	deployer                 KMSPreflightDeployer
+	encryptionDeployer       statemachine.Deployer
 	provider                 Provider
 	preconditionsFulfilledFn preconditionsFulfilled
 	encryptionStatusProvider kms.EncryptionStatusProvider
@@ -280,28 +285,39 @@ type kmsPreflightController struct {
 // so that its logs can be inspected, then cleaned up by a subsequent sync.
 func NewKMSPreflightController(
 	instanceName string,
+	unsupportedConfigPrefix []string,
 	provider Provider,
 	preconditionsFulfilledFn preconditionsFulfilled,
 	deployer KMSPreflightDeployer,
+	// encryptionDeployer is the same statemachine.Deployer used by the key and state
+	// controllers. It is consulted when computing the encryption-config Secret for
+	// the preflight pod in a temporary namespace.
+	encryptionDeployer statemachine.Deployer,
 	operatorClient operatorv1helpers.OperatorClient,
 	apiServerClient configv1client.APIServerInterface,
 	apiServerInformer configv1informers.APIServerInformer,
 	// coreClient reads referenced Secrets and ConfigMaps in openshift-config for hash
-	// computation. No informer is needed: the key-controller detects config changes and
-	// updates ObservedConfigHash, which triggers this controller via the operatorClient
-	// informer. The minute-based resync covers the rest.
+	// computation and creates the temporary namespace used to materialize encryption
+	// config for preflight. No informer is needed for openshift-config: the key-controller
+	// detects config changes and updates ObservedConfigHash, which triggers this
+	// controller via the operatorClient informer. The minute-based resync covers the rest.
 	coreClient corev1client.CoreV1Interface,
+	encryptionSecretSelector metav1.ListOptions,
 	encryptionStatusProvider kms.EncryptionStatusProvider,
 	eventRecorder events.Recorder,
 ) factory.Controller {
 	c := &kmsPreflightController{
-		controllerInstanceName: factory.ControllerInstanceName(instanceName, "EncryptionKMSPreflight"),
+		controllerInstanceName:   factory.ControllerInstanceName(instanceName, "EncryptionKMSPreflight"),
+		instanceName:             instanceName,
+		unsupportedConfigPrefix:  unsupportedConfigPrefix,
+		encryptionSecretSelector: encryptionSecretSelector,
 
 		operatorClient:  operatorClient,
 		apiServerClient: apiServerClient,
 		coreClient:      coreClient,
 
 		deployer:                 deployer,
+		encryptionDeployer:       encryptionDeployer,
 		provider:                 provider,
 		preconditionsFulfilledFn: preconditionsFulfilledFn,
 		encryptionStatusProvider: encryptionStatusProvider,
@@ -387,7 +403,10 @@ func (c *kmsPreflightController) sync(ctx context.Context, syncCtx factory.SyncC
 //     2a. Result already recorded as Failed and pod is gone: surface the error
 //     without re-deploying. The admin must fix the config (new hash) before
 //     a new check can run.
-//     2b. No result yet: call Deploy. On success, requeue and wait for the pod to report results.
+//     2b. No result yet: compute the encryption-config Secret in a temporary
+//     namespace via key/state controller cores, then call Deploy. On success,
+//     requeue and wait for the pod to report results. Computation does not wait
+//     for encryption deployer convergence (same as in-place KMS field updates).
 //
 //  3. Preflight required, pod exists (Status returns a PodStatus).
 //     Evaluate the pod state via conditions and phase:
@@ -439,8 +458,8 @@ func (c *kmsPreflightController) sync(ctx context.Context, syncCtx factory.SyncC
 //	1         No preflight required — cleanup                   false    nil   False     False        No
 //	1a        Already Succeeded — cleanup, no pod work          false    nil   False     False        No
 //	2a        No pod, already Failed — surface error            false    *pe   True      False        Yes
-//	2b        No pod, Deploy success                            true     nil   False     True         No
-//	2b        No pod, Deploy error                              true     err   True      False        No
+//	2b        No pod, compute / Deploy success                  true     nil   False     True         No
+//	2b        No pod, compute / Deploy error                    true     err   True      False        No
 //	3a        Pod Failed — keep for inspection                  false    *pe   True      False        Yes
 //	3b        No hash, pod Running, no timeout                  true     nil   False     True         No
 //	3b        No hash, timeout exceeded                         true     *pe   True      False        Yes
@@ -485,8 +504,22 @@ func (c *kmsPreflightController) runPreflightChecks(ctx context.Context) (requeu
 				message: fmt.Sprintf("preflight check failed for hash %s: pod was removed but failure is recorded in status", requiredHash),
 			}
 		}
-		// TODO: compute the encryption configuration and pass it to the deployer
-		if err := c.deployer.Deploy(ctx, requiredHash, nil); err != nil {
+		encryptionSecret, err := computeEncryptionConfigSecretInTempNamespace(
+			ctx,
+			requiredHash,
+			c.instanceName,
+			c.unsupportedConfigPrefix,
+			c.provider,
+			c.encryptionDeployer,
+			c.operatorClient,
+			c.apiServerClient,
+			c.coreClient,
+			c.encryptionSecretSelector,
+		)
+		if err != nil {
+			return true, "", "", fmt.Errorf("failed to compute encryption config for preflight: %w", err)
+		}
+		if err := c.deployer.Deploy(ctx, requiredHash, encryptionSecret); err != nil {
 			return true, "", "", err
 		}
 		return true, "RunningPreflightCheck", fmt.Sprintf("Deploying preflight pod for hash %s", requiredHash), nil

--- a/pkg/operator/encryption/controllers/kms_preflight_controller_test.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller_test.go
@@ -24,6 +24,7 @@ import (
 	applyoperatorv1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
 
 	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
 	"github.com/openshift/library-go/pkg/operator/encryption/kms"
 	encryptiontesting "github.com/openshift/library-go/pkg/operator/encryption/testing"
 	"github.com/openshift/library-go/pkg/operator/events"
@@ -314,16 +315,18 @@ func TestKMSConfigHasher(t *testing.T) {
 }
 
 type fakeDeployer struct {
-	deployed   bool
-	cleaned    bool
-	deployErr  error
-	statusErr  error
-	cleanupErr error
-	podStatus  corev1.PodStatus
+	deployed                   bool
+	cleaned                    bool
+	deployErr                  error
+	statusErr                  error
+	cleanupErr                 error
+	podStatus                  corev1.PodStatus
+	lastEncryptionConfigSecret *corev1.Secret
 }
 
-func (f *fakeDeployer) Deploy(_ context.Context, _ string, _ *corev1.Secret) error {
+func (f *fakeDeployer) Deploy(_ context.Context, _ string, encryptionConfiguration *corev1.Secret) error {
 	f.deployed = true
+	f.lastEncryptionConfigSecret = encryptionConfiguration
 	return f.deployErr
 }
 
@@ -999,16 +1002,20 @@ func TestKMSPreflightController(t *testing.T) {
 			if deployer == nil {
 				deployer = &fakeDeployer{}
 			}
+			encryptionSecretSelector := metav1.ListOptions{LabelSelector: "encryption.apiserver.operator.openshift.io/component=test"}
 
 			target := NewKMSPreflightController(
 				"test",
+				nil,
 				provider,
 				preconditionsFn,
 				deployer,
+				&staticEncryptionDeployer{},
 				fakeOperatorClient,
 				fakeApiServerClient,
 				fakeApiServerInformer,
 				fakeKubeClient.CoreV1(),
+				encryptionSecretSelector,
 				scenario.encryptionStatusProvider,
 				eventRecorder,
 			)
@@ -1039,8 +1046,172 @@ func TestKMSPreflightController(t *testing.T) {
 			if fakeDeployerInstance.cleaned != scenario.expectedPreflightPodCleanup {
 				t.Errorf("deployer.Cleanup called: got %v, want %v", fakeDeployerInstance.cleaned, scenario.expectedPreflightPodCleanup)
 			}
+			if fakeDeployerInstance.deployed {
+				if fakeDeployerInstance.lastEncryptionConfigSecret == nil {
+					t.Fatalf("expected Deploy to receive a non-nil encryption config secret")
+				}
+				if fakeDeployerInstance.lastEncryptionConfigSecret.Data["encryption-config"] == nil {
+					t.Fatalf("expected encryption config secret to contain encryption-config data")
+				}
+			}
 
 			encryptiontesting.ValidateOperatorClientConditions(t, fakeOperatorClient, scenario.expectedConditions)
 		})
+	}
+}
+
+func TestKMSPreflightController_DeployUsesTempNamespaceEncryptionConfig(t *testing.T) {
+	apiServer := apiServerWithWellKnownVaultKMS()
+	const matchingHash = "cuZm_g=="
+
+	fakeOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(
+		&operatorv1.StaticPodOperatorSpec{OperatorSpec: operatorv1.OperatorSpec{ManagementState: operatorv1.Managed}},
+		&operatorv1.StaticPodOperatorStatus{OperatorStatus: operatorv1.OperatorStatus{
+			Conditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
+				{Type: "EncryptionKMSPreflightControllerProgressing", Status: "False"},
+			},
+		}},
+		nil,
+		nil,
+	)
+	fakeKubeClient := fake.NewSimpleClientset(&wellKnownBaseSecret, &wellKnownBaseConfigMap)
+	eventRecorder := events.NewRecorder(fakeKubeClient.CoreV1().Events("test"), "test-kmsPreflightController", &corev1.ObjectReference{}, clocktesting.NewFakePassiveClock(time.Now()))
+	fakeConfigClient := configv1clientfake.NewSimpleClientset(apiServer)
+	fakeApiServerInformer := configv1informers.NewSharedInformerFactory(fakeConfigClient, time.Minute).Config().V1().APIServers()
+	deployer := &fakeDeployer{statusErr: apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "kms-preflight")}
+
+	target := NewKMSPreflightController(
+		"test",
+		nil,
+		newTestProvider([]schema.GroupResource{{Group: "", Resource: "secrets"}}),
+		alwaysFulfilledPreconditions,
+		deployer,
+		&staticEncryptionDeployer{},
+		fakeOperatorClient,
+		fakeConfigClient.ConfigV1().APIServers(),
+		fakeApiServerInformer,
+		fakeKubeClient.CoreV1(),
+		metav1.ListOptions{LabelSelector: "encryption.apiserver.operator.openshift.io/component=test"},
+		&fakeEncryptionStatusProvider{observedConfigHash: matchingHash},
+		eventRecorder,
+	)
+
+	if err := target.Sync(context.TODO(), factory.NewSyncContext("test", eventRecorder)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !deployer.deployed {
+		t.Fatal("expected Deploy to be called")
+	}
+	assertDeployedPreflightEncryptionConfig(t, deployer.lastEncryptionConfigSecret)
+
+	// Temp namespace should be cleaned up after computing the encryption config.
+	tempNS := preflightTempNamespaceName(matchingHash)
+	if _, err := fakeKubeClient.CoreV1().Namespaces().Get(context.TODO(), tempNS, metav1.GetOptions{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("expected temp namespace %q to be deleted, got err=%v", tempNS, err)
+	}
+
+	encryptiontesting.ValidateOperatorClientConditions(t, fakeOperatorClient, []operatorv1.OperatorCondition{
+		{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
+		{Type: "EncryptionKMSPreflightControllerProgressing", Status: "True", Reason: "RunningPreflightCheck", Message: "Deploying preflight pod for hash cuZm_g=="},
+	})
+}
+
+func TestKMSPreflightController_DeploysWhenEncryptionDeployerNotConverged(t *testing.T) {
+	apiServer := apiServerWithWellKnownVaultKMS()
+	const matchingHash = "cuZm_g=="
+
+	fakeOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(
+		&operatorv1.StaticPodOperatorSpec{OperatorSpec: operatorv1.OperatorSpec{ManagementState: operatorv1.Managed}},
+		&operatorv1.StaticPodOperatorStatus{OperatorStatus: operatorv1.OperatorStatus{
+			Conditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
+				{Type: "EncryptionKMSPreflightControllerProgressing", Status: "False"},
+			},
+		}},
+		nil,
+		nil,
+	)
+	fakeKubeClient := fake.NewSimpleClientset(&wellKnownBaseSecret, &wellKnownBaseConfigMap)
+	eventRecorder := events.NewRecorder(fakeKubeClient.CoreV1().Events("test"), "test-kmsPreflightController", &corev1.ObjectReference{}, clocktesting.NewFakePassiveClock(time.Now()))
+	fakeConfigClient := configv1clientfake.NewSimpleClientset(apiServer)
+	fakeApiServerInformer := configv1informers.NewSharedInformerFactory(fakeConfigClient, time.Minute).Config().V1().APIServers()
+	deployer := &fakeDeployer{statusErr: apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "kms-preflight")}
+
+	target := NewKMSPreflightController(
+		"test",
+		nil,
+		newTestProvider([]schema.GroupResource{{Group: "", Resource: "secrets"}}),
+		alwaysFulfilledPreconditions,
+		deployer,
+		&staticEncryptionDeployerNotConverged{},
+		fakeOperatorClient,
+		fakeConfigClient.ConfigV1().APIServers(),
+		fakeApiServerInformer,
+		fakeKubeClient.CoreV1(),
+		metav1.ListOptions{LabelSelector: "encryption.apiserver.operator.openshift.io/component=test"},
+		&fakeEncryptionStatusProvider{observedConfigHash: matchingHash},
+		eventRecorder,
+	)
+
+	if err := target.Sync(context.TODO(), factory.NewSyncContext("test", eventRecorder)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !deployer.deployed {
+		t.Fatal("expected Deploy to be called even when encryption deployer is not converged")
+	}
+	assertDeployedPreflightEncryptionConfig(t, deployer.lastEncryptionConfigSecret)
+
+	encryptiontesting.ValidateOperatorClientConditions(t, fakeOperatorClient, []operatorv1.OperatorCondition{
+		{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
+		{Type: "EncryptionKMSPreflightControllerProgressing", Status: "True", Reason: "RunningPreflightCheck", Message: "Deploying preflight pod for hash cuZm_g=="},
+	})
+}
+
+func apiServerWithWellKnownVaultKMS() *configv1.APIServer {
+	return &configv1.APIServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Spec: configv1.APIServerSpec{
+			Encryption: configv1.APIServerEncryption{
+				Type: "KMS",
+				KMS: configv1.KMSPluginConfig{
+					Type:  configv1.VaultKMSProvider,
+					Vault: wellKnownBaseVaultConfig,
+				},
+			},
+		},
+	}
+}
+
+func assertDeployedPreflightEncryptionConfig(t *testing.T, secret *corev1.Secret) {
+	t.Helper()
+	if secret == nil {
+		t.Fatal("expected Deploy to receive a non-nil encryption config secret")
+	}
+	if secret.Data["encryption-config"] == nil {
+		t.Fatal("expected encryption config secret to contain encryption-config data")
+	}
+
+	cfg, err := encryptiondata.FromSecret(secret)
+	if err != nil {
+		t.Fatalf("failed to parse encryption config secret: %v", err)
+	}
+	if cfg == nil || cfg.Encryption == nil {
+		t.Fatal("expected non-empty encryption configuration")
+	}
+
+	foundPreflightEndpoint := false
+	for _, resource := range cfg.Encryption.Resources {
+		for _, providerCfg := range resource.Providers {
+			if providerCfg.KMS == nil {
+				continue
+			}
+			if providerCfg.KMS.Endpoint == preflightKMSSocketEndpoint {
+				foundPreflightEndpoint = true
+			}
+		}
+	}
+	if !foundPreflightEndpoint {
+		t.Fatalf("expected write-key KMS endpoint rewritten to %s", preflightKMSSocketEndpoint)
 	}
 }

--- a/pkg/operator/encryption/controllers/kms_preflight_sandbox.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_sandbox.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	preflightKMSSocketEndpoint = "unix:///var/run/kmsplugin/kms.sock"
+	preflightKMSSocketEndpoint  = "unix:///var/run/kmsplugin/kms.sock"
 	preflightTempNamespaceLabel = "encryption.apiserver.operator.openshift.io/kms-preflight"
 )
 
@@ -223,6 +223,28 @@ func deletePreflightTempNamespace(ctx context.Context, coreClient corev1client.C
 	err := coreClient.Namespaces().Delete(ctx, name, metav1.DeleteOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
 		return err
+	}
+	return nil
+}
+
+// cleanupPreflightTempNamespaces deletes any leftover namespaces labeled as
+// KMS preflight temporary namespaces. Best-effort; used when no specific hash
+// is known (e.g. preflight no longer required).
+func cleanupPreflightTempNamespaces(ctx context.Context, coreClient corev1client.CoreV1Interface) error {
+	list, err := coreClient.Namespaces().List(ctx, metav1.ListOptions{
+		LabelSelector: preflightTempNamespaceLabel + "=true",
+	})
+	if err != nil {
+		return err
+	}
+	var errs []error
+	for i := range list.Items {
+		if err := deletePreflightTempNamespace(ctx, coreClient, list.Items[i].Name); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("failed to delete some preflight temp namespaces: %v", errs)
 	}
 	return nil
 }

--- a/pkg/operator/encryption/controllers/kms_preflight_sandbox.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_sandbox.go
@@ -1,0 +1,318 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
+
+	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
+	"github.com/openshift/library-go/pkg/operator/encryption/secrets"
+	"github.com/openshift/library-go/pkg/operator/encryption/state"
+	"github.com/openshift/library-go/pkg/operator/encryption/statemachine"
+	"github.com/openshift/library-go/pkg/operator/events"
+	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+const (
+	preflightKMSSocketEndpoint = "unix:///var/run/kmsplugin/kms.sock"
+	preflightTempNamespaceLabel = "encryption.apiserver.operator.openshift.io/kms-preflight"
+)
+
+// computeEncryptionConfigSecretInTempNamespace creates an ephemeral namespace, seeds it with
+// existing encryption key secrets, runs the key and state controller cores against that
+// namespace (without writing operator status), and returns the resulting encryption-config Secret.
+// The temporary namespace is always deleted before returning.
+//
+// The live encryption deployer is treated as converged for this computation so preflight can
+// proceed even when API server revisions have not converged. That matches in-place KMS field
+// updates, which also apply without waiting for convergence; migration-triggering changes still
+// only mint keys in the temp namespace (live keys are untouched).
+func computeEncryptionConfigSecretInTempNamespace(
+	ctx context.Context,
+	configHash string,
+	instanceName string,
+	unsupportedConfigPrefix []string,
+	provider Provider,
+	encryptionDeployer statemachine.Deployer,
+	operatorClient operatorv1helpers.OperatorClient,
+	apiServerClient configv1client.APIServerInterface,
+	coreClient corev1client.CoreV1Interface,
+	encryptionSecretSelector metav1.ListOptions,
+) (secret *corev1.Secret, err error) {
+	// Force converged so key/state sync can compute the desired encryption config.
+	// When the live deployer is mid-rollout it returns (nil, false); wrapping keeps any
+	// returned secret (usually nil when not converged) and allows the sync to proceed.
+	effectiveDeployer := forceConvergedDeployer{delegate: encryptionDeployer}
+
+	tempNamespace := preflightTempNamespaceName(configHash)
+	if err := ensurePreflightTempNamespace(ctx, coreClient, tempNamespace); err != nil {
+		return nil, err
+	}
+	defer func() {
+		if cleanupErr := deletePreflightTempNamespace(ctx, coreClient, tempNamespace); cleanupErr != nil {
+			klog.Warningf("failed to delete preflight temp namespace %q: %v", tempNamespace, cleanupErr)
+		}
+	}()
+
+	if err := seedEncryptionKeySecrets(ctx, coreClient, secrets.EncryptionKeysNamespace, tempNamespace, encryptionSecretSelector); err != nil {
+		return nil, err
+	}
+
+	if err := runKeyControllerInNamespace(ctx, tempNamespace, instanceName, unsupportedConfigPrefix, provider, effectiveDeployer, operatorClient, apiServerClient, coreClient, encryptionSecretSelector); err != nil {
+		return nil, err
+	}
+
+	encryptionSecret, err := runStateControllerInNamespace(ctx, tempNamespace, instanceName, provider, effectiveDeployer, operatorClient, coreClient, encryptionSecretSelector)
+	if err != nil {
+		return nil, err
+	}
+
+	keySecrets, err := secrets.ListKeySecretsInNamespace(ctx, coreClient, tempNamespace, encryptionSecretSelector)
+	if err != nil {
+		return nil, err
+	}
+	var latestKeyID uint64
+	foundKey := false
+	for _, s := range keySecrets {
+		id, ok := state.NameToKeyID(s.Name)
+		if !ok {
+			continue
+		}
+		if !foundKey || id > latestKeyID {
+			latestKeyID = id
+			foundKey = true
+		}
+	}
+	if !foundKey {
+		return nil, fmt.Errorf("no encryption key secrets found after key controller run in temp namespace %q", tempNamespace)
+	}
+
+	rewritten, err := rewritePreflightWriteKeyEndpoint(encryptionSecret, latestKeyID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to rewrite preflight KMS endpoint: %w", err)
+	}
+	return rewritten, nil
+}
+
+// forceConvergedDeployer reports converged=true while preserving the delegate's secret/error.
+// Used by preflight so desired encryption-config computation is not blocked on revision rollout.
+type forceConvergedDeployer struct {
+	delegate statemachine.Deployer
+}
+
+func (d forceConvergedDeployer) DeployedEncryptionConfigSecret(ctx context.Context) (*corev1.Secret, bool, error) {
+	secret, _, err := d.delegate.DeployedEncryptionConfigSecret(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+	return secret, true, nil
+}
+
+func (d forceConvergedDeployer) AddEventHandler(handler cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
+	return d.delegate.AddEventHandler(handler)
+}
+
+func (d forceConvergedDeployer) HasSynced() bool {
+	return d.delegate.HasSynced()
+}
+
+func runKeyControllerInNamespace(
+	ctx context.Context,
+	keysNamespace string,
+	instanceName string,
+	unsupportedConfigPrefix []string,
+	provider Provider,
+	encryptionDeployer statemachine.Deployer,
+	operatorClient operatorv1helpers.OperatorClient,
+	apiServerClient configv1client.APIServerInterface,
+	coreClient corev1client.CoreV1Interface,
+	encryptionSecretSelector metav1.ListOptions,
+) error {
+	c := &keyController{
+		operatorClient:           operatorClient,
+		apiServerClient:          apiServerClient,
+		instanceName:             instanceName,
+		controllerInstanceName:   factory.ControllerInstanceName(instanceName, "EncryptionKey"),
+		unsupportedConfigPrefix:  unsupportedConfigPrefix,
+		encryptionSecretSelector: encryptionSecretSelector,
+		deployer:                 encryptionDeployer,
+		provider:                 provider,
+		preconditionsFulfilledFn: func() (bool, error) { return true, nil },
+		secretClient:             coreClient,
+		configMapClient:          coreClient,
+	}
+
+	recorder := events.NewInMemoryRecorder("kms-preflight-key", clock.RealClock{})
+	syncCtx := factory.NewSyncContext("kms-preflight-key", recorder)
+	if err := c.syncInternal(ctx, syncCtx, keySyncOptions{
+		keysNamespace: keysNamespace,
+		writeStatus:   false,
+	}); err != nil {
+		return fmt.Errorf("key controller temp-namespace run failed: %w", err)
+	}
+	return nil
+}
+
+func runStateControllerInNamespace(
+	ctx context.Context,
+	namespace string,
+	instanceName string,
+	provider Provider,
+	encryptionDeployer statemachine.Deployer,
+	operatorClient operatorv1helpers.OperatorClient,
+	coreClient corev1client.CoreV1Interface,
+	encryptionSecretSelector metav1.ListOptions,
+) (*corev1.Secret, error) {
+	c := &stateController{
+		instanceName:             instanceName,
+		controllerInstanceName:   factory.ControllerInstanceName(instanceName, "EncryptionState"),
+		encryptionSecretSelector: encryptionSecretSelector,
+		operatorClient:           operatorClient,
+		secretClient:             coreClient,
+		deployer:                 encryptionDeployer,
+		provider:                 provider,
+		preconditionsFulfilledFn: func() (bool, error) { return true, nil },
+	}
+
+	recorder := events.NewInMemoryRecorder("kms-preflight-state", clock.RealClock{})
+	syncCtx := factory.NewSyncContext("kms-preflight-state", recorder)
+	if err := c.syncInternal(ctx, syncCtx, stateSyncOptions{
+		keysNamespace:             namespace,
+		encryptionConfigNamespace: namespace,
+		writeStatus:               false,
+	}); err != nil {
+		return nil, fmt.Errorf("state controller temp-namespace run failed: %w", err)
+	}
+
+	expectedName := fmt.Sprintf("%s-%s", encryptiondata.EncryptionConfSecretName, instanceName)
+	ecSecret, err := coreClient.Secrets(namespace).Get(ctx, expectedName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("state controller did not create encryption config secret %s/%s: %w", namespace, expectedName, err)
+	}
+	return ecSecret, nil
+}
+
+func ensurePreflightTempNamespace(ctx context.Context, coreClient corev1client.CoreV1Interface, name string) error {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				preflightTempNamespaceLabel: "true",
+			},
+		},
+	}
+	_, err := coreClient.Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("failed to create preflight temp namespace %q: %w", name, err)
+	}
+	return nil
+}
+
+func deletePreflightTempNamespace(ctx context.Context, coreClient corev1client.CoreV1Interface, name string) error {
+	err := coreClient.Namespaces().Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	return nil
+}
+
+// seedEncryptionKeySecrets copies existing encryption key secrets from sourceNamespace into
+// destNamespace so the key/state controllers can build on the live key set without mutating it.
+func seedEncryptionKeySecrets(ctx context.Context, coreClient corev1client.CoreV1Interface, sourceNamespace, destNamespace string, encryptionSecretSelector metav1.ListOptions) error {
+	existing, err := secrets.ListKeySecretsInNamespace(ctx, coreClient, sourceNamespace, encryptionSecretSelector)
+	if err != nil {
+		return fmt.Errorf("failed to list encryption key secrets in %s: %w", sourceNamespace, err)
+	}
+	for _, existingSecret := range existing {
+		copySecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        existingSecret.Name,
+				Namespace:   destNamespace,
+				Labels:      existingSecret.Labels,
+				Annotations: existingSecret.Annotations,
+				Finalizers:  existingSecret.Finalizers,
+			},
+			Type: existingSecret.Type,
+			Data: existingSecret.Data,
+		}
+		_, err := coreClient.Secrets(destNamespace).Create(ctx, copySecret, metav1.CreateOptions{})
+		if err != nil && !apierrors.IsAlreadyExists(err) {
+			return fmt.Errorf("failed to seed encryption key secret %s/%s: %w", destNamespace, copySecret.Name, err)
+		}
+	}
+	return nil
+}
+
+func preflightTempNamespaceName(configHash string) string {
+	sanitized := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-':
+			return r
+		case r >= 'A' && r <= 'Z':
+			return r + ('a' - 'A')
+		default:
+			return '-'
+		}
+	}, configHash)
+	sanitized = strings.Trim(sanitized, "-")
+	for strings.Contains(sanitized, "--") {
+		sanitized = strings.ReplaceAll(sanitized, "--", "-")
+	}
+	if sanitized == "" {
+		sanitized = "unknown"
+	}
+	name := "kms-preflight-" + sanitized
+	if len(name) > 63 {
+		name = strings.TrimRight(name[:63], "-")
+	}
+	return name
+}
+
+// rewritePreflightWriteKeyEndpoint rewrites the write-key KMS endpoint from the
+// per-key production socket (kms-{id}.sock) to the fixed preflight socket
+// (kms.sock). Today's preflight checker dials that fixed path, while the plugin
+// builder uses each provider's Endpoint as -listen-address, so the secret must
+// agree with the checker.
+//
+// TODO: once preflight dials the write-key socket (kms-{id}.sock) directly,
+// this rewrite can be removed and the secret can be used as-is.
+func rewritePreflightWriteKeyEndpoint(secret *corev1.Secret, keyID uint64) (*corev1.Secret, error) {
+	cfg, err := encryptiondata.FromSecret(secret)
+	if err != nil {
+		return nil, err
+	}
+	if cfg == nil || cfg.Encryption == nil {
+		return nil, fmt.Errorf("encryption configuration is empty")
+	}
+
+	// Provider names are "{keyID}_{resource}" (e.g. "2_secrets"). Match on name
+	// rather than endpoint so we identify the write key by its stable identity.
+	wantNamePrefix := fmt.Sprintf("%d_", keyID)
+	rewrote := false
+	for i := range cfg.Encryption.Resources {
+		for j := range cfg.Encryption.Resources[i].Providers {
+			kms := cfg.Encryption.Resources[i].Providers[j].KMS
+			if kms == nil || !strings.HasPrefix(kms.Name, wantNamePrefix) {
+				continue
+			}
+			kms.Endpoint = preflightKMSSocketEndpoint
+			rewrote = true
+		}
+	}
+	if !rewrote {
+		return nil, fmt.Errorf("write-key KMS provider with name prefix %q not found in encryption config", wantNamePrefix)
+	}
+
+	return encryptiondata.ToSecret(secret.Namespace, secret.Name, cfg)
+}

--- a/pkg/operator/encryption/controllers/kms_preflight_sandbox_test.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_sandbox_test.go
@@ -1,0 +1,298 @@
+package controllers
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	configv1clientfake "github.com/openshift/client-go/config/clientset/versioned/fake"
+
+	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
+	"github.com/openshift/library-go/pkg/operator/encryption/secrets"
+	encryptiontesting "github.com/openshift/library-go/pkg/operator/encryption/testing"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+func TestComputeEncryptionConfigSecretInTempNamespace_FirstKMSKey(t *testing.T) {
+	instanceName := "test"
+	configHash := "cuZm_g=="
+	apiServer := apiServerWithWellKnownVaultKMS()
+
+	fakeKubeClient := fake.NewSimpleClientset(&wellKnownBaseSecret, &wellKnownBaseConfigMap)
+	fakeConfigClient := configv1clientfake.NewSimpleClientset(apiServer)
+	fakeOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(
+		&operatorv1.StaticPodOperatorSpec{OperatorSpec: operatorv1.OperatorSpec{ManagementState: operatorv1.Managed}},
+		&operatorv1.StaticPodOperatorStatus{},
+		nil,
+		nil,
+	)
+	provider := newTestProvider([]schema.GroupResource{{Group: "", Resource: "secrets"}})
+	selector := metav1.ListOptions{LabelSelector: "encryption.apiserver.operator.openshift.io/component=" + instanceName}
+
+	secret, err := computeEncryptionConfigSecretInTempNamespace(
+		context.Background(),
+		configHash,
+		instanceName,
+		nil,
+		provider,
+		&staticEncryptionDeployer{},
+		fakeOperatorClient,
+		fakeConfigClient.ConfigV1().APIServers(),
+		fakeKubeClient.CoreV1(),
+		selector,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, secret)
+	require.Equal(t, "encryption-config-"+instanceName, secret.Name)
+
+	cfg, err := encryptiondata.FromSecret(secret)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	require.NotNil(t, cfg.Encryption)
+	require.Contains(t, cfg.KMSPlugins, "1")
+
+	foundPreflightEndpoint := false
+	for _, resource := range cfg.Encryption.Resources {
+		for _, providerCfg := range resource.Providers {
+			if providerCfg.KMS == nil {
+				continue
+			}
+			if providerCfg.KMS.Endpoint == preflightKMSSocketEndpoint {
+				foundPreflightEndpoint = true
+			}
+		}
+	}
+	require.True(t, foundPreflightEndpoint, "expected write-key KMS endpoint rewritten to %s", preflightKMSSocketEndpoint)
+
+	// Production key namespace must remain untouched.
+	liveKeys, err := secrets.ListKeySecrets(context.Background(), fakeKubeClient.CoreV1(), selector)
+	require.NoError(t, err)
+	require.Empty(t, liveKeys)
+
+	tempNS := preflightTempNamespaceName(configHash)
+	_, err = fakeKubeClient.CoreV1().Namespaces().Get(context.Background(), tempNS, metav1.GetOptions{})
+	require.True(t, apierrors.IsNotFound(err), "expected temp namespace cleaned up")
+
+	// Operator degraded condition must not be written by the temp-namespace run.
+	_, status, _, err := fakeOperatorClient.GetOperatorState()
+	require.NoError(t, err)
+	for _, c := range status.Conditions {
+		require.NotEqual(t, "EncryptionKeyControllerDegraded", c.Type)
+		require.NotEqual(t, "EncryptionStateControllerDegraded", c.Type)
+	}
+}
+
+func TestComputeEncryptionConfigSecretInTempNamespace_WorksWhenNotConverged(t *testing.T) {
+	instanceName := "test"
+	configHash := "not-converged"
+	apiServer := apiServerWithWellKnownVaultKMS()
+
+	fakeKubeClient := fake.NewSimpleClientset(&wellKnownBaseSecret, &wellKnownBaseConfigMap)
+	fakeConfigClient := configv1clientfake.NewSimpleClientset(apiServer)
+	fakeOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(
+		&operatorv1.StaticPodOperatorSpec{OperatorSpec: operatorv1.OperatorSpec{ManagementState: operatorv1.Managed}},
+		&operatorv1.StaticPodOperatorStatus{},
+		nil,
+		nil,
+	)
+	provider := newTestProvider([]schema.GroupResource{{Group: "", Resource: "secrets"}})
+	selector := metav1.ListOptions{LabelSelector: "encryption.apiserver.operator.openshift.io/component=" + instanceName}
+
+	secret, err := computeEncryptionConfigSecretInTempNamespace(
+		context.Background(),
+		configHash,
+		instanceName,
+		nil,
+		provider,
+		&staticEncryptionDeployerNotConverged{},
+		fakeOperatorClient,
+		fakeConfigClient.ConfigV1().APIServers(),
+		fakeKubeClient.CoreV1(),
+		selector,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, secret)
+
+	cfg, err := encryptiondata.FromSecret(secret)
+	require.NoError(t, err)
+	require.Contains(t, cfg.KMSPlugins, "1")
+}
+
+func TestComputeEncryptionConfigSecretInTempNamespace_ExistingKeysPlusProviderChange(t *testing.T) {
+	instanceName := "test"
+	configHash := "provider-change"
+	grs := []schema.GroupResource{{Group: "", Resource: "secrets"}}
+	existingKey := encryptiontesting.CreateMigratedEncryptionKeySecretWithKMSPluginConfig(instanceName, grs, 1, time.Now())
+
+	changedPlugin := encryptiontesting.DefaultKMSPluginConfig
+	changedPlugin.Vault.VaultAddress = "https://other-vault.example.com"
+
+	apiServer := &configv1.APIServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Spec: configv1.APIServerSpec{
+			Encryption: configv1.APIServerEncryption{
+				Type: "KMS",
+				KMS:  changedPlugin,
+			},
+		},
+	}
+
+	vaultSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "vault-approle-secret", Namespace: "openshift-config"},
+		Data: map[string][]byte{
+			"role-id":   []byte("role"),
+			"secret-id": []byte("secret"),
+		},
+	}
+	vaultCA := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "vault-ca-bundle", Namespace: "openshift-config"},
+		Data:       map[string]string{"ca-bundle.crt": "ca"},
+	}
+
+	fakeKubeClient := fake.NewSimpleClientset(existingKey, vaultSecret, vaultCA)
+	fakeConfigClient := configv1clientfake.NewSimpleClientset(apiServer)
+	fakeOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(
+		&operatorv1.StaticPodOperatorSpec{OperatorSpec: operatorv1.OperatorSpec{ManagementState: operatorv1.Managed}},
+		&operatorv1.StaticPodOperatorStatus{},
+		nil,
+		nil,
+	)
+	provider := newTestProvider(grs)
+	selector := metav1.ListOptions{LabelSelector: "encryption.apiserver.operator.openshift.io/component=" + instanceName}
+
+	secret, err := computeEncryptionConfigSecretInTempNamespace(
+		context.Background(),
+		configHash,
+		instanceName,
+		nil,
+		provider,
+		&staticEncryptionDeployer{},
+		fakeOperatorClient,
+		fakeConfigClient.ConfigV1().APIServers(),
+		fakeKubeClient.CoreV1(),
+		selector,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, secret)
+
+	cfg, err := encryptiondata.FromSecret(secret)
+	require.NoError(t, err)
+	require.Contains(t, cfg.KMSPlugins, "2")
+
+	var sawWriteKey, sawOldKey bool
+	for _, resource := range cfg.Encryption.Resources {
+		for _, providerCfg := range resource.Providers {
+			if providerCfg.KMS == nil {
+				continue
+			}
+			switch providerCfg.KMS.Endpoint {
+			case preflightKMSSocketEndpoint:
+				sawWriteKey = true
+			case "unix:///var/run/kmsplugin/kms-1.sock":
+				sawOldKey = true
+			case "unix:///var/run/kmsplugin/kms-2.sock":
+				t.Fatalf("write-key endpoint must be rewritten away from per-key socket, got %q", providerCfg.KMS.Endpoint)
+			}
+		}
+	}
+	require.True(t, sawWriteKey, "expected write-key endpoint rewritten to %s", preflightKMSSocketEndpoint)
+	require.True(t, sawOldKey, "expected old key endpoint left on per-key socket")
+
+	// Live production keys must still be only the original key.
+	liveKeys, err := secrets.ListKeySecrets(context.Background(), fakeKubeClient.CoreV1(), selector)
+	require.NoError(t, err)
+	require.Len(t, liveKeys, 1)
+	require.Equal(t, existingKey.Name, liveKeys[0].Name)
+}
+
+func TestRewritePreflightWriteKeyEndpoint(t *testing.T) {
+	secret, err := encryptiondata.ToSecret(secrets.EncryptionKeysNamespace, "encryption-config-test", &encryptiondata.Config{
+		Encryption: &apiserverconfigv1.EncryptionConfiguration{
+			Resources: []apiserverconfigv1.ResourceConfiguration{{
+				Resources: []string{"secrets"},
+				Providers: []apiserverconfigv1.ProviderConfiguration{
+					{KMS: &apiserverconfigv1.KMSConfiguration{Name: "2_secrets", Endpoint: "unix:///var/run/kmsplugin/kms-2.sock"}},
+					{KMS: &apiserverconfigv1.KMSConfiguration{Name: "1_secrets", Endpoint: "unix:///var/run/kmsplugin/kms-1.sock"}},
+				},
+			}},
+		},
+	})
+	require.NoError(t, err)
+
+	rewritten, err := rewritePreflightWriteKeyEndpoint(secret, 2)
+	require.NoError(t, err)
+	cfg, err := encryptiondata.FromSecret(rewritten)
+	require.NoError(t, err)
+	require.Equal(t, preflightKMSSocketEndpoint, cfg.Encryption.Resources[0].Providers[0].KMS.Endpoint)
+	require.Equal(t, "unix:///var/run/kmsplugin/kms-1.sock", cfg.Encryption.Resources[0].Providers[1].KMS.Endpoint)
+
+	_, err = rewritePreflightWriteKeyEndpoint(secret, 99)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `write-key KMS provider with name prefix "99_" not found`)
+}
+
+func TestPreflightTempNamespaceName(t *testing.T) {
+	require.Equal(t, "kms-preflight-cuzm-g", preflightTempNamespaceName("cuZm_g=="))
+	require.Equal(t, "kms-preflight-unknown", preflightTempNamespaceName("==="))
+	require.LessOrEqual(t, len(preflightTempNamespaceName(strings.Repeat("a", 100))), 63)
+}
+
+func TestCleanupPreflightTempNamespaces(t *testing.T) {
+	ns1 := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name:   "kms-preflight-one",
+		Labels: map[string]string{preflightTempNamespaceLabel: "true"},
+	}}
+	ns2 := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name:   "kms-preflight-two",
+		Labels: map[string]string{preflightTempNamespaceLabel: "true"},
+	}}
+	unrelated := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "openshift-config"}}
+	fakeKubeClient := fake.NewSimpleClientset(ns1, ns2, unrelated)
+
+	require.NoError(t, cleanupPreflightTempNamespaces(context.Background(), fakeKubeClient.CoreV1()))
+
+	_, err := fakeKubeClient.CoreV1().Namespaces().Get(context.Background(), ns1.Name, metav1.GetOptions{})
+	require.True(t, apierrors.IsNotFound(err))
+	_, err = fakeKubeClient.CoreV1().Namespaces().Get(context.Background(), ns2.Name, metav1.GetOptions{})
+	require.True(t, apierrors.IsNotFound(err))
+	_, err = fakeKubeClient.CoreV1().Namespaces().Get(context.Background(), unrelated.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+}
+
+type staticEncryptionDeployer struct {
+	secret *corev1.Secret
+}
+
+func (d *staticEncryptionDeployer) DeployedEncryptionConfigSecret(_ context.Context) (*corev1.Secret, bool, error) {
+	return d.secret, true, nil
+}
+
+func (d *staticEncryptionDeployer) AddEventHandler(_ cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
+	return nil, nil
+}
+
+func (d *staticEncryptionDeployer) HasSynced() bool { return true }
+
+type staticEncryptionDeployerNotConverged struct{}
+
+func (d *staticEncryptionDeployerNotConverged) DeployedEncryptionConfigSecret(context.Context) (*corev1.Secret, bool, error) {
+	return nil, false, nil
+}
+
+func (d *staticEncryptionDeployerNotConverged) AddEventHandler(cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
+	return nil, nil
+}
+
+func (d *staticEncryptionDeployerNotConverged) HasSynced() bool { return true }

--- a/pkg/operator/encryption/controllers/state_controller.go
+++ b/pkg/operator/encryption/controllers/state_controller.go
@@ -16,6 +16,7 @@ import (
 	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
+	"github.com/openshift/library-go/pkg/operator/encryption/secrets"
 	"github.com/openshift/library-go/pkg/operator/encryption/state"
 	"github.com/openshift/library-go/pkg/operator/encryption/statemachine"
 	"github.com/openshift/library-go/pkg/operator/events"
@@ -83,13 +84,30 @@ func NewStateController(
 	)
 }
 
-func (c *stateController) sync(ctx context.Context, syncCtx factory.SyncContext) (err error) {
+func (c *stateController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	return c.syncInternal(ctx, syncCtx, stateSyncOptions{
+		keysNamespace:             secrets.EncryptionKeysNamespace,
+		encryptionConfigNamespace: secrets.EncryptionKeysNamespace,
+		writeStatus:               true,
+	})
+}
+
+// stateSyncOptions controls where key secrets are read, where the encryption-config
+// secret is written, and whether operator status conditions are updated. Preflight
+// callers use a temporary namespace and writeStatus=false.
+type stateSyncOptions struct {
+	keysNamespace             string
+	encryptionConfigNamespace string
+	writeStatus               bool
+}
+
+func (c *stateController) syncInternal(ctx context.Context, syncCtx factory.SyncContext, opts stateSyncOptions) (err error) {
 	// The status for this condition is intentionally omitted to ensure it's correctly set in each branch
 	degradedCondition := applyoperatorv1.OperatorCondition().
 		WithType("EncryptionStateControllerDegraded")
 
 	defer func() {
-		if degradedCondition == nil {
+		if !opts.writeStatus || degradedCondition == nil {
 			return
 		}
 		status := applyoperatorv1.OperatorStatus().WithConditions(degradedCondition)
@@ -108,7 +126,7 @@ func (c *stateController) sync(ctx context.Context, syncCtx factory.SyncContext)
 		return err // we will get re-kicked when the operator status updates
 	}
 
-	configError := c.generateAndApplyCurrentEncryptionConfigSecret(ctx, syncCtx.Queue(), syncCtx.Recorder(), c.provider.EncryptedGRs())
+	configError := c.generateAndApplyCurrentEncryptionConfigSecret(ctx, syncCtx.Queue(), syncCtx.Recorder(), c.provider.EncryptedGRs(), opts)
 	if configError != nil {
 		degradedCondition = degradedCondition.
 			WithStatus(operatorv1.ConditionTrue).
@@ -126,8 +144,8 @@ type eventWithReason struct {
 	message string
 }
 
-func (c *stateController) generateAndApplyCurrentEncryptionConfigSecret(ctx context.Context, queue workqueue.RateLimitingInterface, recorder events.Recorder, encryptedGRs []schema.GroupResource) error {
-	currentConfig, desiredEncryptionState, encryptionSecrets, transitioningReason, err := statemachine.GetEncryptionConfigAndState(ctx, c.deployer, c.secretClient, c.encryptionSecretSelector, encryptedGRs)
+func (c *stateController) generateAndApplyCurrentEncryptionConfigSecret(ctx context.Context, queue workqueue.RateLimitingInterface, recorder events.Recorder, encryptedGRs []schema.GroupResource, opts stateSyncOptions) error {
+	currentConfig, desiredEncryptionState, encryptionSecrets, transitioningReason, err := statemachine.GetEncryptionConfigAndStateInNamespace(ctx, c.deployer, c.secretClient, opts.keysNamespace, c.encryptionSecretSelector, encryptedGRs)
 	if err != nil {
 		return err
 	}
@@ -147,7 +165,7 @@ func (c *stateController) generateAndApplyCurrentEncryptionConfigSecret(ctx cont
 	if err != nil {
 		return err
 	}
-	changed, err := c.applyEncryptionConfigSecret(ctx, desiredSecretData, recorder)
+	changed, err := c.applyEncryptionConfigSecret(ctx, desiredSecretData, recorder, opts.encryptionConfigNamespace)
 	if err != nil {
 		return err
 	}
@@ -163,8 +181,8 @@ func (c *stateController) generateAndApplyCurrentEncryptionConfigSecret(ctx cont
 	return nil
 }
 
-func (c *stateController) applyEncryptionConfigSecret(ctx context.Context, secretData *encryptiondata.Config, recorder events.Recorder) (bool, error) {
-	s, err := encryptiondata.ToSecret("openshift-config-managed", fmt.Sprintf("%s-%s", encryptiondata.EncryptionConfSecretName, c.instanceName), secretData)
+func (c *stateController) applyEncryptionConfigSecret(ctx context.Context, secretData *encryptiondata.Config, recorder events.Recorder, encryptionConfigNamespace string) (bool, error) {
+	s, err := encryptiondata.ToSecret(encryptionConfigNamespace, fmt.Sprintf("%s-%s", encryptiondata.EncryptionConfSecretName, c.instanceName), secretData)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/operator/encryption/secrets/secrets.go
+++ b/pkg/operator/encryption/secrets/secrets.go
@@ -131,7 +131,7 @@ func FromKeyState(component string, ks state.KeyState) (*corev1.Secret, error) {
 	s := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("encryption-key-%s-%s", component, ks.Key.Name),
-			Namespace: "openshift-config-managed",
+			Namespace: EncryptionKeysNamespace,
 			Labels: map[string]string{
 				EncryptionKeySecretsLabel: component,
 			},
@@ -203,9 +203,14 @@ func (m *MigratedGroupResources) HasResource(resource schema.GroupResource) bool
 	return false
 }
 
-// ListKeySecrets returns the current key secrets from openshift-config-managed.
+// ListKeySecrets returns the current key secrets from EncryptionKeysNamespace.
 func ListKeySecrets(ctx context.Context, secretClient corev1client.SecretsGetter, encryptionSecretSelector metav1.ListOptions) ([]*corev1.Secret, error) {
-	encryptionSecretList, err := secretClient.Secrets("openshift-config-managed").List(ctx, encryptionSecretSelector)
+	return ListKeySecretsInNamespace(ctx, secretClient, EncryptionKeysNamespace, encryptionSecretSelector)
+}
+
+// ListKeySecretsInNamespace returns the current key secrets from the given namespace.
+func ListKeySecretsInNamespace(ctx context.Context, secretClient corev1client.SecretsGetter, namespace string, encryptionSecretSelector metav1.ListOptions) ([]*corev1.Secret, error) {
+	encryptionSecretList, err := secretClient.Secrets(namespace).List(ctx, encryptionSecretSelector)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operator/encryption/secrets/types.go
+++ b/pkg/operator/encryption/secrets/types.go
@@ -5,6 +5,10 @@ import (
 )
 
 const (
+	// EncryptionKeysNamespace is the namespace where encryption key secrets and the
+	// consolidated encryption-config secret are stored in production.
+	EncryptionKeysNamespace = "openshift-config-managed"
+
 	// This label is used to find secrets that build up the final encryption config.  The names of the
 	// secrets are in format <shared prefix>-<unique monotonically increasing uint> (the uint is the keyID).
 	// For example, openshift-kube-apiserver-encryption-3.  Note that other than the -3 postfix, the name of

--- a/pkg/operator/encryption/statemachine/transition.go
+++ b/pkg/operator/encryption/statemachine/transition.go
@@ -35,6 +35,19 @@ func GetEncryptionConfigAndState(
 	encryptionSecretSelector metav1.ListOptions,
 	encryptedGRs []schema.GroupResource,
 ) (current *encryptiondata.Config, desired map[schema.GroupResource]state.GroupResourceState, encryptionSecrets []*corev1.Secret, transitioningReason string, err error) {
+	return GetEncryptionConfigAndStateInNamespace(ctx, deployer, secretClient, secrets.EncryptionKeysNamespace, encryptionSecretSelector, encryptedGRs)
+}
+
+// GetEncryptionConfigAndStateInNamespace is like GetEncryptionConfigAndState but lists
+// encryption key secrets from keysNamespace instead of the default production namespace.
+func GetEncryptionConfigAndStateInNamespace(
+	ctx context.Context,
+	deployer Deployer,
+	secretClient corev1client.SecretsGetter,
+	keysNamespace string,
+	encryptionSecretSelector metav1.ListOptions,
+	encryptedGRs []schema.GroupResource,
+) (current *encryptiondata.Config, desired map[schema.GroupResource]state.GroupResourceState, encryptionSecrets []*corev1.Secret, transitioningReason string, err error) {
 	// get current config
 	encryptionConfigSecret, converged, err := deployer.DeployedEncryptionConfigSecret(ctx)
 	if err != nil {
@@ -52,7 +65,7 @@ func GetEncryptionConfigAndState(
 	}
 
 	// compute desired config
-	encryptionSecrets, err = secrets.ListKeySecrets(ctx, secretClient, encryptionSecretSelector)
+	encryptionSecrets, err = secrets.ListKeySecretsInNamespace(ctx, secretClient, keysNamespace, encryptionSecretSelector)
 	if err != nil {
 		return nil, nil, nil, "", err
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * KMS preflight checks now generate and validate encryption configuration in an isolated temporary environment.
  * Preflight processing supports existing encryption keys, provider changes, and deployments that are not yet fully converged.
  * Encryption keys and configuration can be read from configurable namespaces.
  * Temporary environments are automatically cleaned up, with cleanup issues reported as warnings.
* **Bug Fixes**
  * KMS endpoints are correctly rewritten for preflight validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->