### PR TITLE
kms: remove unused EncryptionConfigurationComputer interface

### DIFF
--- a/pkg/operator/apiserver/controllerset/apiservercontrollerset.go
+++ b/pkg/operator/apiserver/controllerset/apiservercontrollerset.go
@@ -372,26 +372,24 @@ func (cs *APIServerControllerSet) WithEncryptionControllers(
 	resourceSyncer *resourcesynccontroller.ResourceSyncController,
 	encryptionStatusProvider kms.EncryptionStatusProvider,
 	preflightDeployer controllers.KMSPreflightDeployer,
-	encryptionConfigurationComputer controllers.EncryptionConfigurationComputer,
 ) *APIServerControllerSet {
 
 	cs.encryptionControllers = encryptionControllerBuilder{
 		operatorClient: cs.operatorClient,
 		eventRecorder:  cs.eventRecorder,
 
-		component:                       component,
-		provider:                        provider,
-		deployer:                        deployer,
-		migrator:                        migrator,
-		apiServerClient:                 apiServerClient,
-		apiServerInformer:               apiServerInformer,
-		kubeInformersForNamespaces:      kubeInformersForNamespaces,
-		secretsClient:                   secretsClient,
-		configMapClient:                 configMapClient,
-		resourceSyncer:                  resourceSyncer,
-		encryptionStatusProvider:        encryptionStatusProvider,
-		preflightDeployer:               preflightDeployer,
-		encryptionConfigurationComputer: encryptionConfigurationComputer,
+		component:                  component,
+		provider:                   provider,
+		deployer:                   deployer,
+		migrator:                   migrator,
+		apiServerClient:            apiServerClient,
+		apiServerInformer:          apiServerInformer,
+		kubeInformersForNamespaces: kubeInformersForNamespaces,
+		secretsClient:              secretsClient,
+		configMapClient:            configMapClient,
+		resourceSyncer:             resourceSyncer,
+		encryptionStatusProvider:   encryptionStatusProvider,
+		preflightDeployer:          preflightDeployer,
 	}
 
 	return cs
@@ -489,19 +487,18 @@ type encryptionControllerBuilder struct {
 	operatorClient v1helpers.OperatorClient
 	eventRecorder  events.Recorder
 
-	component                       string
-	provider                        controllers.Provider
-	deployer                        statemachine.Deployer
-	migrator                        migrators.Migrator
-	secretsClient                   corev1.SecretsGetter
-	configMapClient                 corev1.ConfigMapsGetter
-	apiServerClient                 configv1client.APIServerInterface
-	apiServerInformer               configv1informers.APIServerInformer
-	kubeInformersForNamespaces      v1helpers.KubeInformersForNamespaces
-	resourceSyncer                  *resourcesynccontroller.ResourceSyncController
-	encryptionStatusProvider        kms.EncryptionStatusProvider
-	preflightDeployer               controllers.KMSPreflightDeployer
-	encryptionConfigurationComputer controllers.EncryptionConfigurationComputer
+	component                  string
+	provider                   controllers.Provider
+	deployer                   statemachine.Deployer
+	migrator                   migrators.Migrator
+	secretsClient              corev1.SecretsGetter
+	configMapClient            corev1.ConfigMapsGetter
+	apiServerClient            configv1client.APIServerInterface
+	apiServerInformer          configv1informers.APIServerInformer
+	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces
+	resourceSyncer             *resourcesynccontroller.ResourceSyncController
+	encryptionStatusProvider   kms.EncryptionStatusProvider
+	preflightDeployer          controllers.KMSPreflightDeployer
 
 	unsupportedConfigPrefix []string
 }
@@ -527,7 +524,6 @@ func (e *encryptionControllerBuilder) build() []controllerWrapper {
 		e.resourceSyncer,
 		e.encryptionStatusProvider,
 		e.preflightDeployer,
-		e.encryptionConfigurationComputer,
 	)
 	if err != nil {
 		e.creationError = err

--- a/pkg/operator/encryption/controllers.go
+++ b/pkg/operator/encryption/controllers.go
@@ -40,7 +40,6 @@ func NewControllers(
 	resourceSyncer *resourcesynccontroller.ResourceSyncController,
 	encryptionStatusProvider kms.EncryptionStatusProvider,
 	preflightDeployer controllers.KMSPreflightDeployer,
-	encryptionConfigurationComputer controllers.EncryptionConfigurationComputer,
 ) (Controllers, error) {
 	// avoid using the CachedSecretGetter as we need strong guarantees that our encryptionSecretSelector works
 	// otherwise we could see secrets from a different component (which will break our keyID invariants)
@@ -132,13 +131,11 @@ func NewControllers(
 		),
 	}
 
-	// TODO: drop EncryptionConfigurationComputer once operators stop passing NoopEncryptionConfigurationComputer.
 	encryptionControllers = append(encryptionControllers, controllers.NewKMSPreflightController(
 		component,
 		provider,
 		encryptionEnabledChecker.PreconditionFulfilled,
 		preflightDeployer,
-		encryptionConfigurationComputer,
 		operatorClient,
 		apiServerClient,
 		secretsClient,

--- a/pkg/operator/encryption/controllers/kms_preflight_controller.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller.go
@@ -29,22 +29,6 @@ import (
 	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
 )
 
-// EncryptionConfigurationComputer computes the encryption configuration secret
-// passed to the preflight deployer right before it creates a new deployment.
-type EncryptionConfigurationComputer interface {
-	ComputeEncryptionConfiguration(ctx context.Context) (*corev1.Secret, error)
-}
-
-// NoopEncryptionConfigurationComputer is a placeholder EncryptionConfigurationComputer
-// that returns nil until a real implementation is available.
-type NoopEncryptionConfigurationComputer struct{}
-
-var _ EncryptionConfigurationComputer = NoopEncryptionConfigurationComputer{}
-
-func (NoopEncryptionConfigurationComputer) ComputeEncryptionConfiguration(_ context.Context) (*corev1.Secret, error) {
-	return nil, nil
-}
-
 // kmsConfigHasherResourceProvider abstracts fetching the Secret and ConfigMap referenced
 // by a KMS provider config.
 type kmsConfigHasherResourceProvider interface {
@@ -226,9 +210,6 @@ type kmsPreflightController struct {
 
 	deployer           KMSPreflightDeployer
 	encryptionDeployer statemachine.Deployer
-	// encryptionConfigurationComputer is called right before Deploy to produce the
-	// encryption configuration secret passed to the deployer.
-	encryptionConfigurationComputer EncryptionConfigurationComputer
 	// dirtyDeployer is true when preflight resources may exist in the cluster.
 	// Set to true after each Deploy and cleared to false after a successful Cleanup,
 	// so that repeated Cleanup calls in steady state issue no API requests.
@@ -319,7 +300,6 @@ func NewKMSPreflightController(
 	provider Provider,
 	preconditionsFulfilledFn preconditionsFulfilled,
 	deployer KMSPreflightDeployer,
-	encryptionConfigurationComputer EncryptionConfigurationComputer,
 	operatorClient operatorv1helpers.OperatorClient,
 	apiServerClient configv1client.APIServerInterface,
 	// secretsClient and configMapsClient read referenced Secrets and ConfigMaps in
@@ -345,9 +325,8 @@ func NewKMSPreflightController(
 		secretsClient:    secretsClient,
 		configMapsClient: configMapsClient,
 
-		deployer:                        deployer,
-		encryptionDeployer:              encryptionDeployer,
-		encryptionConfigurationComputer: encryptionConfigurationComputer,
+		deployer:           deployer,
+		encryptionDeployer: encryptionDeployer,
 		// assume resources may exist from a previous process run
 		dirtyDeployer:            true,
 		provider:                 provider,
@@ -368,11 +347,6 @@ func NewKMSPreflightController(
 }
 
 func (c *kmsPreflightController) computeEncryptionConfiguration(ctx context.Context) (*corev1.Secret, error) {
-	// TODO: remove this fallback once EncryptionConfigurationComputer is deleted.
-	if c.encryptionConfigurationComputer != nil {
-		return c.encryptionConfigurationComputer.ComputeEncryptionConfiguration(ctx)
-	}
-
 	// ListKeysWhileProgressing=true so preflight can still list keys and compute a plan even when there
 	// is no convergence yet. The key controller sets this to false to avoid extra Lists during rollout.
 	planner := NewEncryptionPlanner(c.instanceName, c.unsupportedConfigPrefix, c.encryptionDeployer, c.secretsClient, c.configMapsClient, c.apiServerClient, c.operatorClient, c.encryptionSecretSelector)

--- a/pkg/operator/encryption/controllers/kms_preflight_controller_test.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/encryption/kms"
+	"github.com/openshift/library-go/pkg/operator/encryption/secrets"
 	encryptiontesting "github.com/openshift/library-go/pkg/operator/encryption/testing"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
@@ -373,19 +374,6 @@ func (f *fakeEncryptionStatusProvider) UpdateKMSEncryptionStatus(_ context.Conte
 
 var _ kms.EncryptionStatusProvider = &fakeEncryptionStatusProvider{}
 
-type fakeEncryptionConfigurationComputer struct {
-	secret    *corev1.Secret
-	err       error
-	callCount int
-}
-
-func (f *fakeEncryptionConfigurationComputer) ComputeEncryptionConfiguration(_ context.Context) (*corev1.Secret, error) {
-	f.callCount++
-	return f.secret, f.err
-}
-
-var _ EncryptionConfigurationComputer = &fakeEncryptionConfigurationComputer{}
-
 func TestKMSPreflightController(t *testing.T) {
 	apiServerWithKMS := &configv1.APIServer{
 		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
@@ -407,8 +395,6 @@ func TestKMSPreflightController(t *testing.T) {
 	scenarios := []struct {
 		name                                        string
 		deployer                                    KMSPreflightDeployer
-		encryptionConfigurationComputer             EncryptionConfigurationComputer
-		expectedComputerCallCount                   int
 		encryptionStatusProvider                    *fakeEncryptionStatusProvider
 		apiServerObjects                            []runtime.Object
 		coreObjects                                 []runtime.Object
@@ -483,37 +469,16 @@ func TestKMSPreflightController(t *testing.T) {
 		},
 		{
 			// Scenario 2b: deploying — progressing.
-			name:     "hashes match, no pod exists, deploys and returns",
-			deployer: &fakeDeployer{statusErr: apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "kms-preflight")},
-			encryptionConfigurationComputer: &fakeEncryptionConfigurationComputer{secret: &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{Name: "enc-config", Namespace: "test"},
-			}},
-			encryptionStatusProvider:  &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
-			apiServerObjects:          []runtime.Object{apiServerWithKMS},
-			coreObjects:               []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			initialDirtyDeployer:      true,
-			preconditionsMet:          true,
-			expectedComputerCallCount: 1,
+			name:                     "hashes match, no pod exists, deploys and returns",
+			deployer:                 &fakeDeployer{statusErr: apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "kms-preflight")},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
+			apiServerObjects:         []runtime.Object{apiServerWithKMS},
+			coreObjects:              []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			initialDirtyDeployer:     true,
+			preconditionsMet:         true,
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
 				{Type: "EncryptionKMSPreflightControllerProgressing", Status: "True", Reason: "RunningPreflightCheck", Message: "Deploying preflight pod for hash cuZm_g=="},
-			},
-		},
-		{
-			// Scenario 2b: computer fails before deploy.
-			name:                            "encryption configuration computer fails, reports error",
-			deployer:                        &fakeDeployer{statusErr: apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "kms-preflight")},
-			encryptionConfigurationComputer: &fakeEncryptionConfigurationComputer{err: fmt.Errorf("vault unreachable")},
-			encryptionStatusProvider:        &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
-			apiServerObjects:                []runtime.Object{apiServerWithKMS},
-			coreObjects:                     []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			initialDirtyDeployer:            true,
-			preconditionsMet:                true,
-			expectedComputerCallCount:       1,
-			expectedError:                   "failed to compute encryption configuration: vault unreachable",
-			expectedConditions: []operatorv1.OperatorCondition{
-				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "Error", Message: "failed to compute encryption configuration: vault unreachable"},
-				{Type: "EncryptionKMSPreflightControllerProgressing", Status: "False"},
 			},
 		},
 		{
@@ -866,15 +831,14 @@ func TestKMSPreflightController(t *testing.T) {
 		},
 		{
 			// Scenario 2b: deploy error — transient, not terminal.
-			name:                      "deploy fails, reports error",
-			deployer:                  &fakeDeployer{statusErr: apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "kms-preflight"), deployErr: fmt.Errorf("quota exceeded")},
-			encryptionStatusProvider:  &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
-			apiServerObjects:          []runtime.Object{apiServerWithKMS},
-			coreObjects:               []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
-			initialDirtyDeployer:      true,
-			preconditionsMet:          true,
-			expectedComputerCallCount: 1,
-			expectedError:             "quota exceeded",
+			name:                     "deploy fails, reports error",
+			deployer:                 &fakeDeployer{statusErr: apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "kms-preflight"), deployErr: fmt.Errorf("quota exceeded")},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
+			apiServerObjects:         []runtime.Object{apiServerWithKMS},
+			coreObjects:              []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			initialDirtyDeployer:     true,
+			preconditionsMet:         true,
+			expectedError:            "quota exceeded",
 			expectedConditions: []operatorv1.OperatorCondition{
 				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "True", Reason: "Error", Message: "quota exceeded"},
 				{Type: "EncryptionKMSPreflightControllerProgressing", Status: "False"},
@@ -1068,23 +1032,20 @@ func TestKMSPreflightController(t *testing.T) {
 				deployer = &fakeDeployer{}
 			}
 
-			computer := scenario.encryptionConfigurationComputer
-			if computer == nil {
-				computer = &fakeEncryptionConfigurationComputer{}
-			}
-
 			c := &kmsPreflightController{
-				controllerInstanceName:          factory.ControllerInstanceName("test", "EncryptionKMSPreflight"),
-				operatorClient:                  fakeOperatorClient,
-				apiServerClient:                 fakeApiServerClient,
-				secretsClient:                   fakeKubeClient.CoreV1(),
-				configMapsClient:                fakeKubeClient.CoreV1(),
-				deployer:                        deployer,
-				encryptionConfigurationComputer: computer,
-				dirtyDeployer:                   scenario.initialDirtyDeployer,
-				provider:                        provider,
-				preconditionsFulfilledFn:        preconditionsFn,
-				encryptionStatusProvider:        scenario.encryptionStatusProvider,
+				controllerInstanceName:   factory.ControllerInstanceName("test", "EncryptionKMSPreflight"),
+				instanceName:             "test",
+				encryptionSecretSelector: metav1.ListOptions{LabelSelector: secrets.EncryptionKeySecretsLabel + "=test"},
+				operatorClient:           fakeOperatorClient,
+				apiServerClient:          fakeApiServerClient,
+				secretsClient:            fakeKubeClient.CoreV1(),
+				configMapsClient:         fakeKubeClient.CoreV1(),
+				deployer:                 deployer,
+				encryptionDeployer:       &fakeEncryptionDeployer{converged: true},
+				dirtyDeployer:            scenario.initialDirtyDeployer,
+				provider:                 provider,
+				preconditionsFulfilledFn: preconditionsFn,
+				encryptionStatusProvider: scenario.encryptionStatusProvider,
 			}
 
 			err := c.sync(context.TODO(), factory.NewSyncContext("test", eventRecorder))
@@ -1110,17 +1071,8 @@ func TestKMSPreflightController(t *testing.T) {
 			if !ok {
 				t.Fatalf("deployer is not *fakeDeployer")
 			}
-			fakeComputerInstance, ok := computer.(*fakeEncryptionConfigurationComputer)
-			if !ok {
-				t.Fatalf("computer is not *fakeEncryptionConfigurationComputer")
-			}
-			if fakeComputerInstance.callCount != scenario.expectedComputerCallCount {
-				t.Errorf("computer.ComputeEncryptionConfiguration call count: got %d, want %d", fakeComputerInstance.callCount, scenario.expectedComputerCallCount)
-			}
-			if fakeDeployerInstance.deployed {
-				if !equality.Semantic.DeepEqual(fakeDeployerInstance.deployedEncryptionConfig, fakeComputerInstance.secret) {
-					t.Errorf("deployer received wrong encryptionConfig: got %v, want %v", fakeDeployerInstance.deployedEncryptionConfig, fakeComputerInstance.secret)
-				}
+			if fakeDeployerInstance.deployed && fakeDeployerInstance.deployedEncryptionConfig == nil {
+				t.Errorf("deployer received nil encryptionConfig")
 			}
 			if fakeDeployerInstance.cleanupCount != scenario.expectedPreflightDeployerCleanupCount {
 				t.Errorf("deployer.Cleanup call count: got %d, want %d", fakeDeployerInstance.cleanupCount, scenario.expectedPreflightDeployerCleanupCount)

--- a/test/e2e-encryption/encryption_test.go
+++ b/test/e2e-encryption/encryption_test.go
@@ -173,7 +173,6 @@ func TestEncryptionIntegration(tt *testing.T) {
 		nil, // resourceSyncer
 		&dynamicKMSEncryptionStatusProvider{client: dynamicClient.Resource(operatorGVR)},
 		kmsPreflightDeployer,
-		controllers.NoopEncryptionConfigurationComputer{},
 	)
 	if err != nil {
 		t.Fatalf("failed to initialize controllers: %v", err)


### PR DESCRIPTION
Preflight now always computes encryption configuration via EncryptionPlanner, so drop the noop interface and its parameter from controller constructors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified encryption controller configuration by removing an unnecessary compatibility dependency.
  * Encryption preflight processing now consistently uses the active encryption deployer and Kubernetes configuration.
* **Tests**
  * Updated encryption validation and integration tests to reflect the streamlined configuration flow.
  * Added coverage confirming encryption configuration is supplied during deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->