### PR TITLE
NO-JIRA: Add security context as drift exception for preflight deployer

### DIFF
--- a/test/library/encryption/preflight_drift.go
+++ b/test/library/encryption/preflight_drift.go
@@ -52,6 +52,10 @@ var DefaultPreflightPodSpecDriftIgnore = []string{
 	"PriorityClassName",
 	// KAS sets an explicit numeric priority; preflight leaves it to the PriorityClass.
 	"Priority",
+
+	// SCC admission sets SELinuxOptions, FSGroup, SeccompProfile etc. per SA binding;
+	// preflight and operand run under different service accounts so values always differ.
+	"SecurityContext",
 }
 
 // AssertNoPreflightConfigDrift fetches the preflight pod and a Running operand pod matching

--- a/test/library/encryption/preflight_drift_test.go
+++ b/test/library/encryption/preflight_drift_test.go
@@ -53,6 +53,21 @@ func TestDefaultPreflightPodSpecDriftIgnore(t *testing.T) {
 		}
 	})
 
+	t.Run("SCC-assigned SecurityContext fields do not fail", func(t *testing.T) {
+		preflightSpec := base.DeepCopy()
+		seLevel := "s0:c26,c25"
+		fsGroup := int64(1000700000)
+		seccompType := corev1.SeccompProfileTypeRuntimeDefault
+		preflightSpec.SecurityContext = &corev1.PodSecurityContext{
+			SELinuxOptions: &corev1.SELinuxOptions{Level: seLevel},
+			FSGroup:        &fsGroup,
+			SeccompProfile: &corev1.SeccompProfile{Type: seccompType},
+		}
+		if diff := cmp.Diff(base, preflightSpec, opts...); diff != "" {
+			t.Fatalf("expected SCC-assigned SecurityContext to be ignored, got:\n%s", diff)
+		}
+	})
+
 	t.Run("unexpected HostNetwork drift fails", func(t *testing.T) {
 		preflightSpec := base.DeepCopy()
 		preflightSpec.HostNetwork = false


### PR DESCRIPTION
As seen here https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_cluster-openshift-apiserver-operator/745/pull-ci-openshift-cluster-openshift-apiserver-operator-main-e2e-aws-operator-encryption-kms-2/2084875953514745856, preflight deployer's security context does not match with the operand pod, since they run with different service account. 

This PR adds security context in exception list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented preflight drift checks from flagging security context values automatically assigned by the platform.
  - Improved handling of SELinux options, filesystem group settings, and seccomp profiles during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->