### PR TITLE
NO-JIRA: add KMS key rotation annotations

### DIFF
--- a/pkg/operator/encryption/secrets/remote_key.go
+++ b/pkg/operator/encryption/secrets/remote_key.go
@@ -1,0 +1,81 @@
+package secrets
+
+import (
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/openshift/library-go/pkg/operator/encryption/state"
+)
+
+// RemoteKeyAnnotations is the annotation-backed view of state.RemoteKeyState.
+type RemoteKeyAnnotations = state.RemoteKeyState
+
+// ReadRemoteKeyAnnotations reads remote key rotation annotations from a key secret.
+func ReadRemoteKeyAnnotations(s *corev1.Secret) (RemoteKeyAnnotations, error) {
+	if s == nil {
+		return RemoteKeyAnnotations{}, nil
+	}
+	return readRemoteKeyAnnotations(s.Annotations, s.Namespace, s.Name)
+}
+
+func readRemoteKeyAnnotations(annotations map[string]string, namespace, name string) (RemoteKeyAnnotations, error) {
+	rk := RemoteKeyAnnotations{
+		TargetRemoteKeyID:   annotations[EncryptionSecretTargetRemoteKeyID],
+		MigratedRemoteKeyID: annotations[EncryptionSecretMigratedRemoteKeyID],
+		ConvergedID:         annotations[EncryptionSecretRemoteKeyConvergedID],
+	}
+	if v, ok := annotations[EncryptionSecretRemoteKeyConvergedAt]; ok && len(v) > 0 {
+		ts, err := time.Parse(time.RFC3339, v)
+		if err != nil {
+			return RemoteKeyAnnotations{}, fmt.Errorf("secret %s/%s has invalid %s annotation: %v", namespace, name, EncryptionSecretRemoteKeyConvergedAt, err)
+		}
+		rk.ConvergedAt = ts
+	}
+	return rk, nil
+}
+
+// ApplyRemoteKeyAnnotations writes remote key rotation annotations into the given map.
+// Empty values remove the corresponding annotation keys.
+func ApplyRemoteKeyAnnotations(annotations map[string]string, rk RemoteKeyAnnotations) {
+	setOrDeleteAnnotation(annotations, EncryptionSecretTargetRemoteKeyID, rk.TargetRemoteKeyID)
+	setOrDeleteAnnotation(annotations, EncryptionSecretMigratedRemoteKeyID, rk.MigratedRemoteKeyID)
+	setOrDeleteAnnotation(annotations, EncryptionSecretRemoteKeyConvergedID, rk.ConvergedID)
+	if rk.ConvergedAt.IsZero() {
+		delete(annotations, EncryptionSecretRemoteKeyConvergedAt)
+	} else {
+		annotations[EncryptionSecretRemoteKeyConvergedAt] = rk.ConvergedAt.Format(time.RFC3339)
+	}
+}
+
+func setOrDeleteAnnotation(annotations map[string]string, key, value string) {
+	if len(value) == 0 {
+		delete(annotations, key)
+		return
+	}
+	annotations[key] = value
+}
+
+// TargetDiffersFromMigrated reports whether target-remote-key-id and
+// migrated-remote-key-id are both set and differ.
+func TargetDiffersFromMigrated(rk RemoteKeyAnnotations) bool {
+	return len(rk.MigratedRemoteKeyID) > 0 &&
+		len(rk.TargetRemoteKeyID) > 0 &&
+		rk.MigratedRemoteKeyID != rk.TargetRemoteKeyID
+}
+
+// IsBootstrapped reports whether the initial remote key bootstrap has completed.
+func IsBootstrapped(rk RemoteKeyAnnotations) bool {
+	return len(rk.MigratedRemoteKeyID) > 0
+}
+
+// MigrationWriteKeyName returns the StorageVersionMigration write-key annotation value.
+// First enablement uses the plain key name even when target-remote-key-id is set.
+// Remote key rotation uses a suffixed key only while TargetDiffersFromMigrated is true.
+func MigrationWriteKeyName(keyName string, rk RemoteKeyAnnotations) string {
+	if !TargetDiffersFromMigrated(rk) {
+		return keyName
+	}
+	return keyName + "-" + rk.TargetRemoteKeyID
+}

