### PR TITLE
CNTRLPLANE-3237: test/preflight_deploy.go: fix preflight e2e socket endpoint to match validation pattern

### DIFF
--- a/test/library/encryption/preflight_deploy.go
+++ b/test/library/encryption/preflight_deploy.go
@@ -22,7 +22,7 @@ const (
 	preflightDeployConfigHash = "e2e-preflight-drift"
 	// PreflightDeployCallTimeout is the KMS gRPC call timeout used by preflight e2e Deploy.
 	PreflightDeployCallTimeout  = 10 * time.Second
-	preflightKMSSocketEndpoint  = "unix:///var/run/kmsplugin/kms.sock"
+	preflightKMSSocketEndpoint  = "unix:///var/run/kmsplugin/kms-1.sock"
 	preflightStatusPollInterval = 5 * time.Second
 	preflightStatusPollTimeout  = 5 * time.Minute
 	openshiftConfigNS           = "openshift-config"


### PR DESCRIPTION
fixes the socket endpoint to use `kms-1.sock` to match the validation pattern.

this should unblock https://github.com/openshift/cluster-kube-apiserver-operator/pull/2271

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the preflight deployment configuration to use the correct KMS socket endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->