### PR TITLE
NO-JIRA: add KMS remote-key rotation reconciler

### DIFF
--- a/pkg/operator/encryption/controllers/key_controller.go
+++ b/pkg/operator/encryption/controllers/key_controller.go
@@ -168,7 +168,7 @@ func (c *keyController) sync(ctx context.Context, syncCtx factory.SyncContext) (
 		return err // we will get re-kicked when the operator status updates
 	}
 
-	err = c.checkAndCreateKeys(ctx, syncCtx, c.provider.EncryptedGRs())
+	err = c.syncEncryptionKeys(ctx, syncCtx)
 	if err != nil {
 		degradedCondition = degradedCondition.
 			WithStatus(operatorv1.ConditionTrue).
@@ -182,7 +182,8 @@ func (c *keyController) sync(ctx context.Context, syncCtx factory.SyncContext) (
 	return err
 }
 
-func (c *keyController) checkAndCreateKeys(ctx context.Context, syncContext factory.SyncContext, encryptedGRs []schema.GroupResource) error {
+func (c *keyController) syncEncryptionKeys(ctx context.Context, syncContext factory.SyncContext) error {
+	encryptedGRs := c.provider.EncryptedGRs()
 	planner := NewEncryptionPlanner(c.instanceName, c.unsupportedConfigPrefix, c.deployer, c.secretClient, c.configMapClient, c.apiServerClient, c.operatorClient, c.encryptionSecretSelector)
 	snap, err := planner.Load(ctx, encryptedGRs, LoadOptions{})
 	if err != nil {
@@ -193,6 +194,21 @@ func (c *keyController) checkAndCreateKeys(ctx context.Context, syncContext fact
 		return nil
 	}
 
+	if err := c.checkAndCreateKeysFromSnap(ctx, syncContext, planner, snap); err != nil {
+		return err
+	}
+
+	requeueAfter, err := c.reconcileRemoteKeyRotationFromSnap(ctx, snap)
+	if err != nil {
+		return err
+	}
+	if requeueAfter > 0 {
+		syncContext.Queue().AddAfter(syncContext.QueueKey(), requeueAfter)
+	}
+	return nil
+}
+
+func (c *keyController) checkAndCreateKeysFromSnap(ctx context.Context, syncContext factory.SyncContext, planner *EncryptionPlanner, snap *KeyPlanningSnapshot) error {
 	plan, err := planner.PlanNextKey(snap)
 	if err != nil {
 		return err
@@ -220,8 +236,25 @@ func (c *keyController) checkAndCreateKeys(ctx context.Context, syncContext fact
 	}
 
 	syncContext.Recorder().Eventf("EncryptionKeyCreated", "Secret %q successfully created: %q", keySecret.Name, plan.Reasons)
-
 	return nil
+}
+
+func (c *keyController) reconcileRemoteKeyRotationFromSnap(ctx context.Context, snap *KeyPlanningSnapshot) (time.Duration, error) {
+	if c.encryptionStatusProvider == nil || snap.CurrentMode != state.KMS {
+		return 0, nil
+	}
+
+	writeKey, ok := writeKeyForRemoteKeyRotation(snap.State.DesiredBeforePlan)
+	if !ok || len(writeKey.RemoteKey().TargetRemoteKeyID) == 0 {
+		return 0, nil
+	}
+
+	encryptionStatus, err := c.encryptionStatusProvider.GetKMSEncryptionStatus(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get KMS encryption status for remote key rotation: %w", err)
+	}
+
+	return reconcileRemoteKeyRotation(ctx, c.secretClient, c.instanceName, snap.State.EncryptedGRs, snap.State.DesiredBeforePlan, encryptionStatus, systemRemoteKeyClock{})
 }
 
 func (c *keyController) validateExistingSecret(ctx context.Context, keySecret *corev1.Secret, keyID uint64) error {

--- a/pkg/operator/encryption/controllers/remote_key_reconciler.go
+++ b/pkg/operator/encryption/controllers/remote_key_reconciler.go
@@ -1,0 +1,197 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	"github.com/openshift/library-go/pkg/operator/encryption/kms/health"
+	"github.com/openshift/library-go/pkg/operator/encryption/secrets"
+	"github.com/openshift/library-go/pkg/operator/encryption/state"
+)
+
+const remoteKeyConvergenceDuration = 5 * time.Minute
+
+type remoteKeyClock interface {
+	Now() time.Time
+}
+
+type systemRemoteKeyClock struct{}
+
+func (systemRemoteKeyClock) Now() time.Time { return time.Now() }
+
+// reconcileRemoteKeyRotation maintains KMS remote key rotation annotations on the
+// encryption key secret for the current KMS write key. External remote-key rotation
+// does not mint a new encryption key secret or trigger stateController; only
+// migrationController re-encrypts etcd data.
+func reconcileRemoteKeyRotation(
+	ctx context.Context,
+	secretClient corev1client.SecretsGetter,
+	instanceName string,
+	encryptedGRs []schema.GroupResource,
+	desiredState map[schema.GroupResource]state.GroupResourceState,
+	encryptionStatus *operatorv1.KMSEncryptionStatus,
+	clock remoteKeyClock,
+) (time.Duration, error) {
+	if encryptionStatus == nil {
+		return 0, nil
+	}
+
+	writeKey, ok := writeKeyForRemoteKeyRotation(desiredState)
+	if !ok {
+		return 0, nil
+	}
+
+	secretName := fmt.Sprintf("encryption-key-%s-%s", instanceName, writeKey.Key.Name)
+	rk, err := readRemoteKeyAnnotationsFromSecret(ctx, secretClient, secretName)
+	if err != nil {
+		return 0, err
+	}
+	if len(rk.TargetRemoteKeyID) == 0 {
+		return 0, nil
+	}
+
+	// During KMS-to-KMS migration multiple plugin key IDs can report at once; scope
+	// convergence to the current write key's keyID so backup/read-only plugins are ignored.
+	reports := health.ReportsForKeyID(encryptionStatus.HealthReports, writeKey.Key.Name)
+	convergenceResult := health.ConvergedRemoteKeyID(reports)
+	if convergenceResult.RemoteKeyID == "" {
+		return 0, nil
+	}
+
+	if !secrets.IsBootstrapped(rk) {
+		requeue, err := reconcileRemoteKeyBootstrap(ctx, secretClient, secretName, encryptedGRs, writeKey, convergenceResult)
+		return requeue, err
+	}
+
+	return reconcileRemoteKeyPromotion(ctx, secretClient, secretName, rk, convergenceResult, clock)
+}
+
+func writeKeyForRemoteKeyRotation(desiredState map[schema.GroupResource]state.GroupResourceState) (state.KeyState, bool) {
+	for _, grState := range desiredState {
+		if grState.HasWriteKey() && grState.WriteKey.Mode == state.KMS {
+			return grState.WriteKey, true
+		}
+	}
+	return state.KeyState{}, false
+}
+
+func readRemoteKeyAnnotationsFromSecret(ctx context.Context, secretClient corev1client.SecretsGetter, secretName string) (secrets.RemoteKeyAnnotations, error) {
+	s, err := secretClient.Secrets("openshift-config-managed").Get(ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		return secrets.RemoteKeyAnnotations{}, err
+	}
+	return secrets.ReadRemoteKeyAnnotations(s)
+}
+
+func reconcileRemoteKeyBootstrap(
+	ctx context.Context,
+	secretClient corev1client.SecretsGetter,
+	secretName string,
+	encryptedGRs []schema.GroupResource,
+	writeKey state.KeyState,
+	convergenceResult health.ConvergenceResult,
+) (time.Duration, error) {
+	if !convergenceResult.Converged {
+		return 0, nil
+	}
+	allMigrated, _, _ := state.MigratedFor(encryptedGRs, writeKey)
+	if !allMigrated {
+		return 0, nil
+	}
+
+	err := secrets.PatchRemoteKeyAnnotations(ctx, secretClient.Secrets("openshift-config-managed"), secretName, func(rk *secrets.RemoteKeyAnnotations) (bool, error) {
+		if secrets.IsBootstrapped(*rk) {
+			return false, nil
+		}
+		if len(rk.TargetRemoteKeyID) == 0 {
+			return false, nil
+		}
+		rk.MigratedRemoteKeyID = rk.TargetRemoteKeyID
+		return true, nil
+	})
+	return 0, err
+}
+
+func reconcileRemoteKeyPromotion(
+	ctx context.Context,
+	secretClient corev1client.SecretsGetter,
+	secretName string,
+	rk secrets.RemoteKeyAnnotations,
+	convergence health.ConvergenceResult,
+	clock remoteKeyClock,
+) (time.Duration, error) {
+	if !convergence.Converged {
+		return 0, clearRemoteKeyConvergence(ctx, secretClient, secretName, rk)
+	}
+
+	if convergence.RemoteKeyID == rk.TargetRemoteKeyID {
+		return 0, clearRemoteKeyConvergence(ctx, secretClient, secretName, rk)
+	}
+
+	now := clock.Now()
+	requeueAfter, promote, err := nextRemoteKeyPromotionAction(rk, convergence.RemoteKeyID, now)
+	if err != nil {
+		return 0, err
+	}
+
+	if promote {
+		err = secrets.PatchRemoteKeyAnnotations(ctx, secretClient.Secrets("openshift-config-managed"), secretName, func(rk *secrets.RemoteKeyAnnotations) (bool, error) {
+			if rk.TargetRemoteKeyID == convergence.RemoteKeyID {
+				return false, nil
+			}
+			if secrets.NeedsRemoteKeyMigration(*rk) {
+				return false, nil
+			}
+			rk.TargetRemoteKeyID = convergence.RemoteKeyID
+			rk.ConvergedID = ""
+			rk.ConvergedAt = time.Time{}
+			return true, nil
+		})
+		return 0, err
+	}
+
+	err = secrets.PatchRemoteKeyAnnotations(ctx, secretClient.Secrets("openshift-config-managed"), secretName, func(rk *secrets.RemoteKeyAnnotations) (bool, error) {
+		if rk.ConvergedID == convergence.RemoteKeyID && !rk.ConvergedAt.IsZero() {
+			return false, nil
+		}
+		rk.ConvergedID = convergence.RemoteKeyID
+		rk.ConvergedAt = now
+		return true, nil
+	})
+	return requeueAfter, err
+}
+
+func nextRemoteKeyPromotionAction(rk secrets.RemoteKeyAnnotations, candidateRemoteKeyID string, now time.Time) (time.Duration, bool, error) {
+	if rk.ConvergedID != candidateRemoteKeyID || rk.ConvergedAt.IsZero() {
+		return remoteKeyConvergenceDuration, false, nil
+	}
+	elapsed := now.Sub(rk.ConvergedAt)
+	if elapsed < remoteKeyConvergenceDuration {
+		return remoteKeyConvergenceDuration - elapsed, false, nil
+	}
+	if secrets.NeedsRemoteKeyMigration(rk) {
+		return 0, false, nil
+	}
+	return 0, true, nil
+}
+
+func clearRemoteKeyConvergence(ctx context.Context, secretClient corev1client.SecretsGetter, secretName string, rk secrets.RemoteKeyAnnotations) error {
+	if rk.ConvergedID == "" && rk.ConvergedAt.IsZero() {
+		return nil
+	}
+	return secrets.PatchRemoteKeyAnnotations(ctx, secretClient.Secrets("openshift-config-managed"), secretName, func(rk *secrets.RemoteKeyAnnotations) (bool, error) {
+		if rk.ConvergedID == "" && rk.ConvergedAt.IsZero() {
+			return false, nil
+		}
+		rk.ConvergedID = ""
+		rk.ConvergedAt = time.Time{}
+		return true, nil
+	})
+}

--- a/pkg/operator/encryption/controllers/remote_key_reconciler_test.go
+++ b/pkg/operator/encryption/controllers/remote_key_reconciler_test.go
@@ -1,0 +1,239 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/fake"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
+
+	"github.com/openshift/library-go/pkg/operator/encryption/secrets"
+	"github.com/openshift/library-go/pkg/operator/encryption/state"
+)
+
+type fixedRemoteKeyClock struct {
+	now time.Time
+}
+
+func (c fixedRemoteKeyClock) Now() time.Time { return c.now }
+
+func TestReconcileRemoteKeyBootstrap(t *testing.T) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "openshift-config-managed",
+			Name:      "encryption-key-test-3",
+			Annotations: map[string]string{
+				secrets.EncryptionSecretTargetRemoteKeyID: "remote-old",
+			},
+		},
+	}
+	client := fake.NewSimpleClientset(secret)
+
+	writeKey := state.KeyState{
+		Key:  apiserverconfigv1.Key{Name: "3", Secret: "c2VjcmV0"},
+		Mode: state.KMS,
+		Migrated: state.MigrationState{
+			Resources: []schema.GroupResource{{Resource: "secrets"}},
+		},
+		KMS: &state.KMSState{
+			RemoteKey: state.RemoteKeyState{TargetRemoteKeyID: "remote-old"},
+		},
+	}
+	desired := map[schema.GroupResource]state.GroupResourceState{
+		{Resource: "secrets"}: {WriteKey: writeKey},
+	}
+	status := &operatorv1.KMSEncryptionStatus{
+		HealthReports: []operatorv1.KMSPluginHealthReport{
+			{KeyID: "3", RemoteKeyID: "remote-new"},
+			{KeyID: "3", RemoteKeyID: "remote-new"},
+		},
+	}
+
+	_, err := reconcileRemoteKeyRotation(context.Background(), client.CoreV1(), "test", []schema.GroupResource{{Resource: "secrets"}}, desired, status, fixedRemoteKeyClock{now: time.Now()})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	updated, err := client.CoreV1().Secrets("openshift-config-managed").Get(context.Background(), secret.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get secret: %v", err)
+	}
+	if updated.Annotations[secrets.EncryptionSecretMigratedRemoteKeyID] != "remote-old" {
+		t.Fatalf("expected bootstrap migrated-remote-key-id=remote-old, got %q", updated.Annotations[secrets.EncryptionSecretMigratedRemoteKeyID])
+	}
+}
+
+func TestReconcileRemoteKeyPromotion(t *testing.T) {
+	start := time.Date(2026, 8, 31, 10, 0, 0, 0, time.UTC)
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "openshift-config-managed",
+			Name:      "encryption-key-test-3",
+			Annotations: map[string]string{
+				secrets.EncryptionSecretTargetRemoteKeyID:    "remote-old",
+				secrets.EncryptionSecretMigratedRemoteKeyID:  "remote-old",
+				secrets.EncryptionSecretRemoteKeyConvergedID: "remote-new",
+				secrets.EncryptionSecretRemoteKeyConvergedAt: start.Format(time.RFC3339),
+			},
+		},
+	}
+	client := fake.NewSimpleClientset(secret)
+
+	writeKey := state.KeyState{
+		Key:  apiserverconfigv1.Key{Name: "3", Secret: "c2VjcmV0"},
+		Mode: state.KMS,
+		Migrated: state.MigrationState{
+			Resources: []schema.GroupResource{{Resource: "secrets"}},
+		},
+		KMS: &state.KMSState{
+			RemoteKey: state.RemoteKeyState{
+				TargetRemoteKeyID:   "remote-old",
+				MigratedRemoteKeyID: "remote-old",
+				ConvergedID:         "remote-new",
+				ConvergedAt:         start,
+			},
+		},
+	}
+	desired := map[schema.GroupResource]state.GroupResourceState{
+		{Resource: "secrets"}: {WriteKey: writeKey},
+	}
+	status := &operatorv1.KMSEncryptionStatus{
+		HealthReports: []operatorv1.KMSPluginHealthReport{
+			{KeyID: "3", RemoteKeyID: "remote-new"},
+			{KeyID: "3", RemoteKeyID: "remote-new"},
+		},
+	}
+
+	_, err := reconcileRemoteKeyRotation(context.Background(), client.CoreV1(), "test", []schema.GroupResource{{Resource: "secrets"}}, desired, status, fixedRemoteKeyClock{now: start.Add(6 * time.Minute)})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	updated, err := client.CoreV1().Secrets("openshift-config-managed").Get(context.Background(), secret.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get secret: %v", err)
+	}
+	if updated.Annotations[secrets.EncryptionSecretTargetRemoteKeyID] != "remote-new" {
+		t.Fatalf("expected promoted target-remote-key-id=remote-new, got %q", updated.Annotations[secrets.EncryptionSecretTargetRemoteKeyID])
+	}
+	if _, ok := updated.Annotations[secrets.EncryptionSecretRemoteKeyConvergedID]; ok {
+		t.Fatal("expected convergence annotations to be cleared after promotion")
+	}
+}
+
+func TestReconcileRemoteKeyIgnoresOtherKeyIDReports(t *testing.T) {
+	start := time.Date(2026, 8, 31, 10, 0, 0, 0, time.UTC)
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "openshift-config-managed",
+			Name:      "encryption-key-test-3",
+			Annotations: map[string]string{
+				secrets.EncryptionSecretTargetRemoteKeyID:    "remote-old",
+				secrets.EncryptionSecretMigratedRemoteKeyID:  "remote-old",
+				secrets.EncryptionSecretRemoteKeyConvergedID: "remote-new",
+				secrets.EncryptionSecretRemoteKeyConvergedAt: start.Format(time.RFC3339),
+			},
+		},
+	}
+	client := fake.NewSimpleClientset(secret)
+
+	writeKey := state.KeyState{
+		Key:  apiserverconfigv1.Key{Name: "3", Secret: "c2VjcmV0"},
+		Mode: state.KMS,
+		Migrated: state.MigrationState{
+			Resources: []schema.GroupResource{{Resource: "secrets"}},
+		},
+		KMS: &state.KMSState{
+			RemoteKey: state.RemoteKeyState{
+				TargetRemoteKeyID:   "remote-old",
+				MigratedRemoteKeyID: "remote-old",
+				ConvergedID:         "remote-new",
+				ConvergedAt:         start,
+			},
+		},
+	}
+	desired := map[schema.GroupResource]state.GroupResourceState{
+		{Resource: "secrets"}: {WriteKey: writeKey},
+	}
+	status := &operatorv1.KMSEncryptionStatus{
+		HealthReports: []operatorv1.KMSPluginHealthReport{
+			{KeyID: "3", RemoteKeyID: "remote-new"},
+			{KeyID: "3", RemoteKeyID: "remote-new"},
+			{KeyID: "2", RemoteKeyID: "remote-old"},
+		},
+	}
+
+	_, err := reconcileRemoteKeyRotation(context.Background(), client.CoreV1(), "test", []schema.GroupResource{{Resource: "secrets"}}, desired, status, fixedRemoteKeyClock{now: start.Add(6 * time.Minute)})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	updated, err := client.CoreV1().Secrets("openshift-config-managed").Get(context.Background(), secret.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get secret: %v", err)
+	}
+	if updated.Annotations[secrets.EncryptionSecretTargetRemoteKeyID] != "remote-new" {
+		t.Fatalf("expected promoted target-remote-key-id=remote-new, got %q", updated.Annotations[secrets.EncryptionSecretTargetRemoteKeyID])
+	}
+}
+
+func TestReconcileRemoteKeyDeferredPromotion(t *testing.T) {
+	start := time.Date(2026, 8, 31, 10, 0, 0, 0, time.UTC)
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "openshift-config-managed",
+			Name:      "encryption-key-test-3",
+			Annotations: map[string]string{
+				secrets.EncryptionSecretTargetRemoteKeyID:    "remote-a",
+				secrets.EncryptionSecretMigratedRemoteKeyID:  "remote-old",
+				secrets.EncryptionSecretRemoteKeyConvergedID: "remote-b",
+				secrets.EncryptionSecretRemoteKeyConvergedAt: start.Format(time.RFC3339),
+			},
+		},
+	}
+	client := fake.NewSimpleClientset(secret)
+
+	writeKey := state.KeyState{
+		Key:  apiserverconfigv1.Key{Name: "3", Secret: "c2VjcmV0"},
+		Mode: state.KMS,
+		Migrated: state.MigrationState{
+			Resources: []schema.GroupResource{{Resource: "secrets"}},
+		},
+		KMS: &state.KMSState{
+			RemoteKey: state.RemoteKeyState{
+				TargetRemoteKeyID:   "remote-a",
+				MigratedRemoteKeyID: "remote-old",
+				ConvergedID:         "remote-b",
+				ConvergedAt:         start,
+			},
+		},
+	}
+	desired := map[schema.GroupResource]state.GroupResourceState{
+		{Resource: "secrets"}: {WriteKey: writeKey},
+	}
+	status := &operatorv1.KMSEncryptionStatus{
+		HealthReports: []operatorv1.KMSPluginHealthReport{
+			{KeyID: "3", RemoteKeyID: "remote-b"},
+			{KeyID: "3", RemoteKeyID: "remote-b"},
+		},
+	}
+
+	_, err := reconcileRemoteKeyRotation(context.Background(), client.CoreV1(), "test", []schema.GroupResource{{Resource: "secrets"}}, desired, status, fixedRemoteKeyClock{now: start.Add(6 * time.Minute)})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	updated, err := client.CoreV1().Secrets("openshift-config-managed").Get(context.Background(), secret.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get secret: %v", err)
+	}
+	if updated.Annotations[secrets.EncryptionSecretTargetRemoteKeyID] != "remote-a" {
+		t.Fatalf("expected target to remain remote-a during in-flight migration, got %q", updated.Annotations[secrets.EncryptionSecretTargetRemoteKeyID])
+	}
+}

