### PR TITLE
NO-JIRA: add KMS remote-key rotation state and secret annotations

### DIFF
--- a/pkg/operator/encryption/secrets/remote_key.go
+++ b/pkg/operator/encryption/secrets/remote_key.go
@@ -1,0 +1,125 @@
+package secrets
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/util/retry"
+
+	"github.com/openshift/library-go/pkg/operator/encryption/state"
+)
+
+// RemoteKeyAnnotations is the annotation-backed view of state.RemoteKeyState.
+type RemoteKeyAnnotations = state.RemoteKeyState
+
+// ReadRemoteKeyAnnotations reads remote key rotation annotations from a key secret.
+func ReadRemoteKeyAnnotations(s *corev1.Secret) (RemoteKeyAnnotations, error) {
+	if s == nil {
+		return RemoteKeyAnnotations{}, nil
+	}
+	return readRemoteKeyAnnotations(s.Annotations, s.Namespace, s.Name)
+}
+
+func readRemoteKeyAnnotations(annotations map[string]string, namespace, name string) (RemoteKeyAnnotations, error) {
+	rk := RemoteKeyAnnotations{
+		TargetRemoteKeyID:   annotations[EncryptionSecretTargetRemoteKeyID],
+		MigratedRemoteKeyID: annotations[EncryptionSecretMigratedRemoteKeyID],
+		ConvergedID:         annotations[EncryptionSecretRemoteKeyConvergedID],
+	}
+	if v, ok := annotations[EncryptionSecretRemoteKeyConvergedAt]; ok && len(v) > 0 {
+		ts, err := time.Parse(time.RFC3339, v)
+		if err != nil {
+			return RemoteKeyAnnotations{}, fmt.Errorf("secret %s/%s has invalid %s annotation: %v", namespace, name, EncryptionSecretRemoteKeyConvergedAt, err)
+		}
+		rk.ConvergedAt = ts
+	}
+	return rk, nil
+}
+
+// ApplyRemoteKeyAnnotations writes remote key rotation annotations into the given map.
+// Empty values remove the corresponding annotation keys.
+func ApplyRemoteKeyAnnotations(annotations map[string]string, rk RemoteKeyAnnotations) {
+	setOrDeleteAnnotation(annotations, EncryptionSecretTargetRemoteKeyID, rk.TargetRemoteKeyID)
+	setOrDeleteAnnotation(annotations, EncryptionSecretMigratedRemoteKeyID, rk.MigratedRemoteKeyID)
+	setOrDeleteAnnotation(annotations, EncryptionSecretRemoteKeyConvergedID, rk.ConvergedID)
+	if rk.ConvergedAt.IsZero() {
+		delete(annotations, EncryptionSecretRemoteKeyConvergedAt)
+	} else {
+		annotations[EncryptionSecretRemoteKeyConvergedAt] = rk.ConvergedAt.Format(time.RFC3339)
+	}
+}
+
+func setOrDeleteAnnotation(annotations map[string]string, key, value string) {
+	if len(value) == 0 {
+		delete(annotations, key)
+		return
+	}
+	annotations[key] = value
+}
+
+// NeedsRemoteKeyMigration reports whether migrated-remote-key-id is set,
+// target-remote-key-id is non-empty, and they differ (needsMigration).
+func NeedsRemoteKeyMigration(rk RemoteKeyAnnotations) bool {
+	return len(rk.MigratedRemoteKeyID) > 0 &&
+		len(rk.TargetRemoteKeyID) > 0 &&
+		rk.MigratedRemoteKeyID != rk.TargetRemoteKeyID
+}
+
+// IsBootstrapped reports whether the initial remote key bootstrap has completed.
+func IsBootstrapped(rk RemoteKeyAnnotations) bool {
+	return len(rk.MigratedRemoteKeyID) > 0
+}
+
+// MigrationWriteKeyName returns the StorageVersionMigration write-key annotation value.
+// When target-remote-key-id is set, the write-key is always suffixed with that ID
+// (first enablement and remote-key rotation). Plain keyName is used only when
+// target-remote-key-id is unset.
+func MigrationWriteKeyName(keyName string, rk RemoteKeyAnnotations) string {
+	if len(rk.TargetRemoteKeyID) == 0 {
+		return keyName
+	}
+	return keyName + "-" + rk.TargetRemoteKeyID
+}
+
+// RemoteKeyIDFromMigrationWriteKey extracts the remote key ID suffix from a migration write-key value.
+func RemoteKeyIDFromMigrationWriteKey(keyName, migrationWriteKey string) (string, bool) {
+	prefix := keyName + "-"
+	if !strings.HasPrefix(migrationWriteKey, prefix) {
+		return "", false
+	}
+	remoteKeyID := strings.TrimPrefix(migrationWriteKey, prefix)
+	if len(remoteKeyID) == 0 {
+		return "", false
+	}
+	return remoteKeyID, true
+}
+
+// PatchRemoteKeyAnnotations updates remote key annotations on a key secret using
+// get-modify-update with conflict retry. Other annotations are preserved.
+func PatchRemoteKeyAnnotations(ctx context.Context, client corev1client.SecretInterface, secretName string, mutate func(*RemoteKeyAnnotations) (bool, error)) error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		s, err := client.Get(ctx, secretName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		rk, err := ReadRemoteKeyAnnotations(s)
+		if err != nil {
+			return err
+		}
+		changed, err := mutate(&rk)
+		if err != nil || !changed {
+			return err
+		}
+		if s.Annotations == nil {
+			s.Annotations = map[string]string{}
+		}
+		ApplyRemoteKeyAnnotations(s.Annotations, rk)
+		_, updateErr := client.Update(ctx, s, metav1.UpdateOptions{})
+		return updateErr
+	})
+}

