### PR TITLE
CNTRLPLANE-3237: kms: pass prefetched KMS plugin config to EncryptionPlanner.Load

### DIFF
--- a/pkg/operator/encryption/controllers/encryption_configuration_computer.go
+++ b/pkg/operator/encryption/controllers/encryption_configuration_computer.go
@@ -8,6 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 
+	configv1 "github.com/openshift/api/config/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 
 	"github.com/openshift/library-go/pkg/operator/encryption/state"
@@ -18,7 +19,7 @@ import (
 // EncryptionConfigurationComputer computes the encryption configuration secret
 // passed to the KMS preflight deployer right before it creates a new deployment.
 type EncryptionConfigurationComputer interface {
-	ComputeEncryptionConfiguration(ctx context.Context) (*corev1.Secret, error)
+	ComputeEncryptionConfiguration(ctx context.Context, kmsPluginConfig *configv1.KMSPluginConfig) (*corev1.Secret, error)
 }
 
 // encryptionConfigurationComputer is the default EncryptionConfigurationComputer.
@@ -62,11 +63,14 @@ func NewEncryptionConfigurationComputer(
 	}
 }
 
-func (c *encryptionConfigurationComputer) ComputeEncryptionConfiguration(ctx context.Context) (*corev1.Secret, error) {
+func (c *encryptionConfigurationComputer) ComputeEncryptionConfiguration(ctx context.Context, kmsPluginConfig *configv1.KMSPluginConfig) (*corev1.Secret, error) {
 	// ListKeysWhileProgressing=true so preflight can still list keys and compute a plan even when there
 	// is no convergence yet. The key controller sets this to false to avoid extra Lists during rollout.
 	planner := NewEncryptionPlanner(c.instanceName, c.unsupportedConfigPrefix, c.encryptionDeployer, c.secretsClient, c.configMapsClient, c.apiServerClient, c.operatorClient, c.encryptionSecretSelector)
-	snap, err := planner.Load(ctx, c.provider.EncryptedGRs(), LoadOptions{ListKeysWhileProgressing: true})
+	snap, err := planner.Load(ctx, c.provider.EncryptedGRs(), LoadOptions{
+		ListKeysWhileProgressing: true,
+		KMSPluginConfig:          kmsPluginConfig,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operator/encryption/controllers/encryption_planner.go
+++ b/pkg/operator/encryption/controllers/encryption_planner.go
@@ -89,6 +89,9 @@ type LoadOptions struct {
 	// not List during API-server rollouts. Preflight sets this so PlanNextKey
 	// can run. ProgressingReason is still populated in either case.
 	ListKeysWhileProgressing bool
+	// KMSPluginConfig, when set, skips the APIServer GET in Load.
+	// Callers must only set this when encryption type is already known to be KMS.
+	KMSPluginConfig *configv1.KMSPluginConfig
 }
 
 // EncryptionPlanResult is returned by ComputeConfig.
@@ -133,7 +136,7 @@ func (p *EncryptionPlanner) Load(ctx context.Context, encryptedGRs []schema.Grou
 	}
 
 	// Resolve mode before reading deployer/key state so callers fail fast on APIServer/operator errors.
-	currentMode, externalReason, apiEncryption, err := getCurrentModeReasonAndEncryptionConfig(ctx, p.apiServerClient, p.operatorClient, p.unsupportedConfigPrefix)
+	currentMode, externalReason, apiEncryption, err := p.resolveModeReasonAndEncryptionConfig(ctx, opts.KMSPluginConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -171,6 +174,14 @@ func (p *EncryptionPlanner) Load(ctx context.Context, encryptedGRs []schema.Grou
 	}
 
 	return snap, nil
+}
+
+func (p *EncryptionPlanner) resolveModeReasonAndEncryptionConfig(ctx context.Context, kmsConfig *configv1.KMSPluginConfig) (state.Mode, string, configv1.APIServerEncryption, error) {
+	if kmsConfig != nil {
+		apiEncryption := configv1.APIServerEncryption{Type: configv1.EncryptionTypeKMS, KMS: *kmsConfig}
+		return resolveModeReasonFromEncryption(apiEncryption, p.operatorClient, p.unsupportedConfigPrefix)
+	}
+	return getCurrentModeReasonAndEncryptionConfig(ctx, p.apiServerClient, p.operatorClient, p.unsupportedConfigPrefix)
 }
 
 // PlanNextKey deterministically decides whether a new key is needed. It does not generate key material.

--- a/pkg/operator/encryption/controllers/encryption_planner.go
+++ b/pkg/operator/encryption/controllers/encryption_planner.go
@@ -136,7 +136,7 @@ func (p *EncryptionPlanner) Load(ctx context.Context, encryptedGRs []schema.Grou
 	}
 
 	// Resolve mode before reading deployer/key state so callers fail fast on APIServer/operator errors.
-	currentMode, externalReason, apiEncryption, err := p.resolveModeReasonAndEncryptionConfig(ctx, opts.KMSPluginConfig)
+	currentMode, externalReason, apiEncryption, err := p.modeAndExternalReason(ctx, opts.KMSPluginConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -176,12 +176,12 @@ func (p *EncryptionPlanner) Load(ctx context.Context, encryptedGRs []schema.Grou
 	return snap, nil
 }
 
-func (p *EncryptionPlanner) resolveModeReasonAndEncryptionConfig(ctx context.Context, kmsConfig *configv1.KMSPluginConfig) (state.Mode, string, configv1.APIServerEncryption, error) {
-	if kmsConfig != nil {
-		apiEncryption := configv1.APIServerEncryption{Type: configv1.EncryptionTypeKMS, KMS: *kmsConfig}
-		return resolveModeReasonFromEncryption(apiEncryption, p.operatorClient, p.unsupportedConfigPrefix)
+func (p *EncryptionPlanner) modeAndExternalReason(ctx context.Context, kmsPluginConfig *configv1.KMSPluginConfig) (state.Mode, string, configv1.APIServerEncryption, error) {
+	if kmsPluginConfig != nil {
+		apiEncryption := configv1.APIServerEncryption{Type: configv1.EncryptionTypeKMS, KMS: *kmsPluginConfig}
+		return modeAndExternalReasonFromAPIServerEncryption(apiEncryption, p.operatorClient, p.unsupportedConfigPrefix)
 	}
-	return getCurrentModeReasonAndEncryptionConfig(ctx, p.apiServerClient, p.operatorClient, p.unsupportedConfigPrefix)
+	return modeAndExternalReasonFromAPIServer(ctx, p.apiServerClient, p.operatorClient, p.unsupportedConfigPrefix)
 }
 
 // PlanNextKey deterministically decides whether a new key is needed. It does not generate key material.

--- a/pkg/operator/encryption/controllers/encryption_planner_test.go
+++ b/pkg/operator/encryption/controllers/encryption_planner_test.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -10,12 +11,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	configv1clientfake "github.com/openshift/client-go/config/clientset/versioned/fake"
 
 	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
+	"github.com/openshift/library-go/pkg/operator/encryption/state"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
 
@@ -196,6 +199,38 @@ func TestEncryptionPlannerDecideVsMaterialize(t *testing.T) {
 	}
 	if key1.KeyID != key2.KeyID || key1.KeyID != plan1.KeyID {
 		t.Fatalf("key IDs diverged: plan=%d key1=%d key2=%d", plan1.KeyID, key1.KeyID, key2.KeyID)
+	}
+}
+
+func TestEncryptionPlannerLoadWithPrefetchedKMSPluginConfig(t *testing.T) {
+	apiServerWithKMS := newKMSVaultAPIServer()
+	kmsCfg := apiServerWithKMS.Spec.Encryption.KMS
+	encryptedGRs := []schema.GroupResource{{Group: "", Resource: "secrets"}}
+	fakeKubeClient := fake.NewSimpleClientset(&wellKnownBaseSecret, &wellKnownBaseConfigMap)
+	fakeConfigClient := configv1clientfake.NewSimpleClientset(apiServerWithKMS)
+	fakeConfigClient.PrependReactor("get", "apiservers", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("APIServer GET should be skipped when KMSPluginConfig is prefetched")
+	})
+	fakeOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(
+		&operatorv1.StaticPodOperatorSpec{OperatorSpec: operatorv1.OperatorSpec{ManagementState: operatorv1.Managed}},
+		&operatorv1.StaticPodOperatorStatus{},
+		nil,
+		nil,
+	)
+	planner := NewEncryptionPlanner("test", nil, &fakeEncryptionDeployer{converged: true}, fakeKubeClient.CoreV1(), fakeKubeClient.CoreV1(), fakeConfigClient.ConfigV1().APIServers(), fakeOperatorClient, metav1.ListOptions{})
+
+	snap, err := planner.Load(context.TODO(), encryptedGRs, LoadOptions{
+		ListKeysWhileProgressing: true,
+		KMSPluginConfig:          &kmsCfg,
+	})
+	if err != nil {
+		t.Fatalf("Load with prefetched KMS config failed: %v", err)
+	}
+	if snap.CurrentMode != state.KMS {
+		t.Fatalf("expected KMS mode, got %q", snap.CurrentMode)
+	}
+	if snap.APIEncryption.Type != configv1.EncryptionTypeKMS {
+		t.Fatalf("expected KMS encryption type, got %q", snap.APIEncryption.Type)
 	}
 }
 

--- a/pkg/operator/encryption/controllers/key_controller.go
+++ b/pkg/operator/encryption/controllers/key_controller.go
@@ -373,7 +373,7 @@ func fetchReferencedResources(ctx context.Context, providerCfg kmsProviderConfig
 	return refSecret, refCM, nil
 }
 
-func resolveModeReasonFromEncryption(encryption configv1.APIServerEncryption, operatorClient operatorv1helpers.OperatorClient, unsupportedConfigPrefix []string) (state.Mode, string, configv1.APIServerEncryption, error) {
+func modeAndExternalReasonFromAPIServerEncryption(encryption configv1.APIServerEncryption, operatorClient operatorv1helpers.OperatorClient, unsupportedConfigPrefix []string) (state.Mode, string, configv1.APIServerEncryption, error) {
 	operatorSpec, _, _, err := operatorClient.GetOperatorState()
 	if err != nil {
 		return "", "", configv1.APIServerEncryption{}, err
@@ -397,14 +397,15 @@ func resolveModeReasonFromEncryption(encryption configv1.APIServerEncryption, op
 	}
 }
 
-// getCurrentModeReasonAndEncryptionConfig the active encryption mode, any external rotation reason from unsupported config overrides, and the full encryption spec.
-func getCurrentModeReasonAndEncryptionConfig(ctx context.Context, apiServerClient configv1client.APIServerInterface, operatorClient operatorv1helpers.OperatorClient, unsupportedConfigPrefix []string) (state.Mode, string, configv1.APIServerEncryption, error) {
+// modeAndExternalReasonFromAPIServer returns the active encryption mode, any external rotation
+// reason from unsupported config overrides, and the cluster APIServer encryption spec.
+func modeAndExternalReasonFromAPIServer(ctx context.Context, apiServerClient configv1client.APIServerInterface, operatorClient operatorv1helpers.OperatorClient, unsupportedConfigPrefix []string) (state.Mode, string, configv1.APIServerEncryption, error) {
 	apiServer, err := apiServerClient.Get(ctx, "cluster", metav1.GetOptions{})
 	if err != nil {
 		return "", "", configv1.APIServerEncryption{}, err
 	}
 
-	return resolveModeReasonFromEncryption(apiServer.Spec.Encryption, operatorClient, unsupportedConfigPrefix)
+	return modeAndExternalReasonFromAPIServerEncryption(apiServer.Spec.Encryption, operatorClient, unsupportedConfigPrefix)
 }
 
 var _ kmsConfigHasherResourceProvider = &prefetchedKMSConfigHasherResourceProvider{}

--- a/pkg/operator/encryption/controllers/key_controller.go
+++ b/pkg/operator/encryption/controllers/key_controller.go
@@ -373,13 +373,7 @@ func fetchReferencedResources(ctx context.Context, providerCfg kmsProviderConfig
 	return refSecret, refCM, nil
 }
 
-// getCurrentModeReasonAndEncryptionConfig the active encryption mode, any external rotation reason from unsupported config overrides, and the full encryption spec.
-func getCurrentModeReasonAndEncryptionConfig(ctx context.Context, apiServerClient configv1client.APIServerInterface, operatorClient operatorv1helpers.OperatorClient, unsupportedConfigPrefix []string) (state.Mode, string, configv1.APIServerEncryption, error) {
-	apiServer, err := apiServerClient.Get(ctx, "cluster", metav1.GetOptions{})
-	if err != nil {
-		return "", "", configv1.APIServerEncryption{}, err
-	}
-
+func resolveModeReasonFromEncryption(encryption configv1.APIServerEncryption, operatorClient operatorv1helpers.OperatorClient, unsupportedConfigPrefix []string) (state.Mode, string, configv1.APIServerEncryption, error) {
 	operatorSpec, _, _, err := operatorClient.GetOperatorState()
 	if err != nil {
 		return "", "", configv1.APIServerEncryption{}, err
@@ -390,7 +384,6 @@ func getCurrentModeReasonAndEncryptionConfig(ctx context.Context, apiServerClien
 		return "", "", configv1.APIServerEncryption{}, err
 	}
 
-	encryption := apiServer.Spec.Encryption
 	reason := encryptionConfig.Encryption.Reason
 	switch currentMode := state.Mode(encryption.Type); currentMode {
 	case state.AESCBC, state.AESGCM, state.Identity: // secretbox is disabled for now
@@ -402,6 +395,16 @@ func getCurrentModeReasonAndEncryptionConfig(ctx context.Context, apiServerClien
 	default:
 		return "", "", configv1.APIServerEncryption{}, fmt.Errorf("unknown encryption mode configured: %s", currentMode)
 	}
+}
+
+// getCurrentModeReasonAndEncryptionConfig the active encryption mode, any external rotation reason from unsupported config overrides, and the full encryption spec.
+func getCurrentModeReasonAndEncryptionConfig(ctx context.Context, apiServerClient configv1client.APIServerInterface, operatorClient operatorv1helpers.OperatorClient, unsupportedConfigPrefix []string) (state.Mode, string, configv1.APIServerEncryption, error) {
+	apiServer, err := apiServerClient.Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return "", "", configv1.APIServerEncryption{}, err
+	}
+
+	return resolveModeReasonFromEncryption(apiServer.Spec.Encryption, operatorClient, unsupportedConfigPrefix)
 }
 
 var _ kmsConfigHasherResourceProvider = &prefetchedKMSConfigHasherResourceProvider{}

--- a/pkg/operator/encryption/controllers/key_controller_test.go
+++ b/pkg/operator/encryption/controllers/key_controller_test.go
@@ -1316,7 +1316,7 @@ var complexNestedEncryptionConfigJSON = `
 }
 `
 
-func TestGetCurrentModeReasonAndEncryptionConfig(t *testing.T) {
+func TestModeAndExternalReasonFromAPIServer(t *testing.T) {
 	scenarios := []struct {
 		name                  string
 		observedConfig        []byte
@@ -1392,7 +1392,7 @@ func TestGetCurrentModeReasonAndEncryptionConfig(t *testing.T) {
 			fakeApiServerClient := fakeConfigClient.ConfigV1().APIServers()
 
 			// act
-			currentMode, externalReason, encryption, err := getCurrentModeReasonAndEncryptionConfig(context.TODO(), fakeApiServerClient, fakeOperatorClient, scenario.prefix)
+			currentMode, externalReason, encryption, err := modeAndExternalReasonFromAPIServer(context.TODO(), fakeApiServerClient, fakeOperatorClient, scenario.prefix)
 
 			// validate
 			if err != nil {

--- a/pkg/operator/encryption/controllers/kms_preflight_compute_test.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_compute_test.go
@@ -42,7 +42,7 @@ func TestKMSPreflightComputeEncryptionConfiguration(t *testing.T) {
 			instanceName,
 		)
 
-		secret, err := computer.ComputeEncryptionConfiguration(context.TODO())
+		secret, err := computer.ComputeEncryptionConfiguration(context.TODO(), nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -111,7 +111,7 @@ func TestKMSPreflightComputeEncryptionConfiguration(t *testing.T) {
 			instanceName,
 		)
 
-		secret, err := computer.ComputeEncryptionConfiguration(context.TODO())
+		secret, err := computer.ComputeEncryptionConfiguration(context.TODO(), nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -177,7 +177,7 @@ func TestKMSPreflightComputeEncryptionConfiguration(t *testing.T) {
 			instanceName,
 		)
 
-		secret, err := computer.ComputeEncryptionConfiguration(context.TODO())
+		secret, err := computer.ComputeEncryptionConfiguration(context.TODO(), nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -232,7 +232,7 @@ func TestKMSPreflightComputeEncryptionConfiguration(t *testing.T) {
 			instanceName,
 		)
 
-		secret, err := computer.ComputeEncryptionConfiguration(context.TODO())
+		secret, err := computer.ComputeEncryptionConfiguration(context.TODO(), nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -283,7 +283,7 @@ func TestKMSPreflightComputeEncryptionConfiguration(t *testing.T) {
 			instanceName,
 		)
 
-		secret, err := computer.ComputeEncryptionConfiguration(context.TODO())
+		secret, err := computer.ComputeEncryptionConfiguration(context.TODO(), nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -352,7 +352,7 @@ func TestKMSPreflightComputeEncryptionConfiguration(t *testing.T) {
 			instanceName,
 		)
 
-		secret, err := computer.ComputeEncryptionConfiguration(context.TODO())
+		secret, err := computer.ComputeEncryptionConfiguration(context.TODO(), nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -389,7 +389,7 @@ func TestKMSPreflightComputeEncryptionConfiguration(t *testing.T) {
 			instanceName,
 		)
 
-		secret, err := computer.ComputeEncryptionConfiguration(context.TODO())
+		secret, err := computer.ComputeEncryptionConfiguration(context.TODO(), nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -408,7 +408,7 @@ func TestKMSPreflightComputeEncryptionConfiguration(t *testing.T) {
 			instanceName,
 		)
 
-		first, err := computer.ComputeEncryptionConfiguration(context.TODO())
+		first, err := computer.ComputeEncryptionConfiguration(context.TODO(), nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -421,7 +421,7 @@ func TestKMSPreflightComputeEncryptionConfiguration(t *testing.T) {
 		}
 
 		provider.encryptedGRs = []schema.GroupResource{{Resource: "secrets"}, {Resource: "configmaps"}}
-		second, err := computer.ComputeEncryptionConfiguration(context.TODO())
+		second, err := computer.ComputeEncryptionConfiguration(context.TODO(), nil)
 		if err != nil {
 			t.Fatalf("unexpected error after EncryptedGRs change: %v", err)
 		}
@@ -503,7 +503,7 @@ func TestKMSPreflightComputeEncryptionConfigurationErrors(t *testing.T) {
 				instanceName,
 			)
 
-			secret, err := computer.ComputeEncryptionConfiguration(context.TODO())
+			secret, err := computer.ComputeEncryptionConfiguration(context.TODO(), nil)
 			if err == nil {
 				t.Fatalf("expected an error, got secret %+v", secret)
 			}

--- a/pkg/operator/encryption/controllers/kms_preflight_controller.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller.go
@@ -475,7 +475,7 @@ func (c *kmsPreflightController) sync(ctx context.Context, syncCtx factory.SyncC
 //
 // TODO: in the future we might want to add retries for failed preflights.
 func (c *kmsPreflightController) runPreflightChecks(ctx context.Context) (requeue bool, progressReason, progressMessage string, err error) {
-	requiredHash, existingResult, _, err := c.preflightRequired(ctx)
+	requiredHash, existingResult, kmsCfg, err := c.preflightRequired(ctx)
 	if err != nil {
 		return false, "", "", err
 	}
@@ -504,7 +504,7 @@ func (c *kmsPreflightController) runPreflightChecks(ctx context.Context) (requeu
 				message: fmt.Sprintf("preflight check failed for hash %s: pod was removed but failure is recorded in status", requiredHash),
 			}
 		}
-		encryptionConfig, err := c.encryptionConfigurationComputer.ComputeEncryptionConfiguration(ctx)
+		encryptionConfig, err := c.encryptionConfigurationComputer.ComputeEncryptionConfiguration(ctx, &kmsCfg)
 		if err != nil {
 			return true, "", "", fmt.Errorf("failed to compute encryption configuration: %w", err)
 		}

--- a/pkg/operator/encryption/controllers/kms_preflight_controller_test.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller_test.go
@@ -379,7 +379,7 @@ type fakeEncryptionConfigurationComputer struct {
 	callCount int
 }
 
-func (f *fakeEncryptionConfigurationComputer) ComputeEncryptionConfiguration(_ context.Context) (*corev1.Secret, error) {
+func (f *fakeEncryptionConfigurationComputer) ComputeEncryptionConfiguration(_ context.Context, _ *configv1.KMSPluginConfig) (*corev1.Secret, error) {
 	f.callCount++
 	return f.secret, f.err
 }


### PR DESCRIPTION
Avoid a redundant APIServer GET during preflight by reusing the KMS plugin config already returned from preflightRequired.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * KMS preflight checks now calculate encryption settings using the current plugin configuration.
  * Encryption planning can use previously retrieved KMS configuration without an additional API server request.

* **Bug Fixes**
  * Preflight encryption results now reflect validated KMS plugin settings.
  * Existing encryption mode validation and unsupported-configuration error handling remain intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->