### PR TITLE
CNTRLPLANE-3237: kms: add EncryptionPlanner and migrate key, state, and preflight controllers

### DIFF
--- a/pkg/operator/encryption/controllers.go
+++ b/pkg/operator/encryption/controllers.go
@@ -132,6 +132,7 @@ func NewControllers(
 		),
 	}
 
+	// TODO: drop EncryptionConfigurationComputer once operators stop passing NoopEncryptionConfigurationComputer.
 	encryptionControllers = append(encryptionControllers, controllers.NewKMSPreflightController(
 		component,
 		provider,
@@ -144,6 +145,9 @@ func NewControllers(
 		configMapClient,
 		encryptionStatusProvider,
 		eventRecorder,
+		unsupportedConfigPrefix,
+		deployer,
+		encryptionSecretSelector,
 	))
 
 	return encryptionControllers, nil

--- a/pkg/operator/encryption/controllers/encryption_planner.go
+++ b/pkg/operator/encryption/controllers/encryption_planner.go
@@ -1,0 +1,268 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
+	"github.com/openshift/library-go/pkg/operator/encryption/secrets"
+	"github.com/openshift/library-go/pkg/operator/encryption/state"
+	"github.com/openshift/library-go/pkg/operator/encryption/statemachine"
+	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+const (
+	encryptionConfigManagedNS = "openshift-config-managed"
+)
+
+// EncryptionPlanner provides shared key planning and encryption-config computation for the key, state, and KMS preflight controllers without drift.
+type EncryptionPlanner struct {
+	instanceName             string
+	unsupportedConfigPrefix  []string
+	deployer                 statemachine.Deployer
+	secretClient             corev1client.SecretsGetter
+	configMapClient          corev1client.ConfigMapsGetter
+	apiServerClient          configv1client.APIServerInterface
+	operatorClient           operatorv1helpers.OperatorClient
+	encryptionSecretSelector metav1.ListOptions
+}
+
+func NewEncryptionPlanner(instanceName string, unsupportedConfigPrefix []string, deployer statemachine.Deployer, secretClient corev1client.SecretsGetter, configMapClient corev1client.ConfigMapsGetter, apiServerClient configv1client.APIServerInterface, operatorClient operatorv1helpers.OperatorClient, encryptionSecretSelector metav1.ListOptions) *EncryptionPlanner {
+	return &EncryptionPlanner{
+		instanceName:             instanceName,
+		unsupportedConfigPrefix:  unsupportedConfigPrefix,
+		deployer:                 deployer,
+		secretClient:             secretClient,
+		configMapClient:          configMapClient,
+		apiServerClient:          apiServerClient,
+		operatorClient:           operatorClient,
+		encryptionSecretSelector: encryptionSecretSelector,
+	}
+}
+
+// EncryptionStateSnapshot is deployer convergence and persisted key secrets.
+// Produced by LoadState. Input to ComputeConfig.
+type EncryptionStateSnapshot struct {
+	ProgressingReason string
+	CurrentConfig     *encryptiondata.Config
+	DesiredBeforePlan map[schema.GroupResource]state.GroupResourceState
+	KeySecrets        []*corev1.Secret
+	EncryptedGRs      []schema.GroupResource
+}
+
+// KeyPlanningSnapshot adds resolved encryption mode for key planning.
+// Produced by Load. Required by PlanNextKey and MaterializeKey.
+type KeyPlanningSnapshot struct {
+	State              EncryptionStateSnapshot
+	CurrentMode        state.Mode
+	ExternalReason     string
+	APIEncryption      configv1.APIServerEncryption
+	desiredProviderCfg kmsProviderConfig
+}
+
+// KeyPlan is the deterministic result of deciding whether a new key is needed.
+type KeyPlan struct {
+	Needed         bool
+	KeyID          uint64
+	Reasons        []string
+	InternalReason string
+}
+
+// PlannedEncryptionKey is a materialized in-memory key secret ready to persist or include in a candidate config.
+type PlannedEncryptionKey struct {
+	Secret  *corev1.Secret
+	KeyID   uint64
+	Reasons []string
+}
+
+// LoadOptions controls how Load reads key-planning state.
+type LoadOptions struct {
+	// ListKeysWhileProgressing lists persisted key secrets even when the
+	// deployer has not converged. Default false so the key controller does
+	// not List during API-server rollouts. Preflight sets this so PlanNextKey
+	// can run. ProgressingReason is still populated in either case.
+	ListKeysWhileProgressing bool
+}
+
+// EncryptionPlanResult is returned by ComputeConfig.
+type EncryptionPlanResult struct {
+	ProgressingReason string
+	PlannedKey        *PlannedEncryptionKey
+	CurrentConfig     *encryptiondata.Config
+	DesiredState      map[schema.GroupResource]state.GroupResourceState
+	EncryptionConfig  *encryptiondata.Config
+	EncryptionSecret  *corev1.Secret
+	KeySecrets        []*corev1.Secret
+}
+
+// plannedKeyBuildError marks failures while materializing an in-memory planned key (missing referenced Secrets/ConfigMaps, etc.). The key controller wraps these as "failed to create key" for historical degraded messages.
+type plannedKeyBuildError struct {
+	err error
+}
+
+func (e plannedKeyBuildError) Error() string { return e.err.Error() }
+func (e plannedKeyBuildError) Unwrap() error { return e.err }
+
+// LoadState reads deployer convergence and key secrets.
+func (p *EncryptionPlanner) LoadState(ctx context.Context, encryptedGRs []schema.GroupResource) (*EncryptionStateSnapshot, error) {
+	currentConfig, desiredBeforePlan, keySecrets, progressingReason, err := statemachine.GetEncryptionConfigAndState(ctx, p.deployer, p.secretClient, p.encryptionSecretSelector, encryptedGRs)
+	if err != nil {
+		return nil, err
+	}
+	return &EncryptionStateSnapshot{
+		ProgressingReason: progressingReason,
+		CurrentConfig:     currentConfig,
+		DesiredBeforePlan: desiredBeforePlan,
+		KeySecrets:        keySecrets,
+		EncryptedGRs:      encryptedGRs,
+	}, nil
+}
+
+// Load resolves encryption mode and reads deployer/key state for key planning.
+// The returned snapshot is non-nil when err is nil.
+func (p *EncryptionPlanner) Load(ctx context.Context, encryptedGRs []schema.GroupResource, opts LoadOptions) (*KeyPlanningSnapshot, error) {
+	if p.apiServerClient == nil || p.operatorClient == nil {
+		return nil, fmt.Errorf("Load requires apiServerClient and operatorClient")
+	}
+
+	// Resolve mode before reading deployer/key state so callers fail fast on APIServer/operator errors.
+	currentMode, externalReason, apiEncryption, err := getCurrentModeReasonAndEncryptionConfig(ctx, p.apiServerClient, p.operatorClient, p.unsupportedConfigPrefix)
+	if err != nil {
+		return nil, err
+	}
+
+	stateSnap, err := p.LoadState(ctx, encryptedGRs)
+	if err != nil {
+		return nil, err
+	}
+
+	// LoadState calls GetEncryptionConfigAndState, which returns before listing keys when the deployer has not converged.
+	// Preflight loads keys and desired state here via ListKeysWhileProgressing; the key controller skips this to avoid Lists during rollout.
+	if len(stateSnap.ProgressingReason) > 0 && opts.ListKeysWhileProgressing {
+		keySecrets, err := secrets.ListKeySecrets(ctx, p.secretClient, p.encryptionSecretSelector)
+		if err != nil {
+			return nil, err
+		}
+		stateSnap.KeySecrets = keySecrets
+		stateSnap.DesiredBeforePlan = statemachine.GetDesiredEncryptionState(stateSnap.CurrentConfig, keySecrets, encryptedGRs)
+	}
+
+	snap := &KeyPlanningSnapshot{
+		State:              *stateSnap,
+		CurrentMode:        currentMode,
+		ExternalReason:     externalReason,
+		APIEncryption:      apiEncryption,
+		desiredProviderCfg: noopKMSProviderConfig{},
+	}
+
+	if currentMode == state.KMS {
+		desiredProviderCfg, err := newKMSProviderConfig(apiEncryption.KMS)
+		if err != nil {
+			return nil, err
+		}
+		snap.desiredProviderCfg = desiredProviderCfg
+	}
+
+	return snap, nil
+}
+
+// PlanNextKey deterministically decides whether a new key is needed. It does not generate key material.
+func (p *EncryptionPlanner) PlanNextKey(snap *KeyPlanningSnapshot) (*KeyPlan, error) {
+	if snap == nil {
+		return nil, fmt.Errorf("snapshot is required")
+	}
+
+	hasBeenOnBefore := snap.State.CurrentConfig != nil || len(snap.State.KeySecrets) > 0
+	if snap.CurrentMode == state.Identity && !hasBeenOnBefore {
+		return &KeyPlan{}, nil
+	}
+
+	keyPlan, err := planNextEncryptionKey(snap.State.DesiredBeforePlan, snap.CurrentMode, snap.ExternalReason, snap.State.EncryptedGRs, snap.desiredProviderCfg)
+	if err != nil {
+		return nil, err
+	}
+	return &KeyPlan{
+		Needed:         keyPlan.needed,
+		KeyID:          keyPlan.keyID,
+		Reasons:        keyPlan.reasons,
+		InternalReason: keyPlan.internalReason,
+	}, nil
+}
+
+// MaterializeKey builds an in-memory key secret for plan. Non-deterministic (fresh key bytes). Requires plan.Needed == true.
+func (p *EncryptionPlanner) MaterializeKey(ctx context.Context, snap *KeyPlanningSnapshot, plan *KeyPlan) (*PlannedEncryptionKey, error) {
+	if snap == nil {
+		return nil, fmt.Errorf("snapshot is required")
+	}
+	if plan == nil || !plan.Needed {
+		return nil, fmt.Errorf("MaterializeKey requires a needed key plan")
+	}
+	if p.configMapClient == nil {
+		return nil, fmt.Errorf("configMapClient is required for MaterializeKey")
+	}
+
+	ks, _, _, err := buildEncryptionKeyState(ctx, plan.KeyID, snap.CurrentMode, snap.APIEncryption, snap.desiredProviderCfg, p.secretClient, p.configMapClient, plan.InternalReason, snap.ExternalReason)
+	if err != nil {
+		return nil, plannedKeyBuildError{err: err}
+	}
+	keySecret, err := secrets.FromKeyState(p.instanceName, ks)
+	if err != nil {
+		return nil, plannedKeyBuildError{err: err}
+	}
+	return &PlannedEncryptionKey{
+		Secret:  keySecret,
+		KeyID:   plan.KeyID,
+		Reasons: plan.Reasons,
+	}, nil
+}
+
+// ComputeConfig builds the desired encryption-config secret from persisted keys, optionally including plannedKey.
+// When plannedKey is nil it reuses DesiredBeforePlan instead of recomputing desired state.
+func (p *EncryptionPlanner) ComputeConfig(state *EncryptionStateSnapshot, plannedKey *PlannedEncryptionKey) (*EncryptionPlanResult, error) {
+	if state == nil {
+		return nil, fmt.Errorf("snapshot is required")
+	}
+
+	keySecrets := state.KeySecrets
+	if plannedKey != nil && plannedKey.Secret != nil {
+		keySecrets = append(append([]*corev1.Secret{}, state.KeySecrets...), plannedKey.Secret)
+	}
+
+	out := &EncryptionPlanResult{
+		CurrentConfig: state.CurrentConfig,
+		KeySecrets:    keySecrets,
+		PlannedKey:    plannedKey,
+	}
+
+	if state.CurrentConfig == nil && len(keySecrets) == 0 {
+		return out, nil
+	}
+
+	// DesiredBeforePlan already reflects persisted keys. Recompute only when a planned key was appended
+	out.DesiredState = state.DesiredBeforePlan
+	if plannedKey != nil && plannedKey.Secret != nil {
+		out.DesiredState = statemachine.GetDesiredEncryptionState(state.CurrentConfig, keySecrets, state.EncryptedGRs)
+	}
+
+	cfg, err := encryptiondata.FromEncryptionState(out.DesiredState)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build encryption config: %w", err)
+	}
+	out.EncryptionConfig = cfg
+
+	secretName := fmt.Sprintf("%s-%s", encryptiondata.EncryptionConfSecretName, p.instanceName)
+	secret, err := encryptiondata.ToSecret(encryptionConfigManagedNS, secretName, cfg)
+	if err != nil {
+		return nil, err
+	}
+	out.EncryptionSecret = secret
+
+	return out, nil
+}