--- a/pkg/operator/encryption/secrets/remote_key_patch_test.go
+++ b/pkg/operator/encryption/secrets/remote_key_patch_test.go
@@ -1,0 +1,83 @@
+package secrets
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/openshift/library-go/pkg/operator/encryption/state"
+)
+
+func TestPatchRemoteKeyAnnotationsPreservesOtherAnnotations(t *testing.T) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "openshift-config-managed",
+			Name:      "encryption-key-test-3",
+			Annotations: map[string]string{
+				EncryptionSecretTargetRemoteKeyID:   "remote-old",
+				EncryptionSecretMigratedRemoteKeyID: "remote-old",
+				EncryptionSecretMigratedTimestamp:   "2026-08-31T10:00:00Z",
+			},
+		},
+	}
+	client := fake.NewSimpleClientset(secret)
+
+	err := PatchRemoteKeyAnnotations(context.Background(), client.CoreV1().Secrets(secret.Namespace), secret.Name, func(rk *RemoteKeyAnnotations) (bool, error) {
+		rk.TargetRemoteKeyID = "remote-new"
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("patch failed: %v", err)
+	}
+
+	updated, err := client.CoreV1().Secrets(secret.Namespace).Get(context.Background(), secret.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get secret: %v", err)
+	}
+	if updated.Annotations[EncryptionSecretTargetRemoteKeyID] != "remote-new" {
+		t.Fatalf("target not updated")
+	}
+	if updated.Annotations[EncryptionSecretMigratedTimestamp] == "" {
+		t.Fatal("expected migrated timestamp annotation to be preserved")
+	}
+}
+
+func TestPatchRemoteKeyAnnotationsConcurrentWriters(t *testing.T) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   "openshift-config-managed",
+			Name:        "encryption-key-test-3",
+			Annotations: map[string]string{},
+		},
+	}
+	client := fake.NewSimpleClientset(secret)
+
+	if err := PatchRemoteKeyAnnotations(context.Background(), client.CoreV1().Secrets(secret.Namespace), secret.Name, func(rk *RemoteKeyAnnotations) (bool, error) {
+		rk.TargetRemoteKeyID = "remote-new"
+		return true, nil
+	}); err != nil {
+		t.Fatalf("first patch failed: %v", err)
+	}
+
+	if err := PatchRemoteKeyAnnotations(context.Background(), client.CoreV1().Secrets(secret.Namespace), secret.Name, func(rk *RemoteKeyAnnotations) (bool, error) {
+		rk.MigratedRemoteKeyID = "remote-new"
+		return true, nil
+	}); err != nil {
+		t.Fatalf("second patch failed: %v", err)
+	}
+
+	updated, err := client.CoreV1().Secrets(secret.Namespace).Get(context.Background(), secret.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get secret: %v", err)
+	}
+	rk := state.RemoteKeyState{
+		TargetRemoteKeyID:   updated.Annotations[EncryptionSecretTargetRemoteKeyID],
+		MigratedRemoteKeyID: updated.Annotations[EncryptionSecretMigratedRemoteKeyID],
+	}
+	if rk.TargetRemoteKeyID != "remote-new" || rk.MigratedRemoteKeyID != "remote-new" {
+		t.Fatalf("unexpected annotations: %#v", updated.Annotations)
+	}
+}