--- a/pkg/operator/encryption/kms/health/convergence.go
+++ b/pkg/operator/encryption/kms/health/convergence.go
@@ -1,0 +1,43 @@
+package health
+
+import (
+	operatorv1 "github.com/openshift/api/operator/v1"
+)
+
+// ConvergenceResult reports whether health reports agree on a single remote key ID.
+type ConvergenceResult struct {
+	Converged   bool
+	RemoteKeyID string
+}
+
+// ConvergedRemoteKeyID returns Converged=true when every report in the slice carries
+// the same RemoteKeyID. The caller is responsible for filtering reports and handling
+// missing or empty entries.
+func ConvergedRemoteKeyID(reports []operatorv1.KMSPluginHealthReport) ConvergenceResult {
+	if len(reports) == 0 {
+		return ConvergenceResult{}
+	}
+	remoteKeyID := reports[0].RemoteKeyID
+	for _, report := range reports[1:] {
+		if report.RemoteKeyID != remoteKeyID {
+			return ConvergenceResult{}
+		}
+	}
+	return ConvergenceResult{
+		Converged:   true,
+		RemoteKeyID: remoteKeyID,
+	}
+}
+
+// ReportsForKeyID returns health reports for the given encryption key ID (kms-{keyID}.sock).
+// During KMS-to-KMS provider migration multiple plugins may report per node; callers use
+// the current write key's keyID so backup/read-only keys are excluded from rotation logic.
+func ReportsForKeyID(reports []operatorv1.KMSPluginHealthReport, keyID string) []operatorv1.KMSPluginHealthReport {
+	filtered := make([]operatorv1.KMSPluginHealthReport, 0, len(reports))
+	for _, report := range reports {
+		if report.KeyID == keyID {
+			filtered = append(filtered, report)
+		}
+	}
+	return filtered
+}

