### PR TITLE
NO-JIRA: Move to internal plugin config derived from openshift/api

### DIFF
--- a/pkg/operator/encryption/controllers/key_controller.go
+++ b/pkg/operator/encryption/controllers/key_controller.go
@@ -325,7 +325,10 @@ func (c *keyController) generateKeySecret(ctx context.Context, keyID uint64, cur
 				Endpoint:   fmt.Sprintf(kmsEndpointFormat, keyID),
 				Timeout:    &metav1.Duration{Duration: defaultKMSTimeout},
 			},
-			Plugin: apiServerEncryption.KMS,
+			Plugin: state.InternalKMSPluginConfig{
+				Plugin:         apiServerEncryption.KMS,
+				KMSPluginImage: apiServerEncryption.KMS.Vault.KMSPluginImage,
+			},
 		}
 
 		// Fetch the referenced Secret and ConfigMap, copying their data into the
@@ -573,7 +576,7 @@ func needsNewKey(grKeys state.GroupResourceState, currentMode state.Mode, extern
 		if latestKey.KMS == nil {
 			return 0, "", false, fmt.Errorf("KMS-mode key %q has nil KMS state, possibly corrupted key secret", latestKey.Key.Name)
 		}
-		same, err := desiredProviderCfg.sameProviderInstance(latestKey.KMS.Plugin)
+		same, err := desiredProviderCfg.sameProviderInstance(latestKey.KMS.Plugin.Plugin)
 		if err != nil {
 			return 0, "", false, fmt.Errorf("failed to check KMS provider instance: %w", err)
 		}

--- a/pkg/operator/encryption/controllers/key_controller_test.go
+++ b/pkg/operator/encryption/controllers/key_controller_test.go
@@ -386,7 +386,7 @@ func TestKeyController(t *testing.T) {
 
 						// Verify KMS plugin config content
 						kmsPluginConfigData := actualSecret.Data["encryption.apiserver.operator.openshift.io-kms-plugin-config"]
-						expectedPluginConfig, err := encoding.EncodeKMSPluginConfig(encryptiontesting.DefaultKMSPluginConfig)
+						expectedPluginConfig, err := encoding.EncodeInternalKMSPluginConfig(encryptiontesting.DefaultInternalKMSPluginConfig)
 						if err != nil {
 							ts.Fatalf("failed to encode KMS config: %v", err)
 						}
@@ -480,7 +480,7 @@ func TestKeyController(t *testing.T) {
 
 						// Verify KMS plugin config content
 						kmsPluginConfigData := actualSecret.Data["encryption.apiserver.operator.openshift.io-kms-plugin-config"]
-						expectedPluginConfig, err := encoding.EncodeKMSPluginConfig(encryptiontesting.DefaultKMSPluginConfig)
+						expectedPluginConfig, err := encoding.EncodeInternalKMSPluginConfig(encryptiontesting.DefaultInternalKMSPluginConfig)
 						if err != nil {
 							ts.Fatalf("failed to encode KMS config: %v", err)
 						}
@@ -577,7 +577,7 @@ func TestKeyController(t *testing.T) {
 
 						// Verify KMS plugin config content
 						kmsPluginConfigData := actualSecret.Data["encryption.apiserver.operator.openshift.io-kms-plugin-config"]
-						expectedPluginConfig, err := encoding.EncodeKMSPluginConfig(encryptiontesting.DefaultKMSPluginConfig)
+						expectedPluginConfig, err := encoding.EncodeInternalKMSPluginConfig(encryptiontesting.DefaultInternalKMSPluginConfig)
 						if err != nil {
 							ts.Fatalf("failed to encode KMS config: %v", err)
 						}

--- a/pkg/operator/encryption/controllers/state_controller_test.go
+++ b/pkg/operator/encryption/controllers/state_controller_test.go
@@ -745,7 +745,7 @@ func TestStateController(t *testing.T) {
 						}},
 					}},
 				},
-				KMSPlugins: map[string]configv1.KMSPluginConfig{"1": encryptiontesting.DefaultKMSPluginConfig},
+				KMSPlugins: map[string]state.InternalKMSPluginConfig{"1": encryptiontesting.DefaultInternalKMSPluginConfig},
 			},
 			validateFunc: func(ts *testing.T, actions []clientgotesting.Action, destName string, expectedEncryptionCfg *encryptiondata.Config) {
 				wasSecretValidated := false
@@ -817,7 +817,7 @@ func TestStateController(t *testing.T) {
 						}},
 					}},
 				},
-				KMSPlugins: map[string]configv1.KMSPluginConfig{"1": encryptiontesting.DefaultKMSPluginConfig},
+				KMSPlugins: map[string]state.InternalKMSPluginConfig{"1": encryptiontesting.DefaultInternalKMSPluginConfig},
 			},
 			expectedActions: []string{
 				"list:pods:kms",
@@ -875,7 +875,7 @@ func TestStateController(t *testing.T) {
 								}},
 							}},
 						},
-						KMSPlugins: map[string]configv1.KMSPluginConfig{"1": encryptiontesting.DefaultKMSPluginConfig},
+						KMSPlugins: map[string]state.InternalKMSPluginConfig{"1": encryptiontesting.DefaultInternalKMSPluginConfig},
 					}
 					ecs := createEncryptionCfgSecret(t, "kms", "1", ec)
 					return ecs
@@ -897,7 +897,7 @@ func TestStateController(t *testing.T) {
 								}},
 							}},
 						},
-						KMSPlugins: map[string]configv1.KMSPluginConfig{"1": encryptiontesting.DefaultKMSPluginConfig},
+						KMSPlugins: map[string]state.InternalKMSPluginConfig{"1": encryptiontesting.DefaultInternalKMSPluginConfig},
 					}
 					ecs := createEncryptionCfgSecret(t, "openshift-config-managed", "1", ec)
 					ecs.Name = "encryption-config-kms"
