### PR TITLE
NO-JIRA: Dynamic namespace instead of hard coded openshift-config-managed

### DIFF
--- a/pkg/operator/apiserver/controllerset/apiservercontrollerset.go
+++ b/pkg/operator/apiserver/controllerset/apiservercontrollerset.go
@@ -360,6 +360,7 @@ func (cs *APIServerControllerSet) WithoutPruneController() *APIServerControllerS
 
 func (cs *APIServerControllerSet) WithEncryptionControllers(
 	component string,
+	encryptionSecretNamespace string,
 	provider controllers.Provider,
 	deployer statemachine.Deployer,
 	migrator migrators.Migrator,
@@ -376,6 +377,7 @@ func (cs *APIServerControllerSet) WithEncryptionControllers(
 		eventRecorder:  cs.eventRecorder,
 
 		component:                  component,
+		encryptionSecretNamespace:  encryptionSecretNamespace,
 		provider:                   provider,
 		deployer:                   deployer,
 		migrator:                   migrator,
@@ -483,6 +485,7 @@ type encryptionControllerBuilder struct {
 	eventRecorder  events.Recorder
 
 	component                  string
+	encryptionSecretNamespace  string
 	provider                   controllers.Provider
 	deployer                   statemachine.Deployer
 	migrator                   migrators.Migrator
@@ -503,6 +506,7 @@ func (e *encryptionControllerBuilder) build() []controllerWrapper {
 
 	controllers, err := encryption.NewControllers(
 		e.component,
+		e.encryptionSecretNamespace,
 		e.unsupportedConfigPrefix,
 		e.provider,
 		e.deployer,

--- a/pkg/operator/encryption/controllers.go
+++ b/pkg/operator/encryption/controllers.go
@@ -25,6 +25,7 @@ import (
 
 func NewControllers(
 	component string,
+	encryptionSecretNamespace string,
 	unsupportedConfigPrefix []string,
 	provider controllers.Provider,
 	deployer statemachine.Deployer,
@@ -44,7 +45,7 @@ func NewControllers(
 	// TODO: update the eventHandlers used by the controllers to ignore components that do not match their own
 	encryptionSecretSelector := metav1.ListOptions{LabelSelector: secrets.EncryptionKeySecretsLabel + "=" + component}
 
-	encryptionEnabledChecker, err := newEncryptionEnabledPrecondition(apiServerInformer.Lister(), kubeInformersForNamespaces, encryptionSecretSelector.LabelSelector, component)
+	encryptionEnabledChecker, err := newEncryptionEnabledPrecondition(apiServerInformer.Lister(), kubeInformersForNamespaces, encryptionSecretNamespace, encryptionSecretSelector.LabelSelector, component)
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +54,7 @@ func NewControllers(
 	if resourceSyncer != nil {
 		if err := resourceSyncer.SyncSecretConditionally(
 			resourcesynccontroller.ResourceLocation{Namespace: component, Name: encryptiondata.EncryptionConfSecretName},
-			resourcesynccontroller.ResourceLocation{Namespace: "openshift-config-managed", Name: fmt.Sprintf("%s-%s", encryptiondata.EncryptionConfSecretName, component)},
+			resourcesynccontroller.ResourceLocation{Namespace: encryptionSecretNamespace, Name: fmt.Sprintf("%s-%s", encryptiondata.EncryptionConfSecretName, component)},
 			encryptionEnabledChecker.PreconditionFulfilled,
 		); err != nil {
 			return nil, err
@@ -63,6 +64,7 @@ func NewControllers(
 	return []factory.Controller{
 		controllers.NewKeyController(
 			component,
+			encryptionSecretNamespace,
 			unsupportedConfigPrefix,
 			provider,
 			deployer,
@@ -78,6 +80,7 @@ func NewControllers(
 		),
 		controllers.NewStateController(
 			component,
+			encryptionSecretNamespace,
 			provider,
 			deployer,
 			encryptionEnabledChecker.PreconditionFulfilled,
@@ -90,6 +93,7 @@ func NewControllers(
 		),
 		controllers.NewPruneController(
 			component,
+			encryptionSecretNamespace,
 			provider,
 			deployer,
 			encryptionEnabledChecker.PreconditionFulfilled,
@@ -102,6 +106,7 @@ func NewControllers(
 		),
 		controllers.NewMigrationController(
 			component,
+			encryptionSecretNamespace,
 			provider,
 			deployer,
 			encryptionEnabledChecker.PreconditionFulfilled,
@@ -115,6 +120,7 @@ func NewControllers(
 		),
 		controllers.NewConditionController(
 			component,
+			encryptionSecretNamespace,
 			provider,
 			deployer,
 			encryptionEnabledChecker.PreconditionFulfilled,

--- a/pkg/operator/encryption/controllers/condition_controller.go
+++ b/pkg/operator/encryption/controllers/condition_controller.go
@@ -25,8 +25,9 @@ import (
 // conditionController maintains the Encrypted condition. It sets it to true iff there is a
 // fully migrated read-key in the current config, and no later key is of identity type.
 type conditionController struct {
-	controllerInstanceName string
-	operatorClient         operatorv1helpers.OperatorClient
+	controllerInstanceName    string
+	encryptionSecretNamespace string
+	operatorClient            operatorv1helpers.OperatorClient
 
 	encryptionSecretSelector metav1.ListOptions
 
@@ -38,6 +39,7 @@ type conditionController struct {
 
 func NewConditionController(
 	instanceName string,
+	encryptionSecretNamespace string,
 	provider Provider,
 	deployer statemachine.Deployer,
 	preconditionsFulfilledFn preconditionsFulfilled,
@@ -49,8 +51,9 @@ func NewConditionController(
 	eventRecorder events.Recorder,
 ) factory.Controller {
 	c := &conditionController{
-		controllerInstanceName: factory.ControllerInstanceName(instanceName, "EncryptionCondition"),
-		operatorClient:         operatorClient,
+		controllerInstanceName:    factory.ControllerInstanceName(instanceName, "EncryptionCondition"),
+		encryptionSecretNamespace: encryptionSecretNamespace,
+		operatorClient:            operatorClient,
 
 		encryptionSecretSelector: encryptionSecretSelector,
 		deployer:                 deployer,
@@ -60,7 +63,7 @@ func NewConditionController(
 	}
 
 	return factory.New().WithInformers(
-		kubeInformersForNamespaces.InformersFor("openshift-config-managed").Core().V1().Secrets().Informer(),
+		kubeInformersForNamespaces.InformersFor(c.encryptionSecretNamespace).Core().V1().Secrets().Informer(),
 		operatorClient.Informer(),
 		apiServerConfigInformer.Informer(), // do not remove, used by the precondition checker
 		deployer,
@@ -96,7 +99,7 @@ func (c *conditionController) sync(ctx context.Context, _ factory.SyncContext) (
 	}
 
 	encryptedGRs := c.provider.EncryptedGRs()
-	currentConfig, desiredState, foundSecrets, transitioningReason, err := statemachine.GetEncryptionConfigAndState(ctx, c.deployer, c.secretClient, c.encryptionSecretSelector, encryptedGRs)
+	currentConfig, desiredState, foundSecrets, transitioningReason, err := statemachine.GetEncryptionConfigAndState(ctx, c.encryptionSecretNamespace, c.deployer, c.secretClient, c.encryptionSecretSelector, encryptedGRs)
 	if err != nil || len(transitioningReason) > 0 {
 		// do not update the encryption condition (cond). Note: progressing is set elsewhere.
 		cond = nil

--- a/pkg/operator/encryption/controllers/key_controller.go
+++ b/pkg/operator/encryption/controllers/key_controller.go
@@ -69,9 +69,10 @@ type keyController struct {
 	operatorClient  operatorv1helpers.OperatorClient
 	apiServerClient configv1client.APIServerInterface
 
-	controllerInstanceName   string
-	instanceName             string
-	encryptionSecretSelector metav1.ListOptions
+	controllerInstanceName    string
+	instanceName              string
+	encryptionSecretNamespace string
+	encryptionSecretSelector  metav1.ListOptions
 
 	deployer                 statemachine.Deployer
 	secretClient             corev1client.SecretsGetter
@@ -84,6 +85,7 @@ type keyController struct {
 
 func NewKeyController(
 	instanceName string,
+	encryptionSecretNamespace string,
 	unsupportedConfigPrefix []string,
 	provider Provider,
 	deployer statemachine.Deployer,
@@ -101,9 +103,10 @@ func NewKeyController(
 		operatorClient:  operatorClient,
 		apiServerClient: apiServerClient,
 
-		instanceName:            instanceName,
-		controllerInstanceName:  factory.ControllerInstanceName(instanceName, "EncryptionKey"),
-		unsupportedConfigPrefix: unsupportedConfigPrefix,
+		instanceName:              instanceName,
+		controllerInstanceName:    factory.ControllerInstanceName(instanceName, "EncryptionKey"),
+		encryptionSecretNamespace: encryptionSecretNamespace,
+		unsupportedConfigPrefix:   unsupportedConfigPrefix,
 
 		encryptionSecretSelector: encryptionSecretSelector,
 		deployer:                 deployer,
@@ -123,7 +126,7 @@ func NewKeyController(
 		WithInformers(
 			apiServerInformer.Informer(),
 			operatorClient.Informer(),
-			kubeInformersForNamespaces.InformersFor("openshift-config-managed").Core().V1().Secrets().Informer(),
+			kubeInformersForNamespaces.InformersFor(c.encryptionSecretNamespace).Core().V1().Secrets().Informer(),
 			// openshift-config secrets/configmaps are not watched directly. While we could
 			// build a mechanism to watch only the referenced resources, creating and
 			// maintaining it is not free, and watching all resources in the namespace
@@ -181,7 +184,7 @@ func (c *keyController) checkAndCreateKeys(ctx context.Context, syncContext fact
 		return err
 	}
 
-	currentConfig, desiredEncryptionState, secrets, isProgressingReason, err := statemachine.GetEncryptionConfigAndState(ctx, c.deployer, c.secretClient, c.encryptionSecretSelector, encryptedGRs)
+	currentConfig, desiredEncryptionState, secrets, isProgressingReason, err := statemachine.GetEncryptionConfigAndState(ctx, c.encryptionSecretNamespace, c.deployer, c.secretClient, c.encryptionSecretSelector, encryptedGRs)
 	if err != nil {
 		return err
 	}
@@ -251,7 +254,7 @@ func (c *keyController) checkAndCreateKeys(ctx context.Context, syncContext fact
 	if err != nil {
 		return fmt.Errorf("failed to create key: %v", err)
 	}
-	_, createErr := c.secretClient.Secrets("openshift-config-managed").Create(ctx, keySecret, metav1.CreateOptions{})
+	_, createErr := c.secretClient.Secrets(c.encryptionSecretNamespace).Create(ctx, keySecret, metav1.CreateOptions{})
 	if errors.IsAlreadyExists(createErr) {
 		return c.validateExistingSecret(ctx, keySecret, newKeyID)
 	}
@@ -266,7 +269,7 @@ func (c *keyController) checkAndCreateKeys(ctx context.Context, syncContext fact
 }
 
 func (c *keyController) validateExistingSecret(ctx context.Context, keySecret *corev1.Secret, keyID uint64) error {
-	actualKeySecret, err := c.secretClient.Secrets("openshift-config-managed").Get(ctx, keySecret.Name, metav1.GetOptions{})
+	actualKeySecret, err := c.secretClient.Secrets(c.encryptionSecretNamespace).Get(ctx, keySecret.Name, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -342,7 +345,7 @@ func (c *keyController) generateKeySecret(ctx context.Context, keyID uint64, cur
 			}
 		}
 	}
-	return secrets.FromKeyState(c.instanceName, ks)
+	return secrets.FromKeyState(c.encryptionSecretNamespace, c.instanceName, ks)
 }
 
 func (c *keyController) getCurrentModeReasonAndEncryptionConfig(ctx context.Context) (state.Mode, string, configv1.APIServerEncryption, error) {

--- a/pkg/operator/encryption/controllers/key_controller_test.go
+++ b/pkg/operator/encryption/controllers/key_controller_test.go
@@ -881,7 +881,7 @@ func TestKeyController(t *testing.T) {
 			}
 			provider := newTestProvider(scenario.targetGRs)
 
-			target := NewKeyController(scenario.targetNamespace, nil, provider, deployer, alwaysFulfilledPreconditions, fakeOperatorClient, fakeApiServerClient, fakeApiServerInformer, kubeInformers, fakeSecretClient, fakeConfigMapClient, scenario.encryptionSecretSelector, eventRecorder)
+			target := NewKeyController(scenario.targetNamespace, "openshift-config-managed", nil, provider, deployer, alwaysFulfilledPreconditions, fakeOperatorClient, fakeApiServerClient, fakeApiServerInformer, kubeInformers, fakeSecretClient, fakeConfigMapClient, scenario.encryptionSecretSelector, eventRecorder)
 
 			// act
 			err = target.Sync(context.TODO(), factory.NewSyncContext("test", eventRecorder))
@@ -974,7 +974,7 @@ func TestKMSMigrationTriggeredFields(t *testing.T) {
 			require.NoError(t, err)
 
 			provider := newTestProvider([]schema.GroupResource{{Group: "", Resource: "secrets"}})
-			target := NewKeyController("kms", nil, provider, deployer, alwaysFulfilledPreconditions, fakeOperatorClient, fakeApiServerClient, fakeApiServerInformer, kubeInformers, fakeSecretClient, fakeConfigMapClient, metav1.ListOptions{}, eventRecorder)
+			target := NewKeyController("kms", "openshift-config-managed", nil, provider, deployer, alwaysFulfilledPreconditions, fakeOperatorClient, fakeApiServerClient, fakeApiServerInformer, kubeInformers, fakeSecretClient, fakeConfigMapClient, metav1.ListOptions{}, eventRecorder)
 
 			err = target.Sync(context.TODO(), factory.NewSyncContext("test", eventRecorder))
 			require.NoError(t, err)

--- a/pkg/operator/encryption/controllers/migration_controller.go
+++ b/pkg/operator/encryption/controllers/migration_controller.go
@@ -55,8 +55,9 @@ const (
 //     encryption.apiserver.operator.openshift.io/migrated-resources annotations on the
 //     current write-key secrets.
 type migrationController struct {
-	instanceName           string
-	controllerInstanceName string
+	instanceName              string
+	controllerInstanceName    string
+	encryptionSecretNamespace string
 
 	operatorClient operatorv1helpers.OperatorClient
 	secretClient   corev1client.SecretsGetter
@@ -72,6 +73,7 @@ type migrationController struct {
 
 func NewMigrationController(
 	instanceName string,
+	encryptionSecretNamespace string,
 	provider Provider,
 	deployer statemachine.Deployer,
 	preconditionsFulfilledFn preconditionsFulfilled,
@@ -84,9 +86,10 @@ func NewMigrationController(
 	eventRecorder events.Recorder,
 ) factory.Controller {
 	c := &migrationController{
-		instanceName:           instanceName,
-		controllerInstanceName: factory.ControllerInstanceName(instanceName, "EncryptionMigration"),
-		operatorClient:         operatorClient,
+		instanceName:              instanceName,
+		controllerInstanceName:    factory.ControllerInstanceName(instanceName, "EncryptionMigration"),
+		encryptionSecretNamespace: encryptionSecretNamespace,
+		operatorClient:            operatorClient,
 
 		encryptionSecretSelector: encryptionSecretSelector,
 		secretClient:             secretClient,
@@ -99,7 +102,7 @@ func NewMigrationController(
 	return factory.New().ResyncEvery(time.Minute).WithSync(c.sync).WithControllerInstanceName(c.controllerInstanceName).WithInformers(
 		migrator,
 		operatorClient.Informer(),
-		kubeInformersForNamespaces.InformersFor("openshift-config-managed").Core().V1().Secrets().Informer(),
+		kubeInformersForNamespaces.InformersFor(c.encryptionSecretNamespace).Core().V1().Secrets().Informer(),
 		apiServerConfigInformer.Informer(), // do not remove, used by the precondition checker
 		deployer,
 	).ToController(
@@ -168,7 +171,7 @@ func (c *migrationController) sync(ctx context.Context, syncCtx factory.SyncCont
 // TODO doc
 func (c *migrationController) migrateKeysIfNeededAndRevisionStable(ctx context.Context, syncContext factory.SyncContext, encryptedGRs []schema.GroupResource) (migratingResources []schema.GroupResource, err error) {
 	// no storage migration during revision changes
-	currentEncryptionConfig, desiredEncryptionState, _, isTransitionalReason, err := statemachine.GetEncryptionConfigAndState(ctx, c.deployer, c.secretClient, c.encryptionSecretSelector, encryptedGRs)
+	currentEncryptionConfig, desiredEncryptionState, _, isTransitionalReason, err := statemachine.GetEncryptionConfigAndState(ctx, c.encryptionSecretNamespace, c.deployer, c.secretClient, c.encryptionSecretSelector, encryptedGRs)
 	if err != nil {
 		return nil, err
 	}
@@ -177,7 +180,7 @@ func (c *migrationController) migrateKeysIfNeededAndRevisionStable(ctx context.C
 		return nil, nil
 	}
 
-	encryptionSecrets, err := secrets.ListKeySecrets(ctx, c.secretClient, c.encryptionSecretSelector)
+	encryptionSecrets, err := secrets.ListKeySecrets(ctx, c.encryptionSecretNamespace, c.secretClient, c.encryptionSecretSelector)
 	if err != nil {
 		return nil, err
 	}
@@ -252,7 +255,7 @@ func (c *migrationController) migrateKeysIfNeededAndRevisionStable(ctx context.C
 		}
 
 		// update secret annotations
-		oldWriteKey, err := secrets.FromKeyState(c.instanceName, grActualKeys.WriteKey)
+		oldWriteKey, err := secrets.FromKeyState(c.encryptionSecretNamespace, c.instanceName, grActualKeys.WriteKey)
 		if err != nil {
 			errs = append(errs, result)
 			continue

--- a/pkg/operator/encryption/controllers/migration_controller_test.go
+++ b/pkg/operator/encryption/controllers/migration_controller_test.go
@@ -650,6 +650,7 @@ func TestMigrationController(t *testing.T) {
 			// act
 			target := NewMigrationController(
 				"kms",
+				"openshift-config-managed",
 				provider,
 				deployer,
 				alwaysFulfilledPreconditions,

--- a/pkg/operator/encryption/controllers/prune_controller.go
+++ b/pkg/operator/encryption/controllers/prune_controller.go
@@ -37,8 +37,9 @@ const (
 // them.  Keeping a small number of old keys around is meant to help facilitate
 // decryption of old backups (and general precaution).
 type pruneController struct {
-	controllerInstanceName string
-	operatorClient         operatorv1helpers.OperatorClient
+	controllerInstanceName    string
+	encryptionSecretNamespace string
+	operatorClient            operatorv1helpers.OperatorClient
 
 	encryptionSecretSelector metav1.ListOptions
 
@@ -50,6 +51,7 @@ type pruneController struct {
 
 func NewPruneController(
 	instanceName string,
+	encryptionSecretNamespace string,
 	provider Provider,
 	deployer statemachine.Deployer,
 	preconditionsFulfilledFn preconditionsFulfilled,
@@ -61,18 +63,19 @@ func NewPruneController(
 	eventRecorder events.Recorder,
 ) factory.Controller {
 	c := &pruneController{
-		operatorClient:           operatorClient,
-		controllerInstanceName:   factory.ControllerInstanceName(instanceName, "EncryptionPrune"),
-		encryptionSecretSelector: encryptionSecretSelector,
-		deployer:                 deployer,
-		provider:                 provider,
-		preconditionsFulfilledFn: preconditionsFulfilledFn,
-		secretClient:             secretClient,
+		operatorClient:            operatorClient,
+		controllerInstanceName:    factory.ControllerInstanceName(instanceName, "EncryptionPrune"),
+		encryptionSecretNamespace: encryptionSecretNamespace,
+		encryptionSecretSelector:  encryptionSecretSelector,
+		deployer:                  deployer,
+		provider:                  provider,
+		preconditionsFulfilledFn:  preconditionsFulfilledFn,
+		secretClient:              secretClient,
 	}
 
 	return factory.New().ResyncEvery(time.Minute).WithSync(c.sync).WithControllerInstanceName(c.controllerInstanceName).WithInformers(
 		operatorClient.Informer(),
-		kubeInformersForNamespaces.InformersFor("openshift-config-managed").Core().V1().Secrets().Informer(),
+		kubeInformersForNamespaces.InformersFor(c.encryptionSecretNamespace).Core().V1().Secrets().Informer(),
 		apiServerConfigInformer.Informer(), // do not remove, used by the precondition checker
 		deployer,
 	).ToController(
@@ -121,7 +124,7 @@ func (c *pruneController) sync(ctx context.Context, syncCtx factory.SyncContext)
 }
 
 func (c *pruneController) deleteOldMigratedSecrets(ctx context.Context, syncContext factory.SyncContext, encryptedGRs []schema.GroupResource) error {
-	_, desiredEncryptionConfig, _, isProgressingReason, err := statemachine.GetEncryptionConfigAndState(ctx, c.deployer, c.secretClient, c.encryptionSecretSelector, encryptedGRs)
+	_, desiredEncryptionConfig, _, isProgressingReason, err := statemachine.GetEncryptionConfigAndState(ctx, c.encryptionSecretNamespace, c.deployer, c.secretClient, c.encryptionSecretSelector, encryptedGRs)
 	if err != nil {
 		return err
 	}
@@ -135,7 +138,7 @@ func (c *pruneController) deleteOldMigratedSecrets(ctx context.Context, syncCont
 		allUsedKeys = append(allUsedKeys, grKeys.ReadKeys...)
 	}
 
-	allSecrets, err := c.secretClient.Secrets("openshift-config-managed").List(ctx, c.encryptionSecretSelector)
+	allSecrets, err := c.secretClient.Secrets(c.encryptionSecretNamespace).List(ctx, c.encryptionSecretSelector)
 	if err != nil {
 		return err
 	}
@@ -181,7 +184,7 @@ NextEncryptionSecret:
 		if idx > -1 {
 			secret.Finalizers = slices.Delete(secret.Finalizers, idx, idx+1)
 			var updateErr error
-			secret, updateErr = c.secretClient.Secrets("openshift-config-managed").Update(ctx, secret, metav1.UpdateOptions{})
+			secret, updateErr = c.secretClient.Secrets(c.encryptionSecretNamespace).Update(ctx, secret, metav1.UpdateOptions{})
 			deleteErrs = append(deleteErrs, updateErr)
 			if updateErr != nil {
 				continue
@@ -189,7 +192,7 @@ NextEncryptionSecret:
 		}
 
 		// remove the actual secret
-		if err := c.secretClient.Secrets("openshift-config-managed").Delete(ctx, secret.Name, metav1.DeleteOptions{}); err != nil {
+		if err := c.secretClient.Secrets(c.encryptionSecretNamespace).Delete(ctx, secret.Name, metav1.DeleteOptions{}); err != nil {
 			deleteErrs = append(deleteErrs, err)
 		} else {
 			deletedKeys++

--- a/pkg/operator/encryption/controllers/prune_controller_test.go
+++ b/pkg/operator/encryption/controllers/prune_controller_test.go
@@ -189,6 +189,7 @@ func TestPruneController(t *testing.T) {
 
 			target := NewPruneController(
 				"EncryptionPruneController",
+				"openshift-config-managed",
 				provider,
 				deployer,
 				alwaysFulfilledPreconditions,

--- a/pkg/operator/encryption/controllers/state_controller.go
+++ b/pkg/operator/encryption/controllers/state_controller.go
@@ -37,9 +37,10 @@ const stateWorkKey = "key"
 // is converted into a single encryption config.  The logic for determining
 // the current write key is of special interest.
 type stateController struct {
-	instanceName             string
-	controllerInstanceName   string
-	encryptionSecretSelector metav1.ListOptions
+	instanceName              string
+	controllerInstanceName    string
+	encryptionSecretNamespace string
+	encryptionSecretSelector  metav1.ListOptions
 
 	operatorClient           operatorv1helpers.OperatorClient
 	secretClient             corev1client.SecretsGetter
@@ -50,6 +51,7 @@ type stateController struct {
 
 func NewStateController(
 	instanceName string,
+	encryptionSecretNamespace string,
 	provider Provider,
 	deployer statemachine.Deployer,
 	preconditionsFulfilledFn preconditionsFulfilled,
@@ -61,9 +63,10 @@ func NewStateController(
 	eventRecorder events.Recorder,
 ) factory.Controller {
 	c := &stateController{
-		operatorClient:         operatorClient,
-		instanceName:           instanceName,
-		controllerInstanceName: factory.ControllerInstanceName(instanceName, "EncryptionState"),
+		operatorClient:            operatorClient,
+		instanceName:              instanceName,
+		controllerInstanceName:    factory.ControllerInstanceName(instanceName, "EncryptionState"),
+		encryptionSecretNamespace: encryptionSecretNamespace,
 
 		encryptionSecretSelector: encryptionSecretSelector,
 		secretClient:             secretClient,
@@ -74,7 +77,7 @@ func NewStateController(
 
 	return factory.New().ResyncEvery(time.Minute).WithSync(c.sync).WithControllerInstanceName(c.controllerInstanceName).WithInformers(
 		operatorClient.Informer(),
-		kubeInformersForNamespaces.InformersFor("openshift-config-managed").Core().V1().Secrets().Informer(),
+		kubeInformersForNamespaces.InformersFor(c.encryptionSecretNamespace).Core().V1().Secrets().Informer(),
 		apiServerConfigInformer.Informer(), // do not remove, used by the precondition checker
 		deployer,
 	).ToController(
@@ -127,7 +130,7 @@ type eventWithReason struct {
 }
 
 func (c *stateController) generateAndApplyCurrentEncryptionConfigSecret(ctx context.Context, queue workqueue.RateLimitingInterface, recorder events.Recorder, encryptedGRs []schema.GroupResource) error {
-	currentConfig, desiredEncryptionState, encryptionSecrets, transitioningReason, err := statemachine.GetEncryptionConfigAndState(ctx, c.deployer, c.secretClient, c.encryptionSecretSelector, encryptedGRs)
+	currentConfig, desiredEncryptionState, encryptionSecrets, transitioningReason, err := statemachine.GetEncryptionConfigAndState(ctx, c.encryptionSecretNamespace, c.deployer, c.secretClient, c.encryptionSecretSelector, encryptedGRs)
 	if err != nil {
 		return err
 	}
@@ -164,7 +167,7 @@ func (c *stateController) generateAndApplyCurrentEncryptionConfigSecret(ctx cont
 }
 
 func (c *stateController) applyEncryptionConfigSecret(ctx context.Context, secretData *encryptiondata.Config, recorder events.Recorder) (bool, error) {
-	s, err := encryptiondata.ToSecret("openshift-config-managed", fmt.Sprintf("%s-%s", encryptiondata.EncryptionConfSecretName, c.instanceName), secretData)
+	s, err := encryptiondata.ToSecret(c.encryptionSecretNamespace, fmt.Sprintf("%s-%s", encryptiondata.EncryptionConfSecretName, c.instanceName), secretData)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/operator/encryption/controllers/state_controller_test.go
+++ b/pkg/operator/encryption/controllers/state_controller_test.go
@@ -1229,6 +1229,7 @@ func TestStateController(t *testing.T) {
 
 			target := NewStateController(
 				scenario.targetNamespace,
+				"openshift-config-managed",
 				provider,
 				deployer,
 				alwaysFulfilledPreconditions,

--- a/pkg/operator/encryption/preconditions.go
+++ b/pkg/operator/encryption/preconditions.go
@@ -22,7 +22,7 @@ type preconditionChecker struct {
 
 // newEncryptionEnabledPrecondition determines if encryption controllers should synchronise.
 // It uses the cache for gathering data to avoid sending requests to the API servers.
-func newEncryptionEnabledPrecondition(apiServerConfigLister configv1listers.APIServerLister, kubeInformersForNamespaces operatorv1helpers.KubeInformersForNamespaces, encryptionSecretSelectorString, component string) (*preconditionChecker, error) {
+func newEncryptionEnabledPrecondition(apiServerConfigLister configv1listers.APIServerLister, kubeInformersForNamespaces operatorv1helpers.KubeInformersForNamespaces, encryptionSecretNamespace, encryptionSecretSelectorString, component string) (*preconditionChecker, error) {
 	encryptionSecretSelector, err := labels.Parse(encryptionSecretSelectorString)
 	if err != nil {
 		return nil, err
@@ -30,7 +30,7 @@ func newEncryptionEnabledPrecondition(apiServerConfigLister configv1listers.APIS
 	return &preconditionChecker{
 		component:                component,
 		encryptionSecretSelector: encryptionSecretSelector,
-		secretLister:             kubeInformersForNamespaces.SecretLister().Secrets("openshift-config-managed"),
+		secretLister:             kubeInformersForNamespaces.SecretLister().Secrets(encryptionSecretNamespace),
 		apiServerConfigLister:    apiServerConfigLister,
 	}, nil
 }

--- a/pkg/operator/encryption/secrets/secrets.go
+++ b/pkg/operator/encryption/secrets/secrets.go
@@ -117,8 +117,8 @@ func ToKeyState(s *corev1.Secret) (state.KeyState, error) {
 	return key, nil
 }
 
-// ToKeyState converts a key state to a key secret.
-func FromKeyState(component string, ks state.KeyState) (*corev1.Secret, error) {
+// FromKeyState converts a key state to a key secret in the given namespace.
+func FromKeyState(encryptionSecretNamespace, component string, ks state.KeyState) (*corev1.Secret, error) {
 	bs, err := base64.StdEncoding.DecodeString(ks.Key.Secret)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode key string")
@@ -131,7 +131,7 @@ func FromKeyState(component string, ks state.KeyState) (*corev1.Secret, error) {
 	s := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("encryption-key-%s-%s", component, ks.Key.Name),
-			Namespace: "openshift-config-managed",
+			Namespace: encryptionSecretNamespace,
 			Labels: map[string]string{
 				EncryptionKeySecretsLabel: component,
 			},
@@ -203,9 +203,9 @@ func (m *MigratedGroupResources) HasResource(resource schema.GroupResource) bool
 	return false
 }
 
-// ListKeySecrets returns the current key secrets from openshift-config-managed.
-func ListKeySecrets(ctx context.Context, secretClient corev1client.SecretsGetter, encryptionSecretSelector metav1.ListOptions) ([]*corev1.Secret, error) {
-	encryptionSecretList, err := secretClient.Secrets("openshift-config-managed").List(ctx, encryptionSecretSelector)
+// ListKeySecrets returns the current key secrets from the given namespace.
+func ListKeySecrets(ctx context.Context, encryptionSecretNamespace string, secretClient corev1client.SecretsGetter, encryptionSecretSelector metav1.ListOptions) ([]*corev1.Secret, error) {
+	encryptionSecretList, err := secretClient.Secrets(encryptionSecretNamespace).List(ctx, encryptionSecretSelector)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operator/encryption/secrets/secrets_test.go
+++ b/pkg/operator/encryption/secrets/secrets_test.go
@@ -223,7 +223,7 @@ func TestRoundtrip(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, err := FromKeyState(tt.component, tt.ks)
+			s, err := FromKeyState("openshift-config-managed", tt.component, tt.ks)
 			if err != nil {
 				t.Fatalf("unexpected FromKeyState() error: %v", err)
 			}

--- a/pkg/operator/encryption/statemachine/transition.go
+++ b/pkg/operator/encryption/statemachine/transition.go
@@ -30,6 +30,7 @@ type Deployer interface {
 
 func GetEncryptionConfigAndState(
 	ctx context.Context,
+	encryptionSecretNamespace string,
 	deployer Deployer,
 	secretClient corev1client.SecretsGetter,
 	encryptionSecretSelector metav1.ListOptions,
@@ -52,7 +53,7 @@ func GetEncryptionConfigAndState(
 	}
 
 	// compute desired config
-	encryptionSecrets, err = secrets.ListKeySecrets(ctx, secretClient, encryptionSecretSelector)
+	encryptionSecrets, err = secrets.ListKeySecrets(ctx, encryptionSecretNamespace, secretClient, encryptionSecretSelector)
 	if err != nil {
 		return nil, nil, nil, "", err
 	}

--- a/test/e2e-encryption/encryption_test.go
+++ b/test/e2e-encryption/encryption_test.go
@@ -155,6 +155,7 @@ func TestEncryptionIntegration(tt *testing.T) {
 
 	controllers, err := encryption.NewControllers(
 		component,
+		"openshift-config-managed",
 		[]string{},
 		provider,
 		deployer,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Encryption controllers now consistently operate within their configured namespace.
  * Encryption keys, state, configuration, and synchronization secrets are created, monitored, updated, and removed in the correct namespace.
  * Prevents reliance on a fixed namespace, improving support for component-specific encryption configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->