--- a/pkg/operator/encryption/controllers/encryption_planner_test.go
+++ b/pkg/operator/encryption/controllers/encryption_planner_test.go
@@ -1,0 +1,240 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/fake"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	configv1clientfake "github.com/openshift/client-go/config/clientset/versioned/fake"
+
+	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+// TestEncryptionPlannerDriftGuard documents the anti-drift contract: candidate compute must match what the state controller would compute after the planned key Secret is persisted.
+func TestEncryptionPlannerDriftGuard(t *testing.T) {
+	apiServerWithKMS := newKMSVaultAPIServer()
+	encryptedGRs := []schema.GroupResource{{Group: "", Resource: "secrets"}}
+	instanceName := "test"
+
+	existingKey := newExistingKMSKeySecret(t, instanceName, apiServerWithKMS, encryptedGRs, "3")
+	deployed := newDeployedKMSEncryptionConfig(t, instanceName, encryptedGRs, existingKey)
+	coreObjects := []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap, existingKey}
+	fakeKubeClient := fake.NewSimpleClientset(coreObjects...)
+	fakeConfigClient := configv1clientfake.NewSimpleClientset(apiServerWithKMS)
+	fakeOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(
+		&operatorv1.StaticPodOperatorSpec{OperatorSpec: operatorv1.OperatorSpec{ManagementState: operatorv1.Managed}},
+		&operatorv1.StaticPodOperatorStatus{},
+		nil,
+		nil,
+	)
+	deployer := &fakeEncryptionDeployer{converged: true, secret: deployed}
+	secretSelector := metav1.ListOptions{}
+
+	planner := NewEncryptionPlanner(instanceName, nil, deployer, fakeKubeClient.CoreV1(), fakeKubeClient.CoreV1(), fakeConfigClient.ConfigV1().APIServers(), fakeOperatorClient, secretSelector)
+
+	// Preflight/candidate path via snapshot API.
+	snap, err := planner.Load(context.TODO(), encryptedGRs, LoadOptions{ListKeysWhileProgressing: true})
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	plan, err := planner.PlanNextKey(snap)
+	if err != nil {
+		t.Fatalf("PlanNextKey failed: %v", err)
+	}
+	if !plan.Needed {
+		t.Fatal("expected a planned key for provider change")
+	}
+	plannedKey, err := planner.MaterializeKey(context.TODO(), snap, plan)
+	if err != nil {
+		t.Fatalf("MaterializeKey failed: %v", err)
+	}
+	candidate, err := planner.ComputeConfig(&snap.State, plannedKey)
+	if err != nil {
+		t.Fatalf("ComputeConfig (candidate) failed: %v", err)
+	}
+	if candidate.EncryptionSecret == nil {
+		t.Fatal("expected encryption secret from candidate compute")
+	}
+
+	// Persist the planned key, then compute as state controller would.
+	if _, err := fakeKubeClient.CoreV1().Secrets("openshift-config-managed").Create(context.TODO(), plannedKey.Secret, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("failed to persist planned key: %v", err)
+	}
+
+	statePlanner := NewEncryptionPlanner(instanceName, nil, deployer, fakeKubeClient.CoreV1(), nil, nil, nil, secretSelector)
+	stateSnap, err := statePlanner.LoadState(context.TODO(), encryptedGRs)
+	if err != nil {
+		t.Fatalf("LoadState (state) failed: %v", err)
+	}
+	asState, err := statePlanner.ComputeConfig(stateSnap, nil)
+	if err != nil {
+		t.Fatalf("ComputeConfig (state) failed: %v", err)
+	}
+	if asState.EncryptionSecret == nil {
+		t.Fatal("expected encryption secret from state compute")
+	}
+
+	if !equality.Semantic.DeepEqual(candidate.EncryptionSecret.Data, asState.EncryptionSecret.Data) {
+		t.Errorf("drift: Candidate encryption-config data diverges from state compute after key Create")
+	}
+}
+
+func TestEncryptionPlannerFirstKey(t *testing.T) {
+	apiServerWithKMS := newKMSVaultAPIServer()
+	encryptedGRs := []schema.GroupResource{{Group: "", Resource: "secrets"}}
+	fakeKubeClient := fake.NewSimpleClientset(&wellKnownBaseSecret, &wellKnownBaseConfigMap)
+	fakeConfigClient := configv1clientfake.NewSimpleClientset(apiServerWithKMS)
+	fakeOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(
+		&operatorv1.StaticPodOperatorSpec{OperatorSpec: operatorv1.OperatorSpec{ManagementState: operatorv1.Managed}},
+		&operatorv1.StaticPodOperatorStatus{},
+		nil,
+		nil,
+	)
+
+	planner := NewEncryptionPlanner("test", nil, &fakeEncryptionDeployer{converged: true}, fakeKubeClient.CoreV1(), fakeKubeClient.CoreV1(), fakeConfigClient.ConfigV1().APIServers(), fakeOperatorClient, metav1.ListOptions{})
+
+	snap, err := planner.Load(context.TODO(), encryptedGRs, LoadOptions{ListKeysWhileProgressing: true})
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if snap.State.ProgressingReason != "" {
+		t.Fatalf("unexpected progressing: %s", snap.State.ProgressingReason)
+	}
+	plan, err := planner.PlanNextKey(snap)
+	if err != nil {
+		t.Fatalf("PlanNextKey failed: %v", err)
+	}
+	if !plan.Needed || plan.KeyID != 1 {
+		t.Fatalf("expected planned key ID 1, got %+v", plan)
+	}
+
+	plannedKey, err := planner.MaterializeKey(context.TODO(), snap, plan)
+	if err != nil {
+		t.Fatalf("MaterializeKey failed: %v", err)
+	}
+	candidate, err := planner.ComputeConfig(&snap.State, plannedKey)
+	if err != nil {
+		t.Fatalf("ComputeConfig failed: %v", err)
+	}
+	if candidate.EncryptionSecret == nil {
+		t.Fatal("expected encryption secret")
+	}
+	cfg, err := encryptiondata.FromSecret(candidate.EncryptionSecret)
+	if err != nil {
+		t.Fatalf("failed to parse secret: %v", err)
+	}
+	kmsConfigs, err := encryptiondata.ExtractUniqueAndSortedKMSConfigurations(cfg)
+	if err != nil {
+		t.Fatalf("failed to extract KMS configs: %v", err)
+	}
+	if len(kmsConfigs) != 1 || kmsConfigs[0].Name != "1" {
+		t.Fatalf("expected key ID 1, got %+v", kmsConfigs)
+	}
+	if kmsConfigs[0].Endpoint != "unix:///var/run/kmsplugin/kms-1.sock" {
+		t.Errorf("unexpected endpoint, got %s", kmsConfigs[0].Endpoint)
+	}
+}
+
+// TestEncryptionPlannerDecideVsMaterialize documents that PlanNextKey is deterministic over a snapshot while MaterializeKey produces fresh key material each call. Uses aescbc because KMS mode intentionally generates empty key bytes.
+func TestEncryptionPlannerDecideVsMaterialize(t *testing.T) {
+	apiServer := &configv1.APIServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Spec: configv1.APIServerSpec{
+			Encryption: configv1.APIServerEncryption{Type: "aescbc"},
+		},
+	}
+	encryptedGRs := []schema.GroupResource{{Group: "", Resource: "secrets"}}
+	fakeKubeClient := fake.NewSimpleClientset()
+	fakeConfigClient := configv1clientfake.NewSimpleClientset(apiServer)
+	fakeOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(
+		&operatorv1.StaticPodOperatorSpec{OperatorSpec: operatorv1.OperatorSpec{ManagementState: operatorv1.Managed}},
+		&operatorv1.StaticPodOperatorStatus{},
+		nil,
+		nil,
+	)
+	planner := NewEncryptionPlanner("test", nil, &fakeEncryptionDeployer{converged: true}, fakeKubeClient.CoreV1(), fakeKubeClient.CoreV1(), fakeConfigClient.ConfigV1().APIServers(), fakeOperatorClient, metav1.ListOptions{})
+
+	snap, err := planner.Load(context.TODO(), encryptedGRs, LoadOptions{})
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	plan1, err := planner.PlanNextKey(snap)
+	if err != nil {
+		t.Fatalf("PlanNextKey #1 failed: %v", err)
+	}
+	plan2, err := planner.PlanNextKey(snap)
+	if err != nil {
+		t.Fatalf("PlanNextKey #2 failed: %v", err)
+	}
+	if !equality.Semantic.DeepEqual(plan1, plan2) {
+		t.Fatalf("PlanNextKey is not deterministic: %+v vs %+v", plan1, plan2)
+	}
+	if !plan1.Needed {
+		t.Fatal("expected a needed key plan for first aescbc key")
+	}
+
+	key1, err := planner.MaterializeKey(context.TODO(), snap, plan1)
+	if err != nil {
+		t.Fatalf("MaterializeKey #1 failed: %v", err)
+	}
+	key2, err := planner.MaterializeKey(context.TODO(), snap, plan1)
+	if err != nil {
+		t.Fatalf("MaterializeKey #2 failed: %v", err)
+	}
+	if equality.Semantic.DeepEqual(key1.Secret.Data, key2.Secret.Data) {
+		t.Fatal("expected MaterializeKey to produce different key material on successive calls")
+	}
+	if key1.KeyID != key2.KeyID || key1.KeyID != plan1.KeyID {
+		t.Fatalf("key IDs diverged: plan=%d key1=%d key2=%d", plan1.KeyID, key1.KeyID, key2.KeyID)
+	}
+}
+
+func TestEncryptionPlannerLoadListKeysWhileProgressing(t *testing.T) {
+	apiServer := &configv1.APIServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Spec:       configv1.APIServerSpec{Encryption: configv1.APIServerEncryption{Type: "aescbc"}},
+	}
+	encryptedGRs := []schema.GroupResource{{Group: "", Resource: "secrets"}}
+	existingKey := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "encryption-key-test-1", Namespace: "openshift-config-managed"}}
+	fakeKubeClient := fake.NewSimpleClientset(existingKey)
+	fakeConfigClient := configv1clientfake.NewSimpleClientset(apiServer)
+	fakeOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(
+		&operatorv1.StaticPodOperatorSpec{OperatorSpec: operatorv1.OperatorSpec{ManagementState: operatorv1.Managed}},
+		&operatorv1.StaticPodOperatorStatus{},
+		nil,
+		nil,
+	)
+	planner := NewEncryptionPlanner("test", nil, &fakeEncryptionDeployer{converged: false}, fakeKubeClient.CoreV1(), fakeKubeClient.CoreV1(), fakeConfigClient.ConfigV1().APIServers(), fakeOperatorClient, metav1.ListOptions{})
+
+	shortcut, err := planner.Load(context.TODO(), encryptedGRs, LoadOptions{})
+	if err != nil {
+		t.Fatalf("Load (default) failed: %v", err)
+	}
+	if shortcut.State.ProgressingReason == "" {
+		t.Fatal("expected progressing reason when deployer is not converged")
+	}
+	if len(shortcut.State.KeySecrets) != 0 {
+		t.Fatalf("expected no key secrets on default Load, got %d", len(shortcut.State.KeySecrets))
+	}
+
+	proceed, err := planner.Load(context.TODO(), encryptedGRs, LoadOptions{ListKeysWhileProgressing: true})
+	if err != nil {
+		t.Fatalf("Load (ListKeysWhileProgressing) failed: %v", err)
+	}
+	if proceed.State.ProgressingReason == "" {
+		t.Fatal("expected progressing reason to remain set when listing keys")
+	}
+	if len(proceed.State.KeySecrets) == 0 {
+		t.Fatal("expected key secrets when ListKeysWhileProgressing is set")
+	}
+}