@@ -917,22 +917,25 @@ func TestStateController(t *testing.T) {
 			initialResources: []runtime.Object{
 				encryptiontesting.CreateDummyKubeAPIPod("kube-apiserver-1", "kms", "node-1"),
 				encryptiontesting.CreateExpiredMigratedEncryptionKeySecretWithKMSPluginConfig("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 1),
-				encryptiontesting.CreateEncryptionKeySecretWithCustomKMSPluginConfig("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 2, configv1.KMSPluginConfig{
-					Type: configv1.VaultKMSProvider,
-					Vault: configv1.VaultKMSPluginConfig{
-						KMSPluginImage: "registry.example.com/kms-plugin@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
-						VaultAddress:   "https://vault2.example.com",
-						Authentication: configv1.VaultAuthentication{
-							Type: configv1.VaultAuthenticationTypeAppRole,
-							AppRole: configv1.VaultAppRoleAuthentication{
-								Secret: configv1.VaultSecretReference{Name: "vault-approle-secret-2"},
+				encryptiontesting.CreateEncryptionKeySecretWithCustomKMSPluginConfig("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 2, state.InternalKMSPluginConfig{
+					Plugin: configv1.KMSPluginConfig{
+						Type: configv1.VaultKMSProvider,
+						Vault: configv1.VaultKMSPluginConfig{
+							KMSPluginImage: "registry.example.com/kms-plugin@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+							VaultAddress:   "https://vault2.example.com",
+							Authentication: configv1.VaultAuthentication{
+								Type: configv1.VaultAuthenticationTypeAppRole,
+								AppRole: configv1.VaultAppRoleAuthentication{
+									Secret: configv1.VaultSecretReference{Name: "vault-approle-secret-2"},
+								},
 							},
+							TLS: configv1.VaultTLSConfig{
+								CABundle: configv1.VaultConfigMapReference{Name: "vault-ca-bundle-2"},
+							},
+							VaultKeyPath: "transit/keys/test-transit-key-2",
 						},
-						TLS: configv1.VaultTLSConfig{
-							CABundle: configv1.VaultConfigMapReference{Name: "vault-ca-bundle-2"},
-						},
-						VaultKeyPath: "transit/keys/test-transit-key-2",
 					},
+					KMSPluginImage: "registry.example.com/kms-plugin@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
 				}),
 				func() *corev1.Secret { // encryption config in kms namespace
 					ec := &encryptiondata.Config{Encryption: &apiserverconfigv1.EncryptionConfiguration{
@@ -1015,24 +1018,27 @@ func TestStateController(t *testing.T) {
 						}},
 					}},
 				},
-				KMSPlugins: map[string]configv1.KMSPluginConfig{
-					"1": encryptiontesting.DefaultKMSPluginConfig,
+				KMSPlugins: map[string]state.InternalKMSPluginConfig{
+					"1": encryptiontesting.DefaultInternalKMSPluginConfig,
 					"2": {
-						Type: configv1.VaultKMSProvider,
-						Vault: configv1.VaultKMSPluginConfig{
-							KMSPluginImage: "registry.example.com/kms-plugin@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
-							VaultAddress:   "https://vault2.example.com",
-							Authentication: configv1.VaultAuthentication{
-								Type: configv1.VaultAuthenticationTypeAppRole,
-								AppRole: configv1.VaultAppRoleAuthentication{
-									Secret: configv1.VaultSecretReference{Name: "vault-approle-secret-2"},
+						Plugin: configv1.KMSPluginConfig{
+							Type: configv1.VaultKMSProvider,
+							Vault: configv1.VaultKMSPluginConfig{
+								KMSPluginImage: "registry.example.com/kms-plugin@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+								VaultAddress:   "https://vault2.example.com",
+								Authentication: configv1.VaultAuthentication{
+									Type: configv1.VaultAuthenticationTypeAppRole,
+									AppRole: configv1.VaultAppRoleAuthentication{
+										Secret: configv1.VaultSecretReference{Name: "vault-approle-secret-2"},
+									},
 								},
+								TLS: configv1.VaultTLSConfig{
+									CABundle: configv1.VaultConfigMapReference{Name: "vault-ca-bundle-2"},
+								},
+								VaultKeyPath: "transit/keys/test-transit-key-2",
 							},
-							TLS: configv1.VaultTLSConfig{
-								CABundle: configv1.VaultConfigMapReference{Name: "vault-ca-bundle-2"},
-							},
-							VaultKeyPath: "transit/keys/test-transit-key-2",
 						},
+						KMSPluginImage: "registry.example.com/kms-plugin@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
 					},
 				},
 			},
@@ -1133,22 +1139,25 @@ func TestStateController(t *testing.T) {
 						}},
 					}},
 				},
-				KMSPlugins: map[string]configv1.KMSPluginConfig{"2": {
-					Type: configv1.VaultKMSProvider,
-					Vault: configv1.VaultKMSPluginConfig{
-						KMSPluginImage: "registry.example.com/kms-plugin@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
-						VaultAddress:   "https://vault.example.com",
-						TLS: configv1.VaultTLSConfig{
-							CABundle: configv1.VaultConfigMapReference{Name: "vault-ca-bundle"},
-						},
-						Authentication: configv1.VaultAuthentication{
-							Type: configv1.VaultAuthenticationTypeAppRole,
-							AppRole: configv1.VaultAppRoleAuthentication{
-								Secret: configv1.VaultSecretReference{Name: "vault-approle-secret"},
+				KMSPlugins: map[string]state.InternalKMSPluginConfig{"2": {
+					Plugin: configv1.KMSPluginConfig{
+						Type: configv1.VaultKMSProvider,
+						Vault: configv1.VaultKMSPluginConfig{
+							KMSPluginImage: "registry.example.com/kms-plugin@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+							VaultAddress:   "https://vault.example.com",
+							TLS: configv1.VaultTLSConfig{
+								CABundle: configv1.VaultConfigMapReference{Name: "vault-ca-bundle"},
 							},
+							Authentication: configv1.VaultAuthentication{
+								Type: configv1.VaultAuthenticationTypeAppRole,
+								AppRole: configv1.VaultAppRoleAuthentication{
+									Secret: configv1.VaultSecretReference{Name: "vault-approle-secret"},
+								},
+							},
+							VaultKeyPath: "transit/keys/test-transit-key",
 						},
-						VaultKeyPath: "transit/keys/test-transit-key",
 					},
+					KMSPluginImage: "registry.example.com/kms-plugin@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
 				}},
 			},
 			expectedActions: []string{

--- a/pkg/operator/encryption/encoding/encoding.go
+++ b/pkg/operator/encryption/encoding/encoding.go
@@ -4,11 +4,32 @@ import (
 	"fmt"
 
 	configv1 "github.com/openshift/api/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
+
+	"github.com/openshift/library-go/pkg/operator/encryption/state"
 )
+
+var internalKMSPluginConfigGV = schema.GroupVersion{Group: "encryption.operator.openshift.io", Version: "v1"}
+
+// internalKMSPluginConfigEnvelope is an envelope type used to serialize
+// InternalKMSPluginConfig through the Kubernetes codec infrastructure.
+type internalKMSPluginConfigEnvelope struct {
+	metav1.TypeMeta `json:",inline"`
+	Plugin          configv1.KMSPluginConfig `json:"plugin"`
+	KMSPluginImage  string                   `json:"kmsPluginImage,omitempty"`
+}
+
+func (e *internalKMSPluginConfigEnvelope) DeepCopyObject() runtime.Object {
+	out := new(internalKMSPluginConfigEnvelope)
+	*out = *e
+	out.Plugin = *e.Plugin.DeepCopy()
+	return out
+}
 
 var (
 	scheme         = runtime.NewScheme()
@@ -19,6 +40,9 @@ var (
 func init() {
 	utilruntime.Must(configv1.AddToScheme(scheme))
 	utilruntime.Must(apiserverconfigv1.AddToScheme(scheme))
+	scheme.AddKnownTypes(internalKMSPluginConfigGV, &internalKMSPluginConfigEnvelope{})
+	metav1.AddToGroupVersion(scheme, internalKMSPluginConfigGV)
+	codecs = serializer.NewCodecFactory(scheme)
 	info, ok := runtime.SerializerInfoForMediaType(codecs.SupportedMediaTypes(), runtime.ContentTypeJSON)
 	if !ok {
 		panic("json is not a supported media type")
@@ -81,31 +105,31 @@ func DecodeKMSConfiguration(data []byte) (*apiserverconfigv1.KMSConfiguration, e
 	return encryptionConfiguration.Resources[0].Providers[0].KMS, nil
 }
 
-// EncodeKMSPluginConfig serializes a configv1.KMSPluginConfig into a configv1.APIServer wrapper.
-// We use a configv1.APIServer as an envelope type because configv1.KMSPluginConfig is not a runtime.Object.
-func EncodeKMSPluginConfig(kmsConfig configv1.KMSPluginConfig) ([]byte, error) {
-	apiServerObj := &configv1.APIServer{
-		Spec: configv1.APIServerSpec{
-			Encryption: configv1.APIServerEncryption{
-				KMS: kmsConfig,
-			},
-		},
+// EncodeInternalKMSPluginConfig serializes an InternalKMSPluginConfig into its
+// internal envelope representation using Kubernetes codec infrastructure.
+func EncodeInternalKMSPluginConfig(config state.InternalKMSPluginConfig) ([]byte, error) {
+	envelope := &internalKMSPluginConfigEnvelope{
+		Plugin:         config.Plugin,
+		KMSPluginImage: config.KMSPluginImage,
 	}
-	encoder := codecs.EncoderForVersion(jsonSerializer, configv1.SchemeGroupVersion)
-	pluginData, err := runtime.Encode(encoder, apiServerObj)
+	encoder := codecs.EncoderForVersion(jsonSerializer, internalKMSPluginConfigGV)
+	data, err := runtime.Encode(encoder, envelope)
 	if err != nil {
-		return nil, fmt.Errorf("failed to encode KMS plugin config: %w", err)
+		return nil, fmt.Errorf("failed to encode internal KMS plugin config: %w", err)
 	}
-	return pluginData, nil
+	return data, nil
 }
 
-// DecodeKMSPluginConfig extracts a configv1.KMSPluginConfig object from its serialized configv1.APIServer wrapper.
-// We use a configv1.APIServer as an envelope type because KMSPluginConfig is not a runtime.Object.
-func DecodeKMSPluginConfig(data []byte) (configv1.KMSPluginConfig, error) {
-	apiServer := &configv1.APIServer{}
-	err := runtime.DecodeInto(codecs.UniversalDecoder(configv1.SchemeGroupVersion), data, apiServer)
+// DecodeInternalKMSPluginConfig extracts an InternalKMSPluginConfig from its
+// serialized envelope representation.
+func DecodeInternalKMSPluginConfig(data []byte) (state.InternalKMSPluginConfig, error) {
+	envelope := &internalKMSPluginConfigEnvelope{}
+	err := runtime.DecodeInto(codecs.UniversalDecoder(internalKMSPluginConfigGV), data, envelope)
 	if err != nil {
-		return configv1.KMSPluginConfig{}, err
+		return state.InternalKMSPluginConfig{}, fmt.Errorf("failed to decode internal KMS plugin config: %w", err)
 	}
-	return apiServer.Spec.Encryption.KMS, nil
+	return state.InternalKMSPluginConfig{
+		Plugin:         envelope.Plugin,
+		KMSPluginImage: envelope.KMSPluginImage,
+	}, nil
 }

--- a/pkg/operator/encryption/encoding/encoding_test.go
+++ b/pkg/operator/encryption/encoding/encoding_test.go
@@ -1,0 +1,50 @@
+package encoding
+
+import (
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/library-go/pkg/operator/encryption/state"
+)
+
+func TestInternalKMSPluginConfigRoundTrip(t *testing.T) {
+	original := state.InternalKMSPluginConfig{
+		Plugin: configv1.KMSPluginConfig{
+			Type: configv1.VaultKMSProvider,
+			Vault: configv1.VaultKMSPluginConfig{
+				VaultAddress: "https://vault.example.com",
+				VaultKeyPath: "transit/keys/my-key",
+				Authentication: configv1.VaultAuthentication{
+					Type: configv1.VaultAuthenticationTypeAppRole,
+					AppRole: configv1.VaultAppRoleAuthentication{
+						Secret: configv1.VaultSecretReference{Name: "vault-approle"},
+					},
+				},
+			},
+		},
+		KMSPluginImage: "registry.example.com/kms-plugin@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+	}
+
+	encoded, err := EncodeInternalKMSPluginConfig(original)
+	if err != nil {
+		t.Fatalf("encode failed: %v", err)
+	}
+
+	decoded, err := DecodeInternalKMSPluginConfig(encoded)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+
+	if decoded.Plugin.Type != original.Plugin.Type {
+		t.Errorf("Plugin.Type: got %q, want %q", decoded.Plugin.Type, original.Plugin.Type)
+	}
+	if decoded.Plugin.Vault.VaultAddress != original.Plugin.Vault.VaultAddress {
+		t.Errorf("Plugin.Vault.VaultAddress: got %q, want %q", decoded.Plugin.Vault.VaultAddress, original.Plugin.Vault.VaultAddress)
+	}
+	if decoded.Plugin.Vault.VaultKeyPath != original.Plugin.Vault.VaultKeyPath {
+		t.Errorf("Plugin.Vault.VaultKeyPath: got %q, want %q", decoded.Plugin.Vault.VaultKeyPath, original.Plugin.Vault.VaultKeyPath)
+	}
+	if decoded.KMSPluginImage != original.KMSPluginImage {
+		t.Errorf("KMSPluginImage: got %q, want %q", decoded.KMSPluginImage, original.KMSPluginImage)
+	}
+}

--- a/pkg/operator/encryption/encryptiondata/config.go
+++ b/pkg/operator/encryption/encryptiondata/config.go
@@ -12,8 +12,6 @@ import (
 	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
 	"k8s.io/klog/v2"
 
-	configv1 "github.com/openshift/api/config/v1"
-
 	"github.com/openshift/library-go/pkg/operator/encryption/crypto"
 	"github.com/openshift/library-go/pkg/operator/encryption/secrets"
 	"github.com/openshift/library-go/pkg/operator/encryption/state"
@@ -29,7 +27,7 @@ type Config struct {
 	Encryption *apiserverconfigv1.EncryptionConfiguration
 	// KMSPlugins maps keyID to plugin-specific configuration,
 	// carried from Key Secrets into the encryption-config Secret.
-	KMSPlugins map[string]configv1.KMSPluginConfig
+	KMSPlugins map[string]state.InternalKMSPluginConfig
 	// KMSPluginsSecretData maps keyID to secret data carried from
 	// Key Secrets into the encryption-config Secret.
 	// Structure: keyID → referenceName → dataKey → value.
@@ -95,7 +93,7 @@ func (c *Config) HasEncryptionConfiguration() bool {
 // FromEncryptionState converts encryption state to Config.
 func FromEncryptionState(encryptionState map[schema.GroupResource]state.GroupResourceState) (*Config, error) {
 	resourceConfigs := make([]apiserverconfigv1.ResourceConfiguration, 0, len(encryptionState))
-	var kmsPlugins map[string]configv1.KMSPluginConfig
+	var kmsPlugins map[string]state.InternalKMSPluginConfig
 	var kmsPluginsSecretData KMSPluginsReferenceData
 	var kmsPluginsConfigMapData KMSPluginsReferenceData
 
@@ -113,7 +111,7 @@ func FromEncryptionState(encryptionState map[schema.GroupResource]state.GroupRes
 		for _, key := range grKeys.ReadKeys {
 			if key.HasKMSPlugin() {
 				if kmsPlugins == nil {
-					kmsPlugins = map[string]configv1.KMSPluginConfig{}
+					kmsPlugins = map[string]state.InternalKMSPluginConfig{}
 				}
 				if plugin, exists := kmsPlugins[key.Key.Name]; exists {
 					// Sanity check: the same keyID seen from a different resource must carry

--- a/pkg/operator/encryption/encryptiondata/config_test.go
+++ b/pkg/operator/encryption/encryptiondata/config_test.go
@@ -723,7 +723,7 @@ func TestFromEncryptionStateKMSPluginConfigValidation(t *testing.T) {
 						Mode: state.KMS,
 						KMS: &state.KMSState{
 							Encryption: &apiserverconfigv1.KMSConfiguration{APIVersion: "v2", Name: "1", Endpoint: "unix:///var/run/kmsplugin/kms-1.sock"},
-							Plugin:     encryptiontesting.DefaultKMSPluginConfig,
+							Plugin:     encryptiontesting.DefaultInternalKMSPluginConfig,
 						},
 					}},
 				},
@@ -733,7 +733,7 @@ func TestFromEncryptionStateKMSPluginConfigValidation(t *testing.T) {
 						Mode: state.KMS,
 						KMS: &state.KMSState{
 							Encryption: &apiserverconfigv1.KMSConfiguration{APIVersion: "v2", Name: "1", Endpoint: "unix:///var/run/kmsplugin/kms-1.sock"},
-							Plugin:     encryptiontesting.DefaultKMSPluginConfig,
+							Plugin:     encryptiontesting.DefaultInternalKMSPluginConfig,
 						},
 					}},
 				},
@@ -748,13 +748,13 @@ func TestFromEncryptionStateKMSPluginConfigValidation(t *testing.T) {
 						Mode: state.KMS,
 						KMS: &state.KMSState{
 							Encryption: &apiserverconfigv1.KMSConfiguration{APIVersion: "v2", Name: "1", Endpoint: "unix:///var/run/kmsplugin/kms-1.sock"},
-							Plugin: configv1.KMSPluginConfig{
+							Plugin: state.InternalKMSPluginConfig{Plugin: configv1.KMSPluginConfig{
 								Type: configv1.VaultKMSProvider,
 								Vault: configv1.VaultKMSPluginConfig{
 									VaultAddress: "https://vault-a.example.com",
 									VaultKeyPath: "transit/keys/key-a",
 								},
-							},
+							}},
 						},
 					}},
 				},
@@ -764,13 +764,13 @@ func TestFromEncryptionStateKMSPluginConfigValidation(t *testing.T) {
 						Mode: state.KMS,
 						KMS: &state.KMSState{
 							Encryption: &apiserverconfigv1.KMSConfiguration{APIVersion: "v2", Name: "1", Endpoint: "unix:///var/run/kmsplugin/kms-1.sock"},
-							Plugin: configv1.KMSPluginConfig{
+							Plugin: state.InternalKMSPluginConfig{Plugin: configv1.KMSPluginConfig{
 								Type: configv1.VaultKMSProvider,
 								Vault: configv1.VaultKMSPluginConfig{
 									VaultAddress: "https://vault-b.example.com",
 									VaultKeyPath: "transit/keys/key-b",
 								},
-							},
+							}},
 						},
 					}},
 				},
@@ -814,7 +814,7 @@ func TestFromEncryptionStateKMSSecretDataValidation(t *testing.T) {
 						Mode: state.KMS,
 						KMS: &state.KMSState{
 							Encryption: &apiserverconfigv1.KMSConfiguration{APIVersion: "v2", Name: "1", Endpoint: "unix:///var/run/kmsplugin/kms-1.sock"},
-							Plugin:     encryptiontesting.DefaultKMSPluginConfig,
+							Plugin:     encryptiontesting.DefaultInternalKMSPluginConfig,
 							PluginSecretData: func() state.KMSReferenceData {
 								var sd state.KMSReferenceData
 								sd.Set("vault-approle-secret", "role-id", []byte("test-role-id"))
@@ -830,7 +830,7 @@ func TestFromEncryptionStateKMSSecretDataValidation(t *testing.T) {
 						Mode: state.KMS,
 						KMS: &state.KMSState{
 							Encryption: &apiserverconfigv1.KMSConfiguration{APIVersion: "v2", Name: "1", Endpoint: "unix:///var/run/kmsplugin/kms-1.sock"},
-							Plugin:     encryptiontesting.DefaultKMSPluginConfig,
+							Plugin:     encryptiontesting.DefaultInternalKMSPluginConfig,
 							PluginSecretData: func() state.KMSReferenceData {
 								var sd state.KMSReferenceData
 								sd.Set("vault-approle-secret", "role-id", []byte("test-role-id"))
@@ -857,7 +857,7 @@ func TestFromEncryptionStateKMSSecretDataValidation(t *testing.T) {
 						Mode: state.KMS,
 						KMS: &state.KMSState{
 							Encryption: &apiserverconfigv1.KMSConfiguration{APIVersion: "v2", Name: "1", Endpoint: "unix:///var/run/kmsplugin/kms-1.sock"},
-							Plugin:     encryptiontesting.DefaultKMSPluginConfig,
+							Plugin:     encryptiontesting.DefaultInternalKMSPluginConfig,
 							PluginSecretData: func() state.KMSReferenceData {
 								var sd state.KMSReferenceData
 								sd.Set("vault-approle-secret", "role-id", []byte("role-id-a"))
@@ -872,7 +872,7 @@ func TestFromEncryptionStateKMSSecretDataValidation(t *testing.T) {
 						Mode: state.KMS,
 						KMS: &state.KMSState{
 							Encryption: &apiserverconfigv1.KMSConfiguration{APIVersion: "v2", Name: "1", Endpoint: "unix:///var/run/kmsplugin/kms-1.sock"},
-							Plugin:     encryptiontesting.DefaultKMSPluginConfig,
+							Plugin:     encryptiontesting.DefaultInternalKMSPluginConfig,
 							PluginSecretData: func() state.KMSReferenceData {
 								var sd state.KMSReferenceData
 								sd.Set("vault-approle-secret", "role-id", []byte("role-id-b"))
@@ -893,7 +893,7 @@ func TestFromEncryptionStateKMSSecretDataValidation(t *testing.T) {
 						Mode: state.KMS,
 						KMS: &state.KMSState{
 							Encryption: &apiserverconfigv1.KMSConfiguration{APIVersion: "v2", Name: "1", Endpoint: "unix:///var/run/kmsplugin/kms-1.sock"},
-							Plugin:     encryptiontesting.DefaultKMSPluginConfig,
+							Plugin:     encryptiontesting.DefaultInternalKMSPluginConfig,
 						},
 					}},
 				},
@@ -972,8 +972,8 @@ func TestSecretRoundtrip(t *testing.T) {
 						}},
 					}},
 				},
-				KMSPlugins: map[string]configv1.KMSPluginConfig{
-					"1": encryptiontesting.DefaultKMSPluginConfig,
+				KMSPlugins: map[string]state.InternalKMSPluginConfig{
+					"1": encryptiontesting.DefaultInternalKMSPluginConfig,
 				},
 			},
 		},
@@ -999,8 +999,8 @@ func TestSecretRoundtrip(t *testing.T) {
 						}},
 					}},
 				},
-				KMSPlugins: map[string]configv1.KMSPluginConfig{
-					"1": encryptiontesting.DefaultKMSPluginConfig,
+				KMSPlugins: map[string]state.InternalKMSPluginConfig{
+					"1": encryptiontesting.DefaultInternalKMSPluginConfig,
 				},
 				KMSPluginsSecretData: func() encryptiondata.KMSPluginsReferenceData {
 					var sd encryptiondata.KMSPluginsReferenceData
@@ -1039,9 +1039,9 @@ func TestSecretRoundtrip(t *testing.T) {
 						}},
 					}},
 				},
-				KMSPlugins: map[string]configv1.KMSPluginConfig{
-					"1": encryptiontesting.DefaultKMSPluginConfig,
-					"2": encryptiontesting.DefaultKMSPluginConfig,
+				KMSPlugins: map[string]state.InternalKMSPluginConfig{
+					"1": encryptiontesting.DefaultInternalKMSPluginConfig,
+					"2": encryptiontesting.DefaultInternalKMSPluginConfig,
 				},
 				KMSPluginsSecretData: func() encryptiondata.KMSPluginsReferenceData {
 					var sd encryptiondata.KMSPluginsReferenceData
@@ -1082,9 +1082,9 @@ func TestSecretRoundtrip(t *testing.T) {
 						}},
 					}},
 				},
-				KMSPlugins: map[string]configv1.KMSPluginConfig{
-					"1": encryptiontesting.DefaultKMSPluginConfig,
-					"2": encryptiontesting.DefaultKMSPluginConfig,
+				KMSPlugins: map[string]state.InternalKMSPluginConfig{
+					"1": encryptiontesting.DefaultInternalKMSPluginConfig,
+					"2": encryptiontesting.DefaultInternalKMSPluginConfig,
 				},
 			},
 		},
@@ -1120,8 +1120,8 @@ func TestToSecretSecretDataEdgeCases(t *testing.T) {
 				},
 			}},
 		},
-		KMSPlugins: map[string]configv1.KMSPluginConfig{
-			"1": encryptiontesting.DefaultKMSPluginConfig,
+		KMSPlugins: map[string]state.InternalKMSPluginConfig{
+			"1": encryptiontesting.DefaultInternalKMSPluginConfig,
 		},
 	}
 
@@ -1208,8 +1208,8 @@ func TestFromSecretSecretData(t *testing.T) {
 				},
 			}},
 		},
-		KMSPlugins: map[string]configv1.KMSPluginConfig{
-			"1": encryptiontesting.DefaultKMSPluginConfig,
+		KMSPlugins: map[string]state.InternalKMSPluginConfig{
+			"1": encryptiontesting.DefaultInternalKMSPluginConfig,
 		},
 	}
 

--- a/pkg/operator/encryption/encryptiondata/secret.go
+++ b/pkg/operator/encryption/encryptiondata/secret.go
@@ -11,8 +11,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
 
-	configv1 "github.com/openshift/api/config/v1"
-
 	"github.com/openshift/library-go/pkg/operator/encryption/encoding"
 	"github.com/openshift/library-go/pkg/operator/encryption/state"
 )
@@ -63,7 +61,7 @@ func FromSecret(encryptionConfigSecret *corev1.Secret) (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	var kmsPlugins map[string]configv1.KMSPluginConfig
+	var kmsPlugins map[string]state.InternalKMSPluginConfig
 	for key, value := range encryptionConfigSecret.Data {
 		// Not all data keys are plugin configs — the Secret also contains the
 		// encryption-config entry, so skip keys that don't match the pattern.
@@ -74,17 +72,17 @@ func FromSecret(encryptionConfigSecret *corev1.Secret) (*Config, error) {
 		if !found {
 			continue
 		}
-		pluginConfig, err := encoding.DecodeKMSPluginConfig(value)
+		internalConfig, err := encoding.DecodeInternalKMSPluginConfig(value)
 		if err != nil {
 			return nil, fmt.Errorf("failed to decode KMS plugin config for key %s: %w", keyID, err)
 		}
 		if kmsPlugins == nil {
-			kmsPlugins = map[string]configv1.KMSPluginConfig{}
+			kmsPlugins = map[string]state.InternalKMSPluginConfig{}
 		}
 		if _, exists := kmsPlugins[keyID]; exists {
 			return nil, fmt.Errorf("duplicate KMS plugin config for keyID %s", keyID)
 		}
-		kmsPlugins[keyID] = pluginConfig
+		kmsPlugins[keyID] = internalConfig
 	}
 
 	// Extract secret data entries from the encryption-config Secret.
@@ -155,7 +153,7 @@ func ToSecret(ns, name string, secretData *Config) (*corev1.Secret, error) {
 	}
 
 	for keyID, pluginConfig := range secretData.KMSPlugins {
-		encodedPlugin, err := encoding.EncodeKMSPluginConfig(pluginConfig)
+		encodedPlugin, err := encoding.EncodeInternalKMSPluginConfig(pluginConfig)
 		if err != nil {
 			return nil, fmt.Errorf("failed to encode KMS plugin config for key %s: %w", keyID, err)
 		}

--- a/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/api/features"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"github.com/openshift/library-go/pkg/operator/encryption/kms/health"
+	"github.com/openshift/library-go/pkg/operator/encryption/state"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -42,10 +43,10 @@ type sidecarProvider interface {
 
 // newSidecarProvider creates a provider-specific sidecarProvider for the given keyID and plugin configuration,
 // wiring in reference data (secrets, configmaps) via the referenceDataResolver.
-func newSidecarProvider(keyID string, udsPath string, pluginConfig configv1.KMSPluginConfig, refData *referenceDataResolver) (sidecarProvider, error) {
-	switch pluginConfig.Type {
+func newSidecarProvider(keyID string, udsPath string, pluginConfig state.InternalKMSPluginConfig, refData *referenceDataResolver) (sidecarProvider, error) {
+	switch pluginConfig.Plugin.Type {
 	case configv1.VaultKMSProvider:
-		return newVaultSidecarProvider(vaultSidecarPrefix, keyID, udsPath, pluginConfig.Vault, refData)
+		return newVaultSidecarProvider(vaultSidecarPrefix, keyID, udsPath, pluginConfig.Plugin.Vault, pluginConfig.KMSPluginImage, refData)
 	default:
 		return nil, fmt.Errorf("unsupported KMS plugin configuration")
 	}

--- a/pkg/operator/encryption/kms/pluginlifecycle/sidecar_test.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/sidecar_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/api/features"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"github.com/openshift/library-go/pkg/operator/encryption/encoding"
+	"github.com/openshift/library-go/pkg/operator/encryption/state"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -51,7 +52,10 @@ func newSidecarTestFixtures(t *testing.T) sidecarTestFixtures {
 			},
 		},
 	}
-	pluginConfigBytes, err := encoding.EncodeKMSPluginConfig(*vaultConfig)
+	pluginConfigBytes, err := encoding.EncodeInternalKMSPluginConfig(state.InternalKMSPluginConfig{
+		Plugin:         *vaultConfig,
+		KMSPluginImage: vaultConfig.Vault.KMSPluginImage,
+	})
 	require.NoError(t, err)
 
 	encryptionConfig := &apiserverv1.EncryptionConfiguration{
@@ -335,7 +339,10 @@ func TestEnsureKMSPluginSidecarInPodSpec(t *testing.T) {
 						},
 					},
 				}
-				pluginConfig2Bytes, err := encoding.EncodeKMSPluginConfig(*vaultConfig2)
+				pluginConfig2Bytes, err := encoding.EncodeInternalKMSPluginConfig(state.InternalKMSPluginConfig{
+					Plugin:         *vaultConfig2,
+					KMSPluginImage: vaultConfig2.Vault.KMSPluginImage,
+				})
 				require.NoError(t, err)
 
 				pluginConfigKey2 := "kms-plugin-config-777"

--- a/pkg/operator/encryption/kms/pluginlifecycle/vault.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/vault.go
@@ -11,7 +11,7 @@ import (
 
 // newVaultSidecarProvider creates a Vault sidecar provider from the given KMS plugin data.
 // It assumes the input data has been already been validated.
-func newVaultSidecarProvider(name, keyID, udsPath string, vaultConfig configv1.VaultKMSPluginConfig, refData *referenceDataResolver) (*vault, error) {
+func newVaultSidecarProvider(name, keyID, udsPath string, vaultConfig configv1.VaultKMSPluginConfig, pluginImage string, refData *referenceDataResolver) (*vault, error) {
 	secretName := vaultConfig.Authentication.AppRole.Secret.Name
 	if secretName == "" {
 		return nil, fmt.Errorf("vault AppRole authentication secret name cannot be empty")
@@ -48,6 +48,7 @@ func newVaultSidecarProvider(name, keyID, udsPath string, vaultConfig configv1.V
 		keyID:        keyID,
 		udsPath:      udsPath,
 		config:       vaultConfig,
+		pluginImage:  pluginImage,
 		roleID:       roleID,
 		secretIDPath: secretIDPath,
 		caBundlePath: caBundlePath,
@@ -60,6 +61,7 @@ type vault struct {
 	keyID        string
 	udsPath      string
 	config       configv1.VaultKMSPluginConfig
+	pluginImage  string
 	roleID       string
 	secretIDPath string
 	caBundlePath string
@@ -106,7 +108,7 @@ func (v *vault) BuildSidecarContainer() (corev1.Container, error) {
 
 	return corev1.Container{
 		Name:            v.Name(),
-		Image:           v.config.KMSPluginImage,
+		Image:           v.pluginImage,
 		Args:            args,
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		// We place the container in InitContainers with RestartPolicyAlways so the kubelet starts it before

--- a/pkg/operator/encryption/kms/pluginlifecycle/vault_test.go
+++ b/pkg/operator/encryption/kms/pluginlifecycle/vault_test.go
@@ -31,6 +31,7 @@ func TestVaultSidecarProvider_BuildSidecarContainer(t *testing.T) {
 	tests := []struct {
 		name               string
 		vaultConfig        configv1.VaultKMSPluginConfig
+		pluginImage        string
 		secretData         state.KMSReferenceData
 		configMapData      state.KMSReferenceData
 		referenceDataDir   string
@@ -42,7 +43,8 @@ func TestVaultSidecarProvider_BuildSidecarContainer(t *testing.T) {
 		expectErr          string
 	}{
 		{
-			name: "builds container with correct args",
+			name:        "builds container with correct args",
+			pluginImage: "quay.io/test/vault:v2",
 			vaultConfig: configv1.VaultKMSPluginConfig{
 				KMSPluginImage:     "quay.io/test/vault:v2",
 				VaultAddress:       "https://vault.example.com:8200",
@@ -101,7 +103,8 @@ func TestVaultSidecarProvider_BuildSidecarContainer(t *testing.T) {
 			},
 		},
 		{
-			name: "appends to existing containers",
+			name:        "appends to existing containers",
+			pluginImage: "quay.io/test/vault:v2",
 			vaultConfig: configv1.VaultKMSPluginConfig{
 				KMSPluginImage: "quay.io/test/vault:v2",
 				VaultAddress:   "https://vault.example.com:8200",
@@ -165,7 +168,8 @@ func TestVaultSidecarProvider_BuildSidecarContainer(t *testing.T) {
 			},
 		},
 		{
-			name: "empty optional fields",
+			name:        "empty optional fields",
+			pluginImage: "quay.io/test/vault:v2",
 			vaultConfig: configv1.VaultKMSPluginConfig{
 				KMSPluginImage: "quay.io/test/vault:v2",
 				VaultAddress:   "https://vault.example.com:8200",
@@ -250,7 +254,7 @@ func TestVaultSidecarProvider_BuildSidecarContainer(t *testing.T) {
 				keyID:                tt.keyID,
 			}
 
-			provider, err := newVaultSidecarProvider(tt.containerName, tt.keyID, tt.udsPath, tt.vaultConfig, refData)
+			provider, err := newVaultSidecarProvider(tt.containerName, tt.keyID, tt.udsPath, tt.vaultConfig, tt.pluginImage, refData)
 			if tt.expectErr != "" {
 				require.EqualError(t, err, tt.expectErr)
 				return

--- a/pkg/operator/encryption/kms/preflight/deployer_test.go
+++ b/pkg/operator/encryption/kms/preflight/deployer_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
+	"github.com/openshift/library-go/pkg/operator/encryption/state"
 	encryptiontesting "github.com/openshift/library-go/pkg/operator/encryption/testing"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
@@ -415,7 +415,7 @@ func testPreflightEncryptionConfigFromData(
 	}
 
 	providers := make([]apiserverconfigv1.ProviderConfiguration, 0, len(keyIDs)+1)
-	plugins := map[string]configv1.KMSPluginConfig{}
+	plugins := map[string]state.InternalKMSPluginConfig{}
 	for _, keyID := range keyIDs {
 		providers = append(providers, apiserverconfigv1.ProviderConfiguration{
 			KMS: &apiserverconfigv1.KMSConfiguration{
@@ -425,7 +425,7 @@ func testPreflightEncryptionConfigFromData(
 				Timeout:    &metav1.Duration{Duration: testDeployerTimeout},
 			},
 		})
-		plugins[strconv.Itoa(keyID)] = encryptiontesting.DefaultKMSPluginConfig
+		plugins[strconv.Itoa(keyID)] = encryptiontesting.DefaultInternalKMSPluginConfig
 	}
 	providers = append(providers, apiserverconfigv1.ProviderConfiguration{
 		Identity: &apiserverconfigv1.IdentityConfiguration{},

--- a/pkg/operator/encryption/secrets/secrets.go
+++ b/pkg/operator/encryption/secrets/secrets.go
@@ -78,11 +78,11 @@ func ToKeyState(s *corev1.Secret) (state.KeyState, error) {
 			return state.KeyState{}, fmt.Errorf("%s can not be empty, when mode is KMS", EncryptionSecretKMSEncryptionConfig)
 		}
 		if v, ok := s.Data[encryptionSecretKMSPluginConfig]; ok && len(v) > 0 {
-			kmsConfig, err := encoding.DecodeKMSPluginConfig(v)
+			internalConfig, err := encoding.DecodeInternalKMSPluginConfig(v)
 			if err != nil {
 				return state.KeyState{}, fmt.Errorf("secret %s/%s has invalid %s data: %w", s.Namespace, s.Name, encryptionSecretKMSPluginConfig, err)
 			}
-			key.KMS.Plugin = kmsConfig
+			key.KMS.Plugin = internalConfig
 		} else {
 			// encryption.apiserver.operator.openshift.io-kms-plugin-config data field is required for KMS
 			// encryption mode.
@@ -171,7 +171,7 @@ func FromKeyState(component string, ks state.KeyState) (*corev1.Secret, error) {
 	}
 
 	if ks.HasKMSPlugin() {
-		pluginData, err := encoding.EncodeKMSPluginConfig(ks.KMS.Plugin)
+		pluginData, err := encoding.EncodeInternalKMSPluginConfig(ks.KMS.Plugin)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/operator/encryption/secrets/secrets_test.go
+++ b/pkg/operator/encryption/secrets/secrets_test.go
@@ -33,6 +33,11 @@ var defaultKMSPluginConfig = configv1.KMSPluginConfig{
 	},
 }
 
+var defaultInternalKMSPluginConfig = state.InternalKMSPluginConfig{
+	Plugin:         defaultKMSPluginConfig,
+	KMSPluginImage: defaultKMSPluginConfig.Vault.KMSPluginImage,
+}
+
 func TestRoundtrip(t *testing.T) {
 	now, _ := time.Parse(time.RFC3339, time.Now().Format(time.RFC3339))
 
@@ -150,7 +155,7 @@ func TestRoundtrip(t *testing.T) {
 						Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
 						Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 					},
-					Plugin: defaultKMSPluginConfig,
+					Plugin: defaultInternalKMSPluginConfig,
 				},
 				Migrated: state.MigrationState{
 					Timestamp: now,
@@ -181,7 +186,7 @@ func TestRoundtrip(t *testing.T) {
 						Endpoint:   "unix:///var/run/kmsplugin/kms-2.sock",
 						Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 					},
-					Plugin: defaultKMSPluginConfig,
+					Plugin: defaultInternalKMSPluginConfig,
 				},
 			},
 		},
@@ -202,7 +207,7 @@ func TestRoundtrip(t *testing.T) {
 						Endpoint:   "unix:///var/run/kmsplugin/kms-1.sock",
 						Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 					},
-					Plugin: defaultKMSPluginConfig,
+					Plugin: defaultInternalKMSPluginConfig,
 					PluginSecretData: func() state.KMSReferenceData {
 						var sd state.KMSReferenceData
 						sd.Set("vault-approle-secret", "role-id", []byte("test-role-id"))

--- a/pkg/operator/encryption/state/types.go
+++ b/pkg/operator/encryption/state/types.go
@@ -57,7 +57,7 @@ func (k *KeyState) HasKMSEncryption() bool {
 }
 
 func (k *KeyState) HasKMSPlugin() bool {
-	return k != nil && k.KMS != nil && k.KMS.Plugin != (configv1.KMSPluginConfig{})
+	return k != nil && k.KMS != nil && k.KMS.Plugin.Plugin != (configv1.KMSPluginConfig{})
 }
 
 func (k *KeyState) HasKMSSecretData() bool {
@@ -68,13 +68,22 @@ func (k *KeyState) HasKMSConfigMapData() bool {
 	return k != nil && k.KMS != nil && len(k.KMS.PluginConfigMapData.entries) > 0
 }
 
+// InternalKMSPluginConfig wraps the API KMSPluginConfig type with additional
+// fields that are not part of the public API but are needed internally by
+// the encryption controllers (e.g. the plugin image, which will move from
+// the API to a ConfigMap).
+type InternalKMSPluginConfig struct {
+	Plugin         configv1.KMSPluginConfig `json:"plugin"`
+	KMSPluginImage string                   `json:"kmsPluginImage,omitempty"`
+}
+
 // KMSState stores all KMS encryption mode related configurations
 type KMSState struct {
 	// Encoded EncryptionConfig that stores the KMS related fields
 	Encryption *apiserverconfigv1.KMSConfiguration
 
 	// Plugin stores KMS plugin specific configurations
-	Plugin configv1.KMSPluginConfig
+	Plugin InternalKMSPluginConfig
 
 	// PluginSecretData stores data key-value pairs fetched from referenced secrets.
 	PluginSecretData KMSReferenceData

--- a/pkg/operator/encryption/testing/helpers.go
+++ b/pkg/operator/encryption/testing/helpers.go
@@ -116,8 +116,13 @@ var DefaultKMSPluginConfig = configv1.KMSPluginConfig{
 	},
 }
 
+var DefaultInternalKMSPluginConfig = state.InternalKMSPluginConfig{
+	Plugin:         DefaultKMSPluginConfig,
+	KMSPluginImage: DefaultKMSPluginConfig.Vault.KMSPluginImage,
+}
+
 func CreateEncryptionKeySecretWithKMSPluginConfig(targetNS string, grs []schema.GroupResource, keyID uint64) *corev1.Secret {
-	return CreateEncryptionKeySecretWithCustomKMSPluginConfig(targetNS, grs, keyID, DefaultKMSPluginConfig)
+	return CreateEncryptionKeySecretWithCustomKMSPluginConfig(targetNS, grs, keyID, DefaultInternalKMSPluginConfig)
 }
 
 func CreateMigratedEncryptionKeySecretWithKMSPluginConfig(targetNS string, grs []schema.GroupResource, keyID uint64, ts time.Time) *corev1.Secret {
@@ -130,7 +135,7 @@ func CreateExpiredMigratedEncryptionKeySecretWithKMSPluginConfig(targetNS string
 	return CreateMigratedEncryptionKeySecretWithKMSPluginConfig(targetNS, grs, keyID, time.Now().Add(-(time.Hour*24*7 + time.Hour)))
 }
 
-func CreateEncryptionKeySecretWithCustomKMSPluginConfig(targetNS string, grs []schema.GroupResource, keyID uint64, pluginConfig configv1.KMSPluginConfig) *corev1.Secret {
+func CreateEncryptionKeySecretWithCustomKMSPluginConfig(targetNS string, grs []schema.GroupResource, keyID uint64, pluginConfig state.InternalKMSPluginConfig) *corev1.Secret {
 	emptyKey := make([]byte, 16)
 	secret := CreateEncryptionKeySecretWithRawKeyWithMode(targetNS, grs, keyID, emptyKey, "KMS")
 	kmsConfig := &apiserverconfigv1.KMSConfiguration{
@@ -144,7 +149,7 @@ func CreateEncryptionKeySecretWithCustomKMSPluginConfig(targetNS string, grs []s
 		panic(fmt.Sprintf("failed to encode KMS encryption config: %v", err))
 	}
 	secret.Data[encryptionSecretKMSEncryptionConfigForTest] = encData
-	pluginData, err := encoding.EncodeKMSPluginConfig(pluginConfig)
+	pluginData, err := encoding.EncodeInternalKMSPluginConfig(pluginConfig)
 	if err != nil {
 		panic(fmt.Sprintf("failed to encode KMS plugin config: %v", err))
 	}

--- a/test/e2e-encryption/encryption_test.go
+++ b/test/e2e-encryption/encryption_test.go
@@ -302,7 +302,7 @@ func TestEncryptionIntegration(tt *testing.T) {
 			require.NoError(t, err)
 			keyPluginData := keySecret.Data["encryption.apiserver.operator.openshift.io-kms-plugin-config"]
 			require.NotEmpty(t, keyPluginData, "key secret %s missing kms-plugin-config data", keyID)
-			keyPluginConfig, err := encoding.DecodeKMSPluginConfig(keyPluginData)
+			keyPluginConfig, err := encoding.DecodeInternalKMSPluginConfig(keyPluginData)
 			require.NoError(t, err)
 			require.Equal(t, keyPluginConfig, pluginConfig, "kms-plugin-config for keyID %s in encryption-config secret does not match key secret", keyID)
 		}
@@ -573,11 +573,11 @@ func TestEncryptionIntegration(tt *testing.T) {
 	require.NoError(t, err)
 	kmsPluginConfigData := kmsKeySecret.Data["encryption.apiserver.operator.openshift.io-kms-plugin-config"]
 	require.NotEmpty(t, kmsPluginConfigData, "expected kms-plugin-config data to be present in key secret")
-	pluginConfig, err := encoding.DecodeKMSPluginConfig(kmsPluginConfigData)
+	pluginConfig, err := encoding.DecodeInternalKMSPluginConfig(kmsPluginConfigData)
 	require.NoError(t, err)
-	require.Equal(t, configv1.VaultKMSProvider, pluginConfig.Type)
-	require.Equal(t, "https://vault.example.com", pluginConfig.Vault.VaultAddress)
-	require.Equal(t, "transit/keys/test-transit-key", pluginConfig.Vault.VaultKeyPath)
+	require.Equal(t, configv1.VaultKMSProvider, pluginConfig.Plugin.Type)
+	require.Equal(t, "https://vault.example.com", pluginConfig.Plugin.Vault.VaultAddress)
+	require.Equal(t, "transit/keys/test-transit-key", pluginConfig.Plugin.Vault.VaultKeyPath)
 
 	t.Logf("Switch back to aescbc from KMS")
 	_, err = fakeApiServerClient.Patch(ctx, "cluster", types.MergePatchType, []byte(`{"spec":{"encryption":{"type":"aescbc","kms":null}}}`), metav1.PatchOptions{})
@@ -660,10 +660,10 @@ func TestEncryptionIntegration(tt *testing.T) {
 	require.NoError(t, err)
 	kmsPluginConfigData13 := kmsKeySecret13.Data["encryption.apiserver.operator.openshift.io-kms-plugin-config"]
 	require.NotEmpty(t, kmsPluginConfigData13)
-	pluginConfig13, err := encoding.DecodeKMSPluginConfig(kmsPluginConfigData13)
+	pluginConfig13, err := encoding.DecodeInternalKMSPluginConfig(kmsPluginConfigData13)
 	require.NoError(t, err)
-	require.Equal(t, "https://vault-new.example.com", pluginConfig13.Vault.VaultAddress)
-	require.Equal(t, "transit/keys/test-transit-key", pluginConfig13.Vault.VaultKeyPath)
+	require.Equal(t, "https://vault-new.example.com", pluginConfig13.Plugin.Vault.VaultAddress)
+	require.Equal(t, "transit/keys/test-transit-key", pluginConfig13.Plugin.Vault.VaultKeyPath)
 
 	t.Logf("KMS non-migration change: only KMSPluginImage changes (no new key expected)")
 	_, err = fakeApiServerClient.Patch(ctx, "cluster", types.MergePatchType, []byte(`{"spec":{"encryption":{"type":"KMS","kms":{"type":"Vault","vault":{"kmsPluginImage":"registry.example.com/kms-plugin@sha256:0000000000000000000000000000000000000000000000000000000000000000","vaultAddress":"https://vault-new.example.com","authentication":{"type":"AppRole","appRole":{"secret":{"name":"vault-approle-secret"}}},"vaultKeyPath":"transit/keys/test-transit-key"}}}}}`), metav1.PatchOptions{})

--- a/test/library/encryption/preflight_deploy.go
+++ b/test/library/encryption/preflight_deploy.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/encryption/controllers"
 	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
 	"github.com/openshift/library-go/pkg/operator/encryption/kms/preflight"
+	"github.com/openshift/library-go/pkg/operator/encryption/state"
 )
 
 const (
@@ -189,8 +190,8 @@ func VaultPreflightEncryptionConfigSecret(ctx context.Context, t testing.TB, cli
 				},
 			}},
 		},
-		KMSPlugins: map[string]configv1.KMSPluginConfig{
-			"1": plugin,
+		KMSPlugins: map[string]state.InternalKMSPluginConfig{
+			"1": {Plugin: plugin, KMSPluginImage: plugin.Vault.KMSPluginImage},
 		},
 		KMSPluginsSecretData:    secretData,
 		KMSPluginsConfigMapData: configMapData,


### PR DESCRIPTION
We are planning to remove image field from KMSPluginConfiguration in openshift/api (ref: https://github.com/openshift/enhancements/pull/2082), since it will be populated by the OLM operators and stored in ConfigMap. 

However, encryption controllers still need to carry this image field along to plugin lifecycle. This PR introduces new encodable/decodable internal API type which is derived from KMSPluginConfiguration but extended with image field. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - KMS encryption state now preserves both provider settings and the associated plugin image.
  - Vault-based encryption sidecars use the configured KMS plugin image.
  - KMS configuration secrets support the updated internal format for reliable storage and retrieval.

- **Bug Fixes**
  - Improved provider-instance comparison and KMS migration handling by using complete stored configuration data.
  - Expanded validation for Vault settings, authentication, plugin images, and encryption configuration round trips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->