### PR TITLE
NO-JIRA: set preflight degraded default

### DIFF
--- a/pkg/operator/encryption/controllers/kms_preflight_controller.go
+++ b/pkg/operator/encryption/controllers/kms_preflight_controller.go
@@ -339,7 +339,7 @@ func NewKMSPreflightController(
 }
 
 func (c *kmsPreflightController) sync(ctx context.Context, syncCtx factory.SyncContext) (err error) {
-	degradedCondition := applyoperatorv1.OperatorCondition().WithType("EncryptionKMSPreflightControllerDegraded")
+	degradedCondition := applyoperatorv1.OperatorCondition().WithType("EncryptionKMSPreflightControllerDegraded").WithStatus(operatorv1.ConditionFalse)
 	progressingCondition := applyoperatorv1.OperatorCondition().WithType("EncryptionKMSPreflightControllerProgressing").WithStatus(operatorv1.ConditionFalse)
 
 	defer func() {


### PR DESCRIPTION
This panics under some preflight conditions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved operator status reporting by ensuring the degraded condition is explicitly initialized as false when no degradation is detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->