### PR TITLE
OPRUN-4711: configobserver: add ObserveTLSSecurityProfileWithGroupPaths

### DIFF
--- a/pkg/operator/configobserver/apiserver/observe_tlssecurityprofile.go
+++ b/pkg/operator/configobserver/apiserver/observe_tlssecurityprofile.go
@@ -3,6 +3,7 @@ package apiserver
 import (
 	"fmt"
 	"reflect"
+	"slices"
 
 	"k8s.io/klog/v2"
 
@@ -17,24 +18,38 @@ import (
 // ObserveTLSSecurityProfile observes APIServer.Spec.TLSSecurityProfile field and sets
 // the ServingInfo.MinTLSVersion, ServingInfo.CipherSuites fields of observed config
 func ObserveTLSSecurityProfile(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (map[string]interface{}, []error) {
-	return innerTLSSecurityProfileObservations(genericListers, recorder, existingConfig, []string{"servingInfo", "minTLSVersion"}, []string{"servingInfo", "cipherSuites"})
+	return innerTLSSecurityProfileObservations(genericListers, recorder, existingConfig, []string{"servingInfo", "minTLSVersion"}, []string{"servingInfo", "cipherSuites"}, nil)
 }
 
 // ObserveTLSSecurityProfileWithPaths is like ObserveTLSSecurityProfile, but accepts
 // custom paths for ServingInfo.MinTLSVersion and ServingInfo.CipherSuites fields of observed config.
 func ObserveTLSSecurityProfileWithPaths(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}, minTLSVersionPath, cipherSuitesPath []string) (map[string]interface{}, []error) {
-	return innerTLSSecurityProfileObservations(genericListers, recorder, existingConfig, minTLSVersionPath, cipherSuitesPath)
+	return innerTLSSecurityProfileObservations(genericListers, recorder, existingConfig, minTLSVersionPath, cipherSuitesPath, nil)
+}
+
+// ObserveTLSSecurityProfileWithGroupPaths is like ObserveTLSSecurityProfileWithPaths but also
+// observes the TLS group (curve) preferences at groupsPath. Group names are stored as []string
+// matching the TLSGroup constants from openshift/api and can be passed directly to operands
+// that accept group names as CLI arguments.
+func ObserveTLSSecurityProfileWithGroupPaths(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}, minTLSVersionPath, cipherSuitesPath, groupsPath []string) (map[string]interface{}, []error) {
+	return innerTLSSecurityProfileObservations(genericListers, recorder, existingConfig, minTLSVersionPath, cipherSuitesPath, groupsPath)
 }
 
 // ObserveTLSSecurityProfileToArguments observes APIServer.Spec.TLSSecurityProfile field and sets
 // the tls-min-version and tls-cipher-suites fileds of observedConfig.apiServerArguments
 func ObserveTLSSecurityProfileToArguments(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (map[string]interface{}, []error) {
-	return innerTLSSecurityProfileObservations(genericListers, recorder, existingConfig, []string{"apiServerArguments", "tls-min-version"}, []string{"apiServerArguments", "tls-cipher-suites"})
+	return innerTLSSecurityProfileObservations(genericListers, recorder, existingConfig, []string{"apiServerArguments", "tls-min-version"}, []string{"apiServerArguments", "tls-cipher-suites"}, nil)
 }
 
-func innerTLSSecurityProfileObservations(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}, minTLSVersionPath, cipherSuitesPath []string) (ret map[string]interface{}, _ []error) {
+// innerTLSSecurityProfileObservations is the shared implementation for all Observe* functions.
+// When groupsPath is non-nil, TLS group preferences are also observed and stored at that path.
+func innerTLSSecurityProfileObservations(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}, minTLSVersionPath, cipherSuitesPath, groupsPath []string) (ret map[string]interface{}, _ []error) {
 	defer func() {
-		ret = configobserver.Pruned(ret, minTLSVersionPath, cipherSuitesPath)
+		paths := [][]string{minTLSVersionPath, cipherSuitesPath}
+		if len(groupsPath) > 0 {
+			paths = append(paths, groupsPath)
+		}
+		ret = configobserver.Pruned(ret, paths...)
 	}()
 
 	listers := genericListers.(APIServerLister)
@@ -52,6 +67,15 @@ func innerTLSSecurityProfileObservations(genericListers configobserver.Listers, 
 		// keep going on read error from existing config
 	}
 
+	var currentGroups []string
+	if len(groupsPath) > 0 {
+		var groupsErr error
+		currentGroups, _, groupsErr = unstructured.NestedStringSlice(existingConfig, groupsPath...)
+		if groupsErr != nil {
+			errs = append(errs, fmt.Errorf("failed to retrieve groups: %v", groupsErr))
+		}
+	}
+
 	apiServer, err := listers.APIServerLister().Get("cluster")
 	if errors.IsNotFound(err) {
 		klog.Warningf("apiserver.config.openshift.io/cluster: not found")
@@ -60,8 +84,12 @@ func innerTLSSecurityProfileObservations(genericListers configobserver.Listers, 
 		return existingConfig, append(errs, err)
 	}
 
+	// Resolve the effective profile spec once and share it between the cipher and
+	// group extractors so the two cannot resolve different profiles.
+	profileSpec := resolveProfileSpec(apiServer.Spec.TLSSecurityProfile)
+
 	observedConfig := map[string]interface{}{}
-	observedMinTLSVersion, observedCipherSuites := getSecurityProfileCiphers(apiServer.Spec.TLSSecurityProfile)
+	observedMinTLSVersion, observedCipherSuites := getSecurityProfileCiphers(profileSpec)
 	if err = unstructured.SetNestedField(observedConfig, observedMinTLSVersion, minTLSVersionPath...); err != nil {
 		return existingConfig, append(errs, err)
 	}
@@ -76,17 +104,35 @@ func innerTLSSecurityProfileObservations(genericListers configobserver.Listers, 
 		recorder.Eventf("ObserveTLSSecurityProfile", "cipherSuites changed to %q", observedCipherSuites)
 	}
 
+	if len(groupsPath) > 0 {
+		observedGroups := getSecurityProfileGroups(profileSpec)
+		// Store the groups (already FIPS-filtered) verbatim, including an empty list.
+		// An empty result (e.g. all groups dropped under FIPS) lets TLS fail rather
+		// than negotiating unrequested curves.
+		if err = unstructured.SetNestedStringSlice(observedConfig, observedGroups, groupsPath...); err != nil {
+			return existingConfig, append(errs, err)
+		}
+		// slices.Equal treats nil and empty as equal, so a first reconcile
+		// (currentGroups nil) against an empty observation is not a change.
+		if !slices.Equal(observedGroups, currentGroups) {
+			recorder.Eventf("ObserveTLSSecurityProfile", "groups changed to %q", observedGroups)
+		}
+	}
+
 	return observedConfig, errs
 }
 
-// Extracts the minimum TLS version and cipher suites from TLSSecurityProfile object,
-// Converts the ciphers to IANA names as supported by Kube ServingInfo config.
-// If profile is nil, returns config defined by the Intermediate TLS Profile
-func getSecurityProfileCiphers(profile *configv1.TLSSecurityProfile) (string, []string) {
-	var profileType configv1.TLSProfileType
-	if profile == nil {
-		profileType = crypto.DefaultTLSProfileType
-	} else {
+// resolveProfileSpec returns the effective TLSProfileSpec for a
+// TLSSecurityProfile. Named profiles (Old/Intermediate/Modern) resolve from the
+// well-known openshift/api table; a Custom profile uses its inline spec. When
+// the profile is nil (e.g. APIServer/cluster not found) or is Custom-typed
+// without an actual custom spec, it falls back to the Intermediate default.
+//
+// It is resolved once per reconcile in innerTLSSecurityProfileObservations and
+// shared by the cipher and group extractors so the two cannot drift.
+func resolveProfileSpec(profile *configv1.TLSSecurityProfile) *configv1.TLSProfileSpec {
+	profileType := crypto.DefaultTLSProfileType
+	if profile != nil {
 		profileType = profile.Type
 	}
 
@@ -99,11 +145,37 @@ func getSecurityProfileCiphers(profile *configv1.TLSSecurityProfile) (string, []
 		profileSpec = configv1.TLSProfiles[profileType]
 	}
 
-	// nothing found / custom type set but no actual custom spec
+	// nothing found / custom type set but no actual custom spec / empty type
 	if profileSpec == nil {
 		profileSpec = configv1.TLSProfiles[crypto.DefaultTLSProfileType]
 	}
+	return profileSpec
+}
 
+// getSecurityProfileCiphers extracts the minimum TLS version and cipher suites
+// from the resolved profile spec, remapping ciphers to the IANA names used by the
+// Kube ServingInfo config.
+func getSecurityProfileCiphers(profileSpec *configv1.TLSProfileSpec) (string, []string) {
 	// need to remap all Ciphers to their respective IANA names used by Go
 	return string(profileSpec.MinTLSVersion), crypto.OpenSSLToIANACipherSuites(profileSpec.Ciphers)
+}
+
+// getSecurityProfileGroups returns the TLS group preference names for the resolved
+// profile spec as []string. The strings match the TLSGroup constants from
+// openshift/api and can be passed directly to operands that accept group names as
+// CLI arguments.
+//
+// When the Go runtime is in FIPS mode, non-FIPS-approved groups are dropped
+// before conversion so consuming components receive an already-safe list.
+// See tls_fips.go for the allowlist and the removal TODO (Go 1.27 without OpenSSL FIPS).
+func getSecurityProfileGroups(profileSpec *configv1.TLSProfileSpec) []string {
+	src := profileSpec.Groups
+	if isFIPSEnabled() {
+		src = fipsApprovedTLSGroups(src)
+	}
+	groups := make([]string, 0, len(src))
+	for _, g := range src {
+		groups = append(groups, string(g))
+	}
+	return groups
 }

--- a/pkg/operator/configobserver/apiserver/observe_tlssecurityprofile_test.go
+++ b/pkg/operator/configobserver/apiserver/observe_tlssecurityprofile_test.go
@@ -2,6 +2,7 @@ package apiserver
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -154,5 +155,236 @@ func TestObserveTLSSecurityProfile(t *testing.T) {
 				})
 			}
 		})
