### PR TITLE
kms: make getCurrentModeReasonAndEncryptionConfig standalone

### DIFF
--- a/pkg/operator/encryption/controllers/key_controller.go
+++ b/pkg/operator/encryption/controllers/key_controller.go
@@ -184,7 +184,7 @@ func (c *keyController) sync(ctx context.Context, syncCtx factory.SyncContext) (
 }
 
 func (c *keyController) checkAndCreateKeys(ctx context.Context, syncContext factory.SyncContext, encryptedGRs []schema.GroupResource) error {
-	currentMode, externalReason, apiEncryptionConfiguration, err := c.getCurrentModeReasonAndEncryptionConfig(ctx)
+	currentMode, externalReason, apiEncryptionConfiguration, err := getCurrentModeReasonAndEncryptionConfig(ctx, c.apiServerClient, c.operatorClient, c.unsupportedConfigPrefix)
 	if err != nil {
 		return err
 	}
@@ -394,18 +394,19 @@ func (c *keyController) generateKeySecret(ctx context.Context, keyID uint64, cur
 	return secret, true, nil
 }
 
-func (c *keyController) getCurrentModeReasonAndEncryptionConfig(ctx context.Context) (state.Mode, string, configv1.APIServerEncryption, error) {
-	apiServer, err := c.apiServerClient.Get(ctx, "cluster", metav1.GetOptions{})
+// getCurrentModeReasonAndEncryptionConfig the active encryption mode, any external rotation reason from unsupported config overrides, and the full encryption spec.
+func getCurrentModeReasonAndEncryptionConfig(ctx context.Context, apiServerClient configv1client.APIServerInterface, operatorClient operatorv1helpers.OperatorClient, unsupportedConfigPrefix []string) (state.Mode, string, configv1.APIServerEncryption, error) {
+	apiServer, err := apiServerClient.Get(ctx, "cluster", metav1.GetOptions{})
 	if err != nil {
 		return "", "", configv1.APIServerEncryption{}, err
 	}
 
-	operatorSpec, _, _, err := c.operatorClient.GetOperatorState()
+	operatorSpec, _, _, err := operatorClient.GetOperatorState()
 	if err != nil {
 		return "", "", configv1.APIServerEncryption{}, err
 	}
 
-	encryptionConfig, err := structuredUnsupportedConfigFrom(operatorSpec.UnsupportedConfigOverrides.Raw, c.unsupportedConfigPrefix)
+	encryptionConfig, err := structuredUnsupportedConfigFrom(operatorSpec.UnsupportedConfigOverrides.Raw, unsupportedConfigPrefix)
 	if err != nil {
 		return "", "", configv1.APIServerEncryption{}, err
 	}

--- a/pkg/operator/encryption/controllers/key_controller_test.go
+++ b/pkg/operator/encryption/controllers/key_controller_test.go
@@ -1359,8 +1359,7 @@ func TestGetCurrentModeReasonAndEncryptionConfig(t *testing.T) {
 			fakeApiServerClient := fakeConfigClient.ConfigV1().APIServers()
 
 			// act
-			target := keyController{unsupportedConfigPrefix: scenario.prefix, operatorClient: fakeOperatorClient, apiServerClient: fakeApiServerClient}
-			currentMode, externalReason, encryption, err := target.getCurrentModeReasonAndEncryptionConfig(context.TODO())
+			currentMode, externalReason, encryption, err := getCurrentModeReasonAndEncryptionConfig(context.TODO(), fakeApiServerClient, fakeOperatorClient, scenario.prefix)
 
 			// validate
 			if err != nil {


### PR DESCRIPTION
## Summary
- Promote `getCurrentModeReasonAndEncryptionConfig` to a package-level helper with explicit APIServer/operator clients and unsupported-config prefix.
- Keep a thin `keyController` method wrapper so existing call sites are unchanged.
- Point the unit test at the standalone function directly.

This is intentionally a small, independently mergeable precursor (same idea as exporting `GetDesiredEncryptionState`) so later EncryptionPlanner work can reuse mode resolution without inventing a parallel helper.

## Test plan
- [x] `go test ./pkg/operator/encryption/controllers/ -run TestGetCurrentModeReasonAndEncryptionConfig`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal encryption configuration state retrieval while preserving existing behavior.
  * Improved flexibility in how encryption configuration details are obtained and evaluated.

* **Tests**
  * Updated automated coverage to validate the revised encryption configuration retrieval flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->