### PR TITLE
CNTRLPLANE-3237: kms preflight deployer report hash part 1

### DIFF
--- a/pkg/operator/encryption/controllers/kms_preflight_controller.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller.go
@@ -205,9 +205,12 @@ type KMSPreflightDeployer interface {
 	// and encryption configuration. It is idempotent.
 	Deploy(ctx context.Context, configHash string, encryptionConfiguration *corev1.Secret) error
 
-	// Status returns the current pod status of the preflight workload.
+	// Status returns the config hash the current preflight workload was deployed
+	// for, together with its pod status. The hash is read from the workload itself
+	// (e.g. a pod annotation), so it is available even when the workload never ran,
+	// letting the controller detect a stale workload from a previous config.
 	// It returns an apierrors.IsNotFound error when no preflight pod exists.
-	Status(ctx context.Context) (corev1.PodStatus, error)
+	Status(ctx context.Context) (string, corev1.PodStatus, error)
 
 	// Cleanup removes all resources created by Deploy.
 	Cleanup(ctx context.Context) error
@@ -478,23 +481,26 @@ func (c *kmsPreflightController) sync(ctx context.Context, syncCtx factory.SyncC
 //     a new check can run.
 //     2b. No result yet: call Deploy. On success, requeue and wait for the pod to report results.
 //
-//  3. Preflight required, pod exists (Status returns a PodStatus).
-//     Evaluate the pod state via conditions and phase:
+//  3. Preflight required, pod exists (Status returns a deployed hash and PodStatus).
+//     The deployed hash comes from the pod's ConfigHashAnnotation, set at creation,
+//     so it is available even when the pod never ran. Scenarios are listed in the
+//     order they are evaluated:
 //
-//     a) Pod phase is Failed — the pod crashed before or after posting
-//     conditions. Report degraded and keep the pod for inspection. The
-//     admin fixes the config, which triggers a new hash and cleanup
-//     via scenario (c).
+//     a) Deployed hash does not match the required hash — stale pod from a
+//     previous config. Clean up; next sync deploys fresh. This is checked
+//     first because the annotation is present regardless of pod phase, so a
+//     stale pod is reaped even when it crashed or never ran
+//     (ImagePullBackOff, Pending), letting a corrected config make progress.
 //
-//     b) No KMSPreflightConfigHash condition yet — the checker has not
-//     started reporting. If the pod phase is Succeeded, it exited
-//     without reporting; return an error. Otherwise requeue and wait.
-//     If the pod has exceeded the startup timeout (3m) without
-//     reporting, return an error with the reason the pod is stuck
-//     (e.g. ImagePullBackOff, Pending).
+//     b) Deployed hash matches, pod phase is Failed — the pod crashed. Report
+//     degraded and keep the pod for inspection. The admin fixes the config,
+//     which triggers a new hash and cleanup via scenario (a).
 //
-//     c) KMSPreflightConfigHash does not match the required hash — stale
-//     pod from a previous config. Clean up; next sync deploys fresh.
+//     c) Deployed hash matches, no KMSPreflightConfigHash condition yet — the
+//     checker has not started reporting. If the pod phase is Succeeded, it
+//     exited without reporting; return an error. Otherwise requeue and wait.
+//     If the pod has exceeded the startup timeout (3m) without reporting,
+//     return an error with the reason the pod is stuck.
 //
 //     d) Hash matches, no KMSPreflightResult yet — check is running.
 //     If the pod phase is Succeeded, it exited without reporting the
@@ -507,7 +513,7 @@ func (c *kmsPreflightController) sync(ctx context.Context, syncCtx factory.SyncC
 //     f) Hash matches, KMSPreflightResult is False — check failed. Report
 //     degraded with the failure message. Keep the pod for inspection.
 //     The admin fixes the config, which triggers a new hash and cleanup
-//     via scenario (c).
+//     via scenario (a).
 //
 // KMSEncryptionStatus.Preflight.Result is written only when the checker ran
 // to completion; infrastructure failures are surfaced through the degraded
@@ -515,7 +521,7 @@ func (c *kmsPreflightController) sync(ctx context.Context, syncCtx factory.SyncC
 //
 //   - 3e (check passed):  writes Result{Succeeded, configHash, remoteKeyID}
 //   - 3f (check failed):  writes Result{Failed,    configHash, remoteKeyID}; EncryptionKMSPreflightControllerDegraded is also set
-//   - 3a, 3b, 3d (infrastructure failures): no write; EncryptionKMSPreflightControllerDegraded is set instead
+//   - 3b, 3c, 3d (infrastructure failures): no write; EncryptionKMSPreflightControllerDegraded is set instead
 //
 // Condition matrix:
 //
@@ -530,12 +536,12 @@ func (c *kmsPreflightController) sync(ctx context.Context, syncCtx factory.SyncC
 //	2a        No pod, already Failed — surface error            false    *pe   True      False        Yes
 //	2b        No pod, Deploy success                            true     nil   False     True         No
 //	2b        No pod, Deploy error                              true     err   True      False        No
-//	3a        Pod Failed — keep for inspection                  false    *pe   True      False        Yes
-//	3b        No hash, pod Running, no timeout                  true     nil   False     True         No
-//	3b        No hash, timeout exceeded                         true     *pe   True      False        Yes
-//	3b        No hash, pod Succeeded without reporting          false    *pe   True      False        Yes
-//	3c        Stale pod — Cleanup success                       true     nil   False     True         No
-//	3c        Stale pod — Cleanup error                         true     err   True      False        No
+//	3a        Stale pod — Cleanup success                       true     nil   False     True         No
+//	3a        Stale pod — Cleanup error                         true     err   True      False        No
+//	3b        Pod Failed — keep for inspection                  false    *pe   True      False        Yes
+//	3c        No hash, pod Running, no timeout                  true     nil   False     True         No
+//	3c        No hash, timeout exceeded                         true     *pe   True      False        Yes
+//	3c        No hash, pod Succeeded without reporting          false    *pe   True      False        Yes
 //	3d        Hash matches, no result, pod Running, no timeout  true     nil   False     True         No
 //	3d        Hash matches, no result, timeout exceeded         true     *pe   True      False        Yes
 //	3d        Hash matches, no result, pod Succeeded            false    *pe   True      False        Yes
@@ -562,7 +568,7 @@ func (c *kmsPreflightController) runPreflightChecks(ctx context.Context) (requeu
 	}
 
 	// Check whether a preflight pod already exists.
-	podStatus, err := c.deployer.Status(ctx)
+	deployedHash, podStatus, err := c.deployer.Status(ctx)
 	// Scenario 2: no pod exists.
 	if apierrors.IsNotFound(err) {
 		// Result already recorded as Failed and the pod is gone: surface the error
@@ -588,15 +594,28 @@ func (c *kmsPreflightController) runPreflightChecks(ctx context.Context) (requeu
 		return false, "", "", fmt.Errorf("failed to get preflight pod status: %w", err)
 	}
 
-	// Scenario 3a: pod crashed. Keep for inspection; the admin will update
-	// the config which triggers a new hash and cleanup via scenario 3c.
+	// Scenario 3a: stale pod from a previous config. The deployed hash is read
+	// from the pod itself (its annotation), so a mismatch is detected regardless
+	// of the pod phase or whether it ever ran (ImagePullBackOff, Pending, or a
+	// crash before it could report a condition). Reap it; the next sync deploys a
+	// fresh pod. This is what lets a failed pod from an old config make way for
+	// the corrected one, so it is checked before the phase/condition scenarios.
+	if deployedHash != requiredHash {
+		if err := c.cleanupDeployer(ctx); err != nil {
+			return true, "", "", err
+		}
+		return true, "RunningPreflightCheck", "Cleaning up preflight pod with stale configuration", nil
+	}
+
+	// Scenario 3b: pod crashed. Keep for inspection; the admin will update the
+	// config which triggers a new hash and cleanup via scenario 3a.
 	if podStatus.Phase == corev1.PodFailed {
 		pe := podFailureError(podStatus)
 		pe.message = fmt.Sprintf("preflight pod failed for hash %s: %s", requiredHash, pe.message)
 		return false, "", "", pe
 	}
 
-	// Scenario 3b: pod has not reported its config hash yet.
+	// Scenario 3c: pod has not reported its config hash yet.
 	hashCondition := FindPodCondition(podStatus.Conditions, KMSPreflightConfigHashPodCondition)
 	if hashCondition == nil {
 		if podStatus.Phase == corev1.PodSucceeded {
@@ -606,14 +625,6 @@ func (c *kmsPreflightController) runPreflightChecks(ctx context.Context) (requeu
 			return true, "", "", pe
 		}
 		return true, "RunningPreflightCheck", fmt.Sprintf("Waiting for preflight pod to report config hash for %s", requiredHash), nil
-	}
-
-	// Scenario 3c: stale pod from a different config.
-	if hashCondition.Message != requiredHash {
-		if err := c.cleanupDeployer(ctx); err != nil {
-			return true, "", "", err
-		}
-		return true, "RunningPreflightCheck", "Cleaning up preflight pod with stale configuration", nil
 	}
 
 	// Scenario 3d: hash matches, waiting for result.
@@ -646,7 +657,7 @@ func (c *kmsPreflightController) runPreflightChecks(ctx context.Context) (requeu
 	}
 
 	// Scenario 3f: check failed. Keep pod for inspection; the admin will
-	// update the config which triggers a new hash and cleanup via scenario 3c.
+	// update the config which triggers a new hash and cleanup via scenario 3a.
 	pe := &preflightError{
 		reason:  "PreflightCheckFailed",
 		message: fmt.Sprintf("preflight check failed for hash %s: %s", requiredHash, resultCondition.Message),

--- a/pkg/operator/encryption/controllers/kms_preflight_controller.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller.go
@@ -482,7 +482,7 @@ func (c *kmsPreflightController) sync(ctx context.Context, syncCtx factory.SyncC
 //     2b. No result yet: call Deploy. On success, requeue and wait for the pod to report results.
 //
 //  3. Preflight required, pod exists (Status returns a deployed hash and PodStatus).
-//     The deployed hash comes from the pod's ConfigHashAnnotation, set at creation,
+//     The deployed hash comes from the pod's config-hash annotation, set at creation,
 //     so it is available even when the pod never ran. Scenarios are listed in the
 //     order they are evaluated:
 //

--- a/pkg/operator/encryption/controllers/kms_preflight_controller_test.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller_test.go
@@ -319,18 +319,20 @@ type fakeDeployer struct {
 	deployErr                error
 	statusErr                error
 	cleanupErr               error
+	deployedHash             string
 	podStatus                corev1.PodStatus
 	deployedEncryptionConfig *corev1.Secret
 }
 
-func (f *fakeDeployer) Deploy(_ context.Context, _ string, encryptionConfig *corev1.Secret) error {
+func (f *fakeDeployer) Deploy(_ context.Context, configHash string, encryptionConfig *corev1.Secret) error {
 	f.deployed = true
+	f.deployedHash = configHash
 	f.deployedEncryptionConfig = encryptionConfig
 	return f.deployErr
 }
 
-func (f *fakeDeployer) Status(_ context.Context) (corev1.PodStatus, error) {
-	return f.podStatus, f.statusErr
+func (f *fakeDeployer) Status(_ context.Context) (string, corev1.PodStatus, error) {
+	return f.deployedHash, f.podStatus, f.statusErr
 }
 
 func (f *fakeDeployer) Cleanup(_ context.Context) error {
@@ -564,7 +566,7 @@ func TestKMSPreflightController(t *testing.T) {
 			},
 		},
 		{
-			// Scenario 3b: terminal — pod exited without reporting hash.
+			// Scenario 3c: terminal — pod exited without reporting hash.
 			name: "pod succeeded without reporting hash, reports error",
 			deployer: &fakeDeployer{podStatus: corev1.PodStatus{
 				Phase: corev1.PodSucceeded,
@@ -741,12 +743,39 @@ func TestKMSPreflightController(t *testing.T) {
 			},
 		},
 		{
-			// Scenario 3c: stale pod, cleanup succeeds — progressing.
-			name: "pod exists, hash is stale, cleans up",
-			deployer: &fakeDeployer{podStatus: corev1.PodStatus{
-				Conditions: []corev1.PodCondition{
-					{Type: KMSPreflightConfigHashPodCondition, Message: "old-hash"},
-					{Type: KMSPreflightResultPodCondition, Status: corev1.ConditionTrue},
+			// Scenario 3a: a Failed pod from a previous (bad) config must be reaped
+			// once the config is corrected, so the fixed config can make progress.
+			// The staleness is detected from the deployed hash, not the pod phase.
+			name: "stale pod that failed for old config is cleaned up",
+			deployer: &fakeDeployer{deployedHash: "old-hash", podStatus: corev1.PodStatus{
+				Phase: corev1.PodFailed,
+			}},
+			encryptionStatusProvider:              &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
+			apiServerObjects:                      []runtime.Object{apiServerWithKMS},
+			coreObjects:                           []runtime.Object{&wellKnownBaseSecret, &wellKnownBaseConfigMap},
+			initialDirtyDeployer:                  true,
+			preconditionsMet:                      true,
+			expectedPreflightDeployerCleanupCount: 1,
+			expectedConditions: []operatorv1.OperatorCondition{
+				{Type: "EncryptionKMSPreflightControllerDegraded", Status: "False"},
+				{Type: "EncryptionKMSPreflightControllerProgressing", Status: "True", Reason: "RunningPreflightCheck", Message: "Cleaning up preflight pod with stale configuration"},
+			},
+		},
+		{
+			// Scenario 3a: a stale pod that never ran (e.g. ImagePullBackOff) reports
+			// no conditions, but the deployed hash from its annotation still lets the
+			// controller detect it as stale and reap it. This is checked before the
+			// phase/condition scenarios, so it works even after a controller restart.
+			name: "stale pod that never ran is cleaned up",
+			deployer: &fakeDeployer{deployedHash: "old-hash", podStatus: corev1.PodStatus{
+				Phase: corev1.PodPending,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name: "kms-preflight-check",
+						State: corev1.ContainerState{
+							Waiting: &corev1.ContainerStateWaiting{Reason: "ImagePullBackOff"},
+						},
+					},
 				},
 			}},
 			encryptionStatusProvider:              &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
@@ -761,7 +790,7 @@ func TestKMSPreflightController(t *testing.T) {
 			},
 		},
 		{
-			// Scenario 3a: terminal — pod crashed.
+			// Scenario 3b: terminal — pod crashed.
 			name: "pod crashed without reporting conditions, keeps pod for inspection",
 			deployer: &fakeDeployer{podStatus: corev1.PodStatus{
 				Phase: corev1.PodFailed,
@@ -790,7 +819,7 @@ func TestKMSPreflightController(t *testing.T) {
 			},
 		},
 		{
-			// Scenario 3b: no hash condition, pod running, no timeout — progressing.
+			// Scenario 3c: no hash condition, pod running, no timeout — progressing.
 			name: "pod exists, no hash condition yet, waits for pod to report",
 			deployer: &fakeDeployer{podStatus: corev1.PodStatus{
 				Phase: corev1.PodRunning,
@@ -806,7 +835,7 @@ func TestKMSPreflightController(t *testing.T) {
 			},
 		},
 		{
-			// Scenario 3b: terminal — no hash, timeout via PodScheduled condition fallback.
+			// Scenario 3c: terminal — no hash, timeout via PodScheduled condition fallback.
 			name: "pod stuck in Pending with no StartTime, falls back to PodScheduled condition for timeout",
 			deployer: &fakeDeployer{podStatus: corev1.PodStatus{
 				Phase: corev1.PodPending,
@@ -826,7 +855,7 @@ func TestKMSPreflightController(t *testing.T) {
 			},
 		},
 		{
-			// Scenario 3b: terminal — no hash, timeout via StartTime.
+			// Scenario 3c: terminal — no hash, timeout via StartTime.
 			name: "pod stuck in Pending without reporting hash, goes degraded with phase",
 			deployer: &fakeDeployer{podStatus: corev1.PodStatus{
 				Phase:     corev1.PodPending,
@@ -844,7 +873,7 @@ func TestKMSPreflightController(t *testing.T) {
 			},
 		},
 		{
-			// Scenario 3b: terminal — ImagePullBackOff timeout.
+			// Scenario 3c: terminal — ImagePullBackOff timeout.
 			name: "pod stuck with ImagePullBackOff, goes degraded with container reason",
 			deployer: &fakeDeployer{podStatus: corev1.PodStatus{
 				Phase:     corev1.PodPending,
@@ -925,15 +954,11 @@ func TestKMSPreflightController(t *testing.T) {
 			},
 		},
 		{
-			// Scenario 3c: cleanup error — transient, not terminal.
+			// Scenario 3a: cleanup error — transient, not terminal.
 			name: "cleanup fails on stale hash, reports error",
 			deployer: &fakeDeployer{
-				cleanupErr: fmt.Errorf("delete forbidden"),
-				podStatus: corev1.PodStatus{
-					Conditions: []corev1.PodCondition{
-						{Type: KMSPreflightConfigHashPodCondition, Message: "old-hash"},
-					},
-				},
+				cleanupErr:   fmt.Errorf("delete forbidden"),
+				deployedHash: "old-hash",
 			},
 			encryptionStatusProvider:              &fakeEncryptionStatusProvider{observedConfigHash: wellKnownMatchingHashForBaseVaultConfig},
 			apiServerObjects:                      []runtime.Object{apiServerWithKMS},
@@ -948,7 +973,7 @@ func TestKMSPreflightController(t *testing.T) {
 			},
 		},
 		{
-			// Scenario 3a: terminal — pod crashed, no terminated container.
+			// Scenario 3b: terminal — pod crashed, no terminated container.
 			name: "pod crashed, no terminated container, keeps pod for inspection",
 			deployer: &fakeDeployer{podStatus: corev1.PodStatus{
 				Phase:   corev1.PodFailed,
@@ -966,7 +991,7 @@ func TestKMSPreflightController(t *testing.T) {
 			},
 		},
 		{
-			// Scenario 3a: terminal — pod crashed with non-zero exit code.
+			// Scenario 3b: terminal — pod crashed with non-zero exit code.
 			name: "pod crashed with terminated container, no message, uses exit code",
 			deployer: &fakeDeployer{podStatus: corev1.PodStatus{
 				Phase: corev1.PodFailed,
@@ -1095,6 +1120,12 @@ func TestKMSPreflightController(t *testing.T) {
 			deployer := scenario.deployer
 			if deployer == nil {
 				deployer = &fakeDeployer{}
+			}
+			// For pod-exists cases (Status does not return NotFound) that don't set
+			// a deployed hash explicitly, default it to the current config hash so
+			// the stale-pod gate treats the pod as current.
+			if fd, ok := deployer.(*fakeDeployer); ok && fd.statusErr == nil && fd.deployedHash == "" {
+				fd.deployedHash = wellKnownMatchingHashForBaseVaultConfig
 			}
 
 			computer := scenario.encryptionConfigurationComputer

--- a/pkg/operator/encryption/kms/preflight/always_succeed_deployer.go
+++ b/pkg/operator/encryption/kms/preflight/always_succeed_deployer.go
@@ -30,11 +30,11 @@ func (d *AlwaysSucceedKMSPreflightDeployer) Deploy(_ context.Context, configHash
 	return nil
 }
 
-func (d *AlwaysSucceedKMSPreflightDeployer) Status(_ context.Context) (corev1.PodStatus, error) {
+func (d *AlwaysSucceedKMSPreflightDeployer) Status(_ context.Context) (string, corev1.PodStatus, error) {
 	if !d.deployed {
-		return corev1.PodStatus{}, apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "kms-preflight")
+		return "", corev1.PodStatus{}, apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "kms-preflight")
 	}
-	return corev1.PodStatus{
+	return d.configHash, corev1.PodStatus{
 		Phase: corev1.PodSucceeded,
 		Conditions: []corev1.PodCondition{
 			{

--- a/pkg/operator/encryption/kms/preflight/always_succeed_deployer_test.go
+++ b/pkg/operator/encryption/kms/preflight/always_succeed_deployer_test.go
@@ -15,18 +15,21 @@ func TestAlwaysSucceedKMSPreflightDeployer(t *testing.T) {
 	d := NewAlwaysSucceedKMSPreflightDeployer()
 
 	// Before Deploy: Status returns NotFound.
-	_, err := d.Status(context.Background())
+	_, _, err := d.Status(context.Background())
 	if !apierrors.IsNotFound(err) {
 		t.Fatalf("expected NotFound before Deploy, got %v", err)
 	}
 
-	// After Deploy: Status returns a succeeded pod with the hash in conditions.
+	// After Deploy: Status returns the deployed hash and a succeeded pod.
 	if err := d.Deploy(context.Background(), hash, nil); err != nil {
 		t.Fatalf("Deploy: %v", err)
 	}
-	podStatus, err := d.Status(context.Background())
+	deployedHash, podStatus, err := d.Status(context.Background())
 	if err != nil {
 		t.Fatalf("Status after Deploy: %v", err)
+	}
+	if deployedHash != hash {
+		t.Errorf("expected deployed hash %q, got %q", hash, deployedHash)
 	}
 	if podStatus.Phase != corev1.PodSucceeded {
 		t.Errorf("expected PodSucceeded, got %s", podStatus.Phase)
@@ -48,7 +51,7 @@ func TestAlwaysSucceedKMSPreflightDeployer(t *testing.T) {
 	if err := d.Cleanup(context.Background()); err != nil {
 		t.Fatalf("Cleanup: %v", err)
 	}
-	_, err = d.Status(context.Background())
+	_, _, err = d.Status(context.Background())
 	if !apierrors.IsNotFound(err) {
 		t.Fatalf("expected NotFound after Cleanup, got %v", err)
 	}
@@ -57,7 +60,7 @@ func TestAlwaysSucceedKMSPreflightDeployer(t *testing.T) {
 	if err := d.Deploy(context.Background(), "", nil); err != nil {
 		t.Fatalf("Deploy with empty hash: %v", err)
 	}
-	podStatus, err = d.Status(context.Background())
+	_, podStatus, err = d.Status(context.Background())
 	if err != nil {
 		t.Fatalf("Status after Deploy with empty hash: %v", err)
 	}

--- a/pkg/operator/encryption/kms/preflight/assets/kms-preflight-pod.yaml
+++ b/pkg/operator/encryption/kms/preflight/assets/kms-preflight-pod.yaml
@@ -7,7 +7,7 @@ metadata:
     # This is used in the operands network AllowLists. Changes here need to reflect in all dependent operators.
     app: openshift-kms-preflight
   annotations:
-    encryption.apiserver.operator.openshift.io/kms-preflight-config-hash: {{.ConfigHash}}
+    {{.ConfigHashAnnotationKey}}: {{.ConfigHash}}
 spec:
   # This is a one-shot preflight check, not a long-running pod.
   # The operator creates it, waits for completion, and inspects the result.

--- a/pkg/operator/encryption/kms/preflight/deployer.go
+++ b/pkg/operator/encryption/kms/preflight/deployer.go
@@ -26,11 +26,11 @@ const (
 	// EncryptionConfigSecretName is the secret Deploy creates for the preflight pod.
 	EncryptionConfigSecretName = "kms-preflight-encryption-config"
 
-	// ConfigHashAnnotation records, on the preflight pod, the config hash it was
+	// configHashAnnotation records, on the preflight pod, the config hash it was
 	// deployed for. It is set at render time (see assets/kms-preflight-pod.yaml)
 	// and read back by Status so the controller can detect a stale pod even when
 	// the pod never ran and therefore never reported any status condition.
-	ConfigHashAnnotation = "encryption.apiserver.operator.openshift.io/kms-preflight-config-hash"
+	configHashAnnotation = "encryption.apiserver.operator.openshift.io/kms-preflight-config-hash"
 
 	preflightRBACName = "kms-preflight"
 	preflightAppLabel = "openshift-kms-preflight"
@@ -118,7 +118,7 @@ func (d *PodPreflightDeployer) Deploy(ctx context.Context, configHash string, en
 }
 
 // Status returns the config hash the current preflight pod was deployed for
-// (from its ConfigHashAnnotation) along with the pod status. The hash lets the
+// (from its configHashAnnotation) along with the pod status. The hash lets the
 // controller detect a stale pod regardless of whether the pod ever ran.
 func (d *PodPreflightDeployer) Status(ctx context.Context) (string, corev1.PodStatus, error) {
 	// preflight status checks are not very frequent, so we use the live client instead of a cached lister
@@ -127,7 +127,7 @@ func (d *PodPreflightDeployer) Status(ctx context.Context) (string, corev1.PodSt
 		return "", corev1.PodStatus{}, fmt.Errorf("failed to get pod for preflight %s/%s: %w", d.namespace, PodName, err)
 	}
 
-	return pod.Annotations[ConfigHashAnnotation], pod.Status, nil
+	return pod.Annotations[configHashAnnotation], pod.Status, nil
 }
 
 func (d *PodPreflightDeployer) Cleanup(ctx context.Context) error {

--- a/pkg/operator/encryption/kms/preflight/deployer.go
+++ b/pkg/operator/encryption/kms/preflight/deployer.go
@@ -26,6 +26,12 @@ const (
 	// EncryptionConfigSecretName is the secret Deploy creates for the preflight pod.
 	EncryptionConfigSecretName = "kms-preflight-encryption-config"
 
+	// ConfigHashAnnotation records, on the preflight pod, the config hash it was
+	// deployed for. It is set at render time (see assets/kms-preflight-pod.yaml)
+	// and read back by Status so the controller can detect a stale pod even when
+	// the pod never ran and therefore never reported any status condition.
+	ConfigHashAnnotation = "encryption.apiserver.operator.openshift.io/kms-preflight-config-hash"
+
 	preflightRBACName = "kms-preflight"
 	preflightAppLabel = "openshift-kms-preflight"
 )
@@ -111,14 +117,17 @@ func (d *PodPreflightDeployer) Deploy(ctx context.Context, configHash string, en
 	return nil
 }
 
-func (d *PodPreflightDeployer) Status(ctx context.Context) (corev1.PodStatus, error) {
+// Status returns the config hash the current preflight pod was deployed for
+// (from its ConfigHashAnnotation) along with the pod status. The hash lets the
+// controller detect a stale pod regardless of whether the pod ever ran.
+func (d *PodPreflightDeployer) Status(ctx context.Context) (string, corev1.PodStatus, error) {
 	// preflight status checks are not very frequent, so we use the live client instead of a cached lister
 	pod, err := d.coreClient.Pods(d.namespace).Get(ctx, PodName, metav1.GetOptions{})
 	if err != nil {
-		return corev1.PodStatus{}, fmt.Errorf("failed to get pod for preflight %s/%s: %w", d.namespace, PodName, err)
+		return "", corev1.PodStatus{}, fmt.Errorf("failed to get pod for preflight %s/%s: %w", d.namespace, PodName, err)
 	}
 
-	return pod.Status, nil
+	return pod.Annotations[ConfigHashAnnotation], pod.Status, nil
 }
 
 func (d *PodPreflightDeployer) Cleanup(ctx context.Context) error {

--- a/pkg/operator/encryption/kms/preflight/deployer_test.go
+++ b/pkg/operator/encryption/kms/preflight/deployer_test.go
@@ -841,6 +841,7 @@ func TestPodPreflightDeployer_Status(t *testing.T) {
 	scenarios := []struct {
 		name        string
 		objects     []runtime.Object
+		expectHash  string
 		expectPhase corev1.PodPhase
 		expectErr   string
 	}{
@@ -849,17 +850,33 @@ func TestPodPreflightDeployer_Status(t *testing.T) {
 			expectErr: "failed to get pod",
 		},
 		{
-			name: "pod returns pod status",
+			name: "pod returns hash and pod status",
+			objects: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        PodName,
+						Namespace:   testNamespace,
+						Annotations: map[string]string{configHashAnnotationKey: testConfigHash},
+					},
+					Status: corev1.PodStatus{Phase: corev1.PodRunning},
+				},
+			},
+			expectHash:  testConfigHash,
+			expectPhase: corev1.PodRunning,
+		},
+		{
+			name: "pod without annotation returns empty hash",
 			objects: []runtime.Object{
 				&corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      PodName,
 						Namespace: testNamespace,
 					},
-					Status: corev1.PodStatus{Phase: corev1.PodRunning},
+					Status: corev1.PodStatus{Phase: corev1.PodPending},
 				},
 			},
-			expectPhase: corev1.PodRunning,
+			expectHash:  "",
+			expectPhase: corev1.PodPending,
 		},
 	}
 
@@ -867,7 +884,7 @@ func TestPodPreflightDeployer_Status(t *testing.T) {
 		t.Run(scenario.name, func(t *testing.T) {
 			deployer, _ := newTestDeployer(t, scenario.objects...)
 
-			status, err := deployer.Status(context.Background())
+			hash, status, err := deployer.Status(context.Background())
 			if scenario.expectErr != "" {
 				if err == nil || !strings.Contains(err.Error(), scenario.expectErr) {
 					t.Fatalf("expected error containing %q, got %v", scenario.expectErr, err)
@@ -876,6 +893,9 @@ func TestPodPreflightDeployer_Status(t *testing.T) {
 			}
 			if err != nil {
 				t.Fatalf("Status() error = %v", err)
+			}
+			if hash != scenario.expectHash {
+				t.Fatalf("expected hash %q, got %q", scenario.expectHash, hash)
 			}
 			if status.Phase != scenario.expectPhase {
 				t.Fatalf("expected phase %q, got %q", scenario.expectPhase, status.Phase)

--- a/pkg/operator/encryption/kms/preflight/pod_template.go
+++ b/pkg/operator/encryption/kms/preflight/pod_template.go
@@ -13,13 +13,14 @@ import (
 )
 
 type kmsPreflightTemplate struct {
-	PodName        string
-	Namespace      string
-	ConfigHash     string
-	OperatorImage  string
-	Command        string
-	KMSCallTimeout string
-	StaticPod      bool
+	PodName                 string
+	Namespace               string
+	ConfigHashAnnotationKey string
+	ConfigHash              string
+	OperatorImage           string
+	Command                 string
+	KMSCallTimeout          string
+	StaticPod               bool
 }
 
 func newKmsPreflightTemplate(
@@ -37,13 +38,14 @@ func newKmsPreflightTemplate(
 	}
 
 	return kmsPreflightTemplate{
-		PodName:        podName,
-		Namespace:      namespace,
-		ConfigHash:     configHash,
-		OperatorImage:  operatorImage,
-		Command:        strings.Join(operatorCommandQuoted, ","),
-		KMSCallTimeout: kmsCallTimeout.String(),
-		StaticPod:      staticPod,
+		PodName:                 podName,
+		Namespace:               namespace,
+		ConfigHashAnnotationKey: configHashAnnotation,
+		ConfigHash:              configHash,
+		OperatorImage:           operatorImage,
+		Command:                 strings.Join(operatorCommandQuoted, ","),
+		KMSCallTimeout:          kmsCallTimeout.String(),
+		StaticPod:               staticPod,
 	}
 }
 

--- a/test/e2e-encryption/encryption_test.go
+++ b/test/e2e-encryption/encryption_test.go
@@ -1128,15 +1128,15 @@ func (d *configurableKMSPreflightDeployer) Deploy(_ context.Context, configHash 
 	return nil
 }
 
-func (d *configurableKMSPreflightDeployer) Status(_ context.Context) (corev1.PodStatus, error) {
+func (d *configurableKMSPreflightDeployer) Status(_ context.Context) (string, corev1.PodStatus, error) {
 	if !d.deployed {
-		return corev1.PodStatus{}, errors.NewNotFound(schema.GroupResource{Resource: "pods"}, "kms-preflight")
+		return "", corev1.PodStatus{}, errors.NewNotFound(schema.GroupResource{Resource: "pods"}, "kms-preflight")
 	}
 	resultStatus, resultMessage := corev1.ConditionTrue, ""
 	if d.fail.Load() {
 		resultStatus, resultMessage = corev1.ConditionFalse, "intentional failure for testing"
 	}
-	return corev1.PodStatus{
+	return d.configHash, corev1.PodStatus{
 		Phase: corev1.PodSucceeded,
 		Conditions: []corev1.PodCondition{
 			{Type: controllers.KMSPreflightConfigHashPodCondition, Status: corev1.ConditionTrue, Message: d.configHash},

--- a/test/library/encryption/preflight_deploy.go
+++ b/test/library/encryption/preflight_deploy.go
@@ -82,8 +82,8 @@ func TestPreflightDeployAndPodMatchesOperand(ctx context.Context, t testing.TB, 
 }
 
 // AssertPreflightDeploy waits for checker pod conditions and validates Deploy side effects
-// (check container, plugin init container, config-hash / result / remote-key-ID conditions).
-// PodSpec drift vs the operand is AssertNoPreflightConfigDrift — call that separately.
+// (check container, plugin init container, deployed config hash, result / remote-key-ID
+// conditions). PodSpec drift vs the operand is AssertNoPreflightConfigDrift — call that separately.
 func AssertPreflightDeploy(ctx context.Context, t testing.TB, clientSet ClientSet, namespace string, deployer *preflight.PodPreflightDeployer) {
 	t.Helper()
 	require.NotNil(t, deployer)
@@ -96,10 +96,11 @@ func AssertPreflightDeploy(ctx context.Context, t testing.TB, clientSet ClientSe
 	require.Equal(t, preflight.CheckContainerName, preflightPod.Spec.Containers[0].Name)
 	require.NotEmpty(t, preflightPod.Spec.InitContainers, "expected KMS plugin init container")
 
+	var deployedHash string
 	var status corev1.PodStatus
 	err = wait.PollUntilContextTimeout(ctx, preflightStatusPollInterval, preflightStatusPollTimeout, true, func(ctx context.Context) (bool, error) {
 		var statusErr error
-		status, statusErr = deployer.Status(ctx)
+		deployedHash, status, statusErr = deployer.Status(ctx)
 		if statusErr != nil {
 			return false, statusErr
 		}
@@ -110,8 +111,7 @@ func AssertPreflightDeploy(ctx context.Context, t testing.TB, clientSet ClientSe
 	})
 	require.NoError(t, err, "waiting for KMSPreflightResult condition")
 
-	hashCond := requirePodCondition(t, status.Conditions, controllers.KMSPreflightConfigHashPodCondition, corev1.ConditionTrue)
-	require.Equal(t, preflightDeployConfigHash, hashCond.Message)
+	require.Equal(t, preflightDeployConfigHash, deployedHash, "deployed config hash from pod annotation")
 
 	resultCond := requirePodCondition(t, status.Conditions, controllers.KMSPreflightResultPodCondition, corev1.ConditionTrue)
 	require.Equal(t, "Succeeded", resultCond.Reason)


### PR DESCRIPTION
the first part from https://github.com/openshift/library-go/pull/2449

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved KMS preflight handling to detect outdated workloads reliably, including failed, pending, or never-started pods.
  - Stale workloads are now cleaned up and replaced before retrying.
  - Configuration matching now uses the deployed workload configuration hash for more accurate status evaluation.
  - Preflight status reporting now consistently includes the deployed configuration version.

- **Tests**
  - Added coverage for stale workload detection, cleanup, retries, and configuration hash reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->