--- a/pkg/operator/encryption/kms/health/convergence_test.go
+++ b/pkg/operator/encryption/kms/health/convergence_test.go
@@ -1,0 +1,56 @@
+package health
+
+import (
+	"testing"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+)
+
+func TestConvergedRemoteKeyID(t *testing.T) {
+	scenarios := []struct {
+		name            string
+		reports         []operatorv1.KMSPluginHealthReport
+		wantConverged   bool
+		wantRemoteKeyID string
+	}{
+		{
+			name: "unanimous",
+			reports: []operatorv1.KMSPluginHealthReport{
+				{KeyID: "3", RemoteKeyID: "remote-a"},
+				{KeyID: "3", RemoteKeyID: "remote-a"},
+			},
+			wantConverged:   true,
+			wantRemoteKeyID: "remote-a",
+		},
+		{
+			name: "split brain",
+			reports: []operatorv1.KMSPluginHealthReport{
+				{KeyID: "3", RemoteKeyID: "remote-a"},
+				{KeyID: "3", RemoteKeyID: "remote-b"},
+			},
+		},
+		{
+			name: "empty",
+		},
+	}
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			got := ConvergedRemoteKeyID(scenario.reports)
+			if got.Converged != scenario.wantConverged || got.RemoteKeyID != scenario.wantRemoteKeyID {
+				t.Fatalf("got %#v want converged=%v remoteKeyID=%q", got, scenario.wantConverged, scenario.wantRemoteKeyID)
+			}
+		})
+	}
+}
+
+func TestReportsForKeyID(t *testing.T) {
+	reports := []operatorv1.KMSPluginHealthReport{
+		{KeyID: "3", RemoteKeyID: "a"},
+		{KeyID: "2", RemoteKeyID: "b"},
+		{KeyID: "3", RemoteKeyID: "a"},
+	}
+	filtered := ReportsForKeyID(reports, "3")
+	if len(filtered) != 2 {
+		t.Fatalf("expected 2 reports, got %d", len(filtered))
+	}
+}