--- a/pkg/operator/encryption/secrets/remote_key_test.go
+++ b/pkg/operator/encryption/secrets/remote_key_test.go
@@ -1,0 +1,119 @@
+package secrets
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/library-go/pkg/operator/encryption/state"
+)
+
+func TestReadRemoteKeyAnnotations(t *testing.T) {
+	ts := time.Date(2026, 8, 31, 10, 0, 0, 0, time.UTC)
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "openshift-config-managed",
+			Name:      "encryption-key-test-1",
+			Annotations: map[string]string{
+				EncryptionSecretTargetRemoteKeyID:    "remote-old",
+				EncryptionSecretMigratedRemoteKeyID:  "remote-old",
+				EncryptionSecretRemoteKeyConvergedID: "remote-new",
+				EncryptionSecretRemoteKeyConvergedAt: ts.Format(time.RFC3339),
+			},
+		},
+	}
+
+	got, err := ReadRemoteKeyAnnotations(secret)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.TargetRemoteKeyID != "remote-old" || got.MigratedRemoteKeyID != "remote-old" {
+		t.Fatalf("unexpected ids: %#v", got)
+	}
+	if got.ConvergedID != "remote-new" || !got.ConvergedAt.Equal(ts) {
+		t.Fatalf("unexpected convergence: %#v", got)
+	}
+}
+
+func TestNeedsRemoteKeyMigration(t *testing.T) {
+	scenarios := []struct {
+		name string
+		rk   state.RemoteKeyState
+		want bool
+	}{
+		{name: "unset migrated", rk: state.RemoteKeyState{TargetRemoteKeyID: "a"}, want: false},
+		{name: "equal", rk: state.RemoteKeyState{TargetRemoteKeyID: "a", MigratedRemoteKeyID: "a"}, want: false},
+		{name: "differs", rk: state.RemoteKeyState{TargetRemoteKeyID: "b", MigratedRemoteKeyID: "a"}, want: true},
+	}
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			if got := NeedsRemoteKeyMigration(scenario.rk); got != scenario.want {
+				t.Fatalf("got %v want %v", got, scenario.want)
+			}
+		})
+	}
+}
+
+func TestMigrationWriteKeyName(t *testing.T) {
+	scenarios := []struct {
+		name    string
+		keyName string
+		rk      state.RemoteKeyState
+		want    string
+	}{
+		{
+			name:    "first enablement",
+			keyName: "3",
+			rk:      state.RemoteKeyState{TargetRemoteKeyID: "remote-old"},
+			want:    "3-remote-old",
+		},
+		{
+			name:    "no target",
+			keyName: "3",
+			rk:      state.RemoteKeyState{},
+			want:    "3",
+		},
+		{
+			name:    "steady state",
+			keyName: "3",
+			rk:      state.RemoteKeyState{TargetRemoteKeyID: "remote-old", MigratedRemoteKeyID: "remote-old"},
+			want:    "3-remote-old",
+		},
+		{
+			name:    "rotation",
+			keyName: "3",
+			rk:      state.RemoteKeyState{TargetRemoteKeyID: "remote-new", MigratedRemoteKeyID: "remote-old"},
+			want:    "3-remote-new",
+		},
+	}
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			if got := MigrationWriteKeyName(scenario.keyName, scenario.rk); got != scenario.want {
+				t.Fatalf("got %q want %q", got, scenario.want)
+			}
+		})
+	}
+}
+
+func TestRemoteKeyIDFromMigrationWriteKey(t *testing.T) {
+	got, ok := RemoteKeyIDFromMigrationWriteKey("3", "3-remote-new")
+	if !ok || got != "remote-new" {
+		t.Fatalf("got %q ok=%v", got, ok)
+	}
+	_, ok = RemoteKeyIDFromMigrationWriteKey("3", "3")
+	if ok {
+		t.Fatal("expected false for plain key name")
+	}
+}
+
+func TestApplyRemoteKeyAnnotationsClearsEmptyValues(t *testing.T) {
+	annotations := map[string]string{
+		EncryptionSecretTargetRemoteKeyID: "old",
+	}
+	ApplyRemoteKeyAnnotations(annotations, state.RemoteKeyState{})
+	if _, ok := annotations[EncryptionSecretTargetRemoteKeyID]; ok {
+		t.Fatal("expected target annotation to be removed")
+	}
+}

