### PR TITLE
NO-JIRA: add KMS remote-key health-report convergence helpers

### DIFF
--- a/pkg/operator/encryption/kms/health/convergence.go
+++ b/pkg/operator/encryption/kms/health/convergence.go
@@ -1,0 +1,39 @@
+package health
+
+import (
+	operatorv1 "github.com/openshift/api/operator/v1"
+)
+
+// ConvergedRemoteKeyID returns the unanimous RemoteKeyID across reports when every
+// report carries the same non-empty RemoteKeyID. An empty return value indicates
+// no convergence (empty input, conflicting IDs, or any empty RemoteKeyID).
+// Callers must filter reports to the relevant key ID and ensure the slice
+// includes every expected node before treating a non-empty result as converged.
+func ConvergedRemoteKeyID(reports []operatorv1.KMSPluginHealthReport) string {
+	if len(reports) == 0 {
+		return ""
+	}
+	remoteKeyID := reports[0].RemoteKeyID
+	if remoteKeyID == "" {
+		return ""
+	}
+	for _, report := range reports[1:] {
+		if report.RemoteKeyID != remoteKeyID {
+			return ""
+		}
+	}
+	return remoteKeyID
+}
+
+// ReportsForKeyID returns health reports for the given encryption key ID (kms-{keyID}.sock).
+// During KMS-to-KMS provider migration multiple plugins may report per node; callers use
+// the current write key's keyID so backup/read-only keys are excluded from rotation logic.
+func ReportsForKeyID(reports []operatorv1.KMSPluginHealthReport, keyID string) []operatorv1.KMSPluginHealthReport {
+	filtered := make([]operatorv1.KMSPluginHealthReport, 0, len(reports))
+	for _, report := range reports {
+		if report.KeyID == keyID {
+			filtered = append(filtered, report)
+		}
+	}
+	return filtered
+}

--- a/pkg/operator/encryption/kms/health/convergence_test.go
+++ b/pkg/operator/encryption/kms/health/convergence_test.go
@@ -1,0 +1,77 @@
+package health
+
+import (
+	"testing"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+)
+
+func TestConvergedRemoteKeyID(t *testing.T) {
+	scenarios := []struct {
+		name            string
+		reports         []operatorv1.KMSPluginHealthReport
+		wantRemoteKeyID string
+	}{
+		{
+			name: "unanimous",
+			reports: []operatorv1.KMSPluginHealthReport{
+				{KeyID: "3", RemoteKeyID: "remote-a"},
+				{KeyID: "3", RemoteKeyID: "remote-a"},
+			},
+			wantRemoteKeyID: "remote-a",
+		},
+		{
+			name: "split brain",
+			reports: []operatorv1.KMSPluginHealthReport{
+				{KeyID: "3", RemoteKeyID: "remote-a"},
+				{KeyID: "3", RemoteKeyID: "remote-b"},
+			},
+		},
+		{
+			name: "empty",
+		},
+		{
+			name: "empty remote key id",
+			reports: []operatorv1.KMSPluginHealthReport{
+				{KeyID: "3", RemoteKeyID: ""},
+				{KeyID: "3", RemoteKeyID: ""},
+			},
+		},
+		{
+			name: "mixed empty remote key id",
+			reports: []operatorv1.KMSPluginHealthReport{
+				{KeyID: "3", RemoteKeyID: "remote-a"},
+				{KeyID: "3", RemoteKeyID: ""},
+			},
+		},
+	}
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			got := ConvergedRemoteKeyID(scenario.reports)
+			if got != scenario.wantRemoteKeyID {
+				t.Fatalf("got %q want %q", got, scenario.wantRemoteKeyID)
+			}
+		})
+	}
+}
+
+func TestReportsForKeyID(t *testing.T) {
+	reports := []operatorv1.KMSPluginHealthReport{
+		{KeyID: "3", RemoteKeyID: "a"},
+		{KeyID: "2", RemoteKeyID: "b"},
+		{KeyID: "3", RemoteKeyID: "a"},
+	}
+	want := []operatorv1.KMSPluginHealthReport{
+		{KeyID: "3", RemoteKeyID: "a"},
+		{KeyID: "3", RemoteKeyID: "a"},
+	}
+	filtered := ReportsForKeyID(reports, "3")
+	if len(filtered) != len(want) {
+		t.Fatalf("expected %d reports, got %d", len(want), len(filtered))
+	}
+	for i, report := range filtered {
+		if report.KeyID != want[i].KeyID || report.RemoteKeyID != want[i].RemoteKeyID {
+			t.Fatalf("filtered[%d] = %#v, want %#v", i, report, want[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add health-report convergence helpers to detect a unanimous remote key ID and to filter reports to the current write key.

Enhancement: https://github.com/openshift/enhancements/pull/2041
E2E PR: https://github.com/openshift/cluster-kube-apiserver-operator/pull/2291
Tracking PR: https://github.com/openshift/library-go/pull/2452


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added KMS health reporting support to determine when all reports consistently identify the same non-empty remote encryption key.
  * Added filtering of health reports by encryption key ID for more targeted status analysis.

* **Tests**
  * Added coverage for consistent, conflicting, empty, and incomplete remote key reports.
  * Added validation that key-based filtering returns the complete matching report set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->