### PR TITLE
CNTRLPLANE-3237: controllers: make preflight result helpers hash-aware

### DIFF
--- a/pkg/operator/encryption/controllers/key_controller.go
+++ b/pkg/operator/encryption/controllers/key_controller.go
@@ -465,11 +465,11 @@ func (c *keyController) ensureKMSPreflightPassed(ctx context.Context, configHash
 	}
 
 	// Scenario 2: preflight passed — proceed.
-	if encryptionStatus.Preflight.Result.ConfigHash == configHash && isPreflightResultSucceeded(&encryptionStatus.Preflight.Result) {
+	if isPreflightResultSucceeded(&encryptionStatus.Preflight.Result, configHash) {
 		return true, nil
 	}
 	// Scenario 3: preflight failed — surface the error.
-	if encryptionStatus.Preflight.Result.ConfigHash == configHash && isPreflightResultFailed(&encryptionStatus.Preflight.Result) {
+	if isPreflightResultFailed(&encryptionStatus.Preflight.Result, configHash) {
 		return false, fmt.Errorf("KMS preflight check failed for config hash %s; fix the KMS configuration to proceed", configHash)
 	}
 	// Scenario 4: back off: preflight check is still in progress.

--- a/pkg/operator/encryption/controllers/kms_preflight_controller.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller.go
@@ -557,7 +557,7 @@ func (c *kmsPreflightController) runPreflightChecks(ctx context.Context) (requeu
 
 	// Result already recorded for this hash as Succeeded: clean up the pod
 	// (idempotent if already gone) and return — no pod work needed.
-	if isPreflightResultSucceeded(existingResult) {
+	if isPreflightResultSucceeded(existingResult, requiredHash) {
 		return false, "", "", c.cleanupDeployer(ctx)
 	}
 
@@ -568,7 +568,7 @@ func (c *kmsPreflightController) runPreflightChecks(ctx context.Context) (requeu
 		// Result already recorded as Failed and the pod is gone: surface the error
 		// without re-deploying. The admin must fix the config (new hash) before a
 		// new check can run.
-		if isPreflightResultFailed(existingResult) {
+		if isPreflightResultFailed(existingResult, requiredHash) {
 			return false, "", "", &preflightError{
 				reason:  "PreflightCheckFailed",
 				message: fmt.Sprintf("preflight check failed for hash %s: pod was removed but failure is recorded in status", requiredHash),
@@ -694,12 +694,16 @@ func (c *kmsPreflightController) ensurePreflightResult(ctx context.Context, exis
 	})
 }
 
-func isPreflightResultSucceeded(result *operatorv1.KMSPreflightResult) bool {
-	return result != nil && result.Status == operatorv1.KMSPreflightResultSucceeded
+// isPreflightResultSucceeded reports a success for requiredHash. Checking the hash
+// too prevents a stale result from being read as a success of the current config.
+func isPreflightResultSucceeded(result *operatorv1.KMSPreflightResult, requiredHash string) bool {
+	return result != nil && result.ConfigHash == requiredHash && result.Status == operatorv1.KMSPreflightResultSucceeded
 }
 
-func isPreflightResultFailed(result *operatorv1.KMSPreflightResult) bool {
-	return result != nil && result.Status == operatorv1.KMSPreflightResultFailed
+// isPreflightResultFailed reports a failure for requiredHash. Checking the hash too
+// prevents a stale result from being read as a failure of the current config.
+func isPreflightResultFailed(result *operatorv1.KMSPreflightResult, requiredHash string) bool {
+	return result != nil && result.ConfigHash == requiredHash && result.Status == operatorv1.KMSPreflightResultFailed
 }
 
 type preflightError struct {
@@ -833,9 +837,5 @@ func (c *kmsPreflightController) preflightRequired(ctx context.Context) (string,
 		return "", nil, configv1.KMSPluginConfig{}, nil
 	}
 
-	if encryptionStatus.Preflight.Result.ConfigHash == requiredHash {
-		r := encryptionStatus.Preflight.Result
-		return requiredHash, &r, apiServer.Spec.Encryption.KMS, nil
-	}
-	return requiredHash, nil, apiServer.Spec.Encryption.KMS, nil
+	return requiredHash, &encryptionStatus.Preflight.Result, apiServer.Spec.Encryption.KMS, nil
 }

--- a/pkg/operator/encryption/controllers/kms_preflight_controller_test.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller_test.go
@@ -500,6 +500,35 @@ func TestKMSPreflightController(t *testing.T) {
 			},
 		},
 		{
+			// Stale Succeeded result (different ConfigHash) must not short-circuit to
+			// cleanup: it does not apply to the required hash, so a fresh check deploys.
+			name:     "result Succeeded for a stale hash, no pod exists — deploys for required hash",
+			deployer: &fakeDeployer{statusErr: apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "kms-preflight")},
+			encryptionConfigurationComputer: &fakeEncryptionConfigurationComputer{secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "enc-config", Namespace: "test"},
+			}},
+			encryptionStatusProvider: &fakeEncryptionStatusProvider{
+				observedConfigHash: wellKnownMatchingHashForBaseVaultConfig,
+				writtenStatus: &operatorv1.KMSPreflightResult{
+					Status:     operatorv1.KMSPreflightResultSucceeded,
+					ConfigHash: "stale-hash",
+				},
+			},
+			apiServerObjects:          []runtime.Object{apiServerWithKMS},
+			coreObjects:               []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			initialDirtyDeployer:      true,
+			preconditionsMet:          true,
+			expectedComputerCallCount: 1,
+			expectedConditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
+				{Type: "EncryptionKMSPreflightControllerProgressing", Status: "True", Reason: "RunningPreflightCheck", Message: "Deploying preflight pod for hash cuZm_g=="},
+			},
+			expectedKMSPreflightResult: &operatorv1.KMSPreflightResult{
+				Status:     operatorv1.KMSPreflightResultSucceeded,
+				ConfigHash: "stale-hash",
+			},
+		},
+		{
 			// Scenario 2b: computer fails before deploy.
 			name:                            "encryption configuration computer fails, reports error",
 			deployer:                        &fakeDeployer{statusErr: apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "kms-preflight")},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented outdated KMS preflight results from being applied after encryption configuration changes.
  * Ensured the system runs a fresh preflight check when stored results no longer match the current configuration.
  * Improved status reporting during refreshed checks, including progressing and non-degraded states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->