### PR TITLE
key_controller: use the actual Secret create error in EncryptionKeyCreateFailed events

### DIFF
--- a/pkg/operator/encryption/controllers/key_controller.go
+++ b/pkg/operator/encryption/controllers/key_controller.go
@@ -269,7 +269,7 @@ func (c *keyController) checkAndCreateKeys(ctx context.Context, syncContext fact
 		return c.validateExistingSecret(ctx, keySecret, newKeyID)
 	}
 	if createErr != nil {
-		syncContext.Recorder().Warningf("EncryptionKeyCreateFailed", "Secret %q failed to create: %v", keySecret.Name, err)
+		syncContext.Recorder().Warningf("EncryptionKeyCreateFailed", "Secret %q failed to create: %v", keySecret.Name, createErr)
 		return createErr
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved warning details when encryption key creation fails, making the underlying error easier to identify.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->