### PR TITLE
OCPBUGS-109578: fix oc darwin client hcp login when insecure tls flag is used

### DIFF
--- a/pkg/oauth/tokenrequest/request_token.go
+++ b/pkg/oauth/tokenrequest/request_token.go
@@ -5,11 +5,13 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"net/url"
+	"runtime"
 	"slices"
 	"strings"
 
@@ -551,6 +553,7 @@ func transportWithSystemRoots(issuer string, clientConfig *restclient.Config) (h
 	resp.Body.Close()
 
 	_, err = verifyServerCertChain(issuerURL.Hostname(), resp.TLS.PeerCertificates)
+
 	switch err.(type) {
 	case nil:
 		// copy the config so we can freely mutate it
@@ -584,6 +587,13 @@ func transportWithSystemRoots(issuer string, clientConfig *restclient.Config) (h
 			klog.V(4).Infof("falling back to kubeconfig CA due to possible IO error: %v", err)
 			return restclient.TransportFor(clientConfig)
 		}
+		// could be string based x509 error...
+		err = convertErrorIfUnknownX509(runtime.GOOS, err)
+		var target unknownX509VerificationError
+		if errors.As(err, &target) {
+			klog.V(4).Infof("falling back to kubeconfig CA due to possible unknown x509 error: %v", err)
+			return restclient.TransportFor(clientConfig)
+		}
 		// unknown error, fail (ideally should never occur)
 		klog.V(4).Infof("unexpected error during system roots probe: %v", err)
 		return nil, err
@@ -607,3 +617,28 @@ func verifyServerCertChain(dnsName string, chain []*x509.Certificate) ([][]*x509
 		DNSName:       dnsName,
 	})
 }
+
+// convertErrorIfUnknownX509 normalizes certificate verification errors on macOS.
+// root_darwin.go in the Go standard library has insufficient typed errors for the
+// macOS platform, leading to a generic string based "x509:" error rather than a
+// typed one. This wraps such an error in an unknownX509VerificationError so callers
+// can react to it the same way they do on Linux/Windows (e.g. falling back to the
+// kubeconfig CA), keeping the approach consistent across platforms. The original
+// error is preserved and remains recoverable via errors.Unwrap/errors.Is.
+//
+// goos is passed in (rather than read from runtime.GOOS) so the darwin branch can
+// be exercised in tests regardless of the platform they run on.
+// https://github.com/golang/go/blob/5a6340ff28c87e099f33c941e3d73e50d715ddf7/src/crypto/x509/root_darwin.go#L74
+func convertErrorIfUnknownX509(goos string, err error) error {
+	if goos == "darwin" && err != nil && strings.HasPrefix(err.Error(), "x509:") {
+		return unknownX509VerificationError{err}
+	}
+	return err
+}
+
+// unknownX509VerificationError wraps an opaque, string based x509 verification
+// error (see convertErrorIfUnknownX509) so it can be matched by type while still
+// preserving the underlying error.
+type unknownX509VerificationError struct{ error }
+
+func (e unknownX509VerificationError) Unwrap() error { return e.error }

--- a/pkg/oauth/tokenrequest/request_token_test.go
+++ b/pkg/oauth/tokenrequest/request_token_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -755,6 +756,67 @@ func TestRequestToken_BrowserFlow(t *testing.T) {
 					t.Errorf(`expected error "%s", got error "%s"`, tc.expectError, err.Error())
 					return
 				}
+			}
+		})
+	}
+}
+
+func TestConvertErrorIfUnknownX509(t *testing.T) {
+	x509Err := errors.New("x509: certificate signed by unknown authority")
+	otherErr := errors.New("some other error")
+
+	for _, tc := range []struct {
+		name string
+		goos string
+		err  error
+		// wrapExpected is true when the error is expected to be wrapped in an
+		// unknownX509VerificationError; otherwise the original error must be
+		// returned unchanged.
+		wrapExpected bool
+	}{
+		{
+			name:         "nil error stays nil on darwin",
+			goos:         "darwin",
+			err:          nil,
+			wrapExpected: false,
+		},
+		{
+			name:         "x509-prefixed error is wrapped on darwin",
+			goos:         "darwin",
+			err:          x509Err,
+			wrapExpected: true,
+		},
+		{
+			name:         "non-x509 error is returned unchanged on darwin",
+			goos:         "darwin",
+			err:          otherErr,
+			wrapExpected: false,
+		},
+		{
+			name:         "x509-prefixed error is left unchanged on linux",
+			goos:         "linux",
+			err:          x509Err,
+			wrapExpected: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := convertErrorIfUnknownX509(tc.goos, tc.err)
+
+			if tc.wrapExpected {
+				wrapped, ok := got.(unknownX509VerificationError)
+				if !ok {
+					t.Fatalf("expected unknownX509VerificationError, got %T: %v", got, got)
+				}
+				if !errors.Is(wrapped, tc.err) {
+					t.Fatalf("expected the original error to be unwrappable, got %v", errors.Unwrap(wrapped))
+				}
+				return
+			}
+
+			// nil passes through as nil; on non-darwin (or non-x509 errors)
+			// the original error is returned unchanged.
+			if got != tc.err {
+				t.Fatalf("expected the original error %v to be returned unchanged, got %T: %v", tc.err, got, got)
 			}
 		})
 	}


### PR DESCRIPTION
This fix resolves a major issue introduced in a recent change where logging in using oc on macos to a hcp client with insecure flag was used.

That PR was reverted - https://github.com/openshift/library-go/pull/2456 . 

On other clusters where there was no error, the
check now panics on strings.HasPrefix(err.Error(), ...) as there was no check to see if err != nil.

This was flagged by coderabbitai in library-go bump pr in oc.

https://github.com/openshift/oc/pull/2391#discussion_r3922929300

This fix fixes an issue seen when oc client is used to login to a HCP cluster on macOS. It falls back to kubeconfig CA when a string based x509 error is observed on the macOS platform.

See https://github.com/golang/go/blob/master/src/crypto/x509/root_darwin.go#L74 for reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved certificate verification error handling on macOS.
  * Untrusted certificate errors are now reported consistently, while successful verification and unrelated errors remain unaffected.

* **Tests**
  * Added coverage for macOS certificate-error conversion, including successful verification, untrusted certificates, and unrelated errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->