### PR TITLE
crypto,configobserver: add TLS group/curve mapping and observer support

### DIFF
--- a/pkg/crypto/crypto.go
+++ b/pkg/crypto/crypto.go
@@ -356,6 +356,54 @@ func OpenSSLToIANACipherSuites(ciphers []string) []string {
 	return ianaCiphers
 }
 
+// tlsGroupToCurveID maps OpenShift API TLSGroup values to Go's tls.CurveID.
+// Ref: https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8
+var tlsGroupToCurveID = map[configv1.TLSGroup]tls.CurveID{
+	configv1.TLSGroupX25519:             tls.X25519,
+	configv1.TLSGroupSecP256r1:          tls.CurveP256,
+	configv1.TLSGroupSecP384r1:          tls.CurveP384,
+	configv1.TLSGroupSecP521r1:          tls.CurveP521,
+	configv1.TLSGroupX25519MLKEM768:     tls.X25519MLKEM768,
+	configv1.TLSGroupSecP256r1MLKEM768:  tls.SecP256r1MLKEM768,  // IANA 4587
+	configv1.TLSGroupSecP384r1MLKEM1024: tls.SecP384r1MLKEM1024, // IANA 4589
+}
+
+// CurveIDForTLSGroup maps an OpenShift API TLSGroup constant to Go's tls.CurveID.
+// Returns (0, false) if the group is not known/mapped by library-go.
+func CurveIDForTLSGroup(group configv1.TLSGroup) (tls.CurveID, bool) {
+	id, ok := tlsGroupToCurveID[group]
+	return id, ok
+}
+
+// CurveIDsForTLSGroups converts a slice of TLSGroup values to their tls.CurveID
+// codes. Returns the recognized curve IDs and a list of unrecognized group names.
+// Unrecognized groups are silently filtered — callers should log warnings.
+func CurveIDsForTLSGroups(groups []configv1.TLSGroup) ([]tls.CurveID, []string) {
+	var curves []tls.CurveID
+	var unrecognized []string
+
+	for _, group := range groups {
+		id, ok := CurveIDForTLSGroup(group)
+		if !ok {
+			unrecognized = append(unrecognized, string(group))
+			continue
+		}
+		curves = append(curves, id)
+	}
+
+	return curves, unrecognized
+}
+
+// ValidTLSGroups returns TLS group names known/mapped by library-go, sorted alphabetically.
+func ValidTLSGroups() []string {
+	groups := make([]string, 0, len(tlsGroupToCurveID))
+	for g := range tlsGroupToCurveID {
+		groups = append(groups, string(g))
+	}
+	sort.Strings(groups)
+	return groups
+}
+
 type TLSCertificateConfig struct {
 	Certs []*x509.Certificate
 	Key   crypto.PrivateKey

--- a/pkg/crypto/crypto_test.go
+++ b/pkg/crypto/crypto_test.go
@@ -2,10 +2,12 @@ package crypto
 
 import (
 	"crypto"
+	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"fmt"
 	"go/importer"
+	"go/types"
 	"os"
 	"path/filepath"
 	"sort"
@@ -19,6 +21,20 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 )
+
+// goTLSGroups lists all TLS supported groups (key exchange mechanisms) recognized
+// by Go's crypto/tls, keyed by Go constant name. Kept in sync with the crypto/tls
+// package by TestConstantMaps.
+// Ref: https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8
+var goTLSGroups = map[string]tls.CurveID{
+	"CurveP256":          tls.CurveP256,
+	"CurveP384":          tls.CurveP384,
+	"CurveP521":          tls.CurveP521,
+	"X25519":             tls.X25519,
+	"X25519MLKEM768":     tls.X25519MLKEM768,
+	"SecP256r1MLKEM768":  tls.SecP256r1MLKEM768,
+	"SecP384r1MLKEM1024": tls.SecP384r1MLKEM1024,
+}
 
 const certificateLifetime = time.Hour * 24 * 365 * 2
 
@@ -36,12 +52,57 @@ func TestConstantMaps(t *testing.T) {
 	}
 	discoveredVersions := map[string]bool{}
 	discoveredCiphers := map[string]bool{}
+	discoveredGroups := map[string]bool{}
+	// knownUnrelatedConstants are TLS package constants that are not versions, ciphers, or groups.
+	// If a new constant appears that isn't classified below, the test logs a warning so it can be
+	// assigned to the correct category or added here.
+	knownUnrelatedConstants := map[string]bool{
+		// Renegotiation modes
+		"RenegotiateNever": true, "RenegotiateOnceAsClient": true, "RenegotiateFreelyAsClient": true,
+		// Client auth types
+		"NoClientCert": true, "RequestClientCert": true, "RequireAnyClientCert": true,
+		"VerifyClientCertIfGiven": true, "RequireAndVerifyClientCert": true,
+		// Deprecated version aliases
+		"TLS10": true, "TLS11": true, "TLS12": true, "TLS13": true, "VersionSSL30": true,
+		// QUIC events
+		"QUICEncryptionLevelInitial": true, "QUICEncryptionLevelEarly": true,
+		"QUICEncryptionLevelHandshake": true, "QUICEncryptionLevelApplication": true,
+		"QUICNoEvent": true, "QUICSetReadSecret": true, "QUICSetWriteSecret": true,
+		"QUICWriteData": true, "QUICTransportParameters": true, "QUICTransportParametersRequired": true,
+		"QUICRejectedEarlyData": true, "QUICHandshakeDone": true, "QUICResumeSession": true,
+		"QUICStoreSession": true, "QUICErrorEvent": true,
+		// Alert codes
+		"AlertNoRenegotiation": true,
+		// Signature schemes
+		"ECDSAWithP256AndSHA256": true, "ECDSAWithP384AndSHA384": true, "ECDSAWithP521AndSHA512": true,
+		"ECDSAWithSHA1": true, "Ed25519": true,
+		"PKCS1WithSHA1": true, "PKCS1WithSHA256": true, "PKCS1WithSHA384": true, "PKCS1WithSHA512": true,
+		"PSSWithSHA256": true, "PSSWithSHA384": true, "PSSWithSHA512": true,
+		// Fallback SCSV sentinel
+		"TLS_FALLBACK_SCSV": true,
+	}
 	for _, declName := range pkg.Scope().Names() {
+		// Only examine exported constants; skip types, funcs, vars, unexported names.
+		obj := pkg.Scope().Lookup(declName)
+		if _, isConst := obj.(*types.Const); !isConst {
+			continue
+		}
 		if strings.HasPrefix(declName, "VersionTLS") {
 			discoveredVersions[declName] = true
+			continue
 		}
 		if strings.HasPrefix(declName, "TLS_RSA_") || strings.HasPrefix(declName, "TLS_ECDHE_") || strings.HasPrefix(declName, "TLS_AES_") || strings.HasPrefix(declName, "TLS_CHACHA20_") {
 			discoveredCiphers[declName] = true
+			continue
+		}
+		if strings.HasPrefix(declName, "CurveP") || strings.HasPrefix(declName, "X25519") || strings.HasPrefix(declName, "SecP") {
+			discoveredGroups[declName] = true
+			continue
+		}
+		if !knownUnrelatedConstants[declName] {
+			// New unclassified constant: decide if it's a version, cipher, group, or unrelated,
+			// then add it to the appropriate map or knownUnrelatedConstants.
+			t.Logf("unclassified tls constant %s — add to the appropriate map", declName)
 		}
 	}
 
@@ -70,6 +131,17 @@ func TestConstantMaps(t *testing.T) {
 	for k := range enabledTLSVersions {
 		if _, ok := discoveredVersions[k]; !ok {
 			t.Errorf("enabledTLSVersions map has %s not in tls package", k)
+		}
+	}
+
+	for k := range discoveredGroups {
+		if _, ok := goTLSGroups[k]; !ok {
+			t.Errorf("discovered group tls.%s not in goTLSGroups map", k)
+		}
+	}
+	for k := range goTLSGroups {
+		if _, ok := discoveredGroups[k]; !ok {
+			t.Errorf("goTLSGroups map has %s not in tls package", k)
 		}
 	}
 
@@ -595,6 +667,124 @@ func TestCiphersUnsupportedByGoAreActuallyUnsupported(t *testing.T) {
 			t.Errorf("cipher %q (IANA: %q) is in ciphersUnsupportedByGo but Go now supports it — "+
 				"remove it from ciphersUnsupportedByGo and add a mapping to openSSLToIANACiphers",
 				opensslName, ianaName)
+		}
+	}
+}
+
+// TestTLSProfileGroupsHaveMappings verifies that all TLS groups defined in the
+// OpenShift TLS security profiles have corresponding mappings in tlsGroupToCurveID.
+func TestTLSProfileGroupsHaveMappings(t *testing.T) {
+	var missingMappings []string
+
+	for profileType, profileSpec := range configv1.TLSProfiles {
+		for _, group := range profileSpec.Groups {
+			if _, found := tlsGroupToCurveID[group]; !found {
+				missingMappings = append(missingMappings, fmt.Sprintf("%s (profile: %s)", group, profileType))
+			}
+		}
+	}
+
+	if len(missingMappings) > 0 {
+		sort.Strings(missingMappings)
+		t.Errorf("The following TLS groups from TLS profiles are missing mappings in tlsGroupToCurveID:\n%s",
+			strings.Join(missingMappings, "\n"))
+	}
+}
+
+func TestCurveIDForTLSGroup(t *testing.T) {
+	tests := []struct {
+		group  configv1.TLSGroup
+		wantID tls.CurveID
+		wantOK bool
+	}{
+		{configv1.TLSGroupX25519, tls.X25519, true},
+		{configv1.TLSGroupSecP256r1, tls.CurveP256, true},
+		{configv1.TLSGroupSecP384r1, tls.CurveP384, true},
+		{configv1.TLSGroupSecP521r1, tls.CurveP521, true},
+		{configv1.TLSGroupX25519MLKEM768, tls.X25519MLKEM768, true},
+		{configv1.TLSGroupSecP256r1MLKEM768, tls.SecP256r1MLKEM768, true},
+		{configv1.TLSGroupSecP384r1MLKEM1024, tls.SecP384r1MLKEM1024, true},
+		{configv1.TLSGroup("UnknownGroup"), 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.group), func(t *testing.T) {
+			gotID, gotOK := CurveIDForTLSGroup(tt.group)
+			if gotID != tt.wantID {
+				t.Errorf("CurveIDForTLSGroup(%q) id = %d, want %d", tt.group, gotID, tt.wantID)
+			}
+			if gotOK != tt.wantOK {
+				t.Errorf("CurveIDForTLSGroup(%q) ok = %v, want %v", tt.group, gotOK, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestCurveIDsForTLSGroups(t *testing.T) {
+	tests := []struct {
+		name             string
+		groups           []configv1.TLSGroup
+		wantCurves       []tls.CurveID
+		wantUnrecognized []string
+	}{
+		{
+			name:       "all recognized",
+			groups:     []configv1.TLSGroup{configv1.TLSGroupX25519, configv1.TLSGroupSecP256r1},
+			wantCurves: []tls.CurveID{tls.X25519, tls.CurveP256},
+		},
+		{
+			name:             "unknown group filtered",
+			groups:           []configv1.TLSGroup{configv1.TLSGroupX25519, "UnknownGroup"},
+			wantCurves:       []tls.CurveID{tls.X25519},
+			wantUnrecognized: []string{"UnknownGroup"},
+		},
+		{
+			name:   "empty",
+			groups: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotCurves, gotUnrecognized := CurveIDsForTLSGroups(tt.groups)
+			if len(gotCurves) != len(tt.wantCurves) {
+				t.Errorf("CurveIDsForTLSGroups curves len = %d, want %d", len(gotCurves), len(tt.wantCurves))
+			} else {
+				for i := range gotCurves {
+					if gotCurves[i] != tt.wantCurves[i] {
+						t.Errorf("CurveIDsForTLSGroups curves[%d] = %d, want %d", i, gotCurves[i], tt.wantCurves[i])
+					}
+				}
+			}
+			if len(gotUnrecognized) != len(tt.wantUnrecognized) {
+				t.Errorf("CurveIDsForTLSGroups unrecognized len = %d, want %d", len(gotUnrecognized), len(tt.wantUnrecognized))
+			}
+		})
+	}
+}
+
+func TestValidTLSGroups(t *testing.T) {
+	groups := ValidTLSGroups()
+	if len(groups) == 0 {
+		t.Error("ValidTLSGroups returned empty list")
+	}
+	// Verify it's sorted
+	for i := 1; i < len(groups); i++ {
+		if groups[i] < groups[i-1] {
+			t.Errorf("ValidTLSGroups not sorted: %q before %q", groups[i-1], groups[i])
+		}
+	}
+	// Verify all groups in tlsGroupToCurveID are present
+	for g := range tlsGroupToCurveID {
+		found := false
+		for _, name := range groups {
+			if name == string(g) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("ValidTLSGroups missing group %q from tlsGroupToCurveID", g)
 		}
 	}
 }

--- a/pkg/operator/configobserver/apiserver/observe_tlssecurityprofile.go
+++ b/pkg/operator/configobserver/apiserver/observe_tlssecurityprofile.go
@@ -26,6 +26,14 @@ func ObserveTLSSecurityProfileWithPaths(genericListers configobserver.Listers, r
 	return innerTLSSecurityProfileObservations(genericListers, recorder, existingConfig, minTLSVersionPath, cipherSuitesPath)
 }
 
+// ObserveTLSSecurityProfileWithGroupPaths is like ObserveTLSSecurityProfileWithPaths but also
+// observes the TLS group (curve) preferences at groupsPath. Group names are stored as []string
+// matching the TLSGroup constants from openshift/api and can be passed directly to operands
+// that accept group names as CLI arguments.
+func ObserveTLSSecurityProfileWithGroupPaths(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}, minTLSVersionPath, cipherSuitesPath, groupsPath []string) (map[string]interface{}, []error) {
+	return innerTLSSecurityProfileObservationsWithGroups(genericListers, recorder, existingConfig, minTLSVersionPath, cipherSuitesPath, groupsPath)
+}
+
 // ObserveTLSSecurityProfileToArguments observes APIServer.Spec.TLSSecurityProfile field and sets
 // the tls-min-version and tls-cipher-suites fileds of observedConfig.apiServerArguments
 func ObserveTLSSecurityProfileToArguments(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (map[string]interface{}, []error) {
@@ -106,4 +114,99 @@ func getSecurityProfileCiphers(profile *configv1.TLSSecurityProfile) (string, []
 
 	// need to remap all Ciphers to their respective IANA names used by Go
 	return string(profileSpec.MinTLSVersion), crypto.OpenSSLToIANACipherSuites(profileSpec.Ciphers)
+}
+
+// getSecurityProfileGroups returns the TLS group preference names for the given
+// TLSSecurityProfile as []string. The strings match the TLSGroup constants from
+// openshift/api and can be passed directly to operands that accept group names as
+// CLI arguments. Returns nil when no groups are configured (e.g. a Custom profile
+// with an empty groups list).
+func getSecurityProfileGroups(profile *configv1.TLSSecurityProfile) []string {
+	var profileType configv1.TLSProfileType
+	if profile == nil {
+		profileType = crypto.DefaultTLSProfileType
+	} else {
+		profileType = profile.Type
+	}
+
+	var profileSpec *configv1.TLSProfileSpec
+	if profileType == configv1.TLSProfileCustomType {
+		if profile.Custom != nil {
+			profileSpec = &profile.Custom.TLSProfileSpec
+		}
+	} else {
+		profileSpec = configv1.TLSProfiles[profileType]
+	}
+
+	if profileSpec == nil {
+		profileSpec = configv1.TLSProfiles[crypto.DefaultTLSProfileType]
+	}
+
+	groups := make([]string, 0, len(profileSpec.Groups))
+	for _, g := range profileSpec.Groups {
+		if _, ok := crypto.CurveIDForTLSGroup(g); !ok {
+			klog.V(4).Infof("Dropping TLS group %q: not supported by Go's crypto/tls", g)
+			continue
+		}
+		groups = append(groups, string(g))
+	}
+	return groups
+}
+
+func innerTLSSecurityProfileObservationsWithGroups(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}, minTLSVersionPath, cipherSuitesPath, groupsPath []string) (ret map[string]interface{}, _ []error) {
+	defer func() {
+		ret = configobserver.Pruned(ret, minTLSVersionPath, cipherSuitesPath, groupsPath)
+	}()
+
+	listers := genericListers.(APIServerLister)
+	errs := []error{}
+
+	currentMinTLSVersion, _, versionErr := unstructured.NestedString(existingConfig, minTLSVersionPath...)
+	if versionErr != nil {
+		errs = append(errs, fmt.Errorf("failed to retrieve spec.servingInfo.minTLSVersion: %v", versionErr))
+	}
+
+	currentCipherSuites, _, suitesErr := unstructured.NestedStringSlice(existingConfig, cipherSuitesPath...)
+	if suitesErr != nil {
+		errs = append(errs, fmt.Errorf("failed to retrieve spec.servingInfo.cipherSuites: %v", suitesErr))
+	}
+
+	currentGroups, _, groupsErr := unstructured.NestedStringSlice(existingConfig, groupsPath...)
+	if groupsErr != nil {
+		errs = append(errs, fmt.Errorf("failed to retrieve groups: %v", groupsErr))
+	}
+
+	apiServer, err := listers.APIServerLister().Get("cluster")
+	if errors.IsNotFound(err) {
+		klog.Warningf("apiserver.config.openshift.io/cluster: not found")
+		apiServer = &configv1.APIServer{}
+	} else if err != nil {
+		return existingConfig, append(errs, err)
+	}
+
+	observedConfig := map[string]interface{}{}
+	observedMinTLSVersion, observedCipherSuites := getSecurityProfileCiphers(apiServer.Spec.TLSSecurityProfile)
+	observedGroups := getSecurityProfileGroups(apiServer.Spec.TLSSecurityProfile)
+
+	if err = unstructured.SetNestedField(observedConfig, observedMinTLSVersion, minTLSVersionPath...); err != nil {
+		return existingConfig, append(errs, err)
+	}
+	if err = unstructured.SetNestedStringSlice(observedConfig, observedCipherSuites, cipherSuitesPath...); err != nil {
+		return existingConfig, append(errs, err)
+	}
+	if err = unstructured.SetNestedStringSlice(observedConfig, observedGroups, groupsPath...); err != nil {
+		return existingConfig, append(errs, err)
+	}
+
+	if observedMinTLSVersion != currentMinTLSVersion {
+		recorder.Eventf("ObserveTLSSecurityProfile", "minTLSVersion changed to %s", observedMinTLSVersion)
+	}
+	if !reflect.DeepEqual(observedCipherSuites, currentCipherSuites) {
+		recorder.Eventf("ObserveTLSSecurityProfile", "cipherSuites changed to %q", observedCipherSuites)
+	}
+	if !reflect.DeepEqual(observedGroups, currentGroups) {
+		recorder.Eventf("ObserveTLSSecurityProfile", "groups changed to %q", observedGroups)
+	}
+
+	return observedConfig, errs
 }

--- a/pkg/operator/configobserver/apiserver/observe_tlssecurityprofile_test.go
+++ b/pkg/operator/configobserver/apiserver/observe_tlssecurityprofile_test.go
@@ -156,3 +156,131 @@ func TestObserveTLSSecurityProfile(t *testing.T) {
 		})
 	}
 }
+
+func TestObserveTLSSecurityProfileWithGroupPaths(t *testing.T) {
+	defaultGroups := []string{"X25519MLKEM768", "X25519", "secp256r1", "secp384r1"}
+
+	tests := []struct {
+		name           string
+		config         *configv1.TLSSecurityProfile
+		expectedGroups []string
+	}{
+		{
+			name:           "NoAPIServerConfig",
+			config:         nil,
+			expectedGroups: defaultGroups,
+		},
+		{
+			name: "IntermediateProfile",
+			config: &configv1.TLSSecurityProfile{
+				Type:         configv1.TLSProfileIntermediateType,
+				Intermediate: &configv1.IntermediateTLSProfile{},
+			},
+			expectedGroups: defaultGroups,
+		},
+		{
+			name: "OldProfile",
+			config: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileOldType,
+				Old:  &configv1.OldTLSProfile{},
+			},
+			expectedGroups: defaultGroups,
+		},
+		{
+			name: "ModernProfile",
+			config: &configv1.TLSSecurityProfile{
+				Type:   configv1.TLSProfileModernType,
+				Modern: &configv1.ModernTLSProfile{},
+			},
+			expectedGroups: defaultGroups,
+		},
+		{
+			name: "CustomProfileNoGroups",
+			config: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						MinTLSVersion: configv1.VersionTLS12,
+						Ciphers:       []string{"ECDHE-RSA-AES128-GCM-SHA256"},
+					},
+				},
+			},
+			expectedGroups: []string{},
+		},
+		{
+			name: "CustomProfileWithGroups",
+			config: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						MinTLSVersion: configv1.VersionTLS12,
+						Ciphers:       []string{"ECDHE-RSA-AES128-GCM-SHA256"},
+						Groups:        []configv1.TLSGroup{configv1.TLSGroupX25519, configv1.TLSGroupSecP256r1},
+					},
+				},
+			},
+			expectedGroups: []string{"X25519", "secp256r1"},
+		},
+		{
+			name: "CustomProfileWithUnknownGroup",
+			config: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						MinTLSVersion: configv1.VersionTLS12,
+						Ciphers:       []string{"ECDHE-RSA-AES128-GCM-SHA256"},
+						Groups:        []configv1.TLSGroup{configv1.TLSGroupX25519, "UnknownFutureGroup"},
+					},
+				},
+			},
+			expectedGroups: []string{"X25519"}, // "UnknownFutureGroup" must be dropped
+		},
+	}
+
+	minTLSVersionPath := []string{"olmTLS", "minTLSVersion"}
+	cipherSuitesPath := []string{"olmTLS", "cipherSuites"}
+	groupsPath := []string{"olmTLS", "curvePreferences"}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			if tt.config != nil {
+				if err := indexer.Add(&configv1.APIServer{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Spec:       configv1.APIServerSpec{TLSSecurityProfile: tt.config},
+				}); err != nil {
+					t.Fatal(err)
+				}
+			}
+			listers := testLister{apiLister: configlistersv1.NewAPIServerLister(indexer)}
+
+			result, errs := ObserveTLSSecurityProfileWithGroupPaths(
+				listers,
+				events.NewInMemoryRecorder(t.Name(), clocktesting.NewFakePassiveClock(time.Now())),
+				map[string]interface{}{},
+				minTLSVersionPath,
+				cipherSuitesPath,
+				groupsPath,
+			)
+			if len(errs) > 0 {
+				t.Errorf("expected 0 errors, got %v", errs)
+			}
+
+			gotGroups, _, err := unstructured.NestedStringSlice(result, groupsPath...)
+			if err != nil {
+				t.Errorf("couldn't get groups from result: %v", err)
+			}
+
+			if !reflect.DeepEqual(gotGroups, tt.expectedGroups) {
+				t.Errorf("got groups = %v, expected %v", gotGroups, tt.expectedGroups)
+			}
+
+			// Verify the result is pruned to only the observed paths
+			for k := range result {
+				if k != "olmTLS" {
+					t.Errorf("unexpected key %q in pruned result", k)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `CurveIDForTLSGroup`, `CurveIDsForTLSGroups`, and `ValidTLSGroups` to `pkg/crypto` to map OpenShift API `TLSGroup` constants to Go `tls.CurveID` values
- Adds `ObserveTLSSecurityProfileWithGroupPaths` to `pkg/operator/configobserver/apiserver` so operators can observe TLS curve preferences alongside ciphers/version
- Adds `getSecurityProfileGroups` which extracts groups as `[]string` from a `TLSSecurityProfile` (strings match `TLSGroup` constants directly, usable as CLI arguments)

Addresses open review comments from PR #2347 (this PR supersedes/builds on that work):
- **Bug fix**: SecP384r1MLKEM1024 IANA ID is 4589, not 4590
- **TODOs resolved**: Go 1.26 is already the module minimum (`go 1.26.0` in go.mod), so `tls.SecP256r1MLKEM768` and `tls.SecP384r1MLKEM1024` named constants are used directly instead of raw numeric IDs
- **Doc fix**: `CurveIDForTLSGroup` and `ValidTLSGroups` now say "known/mapped by library-go" instead of "supported by this Go version"
- **Test improvement**: `TestConstantMaps` now includes `SecP` prefix to catch Go 1.26 group constants, uses type-filtering to classify only `*types.Const` values, and has a default case for unclassified constants
- **Test organization**: `goTLSGroups` moved to `crypto_test.go` (test-only, not production code)

## Test plan

- [x] `go test ./pkg/crypto/...` passes
- [x] `go test ./pkg/operator/configobserver/apiserver/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring TLS curve groups, including post-quantum hybrid groups.
  * TLS security profiles now apply configured groups to API server settings.
  * Unsupported TLS groups are skipped and reported.
  * Added support for custom configuration paths when observing TLS group settings.

* **Tests**
  * Added coverage for TLS group mappings, profile behavior, supported groups, and invalid group handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->