### PR TITLE
Add active maintainers to under-owned OWNERS files

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,7 +2,11 @@ reviewers:
   - bertinatto
   - deads2k
   - p0lyn0mial
+  - sanchezl
+  - ardaguclu
 approvers:
   - bertinatto
   - deads2k
   - p0lyn0mial
+  - sanchezl
+  - ardaguclu

--- a/pkg/authentication/OWNERS
+++ b/pkg/authentication/OWNERS
@@ -4,5 +4,8 @@ reviewers:
   - ibihim
   - stlaz
   - EmilyM1
+  - sanchezl
 approvers:
   - stlaz
+  - ibihim
+  - sanchezl

--- a/pkg/authorization/OWNERS
+++ b/pkg/authorization/OWNERS
@@ -4,5 +4,8 @@ reviewers:
   - ibihim
   - stlaz
   - EmilyM1
+  - sanchezl
 approvers:
   - stlaz
+  - ibihim
+  - sanchezl

--- a/pkg/crypto/OWNERS
+++ b/pkg/crypto/OWNERS
@@ -1,4 +1,7 @@
 reviewers:
   - stlaz
+  - sanchezl
+  - ibihim
 approvers:
   - stlaz
+  - sanchezl

--- a/pkg/oauth/OWNERS
+++ b/pkg/oauth/OWNERS
@@ -6,3 +6,4 @@ reviewers:
   - EmilyM1
 approvers:
   - stlaz
+  - ibihim

--- a/pkg/operator/OWNERS
+++ b/pkg/operator/OWNERS
@@ -4,7 +4,11 @@ reviewers:
   - p0lyn0mial
   - bertinatto
   - jsafrane
+  - sanchezl
+  - ardaguclu
 approvers:
   - p0lyn0mial
   - bertinatto
   - jsafrane
+  - sanchezl
+  - ardaguclu

--- a/pkg/operator/apiserver/OWNERS
+++ b/pkg/operator/apiserver/OWNERS
@@ -2,7 +2,11 @@ reviewers:
   - tkashem
   - p0lyn0mial
   - sttts
+  - sanchezl
+  - ardaguclu
 approvers:
   - tkashem
   - p0lyn0mial
   - sttts
+  - sanchezl
+  - ardaguclu

--- a/pkg/operator/certrotation/OWNERS
+++ b/pkg/operator/certrotation/OWNERS
@@ -1,4 +1,7 @@
 reviewers:
   - stlaz
+  - sanchezl
+  - ibihim
 approvers:
   - stlaz
+  - sanchezl

--- a/pkg/operator/configobserver/apiserver/OWNERS
+++ b/pkg/operator/configobserver/apiserver/OWNERS
@@ -2,7 +2,9 @@ reviewers:
   - tkashem
   - p0lyn0mial
   - sttts
+  - sanchezl
 approvers:
   - tkashem
   - p0lyn0mial
   - sttts
+  - sanchezl

--- a/pkg/operator/staticpod/OWNERS
+++ b/pkg/operator/staticpod/OWNERS
@@ -3,8 +3,10 @@ reviewers:
   - p0lyn0mial
   - sttts
   - tkashem
+  - sanchezl
 approvers:
   - dgrisonnet
   - p0lyn0mial
   - sttts
   - tkashem
+  - sanchezl

--- a/pkg/security/OWNERS
+++ b/pkg/security/OWNERS
@@ -3,5 +3,7 @@ reviewers:
   - s-urbaniak
   - slaskawi
   - stlaz
+  - sanchezl
 approvers:
   - stlaz
+  - sanchezl


### PR DESCRIPTION
## What

Adds active contributors to several `OWNERS` files whose currently listed
owners are largely inactive. No owners are removed in this PR.

## Why

A number of directories list only owners who are no longer active. Because
none of these directories set `no_parent_owners`, PRs are not blocked (parent
approvers still apply), but Prow suggests reviewers and approvers who no longer
respond, and domain expertise is not represented. This backfills active
maintainers based on recent contribution history.

## Changes

| Directory | Added |
|-----------|-------|
| `/` (root) | sanchezl, ardaguclu (reviewer + approver) |
| `pkg/operator/` | sanchezl, ardaguclu (reviewer + approver) |
| `pkg/operator/apiserver/` | sanchezl, ardaguclu (reviewer + approver) |
| `pkg/operator/configobserver/apiserver/` | sanchezl (reviewer + approver) |
| `pkg/operator/staticpod/` | sanchezl (reviewer + approver) |
| `pkg/crypto/` | sanchezl (reviewer + approver), ibihim (reviewer) |
| `pkg/operator/certrotation/` | sanchezl (reviewer + approver), ibihim (reviewer) |
| `pkg/authentication/` | sanchezl (reviewer + approver), ibihim (approver) |
| `pkg/authorization/` | sanchezl (reviewer + approver), ibihim (approver) |
| `pkg/oauth/` | ibihim (approver) |
| `pkg/security/` | sanchezl (reviewer + approver) |

`ibihim` is already a reviewer in the auth directories; this promotes them to
approver there. `ardaguclu` is already an approver in the encryption
directories, so those are unchanged.

Cleanup of inactive owners (via `emeritus_approvers`) is intentionally left for
a separate PR.

/cc @ibihim @ardaguclu please ack being added as owners.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project review and approval assignments across authentication, authorization, cryptography, OAuth, operator, configuration, static pod, and security areas.
  * Expanded the pool of designated reviewers and approvers to improve change review coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->