### PR TITLE
Revert "OCPBUGS-109578: fix oc darwin client hcp login when insecure tls flag is used"

### DIFF
--- a/pkg/oauth/tokenrequest/request_token.go
+++ b/pkg/oauth/tokenrequest/request_token.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"runtime"
 	"slices"
 	"strings"
 
@@ -603,23 +602,8 @@ func verifyServerCertChain(dnsName string, chain []*x509.Certificate) ([][]*x509
 		intermediates.AddCert(c)
 	}
 
-	certChainList, err := chain[0].Verify(x509.VerifyOptions{
+	return chain[0].Verify(x509.VerifyOptions{
 		Intermediates: intermediates,
 		DNSName:       dnsName,
 	})
-
-	if runtime.GOOS == "darwin" && strings.HasPrefix(err.Error(), "x509:") {
-		// this check fills in the gap where root_darwin.go has insufficient
-		// typed errors for macOS platform, leading to a generic string based
-		// x509 error. This will return a proper x509 error which can be used
-		// to return kubeconfig CA client. x509.UnknownAuthorityError was
-		// chosen because this is the fall back also used on Linux/Windows,
-		// keeping the approach consistent across platforms.
-		// https://github.com/golang/go/blob/5a6340ff28c87e099f33c941e3d73e50d715ddf7/src/crypto/x509/root_darwin.go#L74
-		return nil, x509.UnknownAuthorityError{
-			Cert: chain[0],
-		}
-	}
-
-	return certChainList, err
 }


### PR DESCRIPTION
Reverts openshift/library-go#2438.

The proper fix will be implemented in https://github.com/openshift/library-go/pull/2455.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized certificate verification behavior across platforms.
  * Removed macOS-specific handling that converted certificate errors into a different error type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->