--- a/pkg/operator/encryption/secrets/remote_key_test.go
+++ b/pkg/operator/encryption/secrets/remote_key_test.go
@@ -1,0 +1,257 @@
+package secrets
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func mustParseRFC3339(t *testing.T, value string) time.Time {
+	t.Helper()
+
+	ts, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		t.Fatalf("failed to parse %q as RFC3339: %v", value, err)
+	}
+	return ts
+}
+
+func TestReadRemoteKeyAnnotations(t *testing.T) {
+	convergedAt := mustParseRFC3339(t, "2026-01-15T10:00:00Z")
+
+	tests := []struct {
+		name    string
+		secret  *corev1.Secret
+		want    RemoteKeyAnnotations
+		wantErr bool
+	}{
+		{
+			name:   "nil secret",
+			secret: nil,
+			want:   RemoteKeyAnnotations{},
+		},
+		{
+			name: "empty annotations",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "encryption-key-kms-3", Namespace: "openshift-config-managed"},
+			},
+			want: RemoteKeyAnnotations{},
+		},
+		{
+			name: "full annotations",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "encryption-key-kms-3",
+					Namespace: "openshift-config-managed",
+					Annotations: map[string]string{
+						EncryptionSecretTargetRemoteKeyID:    "remote-key-new",
+						EncryptionSecretMigratedRemoteKeyID:  "remote-key-old",
+						EncryptionSecretRemoteKeyConvergedAt: "2026-01-15T10:00:00Z",
+						EncryptionSecretRemoteKeyConvergedID: "remote-key-new",
+					},
+				},
+			},
+			want: RemoteKeyAnnotations{
+				TargetRemoteKeyID:   "remote-key-new",
+				MigratedRemoteKeyID: "remote-key-old",
+				ConvergedAt:         convergedAt,
+				ConvergedID:         "remote-key-new",
+			},
+		},
+		{
+			name: "invalid converged timestamp",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "encryption-key-kms-3",
+					Namespace: "openshift-config-managed",
+					Annotations: map[string]string{
+						EncryptionSecretRemoteKeyConvergedAt: "not-a-timestamp",
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ReadRemoteKeyAnnotations(tt.secret)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ReadRemoteKeyAnnotations() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if got != tt.want {
+				t.Fatalf("ReadRemoteKeyAnnotations() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyRemoteKeyAnnotations(t *testing.T) {
+	convergedAt := mustParseRFC3339(t, "2026-01-15T10:00:00Z")
+
+	annotations := map[string]string{
+		EncryptionSecretTargetRemoteKeyID:    "stale-target",
+		EncryptionSecretMigratedRemoteKeyID:  "stale-migrated",
+		EncryptionSecretRemoteKeyConvergedAt: "2020-01-01T00:00:00Z",
+		EncryptionSecretRemoteKeyConvergedID: "stale-converged",
+		"other.example.com/annotation":       "keep-me",
+	}
+
+	ApplyRemoteKeyAnnotations(annotations, RemoteKeyAnnotations{
+		TargetRemoteKeyID:   "remote-key-new",
+		MigratedRemoteKeyID: "remote-key-new",
+	})
+
+	if annotations[EncryptionSecretTargetRemoteKeyID] != "remote-key-new" {
+		t.Fatalf("target annotation = %q, want %q", annotations[EncryptionSecretTargetRemoteKeyID], "remote-key-new")
+	}
+	if annotations[EncryptionSecretMigratedRemoteKeyID] != "remote-key-new" {
+		t.Fatalf("migrated annotation = %q, want %q", annotations[EncryptionSecretMigratedRemoteKeyID], "remote-key-new")
+	}
+	if _, ok := annotations[EncryptionSecretRemoteKeyConvergedAt]; ok {
+		t.Fatalf("converged-at annotation should be removed")
+	}
+	if _, ok := annotations[EncryptionSecretRemoteKeyConvergedID]; ok {
+		t.Fatalf("converged-id annotation should be removed")
+	}
+	if annotations["other.example.com/annotation"] != "keep-me" {
+		t.Fatalf("unrelated annotation was modified")
+	}
+
+	ApplyRemoteKeyAnnotations(annotations, RemoteKeyAnnotations{
+		TargetRemoteKeyID:   "remote-key-new",
+		MigratedRemoteKeyID: "remote-key-old",
+		ConvergedAt:         convergedAt,
+		ConvergedID:         "remote-key-new",
+	})
+	got, err := ReadRemoteKeyAnnotations(&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Annotations: annotations}})
+	if err != nil {
+		t.Fatalf("ReadRemoteKeyAnnotations() error = %v", err)
+	}
+	if got.TargetRemoteKeyID != "remote-key-new" || got.MigratedRemoteKeyID != "remote-key-old" || got.ConvergedID != "remote-key-new" || !got.ConvergedAt.Equal(convergedAt) {
+		t.Fatalf("roundtrip through Apply/Read = %#v", got)
+	}
+}
+func TestTargetDiffersFromMigrated(t *testing.T) {
+	tests := []struct {
+		name string
+		rk   RemoteKeyAnnotations
+		want bool
+	}{
+		{
+			name: "first enablement with target only",
+			rk: RemoteKeyAnnotations{
+				TargetRemoteKeyID: "remote-key-old",
+			},
+			want: false,
+		},
+		{
+			name: "steady state",
+			rk: RemoteKeyAnnotations{
+				TargetRemoteKeyID:   "remote-key-old",
+				MigratedRemoteKeyID: "remote-key-old",
+			},
+			want: false,
+		},
+		{
+			name: "rotation in progress",
+			rk: RemoteKeyAnnotations{
+				TargetRemoteKeyID:   "remote-key-new",
+				MigratedRemoteKeyID: "remote-key-old",
+			},
+			want: true,
+		},
+		{
+			name: "empty target with migrated set",
+			rk: RemoteKeyAnnotations{
+				MigratedRemoteKeyID: "remote-key-old",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := TargetDiffersFromMigrated(tt.rk); got != tt.want {
+				t.Fatalf("TargetDiffersFromMigrated() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsBootstrapped(t *testing.T) {
+	tests := []struct {
+		name string
+		rk   RemoteKeyAnnotations
+		want bool
+	}{
+		{
+			name: "first enablement",
+			rk: RemoteKeyAnnotations{
+				TargetRemoteKeyID: "remote-key-old",
+			},
+			want: false,
+		},
+		{
+			name: "bootstrapped",
+			rk: RemoteKeyAnnotations{
+				TargetRemoteKeyID:   "remote-key-old",
+				MigratedRemoteKeyID: "remote-key-old",
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsBootstrapped(tt.rk); got != tt.want {
+				t.Fatalf("IsBootstrapped() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMigrationWriteKeyName(t *testing.T) {
+	tests := []struct {
+		name    string
+		keyName string
+		rk      RemoteKeyAnnotations
+		want    string
+	}{
+		{
+			name:    "first enablement keeps plain key name",
+			keyName: "3",
+			rk: RemoteKeyAnnotations{
+				TargetRemoteKeyID: "remote-key-old",
+			},
+			want: "3",
+		},
+		{
+			name:    "steady state keeps plain key name",
+			keyName: "3",
+			rk: RemoteKeyAnnotations{
+				TargetRemoteKeyID:   "remote-key-old",
+				MigratedRemoteKeyID: "remote-key-old",
+			},
+			want: "3",
+		},
+		{
+			name:    "rotation uses suffixed key name",
+			keyName: "3",
+			rk: RemoteKeyAnnotations{
+				TargetRemoteKeyID:   "remote-key-new",
+				MigratedRemoteKeyID: "remote-key-old",
+			},
+			want: "3-remote-key-new",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := MigrationWriteKeyName(tt.keyName, tt.rk); got != tt.want {
+				t.Fatalf("MigrationWriteKeyName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/operator/encryption/secrets/secrets.go
+++ b/pkg/operator/encryption/secrets/secrets.go
@@ -114,6 +114,12 @@ func ToKeyState(s *corev1.Secret) (state.KeyState, error) {
 		return state.KeyState{}, fmt.Errorf("secret %s/%s of mode %q must have non-empty key", s.Namespace, s.Name, keyMode)
 	}
 
+	remoteKey, err := readRemoteKeyAnnotations(s.Annotations, s.Namespace, s.Name)
+	if err != nil {
+		return state.KeyState{}, err
+	}
+	key.RemoteKey = remoteKey
+
 	return key, nil
 }
 
@@ -189,6 +195,8 @@ func FromKeyState(component string, ks state.KeyState) (*corev1.Secret, error) {
 			s.Data[encryptionSecretKMSConfigMapDataPrefix+flatKey] = value
 		}
 	}
+
+	ApplyRemoteKeyAnnotations(s.Annotations, ks.RemoteKey)
 
 	return s, nil
 }

--- a/pkg/operator/encryption/secrets/secrets_test.go
+++ b/pkg/operator/encryption/secrets/secrets_test.go
@@ -220,6 +220,33 @@ func TestRoundtrip(t *testing.T) {
 				ExternalReason: "external",
 			},
 		},
+		{
+			name:      "full kms with remote key annotations",
+			component: "kms",
+			ks: state.KeyState{
+				Key: v1.Key{
+					Name:   "3",
+					Secret: base64.StdEncoding.EncodeToString(emptyKey),
+				},
+				Backed: true,
+				Mode:   "KMS",
+				KMS: &state.KMSState{
+					Encryption: &v1.KMSConfiguration{
+						APIVersion: "v2",
+						Name:       "3",
+						Endpoint:   "unix:///var/run/kmsplugin/kms-3.sock",
+						Timeout:    &metav1.Duration{Duration: 10 * time.Second},
+					},
+					Plugin: defaultKMSPluginConfig,
+				},
+				RemoteKey: state.RemoteKeyState{
+					TargetRemoteKeyID:   "remote-key-new",
+					MigratedRemoteKeyID: "remote-key-old",
+					ConvergedAt:         now,
+					ConvergedID:         "remote-key-new",
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/operator/encryption/secrets/types.go
+++ b/pkg/operator/encryption/secrets/types.go
@@ -67,6 +67,22 @@ const (
 	// values fetched from the referenced configmap in openshift-config. The full data key is
 	// constructed as prefix + configMapName + separator + dataKey.
 	encryptionSecretKMSConfigMapDataPrefix = "encryption.apiserver.operator.openshift.io-kms-plugin-configmap-"
+
+	// EncryptionSecretTargetRemoteKeyID is the desired remote KMS key (KEK) to migrate toward.
+	// Written only by keyController.
+	EncryptionSecretTargetRemoteKeyID = "encryption.apiserver.operator.openshift.io/target-remote-key-id"
+
+	// EncryptionSecretMigratedRemoteKeyID is the last fully migrated remote KMS key (KEK).
+	// Written by keyController at bootstrap and by migrationController on rotation completion.
+	EncryptionSecretMigratedRemoteKeyID = "encryption.apiserver.operator.openshift.io/migrated-remote-key-id"
+
+	// EncryptionSecretRemoteKeyConvergedAt is the RFC3339 timestamp when the candidate remote
+	// key first achieved cluster-wide convergence. Written only by keyController.
+	EncryptionSecretRemoteKeyConvergedAt = "encryption.apiserver.operator.openshift.io/remote-key-converged-at"
+
+	// EncryptionSecretRemoteKeyConvergedID is the candidate remote key the convergence
+	// timestamp belongs to. Written only by keyController.
+	EncryptionSecretRemoteKeyConvergedID = "encryption.apiserver.operator.openshift.io/remote-key-converged-id"
 )
 
 // MigratedGroupResources is the data structured stored in the

--- a/pkg/operator/encryption/state/types.go
+++ b/pkg/operator/encryption/state/types.go
@@ -44,6 +44,8 @@ type KeyState struct {
 	// described whether it is backed by a secret.
 	Backed   bool
 	Migrated MigrationState
+	// RemoteKey tracks KMS remote key rotation progress stored as secret annotations.
+	RemoteKey RemoteKeyState
 	// some controller logic caused this secret to be created by the key controller.
 	InternalReason string
 	// the user via unsupportConfigOverrides.encryption.reason triggered this key.
@@ -171,6 +173,14 @@ type MigrationState struct {
 	Timestamp time.Time
 	// the resources that were migrated at some point in time to this key.
 	Resources []schema.GroupResource
+}
+
+// RemoteKeyState tracks KMS remote key rotation progress stored as secret annotations.
+type RemoteKeyState struct {
+	TargetRemoteKeyID   string
+	MigratedRemoteKeyID string
+	ConvergedAt         time.Time
+	ConvergedID         string
 }
 
 // Mode is the value associated with the encryptionSecretMode annotation


### PR DESCRIPTION
This PR adds all necessary annotations required for KMS key rotation to the existing key state. Aside from the SerDe, it also adds a few helpers to understand where the key state is in the process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for tracking remote KMS key rotation progress.
  - Remote key state is preserved when encryption secrets are read or updated.
  - Added handling for migration status, bootstrap state, convergence timestamps, and migration-specific key names.

- **Bug Fixes**
  - Invalid rotation timestamps are reported, while stale or empty rotation metadata is cleaned up.

- **Tests**
  - Added coverage for annotation parsing, state round-tripping, migration detection, and rotation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->