### PR TITLE
NO-JIRA: preflight: Gracefully handle if mode is changed from KMS

### DIFF
--- a/pkg/operator/encryption/controllers/kms_preflight_controller.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller.go
@@ -422,7 +422,10 @@ func (c *kmsPreflightController) sync(ctx context.Context, syncCtx factory.SyncC
 //     2a. Result already recorded as Failed and pod is gone: surface the error
 //     without re-deploying. The admin must fix the config (new hash) before
 //     a new check can run.
-//     2b. No result yet: call Deploy. On success, requeue and wait for the pod to report results.
+//     2b. No result yet: compute the encryption-config Secret, then call Deploy.
+//     If the encryption mode is no longer KMS, skip deployment — next sync
+//     will re-evaluate whether preflight is required.
+//     On success, requeue and wait for the pod to report results.
 //
 //  3. Preflight required, pod exists (Status returns a PodStatus).
 //     Evaluate the pod state via conditions and phase:
@@ -474,6 +477,7 @@ func (c *kmsPreflightController) sync(ctx context.Context, syncCtx factory.SyncC
 //	1         No preflight required — cleanup                   false    nil   False     False        No
 //	1a        Already Succeeded — cleanup, no pod work          false    nil   False     False        No
 //	2a        No pod, already Failed — surface error            false    *pe   True      False        Yes
+//	2b        No pod, mode no longer KMS — skip                 false    nil   False     False        No
 //	2b        No pod, Deploy success                            true     nil   False     True         No
 //	2b        No pod, Deploy error                              true     err   True      False        No
 //	3a        Pod Failed — keep for inspection                  false    *pe   True      False        Yes
@@ -523,6 +527,11 @@ func (c *kmsPreflightController) runPreflightChecks(ctx context.Context) (requeu
 		encryptionConfig, err := c.encryptionConfigurationComputer.ComputeEncryptionConfiguration(ctx)
 		if err != nil {
 			return true, "", "", fmt.Errorf("failed to compute encryption configuration: %w", err)
+		}
+		if encryptionConfig == nil {
+			// Mode switched away from KMS — nothing to deploy.
+			// Next sync will re-evaluate whether preflight is still required.
+			return false, "", "", nil
 		}
 		c.dirtyDeployer = true
 		if err := c.deployer.Deploy(ctx, requiredHash, encryptionConfig); err != nil {

--- a/pkg/operator/encryption/controllers/kms_preflight_controller_test.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller_test.go
@@ -866,8 +866,12 @@ func TestKMSPreflightController(t *testing.T) {
 		},
 		{
 			// Scenario 2b: deploy error — transient, not terminal.
-			name:                      "deploy fails, reports error",
-			deployer:                  &fakeDeployer{statusErr: apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "kms-preflight"), deployErr: fmt.Errorf("quota exceeded")},
+			name:     "deploy fails, reports error",
+			deployer: &fakeDeployer{statusErr: apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "kms-preflight"), deployErr: fmt.Errorf("quota exceeded")},
+			encryptionConfigurationComputer: &fakeEncryptionConfigurationComputer{secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "encryption-config-test", Namespace: "openshift-config-managed"},
+				Data:       map[string][]byte{"encryption-config": []byte("dummy")},
+			}},
 			encryptionStatusProvider:  &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
 			apiServerObjects:          []runtime.Object{apiServerWithKMS},
 			coreObjects:               []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},


### PR DESCRIPTION
Preflight controller queries APIServer config CRD to ensure that encryption mode is KMS (to continue the process). However, as discussed [here](https://github.com/openshift/library-go/pull/2410/changes/20d847fa4a1a70808a0519f81738d0d2670c1f33#r3827646703),  encryption computation also queries the APIServer config CRD. Therefore, there is a very small window that cluster admin may change the encryption mode moving away from KMS during that time.

This PR handles this gracefully without degrading by introducing a new sub-state for 2b.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved KMS preflight handling when encryption mode changes away from KMS.
  - Skips deployment cleanly when no encryption configuration is required, without unnecessary retries.
  - Preserves validation of encryption configuration during deployment errors.

- **Documentation**
  - Updated deployment scenarios to describe the non-KMS transition path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->