--- a/pkg/operator/encryption/secrets/remote_key.go
+++ b/pkg/operator/encryption/secrets/remote_key.go
@@ -1,0 +1,125 @@
+package secrets
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/util/retry"
+
+	"github.com/openshift/library-go/pkg/operator/encryption/state"
+)
+
+// RemoteKeyAnnotations is the annotation-backed view of state.RemoteKeyState.
+type RemoteKeyAnnotations = state.RemoteKeyState
+
+// ReadRemoteKeyAnnotations reads remote key rotation annotations from a key secret.
+func ReadRemoteKeyAnnotations(s *corev1.Secret) (RemoteKeyAnnotations, error) {
+	if s == nil {
+		return RemoteKeyAnnotations{}, nil
+	}
+	return readRemoteKeyAnnotations(s.Annotations, s.Namespace, s.Name)
+}
+
+func readRemoteKeyAnnotations(annotations map[string]string, namespace, name string) (RemoteKeyAnnotations, error) {
+	rk := RemoteKeyAnnotations{
+		TargetRemoteKeyID:   annotations[EncryptionSecretTargetRemoteKeyID],
+		MigratedRemoteKeyID: annotations[EncryptionSecretMigratedRemoteKeyID],
+		ConvergedID:         annotations[EncryptionSecretRemoteKeyConvergedID],
+	}
+	if v, ok := annotations[EncryptionSecretRemoteKeyConvergedAt]; ok && len(v) > 0 {
+		ts, err := time.Parse(time.RFC3339, v)
+		if err != nil {
+			return RemoteKeyAnnotations{}, fmt.Errorf("secret %s/%s has invalid %s annotation: %v", namespace, name, EncryptionSecretRemoteKeyConvergedAt, err)
+		}
+		rk.ConvergedAt = ts
+	}
+	return rk, nil
+}
+
+// ApplyRemoteKeyAnnotations writes remote key rotation annotations into the given map.
+// Empty values remove the corresponding annotation keys.
+func ApplyRemoteKeyAnnotations(annotations map[string]string, rk RemoteKeyAnnotations) {
+	setOrDeleteAnnotation(annotations, EncryptionSecretTargetRemoteKeyID, rk.TargetRemoteKeyID)
+	setOrDeleteAnnotation(annotations, EncryptionSecretMigratedRemoteKeyID, rk.MigratedRemoteKeyID)
+	setOrDeleteAnnotation(annotations, EncryptionSecretRemoteKeyConvergedID, rk.ConvergedID)
+	if rk.ConvergedAt.IsZero() {
+		delete(annotations, EncryptionSecretRemoteKeyConvergedAt)
+	} else {
+		annotations[EncryptionSecretRemoteKeyConvergedAt] = rk.ConvergedAt.Format(time.RFC3339)
+	}
+}
+
+func setOrDeleteAnnotation(annotations map[string]string, key, value string) {
+	if len(value) == 0 {
+		delete(annotations, key)
+		return
+	}
+	annotations[key] = value
+}
+
+// NeedsRemoteKeyMigration reports whether migrated-remote-key-id is set,
+// target-remote-key-id is non-empty, and they differ (needsMigration).
+func NeedsRemoteKeyMigration(rk RemoteKeyAnnotations) bool {
+	return len(rk.MigratedRemoteKeyID) > 0 &&
+		len(rk.TargetRemoteKeyID) > 0 &&
+		rk.MigratedRemoteKeyID != rk.TargetRemoteKeyID
+}
+
+// IsBootstrapped reports whether the initial remote key bootstrap has completed.
+func IsBootstrapped(rk RemoteKeyAnnotations) bool {
+	return len(rk.MigratedRemoteKeyID) > 0
+}
+
+// MigrationWriteKeyName returns the StorageVersionMigration write-key annotation value.
+// When target-remote-key-id is set, the write-key is always suffixed with that ID
+// (first enablement and remote-key rotation). Plain keyName is used only when
+// target-remote-key-id is unset.
+func MigrationWriteKeyName(keyName string, rk RemoteKeyAnnotations) string {
+	if len(rk.TargetRemoteKeyID) == 0 {
+		return keyName
+	}
+	return keyName + "-" + rk.TargetRemoteKeyID
+}
+
+// RemoteKeyIDFromMigrationWriteKey extracts the remote key ID suffix from a migration write-key value.
+func RemoteKeyIDFromMigrationWriteKey(keyName, migrationWriteKey string) (string, bool) {
+	prefix := keyName + "-"
+	if !strings.HasPrefix(migrationWriteKey, prefix) {
+		return "", false
+	}
+	remoteKeyID := strings.TrimPrefix(migrationWriteKey, prefix)
+	if len(remoteKeyID) == 0 {
+		return "", false
+	}
+	return remoteKeyID, true
+}
+
+// PatchRemoteKeyAnnotations updates remote key annotations on a key secret using
+// get-modify-update with conflict retry. Other annotations are preserved.
+func PatchRemoteKeyAnnotations(ctx context.Context, client corev1client.SecretInterface, secretName string, mutate func(*RemoteKeyAnnotations) (bool, error)) error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		s, err := client.Get(ctx, secretName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		rk, err := ReadRemoteKeyAnnotations(s)
+		if err != nil {
+			return err
+		}
+		changed, err := mutate(&rk)
+		if err != nil || !changed {
+			return err
+		}
+		if s.Annotations == nil {
+			s.Annotations = map[string]string{}
+		}
+		ApplyRemoteKeyAnnotations(s.Annotations, rk)
+		_, updateErr := client.Update(ctx, s, metav1.UpdateOptions{})
+		return updateErr
+	})
+}