+	}
+}
+
+func TestObserveTLSSecurityProfileWithGroupPaths(t *testing.T) {
+	// The observer FIPS-filters groups, so expectations differ by runtime mode.
+	// Under fips140=on, X25519MLKEM768 and X25519 are dropped; only the NIST
+	// P-curves survive.
+	fips := isFIPSEnabled()
+	pick := func(nonFIPS, fipsMode []string) []string {
+		if fips {
+			return fipsMode
+		}
+		return nonFIPS
+	}
+	defaultGroups := pick(
+		[]string{"X25519MLKEM768", "X25519", "secp256r1", "secp384r1"},
+		[]string{"secp256r1", "secp384r1"},
+	)
+
+	testCases := []struct {
+		name           string
+		config         *configv1.TLSSecurityProfile
+		expectedGroups []string
+	}{
+		{
+			name:           "NoAPIServerConfig",
+			config:         nil,
+			expectedGroups: defaultGroups,
+		},
+		{
+			name: "IntermediateProfile",
+			config: &configv1.TLSSecurityProfile{
+				Type:         configv1.TLSProfileIntermediateType,
+				Intermediate: &configv1.IntermediateTLSProfile{},
+			},
+			expectedGroups: defaultGroups,
+		},
+		{
+			name: "OldProfile",
+			config: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileOldType,
+				Old:  &configv1.OldTLSProfile{},
+			},
+			expectedGroups: defaultGroups,
+		},
+		{
+			name: "ModernProfile",
+			config: &configv1.TLSSecurityProfile{
+				Type:   configv1.TLSProfileModernType,
+				Modern: &configv1.ModernTLSProfile{},
+			},
+			expectedGroups: defaultGroups,
+		},
+		{
+			name: "CustomProfileNoGroups",
+			config: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						MinTLSVersion: configv1.VersionTLS12,
+						Ciphers:       []string{"ECDHE-RSA-AES128-GCM-SHA256"},
+					},
+				},
+			},
+			expectedGroups: []string{},
+		},
+		{
+			name: "CustomProfileWithGroups",
+			config: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						MinTLSVersion: configv1.VersionTLS12,
+						Ciphers:       []string{"ECDHE-RSA-AES128-GCM-SHA256"},
+						Groups:        []configv1.TLSGroup{configv1.TLSGroupX25519, configv1.TLSGroupSecP256r1},
+					},
+				},
+			},
+			// Under FIPS the non-approved X25519 is dropped, leaving secp256r1.
+			expectedGroups: pick([]string{"X25519", "secp256r1"}, []string{"secp256r1"}),
+		},
+		{
+			// Under FIPS the ML-KEM hybrid is dropped, leaving an empty list.
+			name: "CustomProfileMLKEMOnly",
+			config: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						MinTLSVersion: configv1.VersionTLS12,
+						Ciphers:       []string{"ECDHE-RSA-AES128-GCM-SHA256"},
+						Groups:        []configv1.TLSGroup{configv1.TLSGroupX25519MLKEM768},
+					},
+				},
+			},
+			expectedGroups: pick([]string{"X25519MLKEM768"}, []string{}),
+		},
+	}
+
+	minTLSVersionPath := []string{"olmTLS", "minTLSVersion"}
+	cipherSuitesPath := []string{"olmTLS", "cipherSuites"}
+	groupsPath := []string{"olmTLS", "curvePreferences"}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			if tc.config != nil {
+				if err := indexer.Add(&configv1.APIServer{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Spec:       configv1.APIServerSpec{TLSSecurityProfile: tc.config},
+				}); err != nil {
+					t.Fatal(err)
+				}
+			}
+			listers := testLister{apiLister: configlistersv1.NewAPIServerLister(indexer)}
+
+			recorder := events.NewInMemoryRecorder(t.Name(), clocktesting.NewFakePassiveClock(time.Now()))
+			result, errs := ObserveTLSSecurityProfileWithGroupPaths(
+				listers,
+				recorder,
+				map[string]interface{}{},
+				minTLSVersionPath,
+				cipherSuitesPath,
+				groupsPath,
+			)
+			if len(errs) > 0 {
+				t.Errorf("expected 0 errors, got %v", errs)
+			}
+
+			gotGroups, found, err := unstructured.NestedStringSlice(result, groupsPath...)
+			if err != nil {
+				t.Errorf("couldn't get groups from result: %v", err)
+			}
+
+			if len(tc.expectedGroups) == 0 {
+				// An empty result is stored verbatim (an explicit []) so handshakes
+				// fail rather than negotiating unrequested curves. The path must be
+				// present but empty.
+				if !found {
+					t.Errorf("expected groups path to be present (as an empty list), but it was omitted")
+				}
+				if len(gotGroups) != 0 {
+					t.Errorf("expected empty groups, got %v", gotGroups)
+				}
+				// A first reconcile with an empty result is nil-vs-empty, which
+				// slices.Equal treats as unchanged: no spurious event.
+				for _, ev := range recorder.Events() {
+					if strings.Contains(ev.Message, "groups changed") {
+						t.Errorf("unexpected groups-changed event for empty result: %q", ev.Message)
+					}
+				}
+			} else {
+				if !reflect.DeepEqual(gotGroups, tc.expectedGroups) {
+					t.Errorf("got groups = %v, expected %v", gotGroups, tc.expectedGroups)
+				}
+				// A real (non-empty) first observation should report the change.
+				sawEvent := false
+				for _, ev := range recorder.Events() {
+					if strings.Contains(ev.Message, "groups changed") {
+						sawEvent = true
+					}
+				}
+				if !sawEvent {
+					t.Errorf("expected a groups-changed event for %v, got none", tc.expectedGroups)
+				}
+			}
+
+			// The group observer must not clobber the sibling fields: minTLSVersion
+			// and cipherSuites still have to be written alongside the groups.
+			if _, found, _ := unstructured.NestedString(result, minTLSVersionPath...); !found {
+				t.Errorf("minTLSVersion missing from result; group observation must not drop sibling fields")
+			}
+			if _, found, _ := unstructured.NestedStringSlice(result, cipherSuitesPath...); !found {
+				t.Errorf("cipherSuites missing from result; group observation must not drop sibling fields")
+			}
+
+			// Verify the result is pruned to only the observed paths
+			for k := range result {
+				if k != "olmTLS" {
+					t.Errorf("unexpected key %q in pruned result", k)
+				}
+			}
+		})
+	}
+}
+
+// TestObserveTLSSecurityProfileWithGroupPathsSteadyState verifies that a
+// reconcile whose observed non-empty groups already match the persisted groups
+// emits NO "groups changed" event. The table test above always starts from an
+// empty existingConfig (currentGroups == nil), so it only ever exercises the
+// nil-vs-empty short-circuit and the "changed from nothing" path of slices.Equal;
+// the "equal, non-empty -> suppress" branch — the actual point of the
+// change-suppression logic — is never hit there. This test feeds a prior
+// observation back in to exercise exactly that branch. It is FIPS-agnostic: the
+// default profile yields a non-empty group list in both modes.
+func TestObserveTLSSecurityProfileWithGroupPathsSteadyState(t *testing.T) {
+	minTLSVersionPath := []string{"olmTLS", "minTLSVersion"}
+	cipherSuitesPath := []string{"olmTLS", "cipherSuites"}
+	groupsPath := []string{"olmTLS", "curvePreferences"}
+
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	listers := testLister{apiLister: configlistersv1.NewAPIServerLister(indexer)}
+
+	// First reconcile from empty establishes the observed groups (and expectedly
+	// fires a change event).
+	first, errs := ObserveTLSSecurityProfileWithGroupPaths(
+		listers,
+		events.NewInMemoryRecorder(t.Name(), clocktesting.NewFakePassiveClock(time.Now())),
+		map[string]interface{}{},
+		minTLSVersionPath, cipherSuitesPath, groupsPath,
+	)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors on first reconcile: %v", errs)
+	}
+	observed, found, err := unstructured.NestedStringSlice(first, groupsPath...)
+	if err != nil || !found || len(observed) == 0 {
+		t.Fatalf("expected a non-empty observed groups list, got found=%v groups=%v err=%v", found, observed, err)
+	}
+
+	// Second reconcile fed the first result back in as existingConfig: groups are
+	// unchanged, so no "groups changed" event must fire (slices.Equal returning
+	// true for two equal non-empty slices).
+	recorder := events.NewInMemoryRecorder(t.Name(), clocktesting.NewFakePassiveClock(time.Now()))
+	if _, errs = ObserveTLSSecurityProfileWithGroupPaths(
+		listers, recorder, first, minTLSVersionPath, cipherSuitesPath, groupsPath,
+	); len(errs) > 0 {
+		t.Fatalf("unexpected errors on second reconcile: %v", errs)
+	}
+	for _, ev := range recorder.Events() {
+		if strings.Contains(ev.Message, "groups changed") {
+			t.Errorf("steady-state reconcile emitted a spurious groups-changed event: %q", ev.Message)
+		}
 	}
 }

