### PR TITLE
Fixing routes.route.openshift.io route-of-life already exists error

### DIFF
--- a/test/library/encryption/helpers.go
+++ b/test/library/encryption/helpers.go
@@ -594,6 +594,7 @@ func CreateAndStoreWellKnownRouteOfLife(ctx context.Context, t testing.TB, cs Cl
 	if errors.IsAlreadyExists(err) {
 		// Leftover from a previous run, or a parallel create race.
 		t.Log("The route already exists, reusing it")
+		return route
 	}
 	require.NoError(t, err)
 


### PR DESCRIPTION
when Create returns AlreadyExists, instead of just logging and still hitting require.NoError(t, err)
```
{  fail [github.com/openshift/library-go@v0.0.0-20260803130200-aa9e8101feb5/test/library/encryption/e_log.go:63]: Aug  3 16:02:45.098: 
	Error Trace:	github.com/openshift/library-go@v0.0.0-20260803130200-aa9e8101feb5/test/library/encryption/helpers.go:598
	            				github.com/openshift/cluster-kube-apiserver-operator/test/e2e-encryption-kms/encryption_kms.go:84
	            				github.com/openshift/library-go@v0.0.0-20260803130200-aa9e8101feb5/test/library/encryption/scenarios.go:144
	            				github.com/openshift/library-go@v0.0.0-20260803130200-aa9e8101feb5/test/library/encryption/helpers.go:569
	            				sync/waitgroup.go:258
	            				runtime/asm_amd64.s:1771
	Error:      	Received unexpected error:
	            	routes.route.openshift.io "route-of-life" already exists
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when a well-known route already exists, allowing the existing route to be reused without reporting an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->