### PR TITLE
kms: extract referencedResourcesFromKeyState helper

### DIFF
--- a/pkg/operator/encryption/controllers/key_controller.go
+++ b/pkg/operator/encryption/controllers/key_controller.go
@@ -394,6 +394,47 @@ func (c *keyController) generateKeySecret(ctx context.Context, keyID uint64, cur
 	return secret, true, nil
 }
 
+// referencedResourcesFromKeyState rebuilds the Secret/ConfigMap objects the hasher expects from credentials already embedded in the planned key state.
+func referencedResourcesFromKeyState(ks state.KeyState, desiredProviderCfg kmsProviderConfig) (*corev1.Secret, *corev1.ConfigMap, error) {
+	var refSecret *corev1.Secret
+	if secretName, expectedKeys, err := desiredProviderCfg.referencedSecretName(); err != nil {
+		return nil, nil, err
+	} else if len(secretName) > 0 {
+		data := map[string][]byte{}
+		for _, key := range expectedKeys {
+			v, ok := ks.KMS.PluginSecretData.Get(secretName, key)
+			if !ok {
+				return nil, nil, fmt.Errorf("planned key secret is missing embedded data for secret %s key %q", secretName, key)
+			}
+			data[key] = v
+		}
+		refSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: openshiftConfigNS},
+			Data:       data,
+		}
+	}
+
+	var refCM *corev1.ConfigMap
+	if cmName, expectedKeys, err := desiredProviderCfg.referencedConfigMapName(); err != nil {
+		return nil, nil, err
+	} else if len(cmName) > 0 {
+		data := map[string]string{}
+		for _, key := range expectedKeys {
+			v, ok := ks.KMS.PluginConfigMapData.Get(cmName, key)
+			if !ok {
+				return nil, nil, fmt.Errorf("planned key secret is missing embedded data for configmap %s key %q", cmName, key)
+			}
+			data[key] = string(v)
+		}
+		refCM = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: cmName, Namespace: openshiftConfigNS},
+			Data:       data,
+		}
+	}
+
+	return refSecret, refCM, nil
+}
+
 // getCurrentModeReasonAndEncryptionConfig the active encryption mode, any external rotation reason from unsupported config overrides, and the full encryption spec.
 func getCurrentModeReasonAndEncryptionConfig(ctx context.Context, apiServerClient configv1client.APIServerInterface, operatorClient operatorv1helpers.OperatorClient, unsupportedConfigPrefix []string) (state.Mode, string, configv1.APIServerEncryption, error) {
 	apiServer, err := apiServerClient.Get(ctx, "cluster", metav1.GetOptions{})

--- a/pkg/operator/encryption/controllers/key_controller_test.go
+++ b/pkg/operator/encryption/controllers/key_controller_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/encryption/encoding"
 	encryptiondatatesting "github.com/openshift/library-go/pkg/operator/encryption/encryptiondata/testing"
 	"github.com/openshift/library-go/pkg/operator/encryption/kms"
+	"github.com/openshift/library-go/pkg/operator/encryption/state"
 	encryptiontesting "github.com/openshift/library-go/pkg/operator/encryption/testing"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
@@ -1477,4 +1478,34 @@ func TestSameProviderInstance(t *testing.T) {
 			require.Equal(t, tt.expected, got)
 		})
 	}
+}
+
+func TestReferencedResourcesFromKeyState(t *testing.T) {
+	vaultConfig := encryptiontesting.DefaultKMSPluginConfig.DeepCopy()
+
+	providerCfg, err := newKMSProviderConfig(*vaultConfig)
+	require.NoError(t, err)
+
+	ks := state.KeyState{
+		KMS: &state.KMSState{
+			Plugin: *vaultConfig,
+		},
+	}
+	require.NoError(t, ks.KMS.PluginSecretData.Set("vault-approle-secret", "role-id", []byte("my-role")))
+	require.NoError(t, ks.KMS.PluginSecretData.Set("vault-approle-secret", "secret-id", []byte("my-secret")))
+	require.NoError(t, ks.KMS.PluginConfigMapData.Set("vault-ca-bundle", "ca-bundle.crt", []byte("pem-data")))
+
+	sec, cm, err := referencedResourcesFromKeyState(ks, providerCfg)
+	require.NoError(t, err)
+
+	require.NotNil(t, sec)
+	require.Equal(t, "vault-approle-secret", sec.Name)
+	require.Equal(t, openshiftConfigNS, sec.Namespace)
+	require.Equal(t, []byte("my-role"), sec.Data["role-id"])
+	require.Equal(t, []byte("my-secret"), sec.Data["secret-id"])
+
+	require.NotNil(t, cm)
+	require.Equal(t, "vault-ca-bundle", cm.Name)
+	require.Equal(t, openshiftConfigNS, cm.Namespace)
+	require.Equal(t, "pem-data", cm.Data["ca-bundle.crt"])
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved encryption configuration handling when restoring referenced credentials and configuration data.
  - Added validation for missing or incomplete referenced resources, with clearer error reporting.
  - Ensured recovered resources retain the expected namespace, names, and stored values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->