--- a/pkg/operator/encryption/secrets/remote_key_patch_test.go
+++ b/pkg/operator/encryption/secrets/remote_key_patch_test.go
@@ -1,0 +1,83 @@
+package secrets
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/openshift/library-go/pkg/operator/encryption/state"
+)
+
+func TestPatchRemoteKeyAnnotationsPreservesOtherAnnotations(t *testing.T) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "openshift-config-managed",
+			Name:      "encryption-key-test-3",
+			Annotations: map[string]string{
+				EncryptionSecretTargetRemoteKeyID:   "remote-old",
+				EncryptionSecretMigratedRemoteKeyID: "remote-old",
+				EncryptionSecretMigratedTimestamp:   "2026-08-31T10:00:00Z",
+			},
+		},
+	}
+	client := fake.NewSimpleClientset(secret)
+
+	err := PatchRemoteKeyAnnotations(context.Background(), client.CoreV1().Secrets(secret.Namespace), secret.Name, func(rk *RemoteKeyAnnotations) (bool, error) {
+		rk.TargetRemoteKeyID = "remote-new"
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("patch failed: %v", err)
+	}
+
+	updated, err := client.CoreV1().Secrets(secret.Namespace).Get(context.Background(), secret.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get secret: %v", err)
+	}
+	if updated.Annotations[EncryptionSecretTargetRemoteKeyID] != "remote-new" {
+		t.Fatalf("target not updated")
+	}
+	if updated.Annotations[EncryptionSecretMigratedTimestamp] == "" {
+		t.Fatal("expected migrated timestamp annotation to be preserved")
+	}
+}
+
+func TestPatchRemoteKeyAnnotationsConcurrentWriters(t *testing.T) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   "openshift-config-managed",
+			Name:        "encryption-key-test-3",
+			Annotations: map[string]string{},
+		},
+	}
+	client := fake.NewSimpleClientset(secret)
+
+	if err := PatchRemoteKeyAnnotations(context.Background(), client.CoreV1().Secrets(secret.Namespace), secret.Name, func(rk *RemoteKeyAnnotations) (bool, error) {
+		rk.TargetRemoteKeyID = "remote-new"
+		return true, nil
+	}); err != nil {
+		t.Fatalf("first patch failed: %v", err)
+	}
+
+	if err := PatchRemoteKeyAnnotations(context.Background(), client.CoreV1().Secrets(secret.Namespace), secret.Name, func(rk *RemoteKeyAnnotations) (bool, error) {
+		rk.MigratedRemoteKeyID = "remote-new"
+		return true, nil
+	}); err != nil {
+		t.Fatalf("second patch failed: %v", err)
+	}
+
+	updated, err := client.CoreV1().Secrets(secret.Namespace).Get(context.Background(), secret.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get secret: %v", err)
+	}
+	rk := state.RemoteKeyState{
+		TargetRemoteKeyID:   updated.Annotations[EncryptionSecretTargetRemoteKeyID],
+		MigratedRemoteKeyID: updated.Annotations[EncryptionSecretMigratedRemoteKeyID],
+	}
+	if rk.TargetRemoteKeyID != "remote-new" || rk.MigratedRemoteKeyID != "remote-new" {
+		t.Fatalf("unexpected annotations: %#v", updated.Annotations)
+	}
+}

