### PR TITLE
kms: export GetDesiredEncryptionState in operator/encryption/statemachine

### DIFF
--- a/pkg/operator/encryption/statemachine/transition.go
+++ b/pkg/operator/encryption/statemachine/transition.go
@@ -56,12 +56,12 @@ func GetEncryptionConfigAndState(
 	if err != nil {
 		return nil, nil, nil, "", err
 	}
-	desiredEncryptionState := getDesiredEncryptionState(secretData, encryptionSecrets, encryptedGRs)
+	desiredEncryptionState := GetDesiredEncryptionState(secretData, encryptionSecrets, encryptedGRs)
 
 	return secretData, desiredEncryptionState, encryptionSecrets, "", nil
 }
 
-// getDesiredEncryptionState returns the desired state of encryption for all resources.
+// GetDesiredEncryptionState returns the desired state of encryption for all resources.
 // To do this it compares the current state against the available secrets and to-be-encrypted resources.
 // oldEncryptionConfig can be nil if there is no config yet.
 // If there are no secrets, the identity is set for all resources as write key.
@@ -73,7 +73,7 @@ func GetEncryptionConfigAndState(
 // 2. every GR must have all the read-keys (existing as secrets) since last complete migration.
 // 3. if (2) is the case, the write-key must be the most recent key.
 // 4. if (2) and (3) are the case, all non-write keys should be removed.
-func getDesiredEncryptionState(oldSecretData *encryptiondata.Config, encryptionSecrets []*corev1.Secret, toBeEncryptedGRs []schema.GroupResource) map[schema.GroupResource]state.GroupResourceState {
+func GetDesiredEncryptionState(oldSecretData *encryptiondata.Config, encryptionSecrets []*corev1.Secret, toBeEncryptedGRs []schema.GroupResource) map[schema.GroupResource]state.GroupResourceState {
 	//
 	// STEP 0: start with old encryption config, and alter it towards the desired state in the following STEPs.
 	//

--- a/pkg/operator/encryption/statemachine/transition_test.go
+++ b/pkg/operator/encryption/statemachine/transition_test.go
@@ -1302,7 +1302,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := getDesiredEncryptionState(tt.args.oldEncryptionConfig, tt.args.encryptionSecrets, tt.args.toBeEncryptedGRs)
+			got := GetDesiredEncryptionState(tt.args.oldEncryptionConfig, tt.args.encryptionSecrets, tt.args.toBeEncryptedGRs)
 			if tt.validate != nil {
 				tt.validate(t, &tt.args, got)
 			}


### PR DESCRIPTION
Export the desired encryption state helper so other encryption controllers can reuse the same state transition logic instead of reimplementing it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Exposed the encryption state helper for broader internal use.
  * Updated related state transition checks to use the exposed helper without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->