### PR TITLE
NO-JIRA: fix perf sno timeout failures

### DIFF
--- a/test/library/encryption/errors.go
+++ b/test/library/encryption/errors.go
@@ -46,7 +46,7 @@ func transientAPIError(err error) bool {
 	switch {
 	case err == nil:
 		return false
-	case errors.IsServerTimeout(err), errors.IsTooManyRequests(err), net.IsProbableEOF(err), net.IsConnectionReset(err), net.IsNoRoutesError(err), isConnectionRefusedError(err), isGolangNetTimeout(err):
+	case errors.IsServiceUnavailable(err), errors.IsServerTimeout(err), errors.IsTooManyRequests(err), net.IsProbableEOF(err), net.IsConnectionReset(err), net.IsNoRoutesError(err), isConnectionRefusedError(err), isGolangNetTimeout(err):
 		return true
 	default:
 		return false

--- a/test/library/encryption/perf_helpers.go
+++ b/test/library/encryption/perf_helpers.go
@@ -26,6 +26,10 @@ func watchForMigrationControllerProgressingCondition(t testing.TB, getOperatorCo
 	err := wait.Poll(waitPollInterval, waitPollTimeout, func() (bool, error) {
 		conditions, err := getOperatorConditionsFn(t)
 		if err != nil {
+			if transientAPIError(err) {
+				t.Logf("failed to get operator conditions, will retry: %v", err)
+				return false, nil
+			}
 			return false, err
 		}
 		for _, cond := range conditions {


### PR DESCRIPTION
fix perf sno timeout failure
https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_cluster-kube-apiserver-operator/2256/pull-ci-openshift-cluster-kube-apiserver-operator-main-e2e-gcp-operator-encryption-perf-single-node/2087793680185298944

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of temporary service-unavailable errors during encryption operations.
  * Polling now logs and retries transient errors instead of stopping immediately.
  * Non-transient errors continue to fail promptly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->