### PR TITLE
NO-JIRA: add KMS rotation key convergence helper

### DIFF
--- a/pkg/operator/encryption/kms/health/convergence.go
+++ b/pkg/operator/encryption/kms/health/convergence.go
@@ -1,0 +1,39 @@
+package health
+
+import (
+	operatorv1 "github.com/openshift/api/operator/v1"
+)
+
+// ConvergenceResult reports whether a set of KMS plugin health reports agree on
+// the same remote key ID.
+type ConvergenceResult struct {
+	Converged   bool
+	RemoteKeyID string
+}
+
+// ConvergedRemoteKeyID returns whether all reports in the slice report the same
+// non-empty RemoteKeyID.
+func ConvergedRemoteKeyID(reports []operatorv1.KMSPluginHealthReport) ConvergenceResult {
+	if len(reports) == 0 {
+		return ConvergenceResult{Converged: false}
+	}
+
+	var remoteKeyID string
+	for _, report := range reports {
+		if report.RemoteKeyID == "" {
+			return ConvergenceResult{Converged: false}
+		}
+		if remoteKeyID == "" {
+			remoteKeyID = report.RemoteKeyID
+			continue
+		}
+		if report.RemoteKeyID != remoteKeyID {
+			return ConvergenceResult{Converged: false}
+		}
+	}
+
+	return ConvergenceResult{
+		Converged:   true,
+		RemoteKeyID: remoteKeyID,
+	}
+}

--- a/pkg/operator/encryption/kms/health/convergence_test.go
+++ b/pkg/operator/encryption/kms/health/convergence_test.go
@@ -1,0 +1,85 @@
+package health
+
+import (
+	"testing"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+)
+
+func TestConvergedRemoteKeyID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		reports []operatorv1.KMSPluginHealthReport
+		want    ConvergenceResult
+	}{
+		{
+			name:    "empty reports",
+			reports: nil,
+			want:    ConvergenceResult{},
+		},
+		{
+			name: "single report",
+			reports: []operatorv1.KMSPluginHealthReport{
+				{NodeName: "node-a", KeyID: "1", RemoteKeyID: "kek-abc"},
+			},
+			want: ConvergenceResult{
+				Converged:   true,
+				RemoteKeyID: "kek-abc",
+			},
+		},
+		{
+			name: "unanimous match across nodes",
+			reports: []operatorv1.KMSPluginHealthReport{
+				{NodeName: "node-a", KeyID: "1", RemoteKeyID: "kek-abc"},
+				{NodeName: "node-b", KeyID: "1", RemoteKeyID: "kek-abc"},
+				{NodeName: "node-c", KeyID: "1", RemoteKeyID: "kek-abc"},
+			},
+			want: ConvergenceResult{
+				Converged:   true,
+				RemoteKeyID: "kek-abc",
+			},
+		},
+		{
+			name: "split-brain across nodes",
+			reports: []operatorv1.KMSPluginHealthReport{
+				{NodeName: "node-a", KeyID: "1", RemoteKeyID: "kek-old"},
+				{NodeName: "node-b", KeyID: "1", RemoteKeyID: "kek-new"},
+			},
+			want: ConvergenceResult{},
+		},
+		{
+			name: "single report empty remote key ID",
+			reports: []operatorv1.KMSPluginHealthReport{
+				{NodeName: "node-a", KeyID: "1", RemoteKeyID: ""},
+			},
+			want: ConvergenceResult{},
+		},
+		{
+			name: "unanimous empty remote key ID",
+			reports: []operatorv1.KMSPluginHealthReport{
+				{NodeName: "node-a", KeyID: "1", RemoteKeyID: ""},
+				{NodeName: "node-b", KeyID: "1", RemoteKeyID: ""},
+			},
+			want: ConvergenceResult{},
+		},
+		{
+			name: "mixed empty and non-empty remote key ID",
+			reports: []operatorv1.KMSPluginHealthReport{
+				{NodeName: "node-a", KeyID: "1", RemoteKeyID: ""},
+				{NodeName: "node-b", KeyID: "1", RemoteKeyID: "kek-abc"},
+			},
+			want: ConvergenceResult{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ConvergedRemoteKeyID(tt.reports)
+			if got != tt.want {
+				t.Fatalf("ConvergedRemoteKeyID() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
simple loop to detect whether all remote key ids are the same non-empty string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added KMS health convergence reporting to identify whether plugin reports agree on a shared remote key ID.
  - Handles missing, empty, and conflicting key IDs with clear convergence results.

- **Tests**
  - Added coverage for empty, single-report, unanimous, conflicting, and mixed key ID scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->