--- a/pkg/operator/encryption/controllers/helpers_test.go
+++ b/pkg/operator/encryption/controllers/helpers_test.go
@@ -1,13 +1,25 @@
 package controllers
 
 import (
+	"context"
+	"encoding/base64"
 	"fmt"
 	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
+	"k8s.io/client-go/tools/cache"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	configv1 "github.com/openshift/api/config/v1"
 
 	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
+	"github.com/openshift/library-go/pkg/operator/encryption/secrets"
+	"github.com/openshift/library-go/pkg/operator/encryption/state"
+	"github.com/openshift/library-go/pkg/operator/encryption/statemachine"
 )
 
 func createEncryptionCfgSecret(t *testing.T, targetNs string, revision string, encryptionCfg *encryptiondata.Config) *corev1.Secret {
@@ -36,4 +48,99 @@ func (p *testProvider) EncryptedGRs() []schema.GroupResource {
 
 func (p *testProvider) ShouldRunEncryptionControllers() (bool, error) {
 	return true, nil
+}
+
+// fakeEncryptionDeployer is a minimal statemachine.Deployer for unit tests that need to control the deployed encryption config and revision convergence.
+type fakeEncryptionDeployer struct {
+	secret    *corev1.Secret
+	converged bool
+	err       error
+}
+
+func (f *fakeEncryptionDeployer) DeployedEncryptionConfigSecret(_ context.Context) (*corev1.Secret, bool, error) {
+	return f.secret, f.converged, f.err
+}
+
+func (f *fakeEncryptionDeployer) AddEventHandler(_ cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
+	return nil, nil
+}
+
+func (f *fakeEncryptionDeployer) HasSynced() bool { return true }
+
+var _ statemachine.Deployer = &fakeEncryptionDeployer{}
+
+func newKMSVaultAPIServer() *configv1.APIServer {
+	return &configv1.APIServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Spec: configv1.APIServerSpec{
+			Encryption: configv1.APIServerEncryption{
+				Type: configv1.EncryptionTypeKMS,
+				KMS: configv1.KMSPluginConfig{
+					Type:  configv1.VaultKMSProvider,
+					Vault: wellKnownBaseVaultConfig,
+				},
+			},
+		},
+	}
+}
+
+// newExistingKMSKeySecret builds a migrated KMS key secret whose plugin config differs from the
+// current apiserver config so needsNewKey reports kms-provider-changed.
+func newExistingKMSKeySecret(t *testing.T, instanceName string, apiServer *configv1.APIServer, encryptedGRs []schema.GroupResource, keyID string) *corev1.Secret {
+	t.Helper()
+
+	oldPlugin := apiServer.Spec.Encryption.KMS
+	oldPlugin.Vault.VaultKeyPath = "transit/keys/old-key"
+	ks := state.KeyState{
+		Key:  apiserverconfigv1.Key{Name: keyID, Secret: base64.StdEncoding.EncodeToString(make([]byte, 16))},
+		Mode: state.KMS,
+		Migrated: state.MigrationState{
+			Resources: encryptedGRs,
+		},
+		KMS: &state.KMSState{
+			Encryption: &apiserverconfigv1.KMSConfiguration{
+				APIVersion: "v2",
+				Name:       keyID,
+				Endpoint:   fmt.Sprintf("unix:///var/run/kmsplugin/kms-%s.sock", keyID),
+				Timeout:    &metav1.Duration{Duration: 10 * time.Second},
+			},
+			Plugin: oldPlugin,
+		},
+	}
+	if err := ks.KMS.PluginSecretData.Set("vault-approle", "role-id", []byte("old-role-id")); err != nil {
+		t.Fatalf("failed to set plugin secret data: %v", err)
+	}
+	if err := ks.KMS.PluginSecretData.Set("vault-approle", "secret-id", []byte("old-secret-id")); err != nil {
+		t.Fatalf("failed to set plugin secret data: %v", err)
+	}
+	if err := ks.KMS.PluginConfigMapData.Set("vault-ca-bundle", "ca-bundle.crt", []byte("old-ca-cert")); err != nil {
+		t.Fatalf("failed to set plugin configmap data: %v", err)
+	}
+	s, err := secrets.FromKeyState(instanceName, ks)
+	if err != nil {
+		t.Fatalf("failed to build existing key secret: %v", err)
+	}
+	return s
+}
+
+// newDeployedKMSEncryptionConfig builds a converged encryption-config secret as the state controller would after the given key secrets are write keys.
+func newDeployedKMSEncryptionConfig(t *testing.T, instanceName string, encryptedGRs []schema.GroupResource, keySecrets ...*corev1.Secret) *corev1.Secret {
+	t.Helper()
+
+	desired := statemachine.GetDesiredEncryptionState(nil, keySecrets, encryptedGRs)
+	cfg, err := encryptiondata.FromEncryptionState(desired)
+	if err != nil {
+		t.Fatalf("failed to build intermediate encryption config: %v", err)
+	}
+	// Second pass promotes the write key once read keys are present.
+	desired = statemachine.GetDesiredEncryptionState(cfg, keySecrets, encryptedGRs)
+	cfg, err = encryptiondata.FromEncryptionState(desired)
+	if err != nil {
+		t.Fatalf("failed to build deployed encryption config: %v", err)
+	}
+	secret, err := encryptiondata.ToSecret("openshift-config-managed", "encryption-config-"+instanceName, cfg)
+	if err != nil {
+		t.Fatalf("failed to serialize deployed encryption config: %v", err)
+	}
+	return secret
 }

--- a/pkg/operator/encryption/controllers/key_controller.go
+++ b/pkg/operator/encryption/controllers/key_controller.go
@@ -183,47 +183,25 @@ func (c *keyController) sync(ctx context.Context, syncCtx factory.SyncContext) (
 }
 
 func (c *keyController) checkAndCreateKeys(ctx context.Context, syncContext factory.SyncContext, encryptedGRs []schema.GroupResource) error {
-	currentMode, externalReason, apiEncryptionConfiguration, err := getCurrentModeReasonAndEncryptionConfig(ctx, c.apiServerClient, c.operatorClient, c.unsupportedConfigPrefix)
+	planner := NewEncryptionPlanner(c.instanceName, c.unsupportedConfigPrefix, c.deployer, c.secretClient, c.configMapClient, c.apiServerClient, c.operatorClient, c.encryptionSecretSelector)
+	snap, err := planner.Load(ctx, encryptedGRs, LoadOptions{})
 	if err != nil {
 		return err
 	}
-
-	currentConfig, desiredEncryptionState, secrets, isProgressingReason, err := statemachine.GetEncryptionConfigAndState(ctx, c.deployer, c.secretClient, c.encryptionSecretSelector, encryptedGRs)
-	if err != nil {
-		return err
-	}
-	if len(isProgressingReason) > 0 {
+	if len(snap.State.ProgressingReason) > 0 {
 		syncContext.Queue().AddAfter(syncContext.QueueKey(), 2*time.Minute)
 		return nil
 	}
 
-	// avoid intended start of encryption
-	hasBeenOnBefore := currentConfig != nil || len(secrets) > 0
-	if currentMode == state.Identity && !hasBeenOnBefore {
-		return nil
-	}
-
-	// note here that desiredEncryptionState is never empty because getDesiredEncryptionState
-	// fills up the state with all resources and set identity write key if write key secrets
-	// are missing.
-
-	var desiredProviderCfg kmsProviderConfig = noopKMSProviderConfig{}
-	if currentMode == state.KMS {
-		var err error
-		desiredProviderCfg, err = newKMSProviderConfig(apiEncryptionConfiguration.KMS)
-		if err != nil {
-			return err
-		}
-	}
-
-	keyPlan, err := planNextEncryptionKey(desiredEncryptionState, currentMode, externalReason, encryptedGRs, desiredProviderCfg)
+	plan, err := planner.PlanNextKey(snap)
 	if err != nil {
 		return err
 	}
-	if !keyPlan.needed {
+	if !plan.Needed {
 		return nil
 	}
-	keySecret, preconditionMet, err := c.generateKeySecret(ctx, keyPlan.keyID, currentMode, apiEncryptionConfiguration, desiredProviderCfg, keyPlan.internalReason, externalReason)
+
+	keySecret, preconditionMet, err := c.generateKeySecret(ctx, plan.KeyID, snap.CurrentMode, snap.APIEncryption, snap.desiredProviderCfg, plan.InternalReason, snap.ExternalReason)
 	if err != nil {
 		return fmt.Errorf("failed to create key: %v", err)
 	}
@@ -231,16 +209,17 @@ func (c *keyController) checkAndCreateKeys(ctx context.Context, syncContext fact
 		syncContext.Queue().AddAfter(syncContext.QueueKey(), 30*time.Second)
 		return nil
 	}
+
 	_, createErr := c.secretClient.Secrets("openshift-config-managed").Create(ctx, keySecret, metav1.CreateOptions{})
 	if errors.IsAlreadyExists(createErr) {
-		return c.validateExistingSecret(ctx, keySecret, keyPlan.keyID)
+		return c.validateExistingSecret(ctx, keySecret, plan.KeyID)
 	}
 	if createErr != nil {
 		syncContext.Recorder().Warningf("EncryptionKeyCreateFailed", "Secret %q failed to create: %v", keySecret.Name, createErr)
 		return createErr
 	}
 
-	syncContext.Recorder().Eventf("EncryptionKeyCreated", "Secret %q successfully created: %q", keySecret.Name, keyPlan.reasons)
+	syncContext.Recorder().Eventf("EncryptionKeyCreated", "Secret %q successfully created: %q", keySecret.Name, plan.Reasons)
 
 	return nil
 }
@@ -263,6 +242,7 @@ func (c *keyController) validateExistingSecret(ctx context.Context, keySecret *c
 
 	return nil // we made this key earlier
 }
+
 // generateKeySecret builds the key secret for the given key ID and mode.
 //
 // For KMS mode it also computes the config hash (from the referenced Secret and

--- a/pkg/operator/encryption/controllers/key_controller.go
+++ b/pkg/operator/encryption/controllers/key_controller.go
@@ -18,7 +18,6 @@ import (
 	apiserverv1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/ptr"
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
@@ -204,12 +203,6 @@ func (c *keyController) checkAndCreateKeys(ctx context.Context, syncContext fact
 		return nil
 	}
 
-	var (
-		newKeyRequired bool
-		newKeyID       uint64
-		reasons        []string
-	)
-
 	// note here that desiredEncryptionState is never empty because getDesiredEncryptionState
 	// fills up the state with all resources and set identity write key if write key secrets
 	// are missing.
@@ -223,40 +216,14 @@ func (c *keyController) checkAndCreateKeys(ctx context.Context, syncContext fact
 		}
 	}
 
-	var commonReason *string
-	for gr, grKeys := range desiredEncryptionState {
-		latestKeyID, internalReason, needed, err := needsNewKey(grKeys, currentMode, externalReason, encryptedGRs, desiredProviderCfg)
-		if err != nil {
-			return err
-		}
-		if !needed {
-			continue
-		}
-
-		if commonReason == nil {
-			commonReason = &internalReason
-		} else if *commonReason != internalReason {
-			commonReason = ptr.To("") // this means we have no common reason
-		}
-
-		newKeyRequired = true
-		nextKeyID := latestKeyID + 1
-		if newKeyID < nextKeyID {
-			newKeyID = nextKeyID
-		}
-		reasons = append(reasons, fmt.Sprintf("%s-%s", gr.Resource, internalReason))
+	keyPlan, err := planNextEncryptionKey(desiredEncryptionState, currentMode, externalReason, encryptedGRs, desiredProviderCfg)
+	if err != nil {
+		return err
 	}
-	if !newKeyRequired {
+	if !keyPlan.needed {
 		return nil
 	}
-
-	if commonReason != nil && len(*commonReason) > 0 && len(reasons) > 1 {
-		reasons = []string{*commonReason} // don't repeat reasons
-	}
-
-	sort.Sort(sort.StringSlice(reasons))
-	internalReason := strings.Join(reasons, ", ")
-	keySecret, preconditionMet, err := c.generateKeySecret(ctx, newKeyID, currentMode, apiEncryptionConfiguration, desiredProviderCfg, internalReason, externalReason)
+	keySecret, preconditionMet, err := c.generateKeySecret(ctx, keyPlan.keyID, currentMode, apiEncryptionConfiguration, desiredProviderCfg, keyPlan.internalReason, externalReason)
 	if err != nil {
 		return fmt.Errorf("failed to create key: %v", err)
 	}
@@ -266,14 +233,14 @@ func (c *keyController) checkAndCreateKeys(ctx context.Context, syncContext fact
 	}
 	_, createErr := c.secretClient.Secrets("openshift-config-managed").Create(ctx, keySecret, metav1.CreateOptions{})
 	if errors.IsAlreadyExists(createErr) {
-		return c.validateExistingSecret(ctx, keySecret, newKeyID)
+		return c.validateExistingSecret(ctx, keySecret, keyPlan.keyID)
 	}
 	if createErr != nil {
 		syncContext.Recorder().Warningf("EncryptionKeyCreateFailed", "Secret %q failed to create: %v", keySecret.Name, createErr)
 		return createErr
 	}
 
-	syncContext.Recorder().Eventf("EncryptionKeyCreated", "Secret %q successfully created: %q", keySecret.Name, reasons)
+	syncContext.Recorder().Eventf("EncryptionKeyCreated", "Secret %q successfully created: %q", keySecret.Name, keyPlan.reasons)
 
 	return nil
 }
@@ -296,68 +263,21 @@ func (c *keyController) validateExistingSecret(ctx context.Context, keySecret *c
 
 	return nil // we made this key earlier
 }
-
 // generateKeySecret builds the key secret for the given key ID and mode.
 //
 // For KMS mode it also computes the config hash (from the referenced Secret and
-// ConfigMap it already reads) and gates on the KMS preflight check. The boolean
-// return value signals the outcome:
+// ConfigMap buildEncryptionKeyState already reads) and gates on the KMS preflight check.
+// The boolean return value signals the outcome:
 //
 //   - (secret, true,  nil) — preflight passed; caller should persist the key.
 //   - (nil,   false, nil) — preflight still in progress; caller should back off.
 //   - (nil,   false, err) — preflight failed or transient error; caller should surface it.
 func (c *keyController) generateKeySecret(ctx context.Context, keyID uint64, currentMode state.Mode, apiServerEncryption configv1.APIServerEncryption, desiredProviderCfg kmsProviderConfig, internalReason, externalReason string) (*corev1.Secret, bool, error) {
-	bs := crypto.ModeToNewKeyFunc[currentMode]()
-	ks := state.KeyState{
-		Key: apiserverv1.Key{
-			Name:   fmt.Sprintf("%d", keyID),
-			Secret: base64.StdEncoding.EncodeToString(bs),
-		},
-		Mode:           currentMode,
-		InternalReason: internalReason,
-		ExternalReason: externalReason,
+	ks, refSecret, refCM, err := buildEncryptionKeyState(ctx, keyID, currentMode, apiServerEncryption, desiredProviderCfg, c.secretClient, c.configMapClient, internalReason, externalReason)
+	if err != nil {
+		return nil, false, err
 	}
 	if currentMode == state.KMS {
-		ks.KMS = &state.KMSState{
-			Encryption: &apiserverv1.KMSConfiguration{
-				APIVersion: "v2",
-				Name:       fmt.Sprintf("%d", keyID),
-				Endpoint:   fmt.Sprintf(kmsEndpointFormat, keyID),
-				Timeout:    &metav1.Duration{Duration: defaultKMSTimeout},
-			},
-			Plugin: apiServerEncryption.KMS,
-		}
-
-		// Fetch the referenced Secret and ConfigMap, copying their data into the
-		// key state. The fetched objects are reused by prefetchedKMSConfigHasherResourceProvider
-		// to compute the config hash without a second API round-trip.
-		refSecret, refCM, err := fetchReferencedResources(ctx, desiredProviderCfg, c.secretClient, c.configMapClient, openshiftConfigNS)
-		if err != nil {
-			return nil, false, err
-		}
-		if refSecret != nil {
-			secretName, expectedKeys, err := desiredProviderCfg.referencedSecretName()
-			if err != nil {
-				return nil, false, err
-			}
-			for _, key := range expectedKeys {
-				if err := ks.KMS.PluginSecretData.Set(secretName, key, refSecret.Data[key]); err != nil {
-					return nil, false, err
-				}
-			}
-		}
-		if refCM != nil {
-			cmName, expectedKeys, err := desiredProviderCfg.referencedConfigMapName()
-			if err != nil {
-				return nil, false, err
-			}
-			for _, key := range expectedKeys {
-				if err := ks.KMS.PluginConfigMapData.Set(cmName, key, []byte(refCM.Data[key])); err != nil {
-					return nil, false, err
-				}
-			}
-		}
-
 		resources := &prefetchedKMSConfigHasherResourceProvider{secret: refSecret, configMap: refCM}
 		hasher, err := newKMSConfigHasher(desiredProviderCfg, resources, openshiftConfigNS)
 		if err != nil {
@@ -375,12 +295,67 @@ func (c *keyController) generateKeySecret(ctx context.Context, keyID uint64, cur
 			return nil, false, nil
 		}
 	}
-
 	secret, err := secrets.FromKeyState(c.instanceName, ks)
 	if err != nil {
 		return nil, false, err
 	}
 	return secret, true, nil
+}
+
+func buildEncryptionKeyState(ctx context.Context, keyID uint64, currentMode state.Mode, apiServerEncryption configv1.APIServerEncryption, desiredProviderCfg kmsProviderConfig, secretClient corev1client.SecretsGetter, configMapClient corev1client.ConfigMapsGetter, internalReason string, externalReason string) (state.KeyState, *corev1.Secret, *corev1.ConfigMap, error) {
+	bs := crypto.ModeToNewKeyFunc[currentMode]()
+	ks := state.KeyState{
+		Key: apiserverv1.Key{
+			Name:   fmt.Sprintf("%d", keyID),
+			Secret: base64.StdEncoding.EncodeToString(bs),
+		},
+		Mode:           currentMode,
+		InternalReason: internalReason,
+		ExternalReason: externalReason,
+	}
+
+	if currentMode != state.KMS {
+		return ks, nil, nil, nil
+	}
+
+	ks.KMS = &state.KMSState{
+		Encryption: &apiserverv1.KMSConfiguration{
+			APIVersion: "v2",
+			Name:       fmt.Sprintf("%d", keyID),
+			Endpoint:   fmt.Sprintf(kmsEndpointFormat, keyID),
+			Timeout:    &metav1.Duration{Duration: defaultKMSTimeout},
+		},
+		Plugin: apiServerEncryption.KMS,
+	}
+
+	refSecret, refCM, err := fetchReferencedResources(ctx, desiredProviderCfg, secretClient, configMapClient, openshiftConfigNS)
+	if err != nil {
+		return state.KeyState{}, nil, nil, err
+	}
+	if refSecret != nil {
+		secretName, expectedKeys, err := desiredProviderCfg.referencedSecretName()
+		if err != nil {
+			return state.KeyState{}, nil, nil, err
+		}
+		for _, key := range expectedKeys {
+			if err := ks.KMS.PluginSecretData.Set(secretName, key, refSecret.Data[key]); err != nil {
+				return state.KeyState{}, nil, nil, err
+			}
+		}
+	}
+	if refCM != nil {
+		cmName, expectedKeys, err := desiredProviderCfg.referencedConfigMapName()
+		if err != nil {
+			return state.KeyState{}, nil, nil, err
+		}
+		for _, key := range expectedKeys {
+			if err := ks.KMS.PluginConfigMapData.Set(cmName, key, []byte(refCM.Data[key])); err != nil {
+				return state.KeyState{}, nil, nil, err
+			}
+		}
+	}
+
+	return ks, refSecret, refCM, nil
 }
 
 // fetchReferencedResources loads the Secret and ConfigMap referenced by providerCfg from namespace, validating that every expected key is present. Either return value may be nil when the provider does not reference that resource type.
@@ -519,6 +494,60 @@ func (c *keyController) ensureKMSPreflightPassed(ctx context.Context, configHash
 	}
 	// Scenario 4: back off: preflight check is still in progress.
 	return false, nil
+}
+
+type encryptionKeyPlan struct {
+	needed         bool
+	keyID          uint64
+	reasons        []string
+	internalReason string
+}
+
+func planNextEncryptionKey(desiredEncryptionState map[schema.GroupResource]state.GroupResourceState, currentMode state.Mode, externalReason string, encryptedGRs []schema.GroupResource, desiredProviderCfg kmsProviderConfig) (*encryptionKeyPlan, error) {
+	plan := &encryptionKeyPlan{}
+	reasons := []string{}
+
+	var (
+		commonReason        string
+		hasCommonReason     bool
+		commonReasonDiffers bool
+	)
+
+	for gr, grKeys := range desiredEncryptionState {
+		latestKeyID, internalReason, needed, err := needsNewKey(grKeys, currentMode, externalReason, encryptedGRs, desiredProviderCfg)
+		if err != nil {
+			return nil, err
+		}
+		if !needed {
+			continue
+		}
+
+		if !hasCommonReason {
+			commonReason = internalReason
+			hasCommonReason = true
+		} else if commonReason != internalReason {
+			commonReasonDiffers = true
+		}
+
+		plan.needed = true
+		nextKeyID := latestKeyID + 1
+		if plan.keyID < nextKeyID {
+			plan.keyID = nextKeyID
+		}
+		reasons = append(reasons, fmt.Sprintf("%s-%s", gr.Resource, internalReason))
+	}
+
+	if !plan.needed {
+		return plan, nil
+	}
+	if hasCommonReason && !commonReasonDiffers && len(reasons) > 1 {
+		reasons = []string{commonReason}
+	}
+
+	sort.Strings(reasons)
+	plan.reasons = reasons
+	plan.internalReason = strings.Join(reasons, ", ")
+	return plan, nil
 }
 
 // needsNewKey checks whether a new key must be created for the given resource. If true, it also returns the latest

--- a/pkg/operator/encryption/controllers/key_controller_test.go
+++ b/pkg/operator/encryption/controllers/key_controller_test.go
@@ -54,6 +54,13 @@ func TestKeyController(t *testing.T) {
 		encryptiontesting.CreateVaultAppRoleSecret("vault-approle-secret", "test-role-id", "test-secret-id"),
 		encryptiontesting.CreateVaultCABundleConfigMap("vault-ca-bundle", "test-ca-cert"),
 	)
+	kmsPreflightFailedHash := kmsCreateKeyStatusProvider.status.Preflight.ObservedConfigHash
+	kmsPreflightFailedStatusProvider := &fakeKMSStatusProvider{}
+	kmsPreflightFailedStatusProvider.status.Preflight.ObservedConfigHash = kmsPreflightFailedHash
+	kmsPreflightFailedStatusProvider.status.Preflight.Result = operatorv1.KMSPreflightResult{
+		Status:     operatorv1.KMSPreflightResultFailed,
+		ConfigHash: kmsPreflightFailedHash,
+	}
 
 	scenarios := []struct {
 		name                     string
@@ -621,6 +628,32 @@ func TestKeyController(t *testing.T) {
 			expectedActions:          []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config", "get:configmaps:openshift-config"},
 			validateFunc: func(ts *testing.T, actions []clientgotesting.Action, targetNamespace string, targetGRs []schema.GroupResource) {
 			},
+		},
+
+		{
+			name: "degraded when KMS preflight check failed",
+			targetGRs: []schema.GroupResource{
+				{Group: "", Resource: "secrets"},
+			},
+			initialObjects: []runtime.Object{
+				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
+				encryptiontesting.CreateVaultAppRoleSecret("vault-approle-secret", "test-role-id", "test-secret-id"),
+				encryptiontesting.CreateVaultCABundleConfigMap("vault-ca-bundle", "test-ca-cert"),
+			},
+			apiServerObjects:         []runtime.Object{apiServerWithKMS},
+			targetNamespace:          "kms",
+			encryptionStatusProvider: kmsPreflightFailedStatusProvider,
+			expectedActions:          []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config", "get:configmaps:openshift-config"},
+			validateOperatorClientFunc: func(ts *testing.T, operatorClient v1helpers.OperatorClient) {
+				expectedCondition := operatorv1.OperatorCondition{
+					Type:    "EncryptionKeyControllerDegraded",
+					Status:  "True",
+					Reason:  "Error",
+					Message: fmt.Sprintf("failed to create key: KMS preflight check failed for config hash %s; fix the KMS configuration to proceed", kmsPreflightFailedHash),
+				}
+				encryptiontesting.ValidateOperatorClientConditions(ts, operatorClient, []operatorv1.OperatorCondition{expectedCondition})
+			},
+			expectedError: fmt.Errorf("failed to create key: KMS preflight check failed for config hash %s; fix the KMS configuration to proceed", kmsPreflightFailedHash),
 		},
 
 		{

--- a/pkg/operator/encryption/controllers/kms_preflight_compute_test.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_compute_test.go
@@ -1,0 +1,624 @@
+package controllers
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
+
+	"k8s.io/client-go/kubernetes/fake"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	configv1clientfake "github.com/openshift/client-go/config/clientset/versioned/fake"
+
+	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
+	"github.com/openshift/library-go/pkg/operator/encryption/secrets"
+	"github.com/openshift/library-go/pkg/operator/encryption/state"
+	"github.com/openshift/library-go/pkg/operator/encryption/statemachine"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+func TestKMSPreflightComputeEncryptionConfiguration(t *testing.T) {
+	apiServerWithKMS := newKMSVaultAPIServer()
+	encryptedGRs := []schema.GroupResource{{Group: "", Resource: "secrets"}}
+	instanceName := "test"
+
+	t.Run("first key, no existing secrets, produces key ID 1", func(t *testing.T) {
+		controller := newKMSPreflightComputeController(
+			[]runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			&fakeEncryptionDeployer{converged: true},
+			apiServerWithKMS,
+			newTestProvider(encryptedGRs),
+			instanceName,
+		)
+
+		secret, err := controller.computeEncryptionConfiguration(context.TODO())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if secret == nil {
+			t.Fatalf("expected a secret, got nil")
+		}
+
+		cfg, err := encryptiondata.FromSecret(secret)
+		if err != nil {
+			t.Fatalf("failed to parse produced secret: %v", err)
+		}
+		kmsConfigs, err := encryptiondata.ExtractUniqueAndSortedKMSConfigurations(cfg)
+		if err != nil {
+			t.Fatalf("failed to extract KMS configurations: %v", err)
+		}
+		if len(kmsConfigs) != 1 {
+			t.Fatalf("expected 1 KMS configuration, got %d: %+v", len(kmsConfigs), kmsConfigs)
+		}
+		if kmsConfigs[0].Name != "1" {
+			t.Errorf("expected key ID 1, got %s", kmsConfigs[0].Name)
+		}
+		if kmsConfigs[0].Endpoint != "unix:///var/run/kmsplugin/kms-1.sock" {
+			t.Errorf("unexpected endpoint: %s", kmsConfigs[0].Endpoint)
+		}
+		assertKMSKeyCredentials(t, cfg, "1", "role-123", "secret-456", "test-ca-cert")
+
+		// Must match the state-controller shape for key 1.
+		simulatedKey, err := secrets.FromKeyState(instanceName, state.KeyState{
+			Key:  apiserverconfigv1.Key{Name: "1", Secret: base64.StdEncoding.EncodeToString(make([]byte, 16))},
+			Mode: state.KMS,
+			KMS: &state.KMSState{
+				Encryption: &apiserverconfigv1.KMSConfiguration{
+					APIVersion: "v2",
+					Name:       "1",
+					Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
+					Timeout:    &metav1.Duration{Duration: 10 * time.Second},
+				},
+				Plugin: apiServerWithKMS.Spec.Encryption.KMS,
+			},
+		})
+		if err != nil {
+			t.Fatalf("failed to build comparison key: %v", err)
+		}
+		ks, err := secrets.ToKeyState(simulatedKey)
+		if err != nil {
+			t.Fatalf("failed to parse comparison key: %v", err)
+		}
+		_ = ks.KMS.PluginSecretData.Set("vault-approle", "role-id", []byte("role-123"))
+		_ = ks.KMS.PluginSecretData.Set("vault-approle", "secret-id", []byte("secret-456"))
+		_ = ks.KMS.PluginConfigMapData.Set("vault-ca-bundle", "ca-bundle.crt", []byte("test-ca-cert"))
+		simulatedKey, err = secrets.FromKeyState(instanceName, ks)
+		if err != nil {
+			t.Fatalf("failed to rebuild comparison key: %v", err)
+		}
+		assertPreflightConfigMatchesStateMachine(t, instanceName, secret, nil, []*corev1.Secret{simulatedKey}, encryptedGRs)
+	})
+
+	t.Run("existing key with deployed config, uses next key ID and retains credentials", func(t *testing.T) {
+		existingKeySecret := newExistingKMSKeySecret(t, instanceName, apiServerWithKMS, encryptedGRs, "3")
+		deployed := newDeployedKMSEncryptionConfig(t, instanceName, encryptedGRs, existingKeySecret)
+		controller := newKMSPreflightComputeController(
+			[]runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap, existingKeySecret},
+			&fakeEncryptionDeployer{converged: true, secret: deployed},
+			apiServerWithKMS,
+			newTestProvider(encryptedGRs),
+			instanceName,
+		)
+
+		secret, err := controller.computeEncryptionConfiguration(context.TODO())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		cfg, err := encryptiondata.FromSecret(secret)
+		if err != nil {
+			t.Fatalf("failed to parse produced secret: %v", err)
+		}
+		kmsConfigs, err := encryptiondata.ExtractUniqueAndSortedKMSConfigurations(cfg)
+		if err != nil {
+			t.Fatalf("failed to extract KMS configurations: %v", err)
+		}
+
+		// Key 3 remains the write key (STEP 2 early return); key 4 is the new read key
+		// the key-controller is about to create. Both must be present.
+		var found3, found4 bool
+		for _, kc := range kmsConfigs {
+			switch kc.Name {
+			case "3":
+				found3 = true
+			case "4":
+				found4 = true
+				if kc.Endpoint != "unix:///var/run/kmsplugin/kms-4.sock" {
+					t.Errorf("unexpected endpoint for key 4: %s", kc.Endpoint)
+				}
+			}
+		}
+		if !found3 || !found4 {
+			t.Fatalf("expected key IDs 3 and 4 among KMS configurations, got %+v", kmsConfigs)
+		}
+		assertKMSKeyCredentials(t, cfg, "3", "old-role-id", "old-secret-id", "old-ca-cert")
+		assertKMSKeyCredentials(t, cfg, "4", "role-123", "secret-456", "test-ca-cert")
+
+		newKey := newExistingKMSKeySecret(t, instanceName, apiServerWithKMS, encryptedGRs, "4")
+		ks, err := secrets.ToKeyState(newKey)
+		if err != nil {
+			t.Fatalf("failed to parse new key: %v", err)
+		}
+		ks.KMS.Encryption.Endpoint = "unix:///var/run/kmsplugin/kms-4.sock"
+		ks.KMS.Plugin = apiServerWithKMS.Spec.Encryption.KMS
+		_ = ks.KMS.PluginSecretData.Set("vault-approle", "role-id", []byte("role-123"))
+		_ = ks.KMS.PluginSecretData.Set("vault-approle", "secret-id", []byte("secret-456"))
+		_ = ks.KMS.PluginConfigMapData.Set("vault-ca-bundle", "ca-bundle.crt", []byte("test-ca-cert"))
+		newKey, err = secrets.FromKeyState(instanceName, ks)
+		if err != nil {
+			t.Fatalf("failed to rebuild new key: %v", err)
+		}
+		deployedCfg, err := encryptiondata.FromSecret(deployed)
+		if err != nil {
+			t.Fatalf("failed to parse deployed config: %v", err)
+		}
+		assertPreflightConfigMatchesStateMachine(t, instanceName, secret, deployedCfg, []*corev1.Secret{existingKeySecret, newKey}, encryptedGRs)
+	})
+
+	t.Run("new candidate key and existing key both use production endpoints", func(t *testing.T) {
+		existingKeySecret := newExistingKMSKeySecret(t, instanceName, apiServerWithKMS, encryptedGRs, "3")
+		deployed := newDeployedKMSEncryptionConfig(t, instanceName, encryptedGRs, existingKeySecret)
+		controller := newKMSPreflightComputeController(
+			[]runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap, existingKeySecret},
+			&fakeEncryptionDeployer{converged: true, secret: deployed},
+			apiServerWithKMS,
+			newTestProvider(encryptedGRs),
+			instanceName,
+		)
+
+		secret, err := controller.computeEncryptionConfiguration(context.TODO())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		cfg, err := encryptiondata.FromSecret(secret)
+		if err != nil {
+			t.Fatalf("failed to parse produced secret: %v", err)
+		}
+		endpointsByKey := kmsConfigEndpointsByName(t, cfg)
+		if endpointsByKey["3"] != "unix:///var/run/kmsplugin/kms-3.sock" {
+			t.Fatalf("expected existing key 3 to keep its original endpoint, got %q", endpointsByKey["3"])
+		}
+		if endpointsByKey["4"] != "unix:///var/run/kmsplugin/kms-4.sock" {
+			t.Fatalf("expected candidate key 4 to use production endpoint %q, got %q", "unix:///var/run/kmsplugin/kms-4.sock", endpointsByKey["4"])
+		}
+	})
+
+	t.Run("unbacked key in deployed config, next key ID follows needsNewKey", func(t *testing.T) {
+		// Deployed config claims write key 5, but its secret was deleted. Only key 3
+		// still exists. The key-controller's needsNewKey reads ReadKeys[0] (unbacked 5)
+		// and creates key 6 — preflight must do the same, not max(secrets)+1=4.
+		key3 := newExistingKMSKeySecret(t, instanceName, apiServerWithKMS, encryptedGRs, "3")
+		unbacked := state.KeyState{
+			Key:  apiserverconfigv1.Key{Name: "5", Secret: base64.StdEncoding.EncodeToString(make([]byte, 16))},
+			Mode: state.KMS,
+			KMS: &state.KMSState{
+				Encryption: &apiserverconfigv1.KMSConfiguration{
+					APIVersion: "v2",
+					Name:       "5",
+					Endpoint:   "unix:///var/run/kmsplugin/kms-5.sock",
+					Timeout:    &metav1.Duration{Duration: 10 * time.Second},
+				},
+				Plugin: apiServerWithKMS.Spec.Encryption.KMS,
+			},
+		}
+		cfg, err := encryptiondata.FromEncryptionState(map[schema.GroupResource]state.GroupResourceState{
+			{Resource: "secrets"}: {WriteKey: unbacked, ReadKeys: []state.KeyState{unbacked}},
+		})
+		if err != nil {
+			t.Fatalf("failed to build unbacked encryption config: %v", err)
+		}
+		deployed, err := encryptiondata.ToSecret("openshift-config-managed", "encryption-config-"+instanceName, cfg)
+		if err != nil {
+			t.Fatalf("failed to serialize unbacked encryption config: %v", err)
+		}
+
+		controller := newKMSPreflightComputeController(
+			[]runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap, key3},
+			&fakeEncryptionDeployer{converged: true, secret: deployed},
+			apiServerWithKMS,
+			newTestProvider(encryptedGRs),
+			instanceName,
+		)
+
+		secret, err := controller.computeEncryptionConfiguration(context.TODO())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		out, err := encryptiondata.FromSecret(secret)
+		if err != nil {
+			t.Fatalf("failed to parse produced secret: %v", err)
+		}
+		kmsConfigs, err := encryptiondata.ExtractUniqueAndSortedKMSConfigurations(out)
+		if err != nil {
+			t.Fatalf("failed to extract KMS configurations: %v", err)
+		}
+		var found6 bool
+		for _, kc := range kmsConfigs {
+			if kc.Name == "4" {
+				t.Errorf("must not use max(existing secrets)+1=4 when unbacked key 5 is latest; got %+v", kmsConfigs)
+			}
+			if kc.Name == "6" {
+				found6 = true
+			}
+		}
+		if !found6 {
+			t.Errorf("expected next key ID 6 (unbacked 5 + 1) among KMS configurations, got %+v", kmsConfigs)
+		}
+	})
+
+	t.Run("invalid key secrets are ignored when computing next key ID", func(t *testing.T) {
+		// A corrupt secret whose name parses as key ID 5 must not bump the next ID.
+		// GetDesiredEncryptionState skips secrets that fail ToKeyState, so valid key 2
+		// → ReadKeys[0] is 2 → next is 3.
+		validKeySecret := newExistingKMSKeySecret(t, instanceName, apiServerWithKMS, encryptedGRs, "2")
+		invalidKeySecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "encryption-key-test-5",
+				Namespace: "openshift-config-managed",
+				Labels:    map[string]string{secrets.EncryptionKeySecretsLabel: instanceName},
+			},
+			Data: map[string][]byte{
+				secrets.EncryptionSecretKeyDataKey: []byte("not-a-valid-key-secret"),
+			},
+		}
+		deployed := newDeployedKMSEncryptionConfig(t, instanceName, encryptedGRs, validKeySecret)
+		controller := newKMSPreflightComputeController(
+			[]runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap, validKeySecret, invalidKeySecret},
+			&fakeEncryptionDeployer{converged: true, secret: deployed},
+			apiServerWithKMS,
+			newTestProvider(encryptedGRs),
+			instanceName,
+		)
+
+		secret, err := controller.computeEncryptionConfiguration(context.TODO())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		cfg, err := encryptiondata.FromSecret(secret)
+		if err != nil {
+			t.Fatalf("failed to parse produced secret: %v", err)
+		}
+		kmsConfigs, err := encryptiondata.ExtractUniqueAndSortedKMSConfigurations(cfg)
+		if err != nil {
+			t.Fatalf("failed to extract KMS configurations: %v", err)
+		}
+
+		var found3 bool
+		for _, kc := range kmsConfigs {
+			if kc.Name == "3" {
+				found3 = true
+			}
+			if kc.Name == "6" {
+				t.Errorf("invalid secret name must not bump next key ID to 6, got %+v", kmsConfigs)
+			}
+		}
+		if !found3 {
+			t.Errorf("expected next key ID 3 among KMS configurations, got %+v", kmsConfigs)
+		}
+	})
+
+	t.Run("no new key needed still returns existing write-key config for preflight", func(t *testing.T) {
+		// Same provider as the current apiserver config and already migrated: planner
+		// says needed=false. Preflight must reuse key 3 with its production endpoint.
+		ks := state.KeyState{
+			Key:  apiserverconfigv1.Key{Name: "3", Secret: base64.StdEncoding.EncodeToString(make([]byte, 16))},
+			Mode: state.KMS,
+			Migrated: state.MigrationState{
+				Resources: encryptedGRs,
+			},
+			KMS: &state.KMSState{
+				Encryption: &apiserverconfigv1.KMSConfiguration{
+					APIVersion: "v2",
+					Name:       "3",
+					Endpoint:   "unix:///var/run/kmsplugin/kms-3.sock",
+					Timeout:    &metav1.Duration{Duration: 10 * time.Second},
+				},
+				Plugin: apiServerWithKMS.Spec.Encryption.KMS,
+			},
+		}
+		if err := ks.KMS.PluginSecretData.Set("vault-approle", "role-id", []byte("role-123")); err != nil {
+			t.Fatalf("failed to set plugin secret data: %v", err)
+		}
+		if err := ks.KMS.PluginSecretData.Set("vault-approle", "secret-id", []byte("secret-456")); err != nil {
+			t.Fatalf("failed to set plugin secret data: %v", err)
+		}
+		if err := ks.KMS.PluginConfigMapData.Set("vault-ca-bundle", "ca-bundle.crt", []byte("test-ca-cert")); err != nil {
+			t.Fatalf("failed to set plugin configmap data: %v", err)
+		}
+		existingKeySecret, err := secrets.FromKeyState(instanceName, ks)
+		if err != nil {
+			t.Fatalf("failed to build existing key secret: %v", err)
+		}
+		deployed := newDeployedKMSEncryptionConfig(t, instanceName, encryptedGRs, existingKeySecret)
+		controller := newKMSPreflightComputeController(
+			[]runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap, existingKeySecret},
+			&fakeEncryptionDeployer{converged: true, secret: deployed},
+			apiServerWithKMS,
+			newTestProvider(encryptedGRs),
+			instanceName,
+		)
+
+		secret, err := controller.computeEncryptionConfiguration(context.TODO())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if secret == nil {
+			t.Fatal("expected a secret")
+		}
+
+		cfg, err := encryptiondata.FromSecret(secret)
+		if err != nil {
+			t.Fatalf("failed to parse produced secret: %v", err)
+		}
+		kmsConfigs, err := encryptiondata.ExtractUniqueAndSortedKMSConfigurations(cfg)
+		if err != nil {
+			t.Fatalf("failed to extract KMS configurations: %v", err)
+		}
+		if len(kmsConfigs) != 1 {
+			t.Fatalf("expected 1 KMS configuration, got %+v", kmsConfigs)
+		}
+		if kmsConfigs[0].Name != "3" {
+			t.Fatalf("expected write key 3, got %s", kmsConfigs[0].Name)
+		}
+		if kmsConfigs[0].Endpoint != "unix:///var/run/kmsplugin/kms-3.sock" {
+			t.Fatalf("expected write-key endpoint %s, got %s", "unix:///var/run/kmsplugin/kms-3.sock", kmsConfigs[0].Endpoint)
+		}
+		assertKMSKeyCredentials(t, cfg, "3", "role-123", "secret-456", "test-ca-cert")
+	})
+
+	t.Run("API server revisions not converged, still computes preflight config", func(t *testing.T) {
+		controller := newKMSPreflightComputeController(
+			[]runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			&fakeEncryptionDeployer{converged: false},
+			apiServerWithKMS,
+			newTestProvider(encryptedGRs),
+			instanceName,
+		)
+
+		secret, err := controller.computeEncryptionConfiguration(context.TODO())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if secret == nil {
+			t.Fatalf("expected a secret, got nil")
+		}
+	})
+
+	t.Run("EncryptedGRs are read at compute time", func(t *testing.T) {
+		provider := &testProvider{encryptedGRs: []schema.GroupResource{{Resource: "secrets"}}}
+		controller := newKMSPreflightComputeController(
+			[]runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			&fakeEncryptionDeployer{converged: true},
+			apiServerWithKMS,
+			provider,
+			instanceName,
+		)
+
+		first, err := controller.computeEncryptionConfiguration(context.TODO())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		firstNames := encryptedResourceNames(t, first)
+		if !firstNames["secrets"] {
+			t.Fatalf("expected secrets in first compute, got %v", firstNames)
+		}
+		if firstNames["configmaps"] {
+			t.Fatalf("did not expect configmaps in first compute, got %v", firstNames)
+		}
+
+		provider.encryptedGRs = []schema.GroupResource{{Resource: "secrets"}, {Resource: "configmaps"}}
+		second, err := controller.computeEncryptionConfiguration(context.TODO())
+		if err != nil {
+			t.Fatalf("unexpected error after EncryptedGRs change: %v", err)
+		}
+		secondNames := encryptedResourceNames(t, second)
+		if !secondNames["secrets"] || !secondNames["configmaps"] {
+			t.Fatalf("expected secrets and configmaps after EncryptedGRs change, got %v", secondNames)
+		}
+	})
+}
+
+func TestKMSPreflightComputeEncryptionConfigurationErrors(t *testing.T) {
+	apiServerWithKMS := newKMSVaultAPIServer()
+	encryptedGRs := []schema.GroupResource{{Group: "", Resource: "secrets"}}
+	instanceName := "test"
+
+	scenarios := []struct {
+		name          string
+		coreObjects   []runtime.Object
+		deployer      *fakeEncryptionDeployer
+		apiServer     *configv1.APIServer
+		expectedError string
+	}{
+		{
+			name:          "missing referenced secret returns an error",
+			coreObjects:   []runtime.Object{&wellKnownBaseConfigMap},
+			deployer:      &fakeEncryptionDeployer{converged: true},
+			apiServer:     apiServerWithKMS,
+			expectedError: "vault-approle",
+		},
+		{
+			name:          "missing referenced configmap returns an error",
+			coreObjects:   []runtime.Object{&wellKnownBaseSecret},
+			deployer:      &fakeEncryptionDeployer{converged: true},
+			apiServer:     apiServerWithKMS,
+			expectedError: "vault-ca-bundle",
+		},
+		{
+			name:          "encryption deployer error is propagated",
+			coreObjects:   nil,
+			deployer:      &fakeEncryptionDeployer{err: fmt.Errorf("boom")},
+			apiServer:     apiServerWithKMS,
+			expectedError: "boom",
+		},
+		{
+			name: "invalid deployed encryption config returns an error",
+			coreObjects: []runtime.Object{
+				&wellKnownBaseSecret,
+				&wellKnownBaseConfigMap,
+			},
+			deployer: &fakeEncryptionDeployer{
+				converged: true,
+				secret: &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "encryption-config-test", Namespace: "openshift-config-managed"},
+					Data:       map[string][]byte{encryptiondata.EncryptionConfSecretKey: []byte("not-valid-json")},
+				},
+			},
+			apiServer:     apiServerWithKMS,
+			expectedError: "",
+		},
+		{
+			name:        "non-KMS mode returns an error",
+			coreObjects: nil,
+			deployer:    &fakeEncryptionDeployer{converged: true},
+			apiServer: &configv1.APIServer{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec:       configv1.APIServerSpec{Encryption: configv1.APIServerEncryption{Type: configv1.EncryptionTypeAESCBC}},
+			},
+			expectedError: "KMS",
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			controller := newKMSPreflightComputeController(
+				scenario.coreObjects,
+				scenario.deployer,
+				scenario.apiServer,
+				newTestProvider(encryptedGRs),
+				instanceName,
+			)
+
+			secret, err := controller.computeEncryptionConfiguration(context.TODO())
+			if err == nil {
+				t.Fatalf("expected an error, got secret %+v", secret)
+			}
+			if scenario.expectedError != "" && !strings.Contains(err.Error(), scenario.expectedError) {
+				t.Fatalf("expected error containing %q, got: %v", scenario.expectedError, err)
+			}
+		})
+	}
+}
+
+func newKMSPreflightComputeController(
+	coreObjects []runtime.Object,
+	encryptionDeployer statemachine.Deployer,
+	apiServer *configv1.APIServer,
+	provider Provider,
+	instanceName string,
+) *kmsPreflightController {
+	fakeKubeClient := fake.NewSimpleClientset(coreObjects...)
+	fakeConfigClient := configv1clientfake.NewSimpleClientset(apiServer)
+	fakeOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(
+		&operatorv1.StaticPodOperatorSpec{OperatorSpec: operatorv1.OperatorSpec{ManagementState: operatorv1.Managed}},
+		&operatorv1.StaticPodOperatorStatus{},
+		nil,
+		nil,
+	)
+	return &kmsPreflightController{
+		instanceName:             instanceName,
+		encryptionSecretSelector: metav1.ListOptions{},
+		operatorClient:           fakeOperatorClient,
+		apiServerClient:          fakeConfigClient.ConfigV1().APIServers(),
+		secretsClient:            fakeKubeClient.CoreV1(),
+		configMapsClient:         fakeKubeClient.CoreV1(),
+		encryptionDeployer:       encryptionDeployer,
+		provider:                 provider,
+	}
+}
+
+func assertKMSKeyCredentials(t *testing.T, cfg *encryptiondata.Config, keyID, roleID, secretID, caBundle string) {
+	t.Helper()
+
+	if _, ok := cfg.KMSPlugins[keyID]; !ok {
+		t.Fatalf("expected plugin config for keyID %s", keyID)
+	}
+	secretData, ok := cfg.KMSPluginsSecretData.Get(keyID)
+	if !ok {
+		t.Fatalf("expected secret data for keyID %s", keyID)
+	}
+	if v, ok := secretData.Get("vault-approle", "role-id"); !ok || string(v) != roleID {
+		t.Errorf("key %s: expected role-id %q, got %q (found=%v)", keyID, roleID, v, ok)
+	}
+	if v, ok := secretData.Get("vault-approle", "secret-id"); !ok || string(v) != secretID {
+		t.Errorf("key %s: expected secret-id %q, got %q (found=%v)", keyID, secretID, v, ok)
+	}
+	cmData, ok := cfg.KMSPluginsConfigMapData.Get(keyID)
+	if !ok {
+		t.Fatalf("expected configmap data for keyID %s", keyID)
+	}
+	if v, ok := cmData.Get("vault-ca-bundle", "ca-bundle.crt"); !ok || string(v) != caBundle {
+		t.Errorf("key %s: expected ca-bundle %q, got %q (found=%v)", keyID, caBundle, v, ok)
+	}
+}
+
+func kmsConfigEndpointsByName(t *testing.T, cfg *encryptiondata.Config) map[string]string {
+	t.Helper()
+
+	kmsConfigs, err := encryptiondata.ExtractUniqueAndSortedKMSConfigurations(cfg)
+	if err != nil {
+		t.Fatalf("failed to extract KMS configurations: %v", err)
+	}
+	endpoints := map[string]string{}
+	for _, kc := range kmsConfigs {
+		endpoints[kc.Name] = kc.Endpoint
+	}
+	return endpoints
+}
+
+func encryptedResourceNames(t *testing.T, secret *corev1.Secret) map[string]bool {
+	t.Helper()
+
+	cfg, err := encryptiondata.FromSecret(secret)
+	if err != nil {
+		t.Fatalf("failed to parse secret: %v", err)
+	}
+	names := map[string]bool{}
+	if cfg.Encryption == nil {
+		return names
+	}
+	for _, rc := range cfg.Encryption.Resources {
+		for _, r := range rc.Resources {
+			names[r] = true
+		}
+	}
+	return names
+}
+
+func assertPreflightConfigMatchesStateMachine(
+	t *testing.T,
+	instanceName string,
+	got *corev1.Secret,
+	deployedCfg *encryptiondata.Config,
+	keySecrets []*corev1.Secret,
+	encryptedGRs []schema.GroupResource,
+) {
+	t.Helper()
+
+	desired := statemachine.GetDesiredEncryptionState(deployedCfg, keySecrets, encryptedGRs)
+	wantCfg, err := encryptiondata.FromEncryptionState(desired)
+	if err != nil {
+		t.Fatalf("failed to build golden config: %v", err)
+	}
+	wantSecret, err := encryptiondata.ToSecret("openshift-config-managed", "encryption-config-"+instanceName, wantCfg)
+	if err != nil {
+		t.Fatalf("failed to serialize golden config: %v", err)
+	}
+	if !equality.Semantic.DeepEqual(got.Data, wantSecret.Data) {
+		t.Errorf("preflight secret data diverges from state-machine golden config")
+	}
+}

