### PR TITLE
OCPBUGS-109578: fix oc darwin client hcp login when insecure tls flag is used

### DIFF
--- a/pkg/oauth/tokenrequest/request_token.go
+++ b/pkg/oauth/tokenrequest/request_token.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"runtime"
 	"slices"
 	"strings"
 
@@ -602,8 +603,23 @@ func verifyServerCertChain(dnsName string, chain []*x509.Certificate) ([][]*x509
 		intermediates.AddCert(c)
 	}
 
-	return chain[0].Verify(x509.VerifyOptions{
+	certChainList, err := chain[0].Verify(x509.VerifyOptions{
 		Intermediates: intermediates,
 		DNSName:       dnsName,
 	})
+
+	if runtime.GOOS == "darwin" && strings.HasPrefix(err.Error(), "x509:") {
+		// this check fills in the gap where root_darwin.go has insufficient
+		// typed errors for macOS platform, leading to a generic string based
+		// x509 error. This will return a proper x509 error which can be used
+		// to return kubeconfig CA client. x509.UnknownAuthorityError was
+		// chosen because this is the fall back also used on Linux/Windows,
+		// keeping the approach consistent across platforms.
+		// https://github.com/golang/go/blob/5a6340ff28c87e099f33c941e3d73e50d715ddf7/src/crypto/x509/root_darwin.go#L74
+		return nil, x509.UnknownAuthorityError{
+			Cert: chain[0],
+		}
+	}
+
+	return certChainList, err
 }


### PR DESCRIPTION
This fix fixes an issue seen when oc client is used to login to a HCP cluster on macOS. It falls back to kubeconfig CA when a string based x509 error is observed on the macOS platform.

See https://github.com/golang/go/blob/master/src/crypto/x509/root_darwin.go#L74 for reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS authentication reliability by falling back to the configured certificate authority when system certificate validation encounters an unexpected error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->