--- a/pkg/operator/encryption/secrets/secrets.go
+++ b/pkg/operator/encryption/secrets/secrets.go
@@ -66,6 +66,11 @@ func ToKeyState(s *corev1.Secret) (state.KeyState, error) {
 		key.Mode = keyMode
 	case state.KMS:
 		key.KMS = &state.KMSState{}
+		remoteKey, err := readRemoteKeyAnnotations(s.Annotations, s.Namespace, s.Name)
+		if err != nil {
+			return state.KeyState{}, err
+		}
+		key.KMS.RemoteKey = remoteKey
 		if v, ok := s.Data[EncryptionSecretKMSEncryptionConfig]; ok && len(v) > 0 {
 			kmsConfiguration, err := encoding.DecodeKMSConfiguration(v)
 			if err != nil {
@@ -160,6 +165,10 @@ func FromKeyState(component string, ks state.KeyState) (*corev1.Secret, error) {
 			return nil, err
 		}
 		s.Annotations[EncryptionSecretMigratedResources] = string(bs)
+	}
+
+	if ks.Mode == state.KMS {
+		ApplyRemoteKeyAnnotations(s.Annotations, ks.RemoteKey())
 	}
 
 	if ks.HasKMSEncryption() {

--- a/pkg/operator/encryption/secrets/secrets_test.go
+++ b/pkg/operator/encryption/secrets/secrets_test.go
@@ -151,6 +151,10 @@ func TestRoundtrip(t *testing.T) {
 						Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 					},
 					Plugin: defaultKMSPluginConfig,
+					RemoteKey: state.RemoteKeyState{
+						TargetRemoteKeyID:   "remote-new",
+						MigratedRemoteKeyID: "remote-old",
+					},
 				},
 				Migrated: state.MigrationState{
 					Timestamp: now,

--- a/pkg/operator/encryption/secrets/types.go
+++ b/pkg/operator/encryption/secrets/types.go
@@ -67,6 +67,15 @@ const (
 	// values fetched from the referenced configmap in openshift-config. The full data key is
 	// constructed as prefix + configMapName + separator + dataKey.
 	encryptionSecretKMSConfigMapDataPrefix = "encryption.apiserver.operator.openshift.io-kms-plugin-configmap-"
+
+	// EncryptionSecretTargetRemoteKeyID is the target remote KMS key ID to migrate toward.
+	EncryptionSecretTargetRemoteKeyID = "encryption.apiserver.operator.openshift.io/target-remote-key-id"
+	// EncryptionSecretMigratedRemoteKeyID is the last fully migrated remote KMS key ID.
+	EncryptionSecretMigratedRemoteKeyID = "encryption.apiserver.operator.openshift.io/migrated-remote-key-id"
+	// EncryptionSecretRemoteKeyConvergedAt records when a candidate remote key ID first achieved cluster convergence.
+	EncryptionSecretRemoteKeyConvergedAt = "encryption.apiserver.operator.openshift.io/remote-key-converged-at"
+	// EncryptionSecretRemoteKeyConvergedID is the candidate remote key ID the converged-at timestamp belongs to.
+	EncryptionSecretRemoteKeyConvergedID = "encryption.apiserver.operator.openshift.io/remote-key-converged-id"
 )
 
 // MigratedGroupResources is the data structured stored in the

--- a/pkg/operator/encryption/state/types.go
+++ b/pkg/operator/encryption/state/types.go
@@ -52,6 +52,14 @@ type KeyState struct {
 	KMS *KMSState
 }
 
+// RemoteKeyState is the in-memory view of remote key rotation annotations.
+type RemoteKeyState struct {
+	TargetRemoteKeyID   string
+	MigratedRemoteKeyID string
+	ConvergedAt         time.Time
+	ConvergedID         string
+}
+
 func (k *KeyState) HasKMSEncryption() bool {
 	return k != nil && k.KMS != nil && k.KMS.Encryption != nil
 }
@@ -68,6 +76,14 @@ func (k *KeyState) HasKMSConfigMapData() bool {
 	return k != nil && k.KMS != nil && len(k.KMS.PluginConfigMapData.entries) > 0
 }
 
+// RemoteKey returns the remote key rotation state. Non-KMS keys have no remote key.
+func (k *KeyState) RemoteKey() RemoteKeyState {
+	if k == nil || k.KMS == nil {
+		return RemoteKeyState{}
+	}
+	return k.KMS.RemoteKey
+}
+
 // KMSState stores all KMS encryption mode related configurations
 type KMSState struct {
 	// Encoded EncryptionConfig that stores the KMS related fields
@@ -81,6 +97,9 @@ type KMSState struct {
 
 	// PluginConfigMapData stores data key-value pairs fetched from referenced configmaps.
 	PluginConfigMapData KMSReferenceData
+
+	// RemoteKey tracks KMS remote key rotation annotations on the backing secret.
+	RemoteKey RemoteKeyState
 }
 
 // KMSReferenceData stores data key-value pairs fetched from referenced secrets or configmaps.


### PR DESCRIPTION
## Summary
- Add `RemoteKeyState` on KMS encryption key state and the secret annotation contract for target/migrated/converged remote key IDs.
- Add read/apply/patch helpers so later rotation work can persist those annotations without rewriting unrelated secret metadata.

Enhancement: https://github.com/openshift/enhancements/pull/2041
E2E PR: https://github.com/openshift/cluster-kube-apiserver-operator/pull/2291
Tracking PR: https://github.com/openshift/library-go/pull/2452


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added remote KMS key rotation tracking for encrypted Kubernetes Secrets.
  * Added support for detecting migration status, recording convergence details, and safely updating key-related metadata.
  * Preserved unrelated Secret annotations during remote-key updates.
  * Added validation for remote-key metadata and support for round-tripping rotation state.

* **Tests**
  * Added coverage for annotation parsing, migration detection, key naming, state updates, and rotation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->