--- a/pkg/operator/encryption/controllers/kms_preflight_controller.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/encryption/kms"
+	"github.com/openshift/library-go/pkg/operator/encryption/state"
+	"github.com/openshift/library-go/pkg/operator/encryption/statemachine"
 	"github.com/openshift/library-go/pkg/operator/events"
 	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
 )
@@ -212,14 +214,18 @@ type KMSPreflightDeployer interface {
 }
 
 type kmsPreflightController struct {
-	controllerInstanceName string
+	controllerInstanceName   string
+	instanceName             string
+	unsupportedConfigPrefix  []string
+	encryptionSecretSelector metav1.ListOptions
 
 	operatorClient   operatorv1helpers.OperatorClient
 	apiServerClient  configv1client.APIServerInterface
 	secretsClient    corev1client.SecretsGetter
 	configMapsClient corev1client.ConfigMapsGetter
 
-	deployer KMSPreflightDeployer
+	deployer           KMSPreflightDeployer
+	encryptionDeployer statemachine.Deployer
 	// encryptionConfigurationComputer is called right before Deploy to produce the
 	// encryption configuration secret passed to the deployer.
 	encryptionConfigurationComputer EncryptionConfigurationComputer
@@ -324,9 +330,15 @@ func NewKMSPreflightController(
 	configMapsClient corev1client.ConfigMapsGetter,
 	encryptionStatusProvider kms.EncryptionStatusProvider,
 	eventRecorder events.Recorder,
+	unsupportedConfigPrefix []string,
+	encryptionDeployer statemachine.Deployer,
+	encryptionSecretSelector metav1.ListOptions,
 ) factory.Controller {
 	c := &kmsPreflightController{
-		controllerInstanceName: factory.ControllerInstanceName(instanceName, "EncryptionKMSPreflight"),
+		controllerInstanceName:   factory.ControllerInstanceName(instanceName, "EncryptionKMSPreflight"),
+		instanceName:             instanceName,
+		unsupportedConfigPrefix:  unsupportedConfigPrefix,
+		encryptionSecretSelector: encryptionSecretSelector,
 
 		operatorClient:   operatorClient,
 		apiServerClient:  apiServerClient,
@@ -334,6 +346,7 @@ func NewKMSPreflightController(
 		configMapsClient: configMapsClient,
 
 		deployer:                        deployer,
+		encryptionDeployer:              encryptionDeployer,
 		encryptionConfigurationComputer: encryptionConfigurationComputer,
 		// assume resources may exist from a previous process run
 		dirtyDeployer:            true,
@@ -352,6 +365,47 @@ func NewKMSPreflightController(
 		c.controllerInstanceName,
 		eventRecorder.WithComponentSuffix("encryption-kms-preflight-controller"),
 	)
+}
+
+func (c *kmsPreflightController) computeEncryptionConfiguration(ctx context.Context) (*corev1.Secret, error) {
+	// TODO: remove this fallback once EncryptionConfigurationComputer is deleted.
+	if c.encryptionConfigurationComputer != nil {
+		return c.encryptionConfigurationComputer.ComputeEncryptionConfiguration(ctx)
+	}
+
+	// ListKeysWhileProgressing=true so preflight can still list keys and compute a plan even when there
+	// is no convergence yet. The key controller sets this to false to avoid extra Lists during rollout.
+	planner := NewEncryptionPlanner(c.instanceName, c.unsupportedConfigPrefix, c.encryptionDeployer, c.secretsClient, c.configMapsClient, c.apiServerClient, c.operatorClient, c.encryptionSecretSelector)
+	snap, err := planner.Load(ctx, c.provider.EncryptedGRs(), LoadOptions{ListKeysWhileProgressing: true})
+	if err != nil {
+		return nil, err
+	}
+	if snap.CurrentMode != "" && snap.CurrentMode != state.KMS {
+		return nil, fmt.Errorf("preflight encryption config computation requires KMS mode, got %q", snap.CurrentMode)
+	}
+
+	plan, err := planner.PlanNextKey(snap)
+	if err != nil {
+		return nil, err
+	}
+
+	var plannedKey *PlannedEncryptionKey
+	if plan.Needed {
+		plannedKey, err = planner.MaterializeKey(ctx, snap, plan)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	result, err := planner.ComputeConfig(&snap.State, plannedKey)
+	if err != nil {
+		return nil, err
+	}
+	if result.EncryptionSecret == nil {
+		return nil, fmt.Errorf("no encryption key secrets available to compute preflight encryption config")
+	}
+
+	return result.EncryptionSecret, nil
 }
 
 func (c *kmsPreflightController) sync(ctx context.Context, syncCtx factory.SyncContext) (err error) {
@@ -520,7 +574,7 @@ func (c *kmsPreflightController) runPreflightChecks(ctx context.Context) (requeu
 				message: fmt.Sprintf("preflight check failed for hash %s: pod was removed but failure is recorded in status", requiredHash),
 			}
 		}
-		encryptionConfig, err := c.encryptionConfigurationComputer.ComputeEncryptionConfiguration(ctx)
+		encryptionConfig, err := c.computeEncryptionConfiguration(ctx)
 		if err != nil {
 			return true, "", "", fmt.Errorf("failed to compute encryption configuration: %w", err)
 		}

--- a/pkg/operator/encryption/controllers/state_controller.go
+++ b/pkg/operator/encryption/controllers/state_controller.go
@@ -127,50 +127,44 @@ type eventWithReason struct {
 }
 
 func (c *stateController) generateAndApplyCurrentEncryptionConfigSecret(ctx context.Context, queue workqueue.RateLimitingInterface, recorder events.Recorder, encryptedGRs []schema.GroupResource) error {
-	currentConfig, desiredEncryptionState, encryptionSecrets, transitioningReason, err := statemachine.GetEncryptionConfigAndState(ctx, c.deployer, c.secretClient, c.encryptionSecretSelector, encryptedGRs)
+	// Mode clients are intentionally nil: the state controller only needs
+	// LoadState + ComputeConfig over persisted keys.
+	planner := NewEncryptionPlanner(c.instanceName, nil, c.deployer, c.secretClient, nil, nil, nil, c.encryptionSecretSelector)
+	stateSnap, err := planner.LoadState(ctx, encryptedGRs)
 	if err != nil {
 		return err
 	}
-	if len(transitioningReason) > 0 {
+	if len(stateSnap.ProgressingReason) > 0 {
 		queue.AddAfter(stateWorkKey, 2*time.Minute)
 		return nil
 	}
 
-	if currentConfig == nil && len(encryptionSecrets) == 0 {
+	result, err := planner.ComputeConfig(stateSnap, nil)
+	if err != nil {
+		return err
+	}
+
+	if result.EncryptionSecret == nil {
 		// we depend on the key controller to create the first key to bootstrap encryption.
 		// Later-on either the config exists or there are keys, even in the case of disabled
 		// encryption via the apiserver config.
 		return nil
 	}
 
-	desiredSecretData, err := encryptiondata.FromEncryptionState(desiredEncryptionState)
-	if err != nil {
-		return err
-	}
-	changed, err := c.applyEncryptionConfigSecret(ctx, desiredSecretData, recorder)
+	_, changed, err := resourceapply.ApplySecret(ctx, c.secretClient, recorder, result.EncryptionSecret)
 	if err != nil {
 		return err
 	}
 
 	if changed {
-		currentEncryptionConfig, _ := encryptiondata.ToEncryptionState(currentConfig, encryptionSecrets)
-		if actionEvents := eventsFromEncryptionConfigChanges(currentEncryptionConfig, desiredEncryptionState); len(actionEvents) > 0 {
+		currentEncryptionConfig, _ := encryptiondata.ToEncryptionState(result.CurrentConfig, result.KeySecrets)
+		if actionEvents := eventsFromEncryptionConfigChanges(currentEncryptionConfig, result.DesiredState); len(actionEvents) > 0 {
 			for _, event := range actionEvents {
 				recorder.Eventf(event.reason, "%s", event.message)
 			}
 		}
 	}
 	return nil
-}
-
-func (c *stateController) applyEncryptionConfigSecret(ctx context.Context, secretData *encryptiondata.Config, recorder events.Recorder) (bool, error) {
-	s, err := encryptiondata.ToSecret("openshift-config-managed", fmt.Sprintf("%s-%s", encryptiondata.EncryptionConfSecretName, c.instanceName), secretData)
-	if err != nil {
-		return false, err
-	}
-
-	_, changed, applyErr := resourceapply.ApplySecret(ctx, c.secretClient, recorder, s)
-	return changed, applyErr
 }
 
 // eventsFromEncryptionConfigChanges return slice of event reasons with messages corresponding to a difference between current and desired encryption state.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved encryption key planning for creation, rotation, migration, and configuration changes.
  - Added candidate encryption configuration generation and validation during KMS preflight checks.
  - Added support for KMS endpoint overrides during preflight validation.

- **Bug Fixes**
  - Prevented key creation when KMS preflight validation fails.
  - Improved handling of missing, invalid, or incomplete KMS credentials.
  - Ensured encryption state and candidate configurations remain consistent.
  - Automatically cleaned up successful KMS preflight workloads.
  - Improved progress reporting while encryption changes are being applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->