--- a/pkg/operator/configobserver/apiserver/tls_fips.go
+++ b/pkg/operator/configobserver/apiserver/tls_fips.go
@@ -1,0 +1,60 @@
+package apiserver
+
+import (
+	"crypto/fips140"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+// fipsTLSGroups is the allowlist of TLSGroup values approved under FIPS 186-5.
+// Only the NIST P-curves qualify. An allowlist is used rather than a blocklist
+// because new groups are non-FIPS by default until they complete formal NIST
+// validation (typically years), so any future group absent from this set is
+// correctly excluded without requiring a library-go update.
+//
+// KNOWN DIVERGENCE (revisit as part of native Go FIPS adoption, HPSTRAT-723).
+// Three sources disagree about the FIPS status of some groups, and this
+// allowlist deliberately takes the strictest position:
+//
+//		group           openshift/api godoc     this allowlist   Go native FIPS (fips140=on)
+//		X25519          "keep" (only            drops            REFUSES
+//		                 X25519MLKEM768 should
+//		                 be ignored in FIPS)
+//		X25519MLKEM768  "ignore in FIPS"        drops            NEGOTIATES it
+//
+//	  - On plain X25519 this allowlist matches the runtime (both exclude it); the
+//	    openshift/api godoc is the outdated one (corrected in OCPBUGS-109794).
+//	  - On X25519MLKEM768 this allowlist is stricter than Go: Go's module will
+//	    negotiate the hybrid, but we drop it because the hybrid embeds X25519 and
+//	    the FIPS status of ML-KEM hybrids is still settling (SP 800-56C key
+//	    derivation guidance).
+//
+// TODO: remove this file once Go 1.27 without OpenSSL FIPS is supported.
+// The filtering exists because operands linked against an OpenSSL FIPS backend
+// (via cgo) hard-reject non-approved curves rather than silently skipping them,
+// which causes crash-loops. When all operands use Go's native FIPS mode (Go
+// 1.27+, no OpenSSL FIPS), crypto/tls filters non-approved curves at
+// negotiation time without crashing, making the pre-filtering here redundant.
+var fipsTLSGroups = map[configv1.TLSGroup]struct{}{
+	configv1.TLSGroupSecP256r1: {},
+	configv1.TLSGroupSecP384r1: {},
+	configv1.TLSGroupSecP521r1: {},
+}
+
+// isFIPSEnabled reports whether the Go runtime is operating in FIPS 140 mode.
+func isFIPSEnabled() bool {
+	return fips140.Enabled()
+}
+
+// fipsApprovedTLSGroups returns the subset of groups that are FIPS-approved,
+// preserving order and dropping the rest.
+func fipsApprovedTLSGroups(groups []configv1.TLSGroup) []configv1.TLSGroup {
+	approved := make([]configv1.TLSGroup, 0, len(groups))
+	for _, g := range groups {
+		if _, ok := fipsTLSGroups[g]; !ok {
+			continue
+		}
+		approved = append(approved, g)
+	}
+	return approved
+}

--- a/pkg/operator/configobserver/apiserver/tls_fips_test.go
+++ b/pkg/operator/configobserver/apiserver/tls_fips_test.go
@@ -1,0 +1,56 @@
+package apiserver
+
+import (
+	"slices"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+// TestFIPSApprovedTLSGroups pins the FIPS allowlist: only the three NIST
+// P-curves are approved. X25519 and every ML-KEM post-quantum hybrid are not.
+// See the KNOWN DIVERGENCE note in tls_fips.go for why.
+func TestFIPSApprovedTLSGroups(t *testing.T) {
+	perGroup := []struct {
+		name         string
+		group        configv1.TLSGroup
+		wantApproved bool
+	}{
+		{"secp256r1 is approved", configv1.TLSGroupSecP256r1, true},
+		{"secp384r1 is approved", configv1.TLSGroupSecP384r1, true},
+		{"secp521r1 is approved", configv1.TLSGroupSecP521r1, true},
+		{"X25519 is not approved", configv1.TLSGroupX25519, false},
+		{"X25519MLKEM768 hybrid is not approved", configv1.TLSGroupX25519MLKEM768, false},
+		{"SecP256r1MLKEM768 hybrid is not approved", configv1.TLSGroupSecP256r1MLKEM768, false},
+		{"SecP384r1MLKEM1024 hybrid is not approved", configv1.TLSGroupSecP384r1MLKEM1024, false},
+		{"unknown group is not approved", configv1.TLSGroup("UnknownFutureGroup"), false},
+	}
+	for _, tc := range perGroup {
+		t.Run(tc.name, func(t *testing.T) {
+			got := fipsApprovedTLSGroups([]configv1.TLSGroup{tc.group})
+			gotApproved := len(got) == 1
+			if gotApproved != tc.wantApproved {
+				t.Errorf("fipsApprovedTLSGroups(%q) = %v, want approved=%v", tc.group, got, tc.wantApproved)
+			}
+		})
+	}
+
+	t.Run("filters a mixed list preserving order", func(t *testing.T) {
+		in := []configv1.TLSGroup{
+			configv1.TLSGroupX25519MLKEM768,
+			configv1.TLSGroupSecP384r1,
+			configv1.TLSGroupX25519,
+			configv1.TLSGroupSecP256r1,
+		}
+		want := []configv1.TLSGroup{configv1.TLSGroupSecP384r1, configv1.TLSGroupSecP256r1}
+		if got := fipsApprovedTLSGroups(in); !slices.Equal(got, want) {
+			t.Errorf("fipsApprovedTLSGroups(%q) = %q, want %q", in, got, want)
+		}
+	})
+
+	t.Run("empty input yields empty output", func(t *testing.T) {
+		if got := fipsApprovedTLSGroups(nil); len(got) != 0 {
+			t.Errorf("fipsApprovedTLSGroups(nil) = %q, want empty", got)
+		}
+	})
+}


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OPRUN-4711

Implements the library-go portion of the [TLS curves configuration enhancement](https://github.com/openshift/enhancements/blob/master/enhancements/security/api-tls-curves-config.md): observe the `TLSSecurityProfile.groups` field so operators can propagate curve (group) preferences to their operands alongside `minTLSVersion` and `cipherSuites`.

## What this adds

**`pkg/operator/configobserver/apiserver`**
- `ObserveTLSSecurityProfileWithGroupPaths` — like `ObserveTLSSecurityProfileWithPaths`, but also observes group preferences at a caller-supplied path. The version/cipher/group observations share one resolved profile spec so they cannot drift.
- When the Go runtime is in FIPS mode, non-FIPS-approved groups are dropped before storing, so consuming components receive an already-safe list. The filtering is in `tls_fips.go` (same package, unexported) and can be removed once Go 1.27 without OpenSSL FIPS is supported — at that point `crypto/tls` will filter non-approved curves at negotiation time without crashing, making the pre-filtering redundant.
- The filtered group list is propagated verbatim, including an empty list. Per the enhancement, if the resulting groups cannot negotiate with a peer the handshake is expected to fail rather than fall back to unrequested curves.

## Design notes (addressing earlier review)

An earlier revision had the FIPS filtering split across `pkg/crypto` as exported helpers (`IsFIPSEnabled`, `FIPSApprovedTLSGroups`). After review feedback those are now unexported and co-located with the observer in `pkg/operator/configobserver/apiserver/tls_fips.go` — the only place they're needed.

## Test plan

- [x] `go test ./pkg/operator/configobserver/apiserver/...`
- [x] same under `GODEBUG=fips140=on`

🤖 Generated with [Claude Code](https://claude.com/claude-code)