### PR TITLE
add retries when apiserver down in sno parallel run

### DIFF
--- a/test/library/encryption/helpers.go
+++ b/test/library/encryption/helpers.go
@@ -102,7 +102,7 @@ func SetAndWaitForEncryptionType(ctx context.Context, t testing.TB, provider Enc
 
 	var previousEncryption configv1.APIServerEncryption
 	var needsUpdate bool
-	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	err = onErrorWithTimeout(waitPollTimeout, retry.DefaultBackoff, orError(errors.IsConflict, transientAPIError), func() error {
 		apiServer, err := clientSet.ApiServerConfig.Get(ctx, "cluster", metav1.GetOptions{})
 		if err != nil {
 			return err
@@ -200,7 +200,7 @@ func WaitForNoNewEncryptionKey(t testing.TB, kubeClient kubernetes.Interface, pr
 	if err := wait.Poll(waitNoKeyPollInterval, waitNoKeyPollTimeout, func() (bool, error) {
 		currentKeyMeta, err := GetLastKeyMeta(t, kubeClient, namespace, labelSelector)
 		if err != nil {
-			return false, err
+			return false, nil
 		}
 
 		if currentKeyMeta.Name != prevKeyMeta.Name {
@@ -241,7 +241,7 @@ func WaitForNextMigratedKey(t testing.TB, kubeClient kubernetes.Interface, prevK
 	if err := wait.Poll(waitPollInterval, waitPollTimeout, func() (bool, error) {
 		currentKeyMeta, err := GetLastKeyMeta(t, kubeClient, namespace, labelSelector)
 		if err != nil {
-			return false, err
+			return false, nil
 		}
 
 		if currentKeyMeta.Name != observedKeyName {
@@ -483,7 +483,7 @@ func WaitForCurrentKeyMigrated(t testing.TB, kubeClient kubernetes.Interface, pr
 	if err := wait.Poll(waitPollInterval, waitPollTimeout, func() (bool, error) {
 		currentKeyMeta, err := GetLastKeyMeta(t, kubeClient, namespace, labelSelector)
 		if err != nil {
-			return false, err
+			return false, nil
 		}
 		if currentKeyMeta.Name != prevKeyMeta.Name {
 			return false, fmt.Errorf("unexpected key observed %q, expected no new key", currentKeyMeta.Name)


### PR DESCRIPTION
In SNO, when kube-apiserver is unavailable, operators can not be accessible. so adding retries when apiserver down in sno parallel run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when creating Secrets, Routes, and OAuth access tokens by waiting for API services to stabilize.
  * Temporary service-unavailable errors are now treated as retryable during resource creation and migration progress checks.
  * Encryption configuration changes now wait for required cluster operators to become available before continuing.
  * Improved migration progress monitoring by continuing to poll when temporary API errors occur.
  * Improved test behavior across single-node and multi-node environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->