--- a/pkg/operator/encryption/secrets/remote_key_test.go
+++ b/pkg/operator/encryption/secrets/remote_key_test.go
@@ -1,0 +1,119 @@
+package secrets
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/library-go/pkg/operator/encryption/state"
+)
+
+func TestReadRemoteKeyAnnotations(t *testing.T) {
+	ts := time.Date(2026, 8, 31, 10, 0, 0, 0, time.UTC)
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "openshift-config-managed",
+			Name:      "encryption-key-test-1",
+			Annotations: map[string]string{
+				EncryptionSecretTargetRemoteKeyID:    "remote-old",
+				EncryptionSecretMigratedRemoteKeyID:  "remote-old",
+				EncryptionSecretRemoteKeyConvergedID: "remote-new",
+				EncryptionSecretRemoteKeyConvergedAt: ts.Format(time.RFC3339),
+			},
+		},
+	}
+
+	got, err := ReadRemoteKeyAnnotations(secret)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.TargetRemoteKeyID != "remote-old" || got.MigratedRemoteKeyID != "remote-old" {
+		t.Fatalf("unexpected ids: %#v", got)
+	}
+	if got.ConvergedID != "remote-new" || !got.ConvergedAt.Equal(ts) {
+		t.Fatalf("unexpected convergence: %#v", got)
+	}
+}
+
+func TestNeedsRemoteKeyMigration(t *testing.T) {
+	scenarios := []struct {
+		name string
+		rk   state.RemoteKeyState
+		want bool
+	}{
+		{name: "unset migrated", rk: state.RemoteKeyState{TargetRemoteKeyID: "a"}, want: false},
+		{name: "equal", rk: state.RemoteKeyState{TargetRemoteKeyID: "a", MigratedRemoteKeyID: "a"}, want: false},
+		{name: "differs", rk: state.RemoteKeyState{TargetRemoteKeyID: "b", MigratedRemoteKeyID: "a"}, want: true},
+	}
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			if got := NeedsRemoteKeyMigration(scenario.rk); got != scenario.want {
+				t.Fatalf("got %v want %v", got, scenario.want)
+			}
+		})
+	}
+}
+
+func TestMigrationWriteKeyName(t *testing.T) {
+	scenarios := []struct {
+		name    string
+		keyName string
+		rk      state.RemoteKeyState
+		want    string
+	}{
+		{
+			name:    "first enablement",
+			keyName: "3",
+			rk:      state.RemoteKeyState{TargetRemoteKeyID: "remote-old"},
+			want:    "3-remote-old",
+		},
+		{
+			name:    "no target",
+			keyName: "3",
+			rk:      state.RemoteKeyState{},
+			want:    "3",
+		},
+		{
+			name:    "steady state",
+			keyName: "3",
+			rk:      state.RemoteKeyState{TargetRemoteKeyID: "remote-old", MigratedRemoteKeyID: "remote-old"},
+			want:    "3-remote-old",
+		},
+		{
+			name:    "rotation",
+			keyName: "3",
+			rk:      state.RemoteKeyState{TargetRemoteKeyID: "remote-new", MigratedRemoteKeyID: "remote-old"},
+			want:    "3-remote-new",
+		},
+	}
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			if got := MigrationWriteKeyName(scenario.keyName, scenario.rk); got != scenario.want {
+				t.Fatalf("got %q want %q", got, scenario.want)
+			}
+		})
+	}
+}
+
+func TestRemoteKeyIDFromMigrationWriteKey(t *testing.T) {
+	got, ok := RemoteKeyIDFromMigrationWriteKey("3", "3-remote-new")
+	if !ok || got != "remote-new" {
+		t.Fatalf("got %q ok=%v", got, ok)
+	}
+	_, ok = RemoteKeyIDFromMigrationWriteKey("3", "3")
+	if ok {
+		t.Fatal("expected false for plain key name")
+	}
+}
+
+func TestApplyRemoteKeyAnnotationsClearsEmptyValues(t *testing.T) {
+	annotations := map[string]string{
+		EncryptionSecretTargetRemoteKeyID: "old",
+	}
+	ApplyRemoteKeyAnnotations(annotations, state.RemoteKeyState{})
+	if _, ok := annotations[EncryptionSecretTargetRemoteKeyID]; ok {
+		t.Fatal("expected target annotation to be removed")
+	}
+}

