### PR TITLE
NO-JIRA: add vault namespace to rotation helpers

### DIFF
--- a/test/library/encryption/kms/vault.go
+++ b/test/library/encryption/kms/vault.go
@@ -213,7 +213,7 @@ func rotateKey(ctx context.Context, t testing.TB) {
 	// Command: vault write -f transit/keys/<key-name>/rotate
 	// Reference: https://developer.hashicorp.com/vault/api-docs/secret/transit#rotate-key
 	cmd := exec.CommandContext(commandCtx, "oc", "exec", defaultVaultPodName, "-n", defaultVaultNamespace, "--",
-		"vault", "write", "-f", fmt.Sprintf("%s/rotate", defaultVaultKeyPath))
+		"vault", "write", "-n", defaultVaultEnterpriseNS, "-f", fmt.Sprintf("%s/rotate", defaultVaultKeyPath))
 
 	t.Logf("Executing: %s", cmd.String())
 	output, err := cmd.Output()
@@ -231,7 +231,7 @@ func getCurrentKeyVersion(ctx context.Context, t testing.TB) int {
 	defer cancel()
 
 	cmd := exec.CommandContext(commandCtx, "oc", "exec", defaultVaultPodName, "-n", defaultVaultNamespace, "--",
-		"vault", "read", "-field=latest_version", defaultVaultKeyPath)
+		"vault", "read", "-n", defaultVaultEnterpriseNS, "-field=latest_version", defaultVaultKeyPath)
 
 	t.Logf("Executing: %s", cmd.String())
 	output, err := cmd.Output()


### PR DESCRIPTION
The vault enterprise NS was missing, otherwise we would receive a 404 on the response.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Vault Enterprise compatibility for key rotation and key-version retrieval by targeting the correct administrative namespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->