### PR TITLE
NO-JIRA: fix namespace on the read path

### DIFF
--- a/test/library/encryption/kms/vault.go
+++ b/test/library/encryption/kms/vault.go
@@ -213,7 +213,7 @@ func rotateKey(ctx context.Context, t testing.TB) {
 	// Command: vault write -f transit/keys/<key-name>/rotate
 	// Reference: https://developer.hashicorp.com/vault/api-docs/secret/transit#rotate-key
 	cmd := exec.CommandContext(commandCtx, "oc", "exec", defaultVaultPodName, "-n", defaultVaultNamespace, "--",
-		"vault", "write", "-n", defaultVaultEnterpriseNS, "-f", fmt.Sprintf("%s/rotate", defaultVaultKeyPath))
+		"vault", "write", fmt.Sprintf("-namespace=%s", defaultVaultEnterpriseNS), "-f", fmt.Sprintf("%s/rotate", defaultVaultKeyPath))
 
 	t.Logf("Executing: %s", cmd.String())
 	output, err := cmd.Output()
@@ -231,7 +231,7 @@ func getCurrentKeyVersion(ctx context.Context, t testing.TB) int {
 	defer cancel()
 
 	cmd := exec.CommandContext(commandCtx, "oc", "exec", defaultVaultPodName, "-n", defaultVaultNamespace, "--",
-		"vault", "read", "-n", defaultVaultEnterpriseNS, "-field=latest_version", defaultVaultKeyPath)
+		"vault", "read", fmt.Sprintf("-namespace=%s", defaultVaultEnterpriseNS), "-field=latest_version", defaultVaultKeyPath)
 
 	t.Logf("Executing: %s", cmd.String())
 	output, err := cmd.Output()


### PR DESCRIPTION
turns out that "-n" only exists on write, but namespace works on both.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Vault CLI commands for transit key rotation and version reads to use the explicit namespace option format, improving command compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->