--- a/pkg/operator/encryption/secrets/secrets.go
+++ b/pkg/operator/encryption/secrets/secrets.go
@@ -66,6 +66,11 @@ func ToKeyState(s *corev1.Secret) (state.KeyState, error) {
 		key.Mode = keyMode
 	case state.KMS:
 		key.KMS = &state.KMSState{}
+		remoteKey, err := readRemoteKeyAnnotations(s.Annotations, s.Namespace, s.Name)
+		if err != nil {
+			return state.KeyState{}, err
+		}
+		key.KMS.RemoteKey = remoteKey
 		if v, ok := s.Data[EncryptionSecretKMSEncryptionConfig]; ok && len(v) > 0 {
 			kmsConfiguration, err := encoding.DecodeKMSConfiguration(v)
 			if err != nil {
@@ -160,6 +165,10 @@ func FromKeyState(component string, ks state.KeyState) (*corev1.Secret, error) {
 			return nil, err
 		}
 		s.Annotations[EncryptionSecretMigratedResources] = string(bs)
+	}
+
+	if ks.Mode == state.KMS {
+		ApplyRemoteKeyAnnotations(s.Annotations, ks.RemoteKey())
 	}
 
 	if ks.HasKMSEncryption() {

--- a/pkg/operator/encryption/secrets/secrets_test.go
+++ b/pkg/operator/encryption/secrets/secrets_test.go
@@ -151,6 +151,10 @@ func TestRoundtrip(t *testing.T) {
 						Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 					},
 					Plugin: defaultKMSPluginConfig,
+					RemoteKey: state.RemoteKeyState{
+						TargetRemoteKeyID:   "remote-new",
+						MigratedRemoteKeyID: "remote-old",
+					},
 				},
 				Migrated: state.MigrationState{
 					Timestamp: now,

--- a/pkg/operator/encryption/secrets/types.go
+++ b/pkg/operator/encryption/secrets/types.go
@@ -67,6 +67,15 @@ const (
 	// values fetched from the referenced configmap in openshift-config. The full data key is
 	// constructed as prefix + configMapName + separator + dataKey.
 	encryptionSecretKMSConfigMapDataPrefix = "encryption.apiserver.operator.openshift.io-kms-plugin-configmap-"
+
+	// EncryptionSecretTargetRemoteKeyID is the target remote KMS key ID to migrate toward.
+	EncryptionSecretTargetRemoteKeyID = "encryption.apiserver.operator.openshift.io/target-remote-key-id"
+	// EncryptionSecretMigratedRemoteKeyID is the last fully migrated remote KMS key ID.
+	EncryptionSecretMigratedRemoteKeyID = "encryption.apiserver.operator.openshift.io/migrated-remote-key-id"
+	// EncryptionSecretRemoteKeyConvergedAt records when a candidate remote key ID first achieved cluster convergence.
+	EncryptionSecretRemoteKeyConvergedAt = "encryption.apiserver.operator.openshift.io/remote-key-converged-at"
+	// EncryptionSecretRemoteKeyConvergedID is the candidate remote key ID the converged-at timestamp belongs to.
+	EncryptionSecretRemoteKeyConvergedID = "encryption.apiserver.operator.openshift.io/remote-key-converged-id"
 )
 
 // MigratedGroupResources is the data structured stored in the

--- a/pkg/operator/encryption/state/types.go
+++ b/pkg/operator/encryption/state/types.go
@@ -52,6 +52,14 @@ type KeyState struct {
 	KMS *KMSState
 }
 
+// RemoteKeyState is the in-memory view of remote key rotation annotations.
+type RemoteKeyState struct {
+	TargetRemoteKeyID   string
+	MigratedRemoteKeyID string
+	ConvergedAt         time.Time
+	ConvergedID         string
+}
+
 func (k *KeyState) HasKMSEncryption() bool {
 	return k != nil && k.KMS != nil && k.KMS.Encryption != nil
 }
@@ -68,6 +76,14 @@ func (k *KeyState) HasKMSConfigMapData() bool {
 	return k != nil && k.KMS != nil && len(k.KMS.PluginConfigMapData.entries) > 0
 }
 
+// RemoteKey returns the remote key rotation state. Non-KMS keys have no remote key.
+func (k *KeyState) RemoteKey() RemoteKeyState {
+	if k == nil || k.KMS == nil {
+		return RemoteKeyState{}
+	}
+	return k.KMS.RemoteKey
+}
+
 // KMSState stores all KMS encryption mode related configurations
 type KMSState struct {
 	// Encoded EncryptionConfig that stores the KMS related fields
@@ -81,6 +97,9 @@ type KMSState struct {
 
 	// PluginConfigMapData stores data key-value pairs fetched from referenced configmaps.
 	PluginConfigMapData KMSReferenceData
+
+	// RemoteKey tracks KMS remote key rotation annotations on the backing secret.
+	RemoteKey RemoteKeyState
 }
 
 // KMSReferenceData stores data key-value pairs fetched from referenced secrets or configmaps.


### PR DESCRIPTION
## Summary
- Add health-report convergence helpers and a remote-key reconciler that bootstraps, records, and promotes a stable KMS remote key ID on the write-key secret.
- Call that reconciler from the encryption key controller after planning, including when no new encryption key is minted.

This PR targets `master` independently. It includes the remote-key state/annotation types so it compiles without stacking on #2458.

Enhancement: https://github.com/openshift/enhancements/pull/2041

## Test plan
- [x] `go test ./pkg/operator/encryption/state/ ./pkg/operator/encryption/secrets/ ./pkg/operator/encryption/kms/health/ ./pkg/operator/encryption/controllers/`
- [ ] CI unit/verify jobs


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added remote KMS key rotation reconciliation.
  - Tracks target, migrated, and converged remote keys through Secret metadata.
  - Promotes a new remote key only after health convergence, migration completion, and a stability period.
  - Filters health status by remote key and supports automatic migration bootstrapping.
  - Preserves existing Secret metadata during updates and reports invalid or failed status updates.

- **Bug Fixes**
  - Prevents key promotion while migration is still in progress.
  - Surfaces errors when remote-key metadata or status cannot be read or updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->