### PR TITLE
OCPBUGS-38662: Add GuardControllerDegradedConditionType constant

### DIFF
--- a/pkg/operator/condition/condition.go
+++ b/pkg/operator/condition/condition.go
@@ -69,4 +69,7 @@ const (
 	// NodeControllerDegradedConditionType is true when the operator observed a master node that is not ready.
 	// Note that a node is not ready when its Condition.NodeReady wasn't set to true
 	NodeControllerDegradedConditionType = "NodeControllerDegraded"
+
+	// GuardControllerDegradedConditionType is true when the guard controller observed an error while managing guard pods or PodDisruptionBudgets.
+	GuardControllerDegradedConditionType = "GuardControllerDegraded"
 )


### PR DESCRIPTION
Introduce a new condition type to track errors in the guard controller.

This will be then used to set custom Degraded inertia in related operators.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a standardized status condition for indicating guard-controller degradation.
  - The condition covers errors involving guard pods or PodDisruptionBudgets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->