### PR TITLE
CNTRLPLANE-3237:  preflight simplify socket flags

### DIFF
--- a/pkg/operator/encryption/kms/pluginlifecycle/builder.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/builder.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -25,7 +26,8 @@ type KMSPluginBuilder struct {
 	staticPod                  bool
 	errorIfNotFound            bool
 
-	healthReporter *healthReporter
+	healthReporter   *healthReporter
+	preflightChecker bool
 }
 
 // NewKMSPluginBuilder creates a builder that defaults to deployment mode.
@@ -61,6 +63,13 @@ func (b *KMSPluginBuilder) WithDiskSecretName(name string) *KMSPluginBuilder {
 // callers like the preflight checker that expect the Secret to be present.
 func (b *KMSPluginBuilder) WithSecretRequired() *KMSPluginBuilder {
 	b.errorIfNotFound = true
+	return b
+}
+
+// WithPreflightChecker enables running the preflight binary that validates
+// KMS plugin readiness before encryption keys are created.
+func (b *KMSPluginBuilder) WithPreflightChecker() *KMSPluginBuilder {
+	b.preflightChecker = true
 	return b
 }
 
@@ -195,7 +204,29 @@ func (b *KMSPluginBuilder) Apply(ctx context.Context, podSpec *corev1.PodSpec, c
 		return err
 	}
 
+	if err := b.applyPreflightChecker(podSpec.Containers, containerName, sockets); err != nil {
+		return err
+	}
+
 	return nil
+}
+
+// applyPreflightChecker injects --kms-sockets into the checker container's args.
+func (b *KMSPluginBuilder) applyPreflightChecker(containers []corev1.Container, containerName string, sockets []string) error {
+	if !b.preflightChecker {
+		return nil
+	}
+
+	for i, c := range containers {
+		if c.Name != containerName {
+			continue
+		}
+		containers[i].Args = append(c.Args,
+			fmt.Sprintf("--kms-sockets=%s", strings.Join(sockets, ",")),
+		)
+		return nil
+	}
+	return fmt.Errorf("container %s not found for preflight socket flag injection", containerName)
 }
 
 func fetchEncryptionConfig(ctx context.Context, encryptionConfigNamespace, encryptionConfigSecretName string, secretClient corev1client.SecretsGetter, errorIfNotFound bool) (*encryptiondata.Config, error) {

--- a/pkg/operator/encryption/kms/pluginlifecycle/builder_test.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/builder_test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"testing"
 
+	"github.com/openshift/library-go/pkg/operator/encryption/encoding"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	apiserverv1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
 	fake "k8s.io/client-go/kubernetes/fake"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/utils/ptr"
@@ -20,11 +23,14 @@ func TestKMSPluginBuilder_Apply(t *testing.T) {
 	}
 
 	tests := []struct {
-		name    string
-		builder *KMSPluginBuilder
-		podSpec *corev1.PodSpec
-		verify  func(t *testing.T, podSpec *corev1.PodSpec)
-		wantErr string
+		name string
+		// containerName is the target container passed to Apply. Defaults to
+		// "kube-apiserver" when empty.
+		containerName string
+		builder       *KMSPluginBuilder
+		podSpec       *corev1.PodSpec
+		verify        func(t *testing.T, podSpec *corev1.PodSpec)
+		wantErr       string
 	}{
 		{
 			name: "static pod mode: resource-dir mount and root UID",
@@ -91,6 +97,65 @@ func TestKMSPluginBuilder_Apply(t *testing.T) {
 			},
 		},
 		{
+			// Mirrors the preflight deployer, which calls Apply with the checker
+			// container (deployer.go uses CheckContainerName) rather than the
+			// apiserver. The preflight checker only fully verifies the first
+			// socket, so the injected order must be keyID-descending (write key
+			// first). The providers below are listed keyID-ascending on purpose to
+			// prove Apply re-sorts them via ExtractUniqueAndSortedKMSConfigurations.
+			name:          "preflight checker: sockets injected sorted by keyID descending",
+			containerName: "kms-preflight-check",
+			builder: NewKMSPluginBuilder().
+				WithPreflightChecker().
+				FromEncryptionConfigSecret("openshift-kube-apiserver", "encryption-config", secretClient(func() *corev1.Secret {
+					multiEncConfig := &apiserverv1.EncryptionConfiguration{
+						Resources: []apiserverv1.ResourceConfiguration{
+							{
+								Resources: []string{"secrets"},
+								Providers: []apiserverv1.ProviderConfiguration{
+									{KMS: &apiserverv1.KMSConfiguration{APIVersion: "v2", Name: "555_secrets", Endpoint: "unix:///var/run/kmsplugin/kms-555.sock"}},
+									{KMS: &apiserverv1.KMSConfiguration{APIVersion: "v2", Name: "777_secrets", Endpoint: "unix:///var/run/kmsplugin/kms-777.sock"}},
+								},
+							},
+						},
+					}
+					multiEncConfigBytes, err := encoding.EncodeEncryptionConfiguration(multiEncConfig)
+					require.NoError(t, err)
+
+					return &corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{Name: "encryption-config", Namespace: "openshift-kube-apiserver"},
+						Data: map[string][]byte{
+							"encryption-config": multiEncConfigBytes,
+							// reuse the fixture's vault plugin config for both keys
+							f.pluginConfigKey:                                        f.pluginConfigBytes,
+							"kms-plugin-config-777":                                  f.pluginConfigBytes,
+							"kms-plugin-secret-vault-approle_role-id-555":            []byte("test-role-id"),
+							"kms-plugin-secret-vault-approle_secret-id-555":          []byte("test-secret-id"),
+							"kms-plugin-configmap-vault-ca-bundle_ca-bundle.crt-555": []byte("test-ca-cert"),
+							"kms-plugin-secret-vault-approle_role-id-777":            []byte("test-role-id"),
+							"kms-plugin-secret-vault-approle_secret-id-777":          []byte("test-secret-id"),
+							"kms-plugin-configmap-vault-ca-bundle_ca-bundle.crt-777": []byte("test-ca-cert"),
+						},
+					}
+				}())),
+			podSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "kms-preflight-check"}},
+				Volumes:    []corev1.Volume{f.resourceDirVolume},
+			},
+			verify: func(t *testing.T, podSpec *corev1.PodSpec) {
+				var checker *corev1.Container
+				for i := range podSpec.Containers {
+					if podSpec.Containers[i].Name == "kms-preflight-check" {
+						checker = &podSpec.Containers[i]
+					}
+				}
+				require.NotNil(t, checker, "kms-preflight-check container must be present")
+				require.Equal(t, []string{
+					"--kms-sockets=unix:///var/run/kmsplugin/kms-777.sock,unix:///var/run/kmsplugin/kms-555.sock",
+				}, checker.Args, "sockets must be injected exactly once, sorted by keyID descending (write key first)")
+			},
+		},
+		{
 			name: "missing secret: no-op",
 			builder: NewKMSPluginBuilder().
 				FromEncryptionConfigSecret("openshift-kube-apiserver", "encryption-config", secretClient()),
@@ -117,7 +182,12 @@ func TestKMSPluginBuilder_Apply(t *testing.T) {
 				original = tt.podSpec.DeepCopy()
 			}
 
-			err := tt.builder.Apply(context.Background(), tt.podSpec, "kube-apiserver")
+			containerName := tt.containerName
+			if containerName == "" {
+				containerName = "kube-apiserver"
+			}
+
+			err := tt.builder.Apply(context.Background(), tt.podSpec, containerName)
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
 				if original != nil {

--- a/pkg/operator/encryption/kms/preflight/cmd.go
+++ b/pkg/operator/encryption/kms/preflight/cmd.go
@@ -4,16 +4,22 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	k8senvelopekmsv2 "k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 )
+
+// kmsSocketPattern matches the socket path each co-located KMSv2 plugin is
+// mounted at, e.g. unix:///var/run/kmsplugin/kms-1.sock.
+var kmsSocketPattern = regexp.MustCompile(`^unix:///var/run/kmsplugin/kms-(\d+)\.sock$`)
 
 type options struct {
 	kmsSockets     []string
@@ -56,6 +62,16 @@ func (o *options) validate() error {
 	if len(o.kmsSockets) == 0 {
 		return fmt.Errorf("--kms-sockets is required, at least one")
 	}
+	socketSet := sets.New[string]()
+	for _, s := range o.kmsSockets {
+		if !kmsSocketPattern.MatchString(s) {
+			return fmt.Errorf("--kms-sockets entry %q must match %s", s, kmsSocketPattern)
+		}
+		if socketSet.Has(s) {
+			return fmt.Errorf("--kms-sockets entry %q is duplicated", s)
+		}
+		socketSet.Insert(s)
+	}
 	if o.kmsCallTimeout <= 0 {
 		return fmt.Errorf("--kms-call-timeout must be greater than 0")
 	}
@@ -76,6 +92,8 @@ func (o *options) run(ctx context.Context) error {
 	// First socket gets full verification, remaining sockets get status-only checks.
 	socketToVerify := o.kmsSockets[0]
 	for _, socket := range o.kmsSockets[1:] {
+		// k8senvelopekmsv2.NewGRPCService is not a public API and may change.
+		// If it breaks, we can inline a minimal gRPC client using k8s.io/kms directly.
 		klog.Infof("Checking reachability of KMS plugin at %s", socket)
 		service, err := k8senvelopekmsv2.NewGRPCService(ctx, socket, "preflight", o.kmsCallTimeout)
 		if err != nil {

--- a/pkg/operator/encryption/kms/preflight/cmd.go
+++ b/pkg/operator/encryption/kms/preflight/cmd.go
@@ -15,9 +15,8 @@ import (
 	"k8s.io/klog/v2"
 )
 
-const kmsSocketEndpoint = "unix:///var/run/kmsplugin/kms.sock"
-
 type options struct {
+	kmsSockets     []string
 	kmsCallTimeout time.Duration
 	podName        string
 	podNamespace   string
@@ -45,6 +44,7 @@ func NewCommand(ctx context.Context) *cobra.Command {
 }
 
 func (o *options) addFlags(fs *pflag.FlagSet) {
+	fs.StringSliceVar(&o.kmsSockets, "kms-sockets", nil, "KMS plugin endpoints in unix:// URI format (e.g. unix:///var/run/kmsplugin/kms-1.sock); the first socket receives full verification (Status + Encrypt + Decrypt), remaining sockets are checked for reachability (Status only)")
 	fs.DurationVar(&o.kmsCallTimeout, "kms-call-timeout", 0, "timeout for each gRPC call to the KMS plugin")
 	fs.StringVar(&o.configHash, "config-hash", o.configHash, "hash of config to use for encryption")
 	fs.StringVar(&o.podName, "pod-name", o.podName, "name of pod to use to report checker status")
@@ -53,6 +53,9 @@ func (o *options) addFlags(fs *pflag.FlagSet) {
 }
 
 func (o *options) validate() error {
+	if len(o.kmsSockets) == 0 {
+		return fmt.Errorf("--kms-sockets is required, at least one")
+	}
 	if o.kmsCallTimeout <= 0 {
 		return fmt.Errorf("--kms-call-timeout must be greater than 0")
 	}
@@ -70,13 +73,25 @@ func (o *options) validate() error {
 }
 
 func (o *options) run(ctx context.Context) error {
-	klog.Infof("Running KMS preflight check at %s", kmsSocketEndpoint)
+	// First socket gets full verification, remaining sockets get status-only checks.
+	socketToVerify := o.kmsSockets[0]
+	for _, socket := range o.kmsSockets[1:] {
+		klog.Infof("Checking reachability of KMS plugin at %s", socket)
+		service, err := k8senvelopekmsv2.NewGRPCService(ctx, socket, "preflight", o.kmsCallTimeout)
+		if err != nil {
+			return fmt.Errorf("failed to create KMS gRPC client for %s: %w", socket, err)
+		}
+		c := newChecker(service)
+		if _, err := c.checkStatus(ctx); err != nil {
+			return fmt.Errorf("KMS plugin at %s is not reachable: %w", socket, err)
+		}
+		klog.Infof("KMS plugin at %s is reachable", socket)
+	}
 
-	// k8senvelopekmsv2.NewGRPCService is not a public API and may change.
-	// If it breaks, we can inline a minimal gRPC client using k8s.io/kms directly.
-	service, err := k8senvelopekmsv2.NewGRPCService(ctx, kmsSocketEndpoint, "preflight", o.kmsCallTimeout)
+	klog.Infof("Running full KMS preflight check at %s", socketToVerify)
+	service, err := k8senvelopekmsv2.NewGRPCService(ctx, socketToVerify, "preflight", o.kmsCallTimeout)
 	if err != nil {
-		return fmt.Errorf("failed to create KMS gRPC client: %w", err)
+		return fmt.Errorf("failed to create KMS gRPC client for %s: %w", socketToVerify, err)
 	}
 
 	kubeConfig, err := clientcmd.BuildConfigFromFlags("", o.kubeconfig)

--- a/pkg/operator/encryption/kms/preflight/cmd_test.go
+++ b/pkg/operator/encryption/kms/preflight/cmd_test.go
@@ -1,0 +1,195 @@
+package preflight
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOptionsValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    options
+		wantErr error
+	}{
+		{
+			name: "valid single socket",
+			opts: options{
+				kmsSockets:     []string{"unix:///var/run/kmsplugin/kms-1.sock"},
+				kmsCallTimeout: 10 * time.Second,
+				configHash:     "abc123",
+				podName:        "kms-preflight",
+				podNamespace:   "openshift-config-managed",
+			},
+		},
+		{
+			name: "valid multiple sockets",
+			opts: options{
+				kmsSockets:     []string{"unix:///var/run/kmsplugin/kms-1.sock", "unix:///var/run/kmsplugin/kms-2.sock"},
+				kmsCallTimeout: 10 * time.Second,
+				configHash:     "abc123",
+				podName:        "kms-preflight",
+				podNamespace:   "openshift-config-managed",
+			},
+		},
+		{
+			name: "no sockets",
+			opts: options{
+				kmsCallTimeout: 10 * time.Second,
+				configHash:     "abc123",
+				podName:        "kms-preflight",
+				podNamespace:   "openshift-config-managed",
+			},
+			wantErr: fmt.Errorf("--kms-sockets is required, at least one"),
+		},
+		{
+			name: "empty socket entry",
+			opts: options{
+				kmsSockets:     []string{""},
+				kmsCallTimeout: 10 * time.Second,
+				configHash:     "abc123",
+				podName:        "kms-preflight",
+				podNamespace:   "openshift-config-managed",
+			},
+			wantErr: fmt.Errorf("--kms-sockets entry %q must match %s", "", kmsSocketPattern),
+		},
+		{
+			name: "duplicate sockets",
+			opts: options{
+				kmsSockets:     []string{"unix:///var/run/kmsplugin/kms-1.sock", "unix:///var/run/kmsplugin/kms-1.sock"},
+				kmsCallTimeout: 10 * time.Second,
+				configHash:     "abc123",
+				podName:        "kms-preflight",
+				podNamespace:   "openshift-config-managed",
+			},
+			wantErr: fmt.Errorf("--kms-sockets entry %q is duplicated", "unix:///var/run/kmsplugin/kms-1.sock"),
+		},
+		{
+			name: "socket missing unix scheme",
+			opts: options{
+				kmsSockets:     []string{"/var/run/kmsplugin/kms-1.sock"},
+				kmsCallTimeout: 10 * time.Second,
+				configHash:     "abc123",
+				podName:        "kms-preflight",
+				podNamespace:   "openshift-config-managed",
+			},
+			wantErr: fmt.Errorf("--kms-sockets entry %q must match %s", "/var/run/kmsplugin/kms-1.sock", kmsSocketPattern),
+		},
+		{
+			name: "socket scheme without path",
+			opts: options{
+				kmsSockets:     []string{"unix://"},
+				kmsCallTimeout: 10 * time.Second,
+				configHash:     "abc123",
+				podName:        "kms-preflight",
+				podNamespace:   "openshift-config-managed",
+			},
+			wantErr: fmt.Errorf("--kms-sockets entry %q must match %s", "unix://", kmsSocketPattern),
+		},
+		{
+			name: "socket wrong directory",
+			opts: options{
+				kmsSockets:     []string{"unix:///tmp/kms-1.sock"},
+				kmsCallTimeout: 10 * time.Second,
+				configHash:     "abc123",
+				podName:        "kms-preflight",
+				podNamespace:   "openshift-config-managed",
+			},
+			wantErr: fmt.Errorf("--kms-sockets entry %q must match %s", "unix:///tmp/kms-1.sock", kmsSocketPattern),
+		},
+		{
+			name: "socket non-numeric index",
+			opts: options{
+				kmsSockets:     []string{"unix:///var/run/kmsplugin/kms-x.sock"},
+				kmsCallTimeout: 10 * time.Second,
+				configHash:     "abc123",
+				podName:        "kms-preflight",
+				podNamespace:   "openshift-config-managed",
+			},
+			wantErr: fmt.Errorf("--kms-sockets entry %q must match %s", "unix:///var/run/kmsplugin/kms-x.sock", kmsSocketPattern),
+		},
+		{
+			name: "socket missing .sock suffix",
+			opts: options{
+				kmsSockets:     []string{"unix:///var/run/kmsplugin/kms-1"},
+				kmsCallTimeout: 10 * time.Second,
+				configHash:     "abc123",
+				podName:        "kms-preflight",
+				podNamespace:   "openshift-config-managed",
+			},
+			wantErr: fmt.Errorf("--kms-sockets entry %q must match %s", "unix:///var/run/kmsplugin/kms-1", kmsSocketPattern),
+		},
+		{
+			name: "socket with surrounding whitespace",
+			opts: options{
+				kmsSockets:     []string{" unix:///var/run/kmsplugin/kms-1.sock "},
+				kmsCallTimeout: 10 * time.Second,
+				configHash:     "abc123",
+				podName:        "kms-preflight",
+				podNamespace:   "openshift-config-managed",
+			},
+			wantErr: fmt.Errorf("--kms-sockets entry %q must match %s", " unix:///var/run/kmsplugin/kms-1.sock ", kmsSocketPattern),
+		},
+		{
+			name: "kms-call-timeout zero",
+			opts: options{
+				kmsSockets:     []string{"unix:///var/run/kmsplugin/kms-1.sock"},
+				kmsCallTimeout: 0,
+				configHash:     "abc123",
+				podName:        "kms-preflight",
+				podNamespace:   "openshift-config-managed",
+			},
+			wantErr: fmt.Errorf("--kms-call-timeout must be greater than 0"),
+		},
+		{
+			name: "kms-call-timeout negative",
+			opts: options{
+				kmsSockets:     []string{"unix:///var/run/kmsplugin/kms-1.sock"},
+				kmsCallTimeout: -time.Second,
+				configHash:     "abc123",
+				podName:        "kms-preflight",
+				podNamespace:   "openshift-config-managed",
+			},
+			wantErr: fmt.Errorf("--kms-call-timeout must be greater than 0"),
+		},
+		{
+			name: "config-hash empty",
+			opts: options{
+				kmsSockets:     []string{"unix:///var/run/kmsplugin/kms-1.sock"},
+				kmsCallTimeout: 10 * time.Second,
+				podName:        "kms-preflight",
+				podNamespace:   "openshift-config-managed",
+			},
+			wantErr: fmt.Errorf("--config-hash is required"),
+		},
+		{
+			name: "pod-name empty",
+			opts: options{
+				kmsSockets:     []string{"unix:///var/run/kmsplugin/kms-1.sock"},
+				kmsCallTimeout: 10 * time.Second,
+				configHash:     "abc123",
+				podNamespace:   "openshift-config-managed",
+			},
+			wantErr: fmt.Errorf("--pod-name is required"),
+		},
+		{
+			name: "pod-namespace empty",
+			opts: options{
+				kmsSockets:     []string{"unix:///var/run/kmsplugin/kms-1.sock"},
+				kmsCallTimeout: 10 * time.Second,
+				configHash:     "abc123",
+				podName:        "kms-preflight",
+			},
+			wantErr: fmt.Errorf("--pod-namespace is required"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.opts.validate()
+			require.Equal(t, tc.wantErr, err)
+		})
+	}
+}

--- a/pkg/operator/encryption/kms/preflight/deployer.go
+++ b/pkg/operator/encryption/kms/preflight/deployer.go
@@ -89,6 +89,7 @@ func (d *PodPreflightDeployer) Deploy(ctx context.Context, configHash string, en
 
 	err = pluginlifecycle.NewKMSPluginBuilder().
 		WithSecretRequired().
+		WithPreflightChecker().
 		FromEncryptionConfigSecret(d.namespace, EncryptionConfigSecretName, d.coreClient).
 		Apply(ctx, &pod.Spec, CheckContainerName)
 	if err != nil {

--- a/pkg/operator/encryption/kms/preflight/deployer_test.go
+++ b/pkg/operator/encryption/kms/preflight/deployer_test.go
@@ -97,6 +97,7 @@ spec:
         - --config-hash=$(CONFIG_HASH)
         - --pod-name=$(POD_NAME)
         - --pod-namespace=$(POD_NAMESPACE)
+        - --kms-sockets=unix:///var/run/kmsplugin/kms.sock
       env:
       - name: POD_NAME
         valueFrom:
@@ -188,6 +189,7 @@ spec:
         - --config-hash=$(CONFIG_HASH)
         - --pod-name=$(POD_NAME)
         - --pod-namespace=$(POD_NAMESPACE)
+        - --kms-sockets=unix:///var/run/kmsplugin/kms.sock
       env:
       - name: POD_NAME
         valueFrom:
@@ -283,7 +285,7 @@ func testPreflightEncryptionConfigFromData(
 					KMS: &apiserverconfigv1.KMSConfiguration{
 						APIVersion: "v2",
 						Name:       "1_secrets",
-						Endpoint:   kmsSocketEndpoint,
+						Endpoint:   "unix:///var/run/kmsplugin/kms.sock",
 						Timeout:    &metav1.Duration{Duration: testDeployerTimeout},
 					},
 				}, {

--- a/pkg/operator/encryption/kms/preflight/deployer_test.go
+++ b/pkg/operator/encryption/kms/preflight/deployer_test.go
@@ -2,6 +2,8 @@ package preflight
 
 import (
 	"context"
+	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -60,7 +62,7 @@ spec:
     - name: vault-kms-plugin-1
       image: registry.example.com/kms-plugin@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890
       args:
-        - -listen-address=unix:///var/run/kmsplugin/kms.sock
+        - -listen-address=unix:///var/run/kmsplugin/kms-1.sock
         - -vault-address=https://vault.example.com
         - -vault-key-path=transit/keys/test-transit-key
         - -approle-role-id=test-role-id
@@ -97,7 +99,7 @@ spec:
         - --config-hash=$(CONFIG_HASH)
         - --pod-name=$(POD_NAME)
         - --pod-namespace=$(POD_NAMESPACE)
-        - --kms-sockets=unix:///var/run/kmsplugin/kms.sock
+        - --kms-sockets=unix:///var/run/kmsplugin/kms-1.sock
       env:
       - name: POD_NAME
         valueFrom:
@@ -152,7 +154,7 @@ spec:
     - name: vault-kms-plugin-1
       image: registry.example.com/kms-plugin@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890
       args:
-        - -listen-address=unix:///var/run/kmsplugin/kms.sock
+        - -listen-address=unix:///var/run/kmsplugin/kms-1.sock
         - -vault-address=https://vault.example.com
         - -vault-key-path=transit/keys/test-transit-key
         - -approle-role-id=test-role-id
@@ -189,7 +191,129 @@ spec:
         - --config-hash=$(CONFIG_HASH)
         - --pod-name=$(POD_NAME)
         - --pod-namespace=$(POD_NAMESPACE)
-        - --kms-sockets=unix:///var/run/kmsplugin/kms.sock
+        - --kms-sockets=unix:///var/run/kmsplugin/kms-1.sock
+      env:
+      - name: POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: POD_NAMESPACE
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.namespace
+      - name: CONFIG_HASH
+        value: abc123
+      resources:
+        requests:
+          memory: 50Mi
+          cpu: 5m
+      volumeMounts:
+        - name: kms-plugin-socket
+          mountPath: /var/run/kmsplugin
+  volumes:
+    - name: kms-plugin-socket
+      emptyDir: {}
+    - name: kms-plugins-data
+      secret:
+        secretName: kms-preflight-encryption-config
+`
+
+var expectedDeployMultiSocketPodYAML = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kms-preflight
+  namespace: openshift-kube-apiserver
+  labels:
+    app: openshift-kms-preflight
+  annotations:
+    encryption.apiserver.operator.openshift.io/kms-preflight-config-hash: abc123
+spec:
+  restartPolicy: Never
+  serviceAccountName: kms-preflight
+  priorityClassName: system-cluster-critical
+  nodeSelector:
+    node-role.kubernetes.io/master: ""
+  tolerations:
+    - key: node-role.kubernetes.io/master
+      operator: Exists
+      effect: NoSchedule
+    - key: node-role.kubernetes.io/master
+      operator: Exists
+      effect: NoExecute
+  initContainers:
+    - name: vault-kms-plugin-2
+      image: registry.example.com/kms-plugin@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890
+      args:
+        - -listen-address=unix:///var/run/kmsplugin/kms-2.sock
+        - -vault-address=https://vault.example.com
+        - -vault-key-path=transit/keys/test-transit-key
+        - -approle-role-id=test-role-id
+        - -approle-secret-id-path=/var/run/secrets/kms-plugin/kms-plugin-secret-vault-approle-secret_secret-id-2
+        - -tls-ca-file=/var/run/secrets/kms-plugin/kms-plugin-configmap-vault-ca-bundle_ca-bundle.crt-2
+        - -metrics-port=0
+      imagePullPolicy: IfNotPresent
+      restartPolicy: Always
+      terminationMessagePolicy: FallbackToLogsOnError
+      resources:
+        requests:
+          memory: 64Mi
+          cpu: 10m
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        readOnlyRootFilesystem: true
+        seccompProfile:
+          type: RuntimeDefault
+      volumeMounts:
+        - name: kms-plugin-socket
+          mountPath: /var/run/kmsplugin
+        - name: kms-plugins-data
+          mountPath: /var/run/secrets/kms-plugin
+          readOnly: true
+    - name: vault-kms-plugin-1
+      image: registry.example.com/kms-plugin@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890
+      args:
+        - -listen-address=unix:///var/run/kmsplugin/kms-1.sock
+        - -vault-address=https://vault.example.com
+        - -vault-key-path=transit/keys/test-transit-key
+        - -approle-role-id=test-role-id
+        - -approle-secret-id-path=/var/run/secrets/kms-plugin/kms-plugin-secret-vault-approle-secret_secret-id-1
+        - -tls-ca-file=/var/run/secrets/kms-plugin/kms-plugin-configmap-vault-ca-bundle_ca-bundle.crt-1
+        - -metrics-port=0
+      imagePullPolicy: IfNotPresent
+      restartPolicy: Always
+      terminationMessagePolicy: FallbackToLogsOnError
+      resources:
+        requests:
+          memory: 64Mi
+          cpu: 10m
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        readOnlyRootFilesystem: true
+        seccompProfile:
+          type: RuntimeDefault
+      volumeMounts:
+        - name: kms-plugin-socket
+          mountPath: /var/run/kmsplugin
+        - name: kms-plugins-data
+          mountPath: /var/run/secrets/kms-plugin
+          readOnly: true
+  containers:
+    - name: kms-preflight-check
+      image: quay.io/openshift-release-dev/ocp-v5.0-art-dev@sha256:test
+      command: ["cluster-kube-apiserver-operator","kms-preflight"]
+      args:
+        - --kms-call-timeout=10s
+        - --config-hash=$(CONFIG_HASH)
+        - --pod-name=$(POD_NAME)
+        - --pod-namespace=$(POD_NAMESPACE)
+        - --kms-sockets=unix:///var/run/kmsplugin/kms-2.sock,unix:///var/run/kmsplugin/kms-1.sock
       env:
       - name: POD_NAME
         valueFrom:
@@ -242,23 +366,32 @@ func testReferenceDataObjects(t *testing.T) []runtime.Object {
 	}
 }
 
-func testPreflightEncryptionConfigSecret(t *testing.T) *corev1.Secret {
+// testPreflightEncryptionConfigSecret builds the encryption-config secret consumed by the
+// deployer, with a KMS provider (and matching reference data) per keyID. When no keyIDs are
+// given it defaults to a single keyID 1, matching the expected single-socket pod YAMLs.
+func testPreflightEncryptionConfigSecret(t *testing.T, keyIDs ...int) *corev1.Secret {
 	t.Helper()
 
+	if len(keyIDs) == 0 {
+		keyIDs = []int{1}
+	}
+
 	var secretData encryptiondata.KMSPluginsReferenceData
-	if err := secretData.SetFromRawKey("1", "vault-approle-secret_role-id", []byte("test-role-id")); err != nil {
-		t.Fatalf("failed to set secret reference data: %v", err)
-	}
-	if err := secretData.SetFromRawKey("1", "vault-approle-secret_secret-id", []byte("test-secret-id")); err != nil {
-		t.Fatalf("failed to set secret reference data: %v", err)
-	}
-
 	var configMapData encryptiondata.KMSPluginsReferenceData
-	if err := configMapData.SetFromRawKey("1", "vault-ca-bundle_ca-bundle.crt", []byte("test-ca-cert")); err != nil {
-		t.Fatalf("failed to set configmap reference data: %v", err)
+	for _, keyID := range keyIDs {
+		id := strconv.Itoa(keyID)
+		if err := secretData.SetFromRawKey(id, "vault-approle-secret_role-id", []byte("test-role-id")); err != nil {
+			t.Fatalf("failed to set secret reference data: %v", err)
+		}
+		if err := secretData.SetFromRawKey(id, "vault-approle-secret_secret-id", []byte("test-secret-id")); err != nil {
+			t.Fatalf("failed to set secret reference data: %v", err)
+		}
+		if err := configMapData.SetFromRawKey(id, "vault-ca-bundle_ca-bundle.crt", []byte("test-ca-cert")); err != nil {
+			t.Fatalf("failed to set configmap reference data: %v", err)
+		}
 	}
 
-	config := testPreflightEncryptionConfigFromData(t, secretData, configMapData)
+	config := testPreflightEncryptionConfigFromData(t, secretData, configMapData, keyIDs...)
 	secret, err := encryptiondata.ToSecret(testNamespace, EncryptionConfigSecretName, config)
 	if err != nil {
 		t.Fatalf("failed to build encryption config secret: %v", err)
@@ -266,12 +399,37 @@ func testPreflightEncryptionConfigSecret(t *testing.T) *corev1.Secret {
 	return secret
 }
 
+// testPreflightEncryptionConfigFromData builds a Config with a KMS provider per keyID (endpoint
+// unix:///var/run/kmsplugin/kms-<keyID>.sock) followed by an identity provider. When no keyIDs
+// are given it defaults to a single keyID 1.
 func testPreflightEncryptionConfigFromData(
 	t *testing.T,
 	secretData encryptiondata.KMSPluginsReferenceData,
 	configMapData encryptiondata.KMSPluginsReferenceData,
+	keyIDs ...int,
 ) *encryptiondata.Config {
 	t.Helper()
+
+	if len(keyIDs) == 0 {
+		keyIDs = []int{1}
+	}
+
+	providers := make([]apiserverconfigv1.ProviderConfiguration, 0, len(keyIDs)+1)
+	plugins := map[string]configv1.KMSPluginConfig{}
+	for _, keyID := range keyIDs {
+		providers = append(providers, apiserverconfigv1.ProviderConfiguration{
+			KMS: &apiserverconfigv1.KMSConfiguration{
+				APIVersion: "v2",
+				Name:       fmt.Sprintf("%d_secrets", keyID),
+				Endpoint:   fmt.Sprintf("unix:///var/run/kmsplugin/kms-%d.sock", keyID),
+				Timeout:    &metav1.Duration{Duration: testDeployerTimeout},
+			},
+		})
+		plugins[strconv.Itoa(keyID)] = encryptiontesting.DefaultKMSPluginConfig
+	}
+	providers = append(providers, apiserverconfigv1.ProviderConfiguration{
+		Identity: &apiserverconfigv1.IdentityConfiguration{},
+	})
 
 	return &encryptiondata.Config{
 		Encryption: &apiserverconfigv1.EncryptionConfiguration{
@@ -281,21 +439,10 @@ func testPreflightEncryptionConfigFromData(
 			},
 			Resources: []apiserverconfigv1.ResourceConfiguration{{
 				Resources: []string{"secrets"},
-				Providers: []apiserverconfigv1.ProviderConfiguration{{
-					KMS: &apiserverconfigv1.KMSConfiguration{
-						APIVersion: "v2",
-						Name:       "1_secrets",
-						Endpoint:   "unix:///var/run/kmsplugin/kms.sock",
-						Timeout:    &metav1.Duration{Duration: testDeployerTimeout},
-					},
-				}, {
-					Identity: &apiserverconfigv1.IdentityConfiguration{},
-				}},
+				Providers: providers,
 			}},
 		},
-		KMSPlugins: map[string]configv1.KMSPluginConfig{
-			"1": encryptiontesting.DefaultKMSPluginConfig,
-		},
+		KMSPlugins:              plugins,
 		KMSPluginsSecretData:    secretData,
 		KMSPluginsConfigMapData: configMapData,
 	}
@@ -347,8 +494,11 @@ func assertNoActionMatching(t *testing.T, actions []clienttesting.Action, verb, 
 
 func TestPodPreflightDeployer_Deploy(t *testing.T) {
 	tests := []struct {
-		name            string
-		newDeployer     func(*testing.T, ...runtime.Object) (*PodPreflightDeployer, *fake.Clientset)
+		name        string
+		newDeployer func(*testing.T, ...runtime.Object) (*PodPreflightDeployer, *fake.Clientset)
+		// keyIDs configures the KMS providers in the encryption config; empty defaults
+		// to a single keyID 1.
+		keyIDs          []int
 		expectedPodYAML string
 	}{
 		{
@@ -361,13 +511,21 @@ func TestPodPreflightDeployer_Deploy(t *testing.T) {
 			newDeployer:     newTestStaticPodDeployer,
 			expectedPodYAML: expectedDeployStaticPodYAML,
 		},
+		{
+			// keyIDs ascending on purpose: the checker must receive them descending
+			// (kms-2 before kms-1), and one sidecar is injected per plugin.
+			name:            "multiple sockets sorted by keyID descending",
+			newDeployer:     newTestDeployer,
+			keyIDs:          []int{1, 2},
+			expectedPodYAML: expectedDeployMultiSocketPodYAML,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 			deployer, kubeClient := tt.newDeployer(t)
-			encryptionConfigSecret := testPreflightEncryptionConfigSecret(t)
+			encryptionConfigSecret := testPreflightEncryptionConfigSecret(t, tt.keyIDs...)
 
 			expectedPod, err := resourceread.ReadPodV1([]byte(tt.expectedPodYAML))
 			if err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added KMS plugin preflight checking with support for multiple Unix socket endpoints.
  * Automatically provides configured KMS socket endpoints to the preflight checker.
  * Additional sockets receive reachability checks, while the primary socket undergoes full verification.
  * KMS socket paths now support multiple encryption keys.

* **Bug Fixes**
  * Added validation for missing, malformed, or duplicate socket endpoints.
  * Improved handling of invalid timeouts and missing configuration values.
  * Reports an error when the configured target container is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->