### PR TITLE
CNTRLPLANE-3237: kms preflight drift positive path

### DIFF
--- a/test/library/encryption/assertion.go
+++ b/test/library/encryption/assertion.go
@@ -464,18 +464,23 @@ func (o kmsOperatorCR) decodeKMSOperatorStatus(obj map[string]interface{}) (kmsO
 	return status, nil
 }
 
-// AssertKMSPreflightSucceededForOperator asserts KMS preflight passed for the operator owning
-// operatorNamespace. previous is the pre-apply snapshot (see ReadKMSPreflightForOperator).
-func AssertKMSPreflightSucceededForOperator(ctx context.Context, t testing.TB, clientSet ClientSet, operatorNamespace string, previous operatorv1.KMSPreflightCheck) {
+// AssertKMSPreflight asserts KMS preflight passed for the operator owning
+// operatorNamespace, then asserts capturedPreflightPod does not drift from the operand
+// PodSpec. previous is the pre-apply snapshot (see ReadKMSPreflightForOperator);
+// namespace/labelSelector locate the operand pod; capturedPreflightPod comes from
+// StartCapturingLatestPreflightPod started before the config was applied.
+func AssertKMSPreflight(ctx context.Context, t testing.TB, clientSet ClientSet, operatorNamespace, namespace, labelSelector string, previous operatorv1.KMSPreflightCheck, capturedPreflightPod *corev1.Pod) {
 	t.Helper()
 	cr := operatorCRForNamespace(t, operatorNamespace)
-	assertKMSPreflightSucceeded(ctx, t, clientSet.DynamicClient, cr, "cluster", previous)
+	observedConfigHash := assertKMSPreflightSucceeded(ctx, t, clientSet.DynamicClient, cr, "cluster", previous)
+	AssertNoPreflightConfigDriftFromCapture(ctx, t, clientSet, namespace, labelSelector, observedConfigHash, capturedPreflightPod)
 }
 
 // assertKMSPreflightSucceeded asserts preflight passed for the CR's current config: degraded is
 // False, preflight reports Succeeded for the observed config hash, remoteKeyID is set (proving a
-// live KMS check ran), and remoteKeyID advanced when the config changed since previous.
-func assertKMSPreflightSucceeded(ctx context.Context, t testing.TB, dynamicClient dynamic.Interface, cr kmsOperatorCR, name string, previous operatorv1.KMSPreflightCheck) {
+// live KMS check ran), and remoteKeyID advanced when the config changed since previous. It
+// returns the observed config hash the check passed for.
+func assertKMSPreflightSucceeded(ctx context.Context, t testing.TB, dynamicClient dynamic.Interface, cr kmsOperatorCR, name string, previous operatorv1.KMSPreflightCheck) string {
 	t.Helper()
 
 	var preflight operatorv1.KMSPreflightCheck
@@ -501,4 +506,5 @@ func assertKMSPreflightSucceeded(ctx context.Context, t testing.TB, dynamicClien
 		"KMS preflight not confirmed for %s/%s: degradedFalse=%t result.status=%q result.configHash=%q observedConfigHash=%q remoteKeyID=%q (previous observedConfigHash=%q remoteKeyID=%q)",
 		cr.gvr.Resource, name, degradedFalse, preflight.Result.Status, preflight.Result.ConfigHash, preflight.ObservedConfigHash, preflight.Result.RemoteKeyID,
 		previous.ObservedConfigHash, previous.Result.RemoteKeyID)
+	return preflight.ObservedConfigHash
 }

--- a/test/library/encryption/helpers.go
+++ b/test/library/encryption/helpers.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -21,12 +22,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	"github.com/openshift/library-go/pkg/operator/encryption/kms/preflight"
 
 	oauthapiv1 "github.com/openshift/api/oauth/v1"
 	routev1 "github.com/openshift/api/route/v1"
@@ -169,7 +172,7 @@ func GetClients(t testing.TB) ClientSet {
 }
 
 // ReadKMSPreflightForOperator returns the operator's current preflight snapshot (zero when unset).
-// Snapshot it before applying a new KMS config and pass it to AssertKMSPreflightSucceededForOperator
+// Snapshot it before applying a new KMS config and pass it to AssertKMSPreflight
 // to confirm a fresh preflight ran for that config.
 func ReadKMSPreflightForOperator(ctx context.Context, t testing.TB, clientSet ClientSet, operatorNamespace string) (operatorv1.KMSPreflightCheck, error) {
 	t.Helper()
@@ -758,4 +761,41 @@ func allTargetGRsMigrated(keyMeta EncryptionKeyMeta, targetGRs []schema.GroupRes
 		}
 	}
 	return true
+}
+
+// StartCapturingLatestPreflightPod watches the preflight pod by name and keeps the
+// latest ADDED/MODIFIED version (UID-locked so a stale pod reusing the name cannot
+// pollute the capture) in an atomic.Pointer. The operator reaps the pod on success,
+// so start this before applying the KMS config; the watch runs until ctx is cancelled.
+func StartCapturingLatestPreflightPod(ctx context.Context, t testing.TB, clientSet ClientSet, namespace string) *atomic.Pointer[corev1.Pod] {
+	t.Helper()
+	w, err := clientSet.Kube.CoreV1().Pods(namespace).Watch(ctx, metav1.ListOptions{FieldSelector: "metadata.name=" + preflight.PodName})
+	require.NoError(t, err)
+	t.Logf("capturing preflight pod %s/%s", namespace, preflight.PodName)
+
+	captured := &atomic.Pointer[corev1.Pod]{}
+	go func() {
+		defer w.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case ev, ok := <-w.ResultChan():
+				if !ok {
+					return
+				}
+				pod, isPod := ev.Object.(*corev1.Pod)
+				if !isPod || (ev.Type != watch.Added && ev.Type != watch.Modified) {
+					continue
+				}
+				if prev := captured.Load(); prev != nil && ev.Type == watch.Modified && prev.UID != pod.UID {
+					continue
+				}
+				captured.Store(pod)
+				t.Logf("captured preflight pod %s/%s (%s, uid=%s, rv=%s, phase=%s)",
+					pod.Namespace, pod.Name, ev.Type, pod.UID, pod.ResourceVersion, pod.Status.Phase)
+			}
+		}
+	}()
+	return captured
 }

--- a/test/library/encryption/helpers.go
+++ b/test/library/encryption/helpers.go
@@ -766,15 +766,23 @@ func allTargetGRsMigrated(keyMeta EncryptionKeyMeta, targetGRs []schema.GroupRes
 // StartCapturingLatestPreflightPod watches the preflight pod by name and keeps the
 // latest ADDED/MODIFIED version (UID-locked so a stale pod reusing the name cannot
 // pollute the capture) in an atomic.Pointer. The operator reaps the pod on success,
-// so start this before applying the KMS config; the watch runs until ctx is cancelled.
-func StartCapturingLatestPreflightPod(ctx context.Context, t testing.TB, clientSet ClientSet, namespace string) *atomic.Pointer[corev1.Pod] {
+// so start this before applying the KMS config. stop cancels the watch and blocks
+// until the goroutine exits, so the pointer can be read without racing a Store; it
+// is idempotent.
+func StartCapturingLatestPreflightPod(ctx context.Context, t testing.TB, clientSet ClientSet, namespace string) (*atomic.Pointer[corev1.Pod], func()) {
 	t.Helper()
+	ctx, cancel := context.WithCancel(ctx)
 	w, err := clientSet.Kube.CoreV1().Pods(namespace).Watch(ctx, metav1.ListOptions{FieldSelector: "metadata.name=" + preflight.PodName})
-	require.NoError(t, err)
+	if err != nil {
+		cancel()
+		require.NoError(t, err)
+	}
 	t.Logf("capturing preflight pod %s/%s", namespace, preflight.PodName)
 
 	captured := &atomic.Pointer[corev1.Pod]{}
+	done := make(chan struct{})
 	go func() {
+		defer close(done)
 		defer w.Stop()
 		for {
 			select {
@@ -797,5 +805,10 @@ func StartCapturingLatestPreflightPod(ctx context.Context, t testing.TB, clientS
 			}
 		}
 	}()
-	return captured
+
+	stop := func() {
+		cancel()
+		<-done
+	}
+	return captured, stop
 }

--- a/test/library/encryption/preflight_drift.go
+++ b/test/library/encryption/preflight_drift.go
@@ -13,6 +13,11 @@ import (
 	"github.com/openshift/library-go/pkg/operator/encryption/kms/preflight"
 )
 
+// preflightConfigHashAnnotation mirrors the unexported annotation the preflight
+// deployer stamps on the pod. Annotation keys are a stable contract, so the test
+// duplicates it rather than exporting it from the production package.
+const preflightConfigHashAnnotation = "encryption.apiserver.operator.openshift.io/kms-preflight-config-hash"
+
 // DefaultPreflightPodSpecDriftIgnore lists PodSpec field names skipped by
 // AssertNoPreflightConfigDrift via cmpopts.IgnoreFields. Unknown diffs outside
 // this list fail the drift check.
@@ -68,6 +73,21 @@ func AssertNoPreflightConfigDrift(ctx context.Context, t testing.TB, clientSet C
 
 	preflightPod, err := clientSet.Kube.CoreV1().Pods(namespace).Get(ctx, preflight.PodName, metav1.GetOptions{})
 	require.NoError(t, err, "preflight pod %s/%s", namespace, preflight.PodName)
+
+	targetPod := findAnyOperandPod(ctx, t, clientSet, namespace, labelSelector)
+	require.NotNil(t, targetPod, "no Running pod in %s matching %q", namespace, labelSelector)
+
+	assertNoPodSpecDrift(t, targetPod, preflightPod, DefaultPreflightPodSpecDriftIgnore...)
+}
+
+// AssertNoPreflightConfigDriftFromCapture runs the PodSpec drift check against a
+// pod recorded by StartCapturingLatestPreflightPod, for use on the positive path where
+// the operator reaps the pod on success. preflightPod must carry expectedConfigHash,
+// proving the diff is against the pod deployed for the config under test.
+func AssertNoPreflightConfigDriftFromCapture(ctx context.Context, t testing.TB, clientSet ClientSet, namespace, labelSelector, expectedConfigHash string, preflightPod *corev1.Pod) {
+	t.Helper()
+	require.NotNil(t, preflightPod, "no preflight pod captured")
+	require.Equal(t, expectedConfigHash, preflightPod.Annotations[preflightConfigHashAnnotation], "captured preflight pod config-hash annotation")
 
 	targetPod := findAnyOperandPod(ctx, t, clientSet, namespace, labelSelector)
 	require.NotNil(t, targetPod, "no Running pod in %s matching %q", namespace, labelSelector)

--- a/test/library/encryption/preflight_drift.go
+++ b/test/library/encryption/preflight_drift.go
@@ -72,12 +72,19 @@ func AssertNoPreflightConfigDrift(ctx context.Context, t testing.TB, clientSet C
 	targetPod := findAnyOperandPod(ctx, t, clientSet, namespace, labelSelector)
 	require.NotNil(t, targetPod, "no Running pod in %s matching %q", namespace, labelSelector)
 
-	diff := cmp.Diff(&targetPod.Spec, &preflightPod.Spec,
-		cmpopts.IgnoreFields(corev1.PodSpec{}, DefaultPreflightPodSpecDriftIgnore...),
+	assertNoPodSpecDrift(t, targetPod, preflightPod, DefaultPreflightPodSpecDriftIgnore...)
+}
+
+// assertNoPodSpecDrift fails if cmp.Diff reports PodSpec drift between operand and
+// preflightPod outside ignoreFields.
+func assertNoPodSpecDrift(t testing.TB, operand, preflightPod *corev1.Pod, ignoreFields ...string) {
+	t.Helper()
+	diff := cmp.Diff(&operand.Spec, &preflightPod.Spec,
+		cmpopts.IgnoreFields(corev1.PodSpec{}, ignoreFields...),
 		cmpopts.EquateEmpty(),
 	)
 	require.Empty(t, diff, "preflight pod %s/%s drifted from target %s/%s:\n%s",
-		preflightPod.Namespace, preflightPod.Name, targetPod.Namespace, targetPod.Name, diff)
+		preflightPod.Namespace, preflightPod.Name, operand.Namespace, operand.Name, diff)
 }
 
 // findAnyOperandPod returns any Running pod matching labelSelector.

--- a/test/library/encryption/scenarios.go
+++ b/test/library/encryption/scenarios.go
@@ -81,11 +81,10 @@ func TestEncryptionTypeKMS(ctx context.Context, t testing.TB, scenario BasicScen
 	require.NoError(e, err)
 	// Capture the preflight pod as the operator creates it; on success the operator reaps it,
 	// so it cannot be fetched live afterwards for the PodSpec drift check below.
-	captureCtx, cancelCapture := context.WithCancel(ctx)
-	defer cancelCapture()
-	capturedPreflightPod := StartCapturingLatestPreflightPod(captureCtx, e, GetClients(e), scenario.Namespace)
+	capturedPreflightPod, stopCapture := StartCapturingLatestPreflightPod(ctx, e, GetClients(e), scenario.Namespace)
+	defer stopCapture()
 	clientSet := SetAndWaitForEncryptionType(ctx, e, provider, scenario.TargetGRs, scenario.Namespace, scenario.LabelSelector)
-	cancelCapture() // preflight has run and its pod is captured; stop the watch
+	stopCapture() // preflight has run; join the watch before reading the capture
 	scenario.AssertFunc(e, clientSet, provider.Type, scenario.Namespace, scenario.LabelSelector)
 	AssertEncryptionConfig(e, clientSet, scenario.EncryptionConfigSecretName, scenario.EncryptionConfigSecretNamespace, scenario.TargetGRs)
 	AssertKMSPreflight(ctx, e, clientSet, scenario.OperatorNamespace, scenario.Namespace, scenario.LabelSelector, previousPreflightStatus, capturedPreflightPod.Load())

--- a/test/library/encryption/scenarios.go
+++ b/test/library/encryption/scenarios.go
@@ -77,12 +77,18 @@ func TestEncryptionTypeKMS(ctx context.Context, t testing.TB, scenario BasicScen
 	e := NewE(t, PrintEventsOnFailure(scenario.OperatorNamespace))
 	// Snapshot preflight before applying the new config so the assertion can confirm a fresh
 	// preflight ran for it (the remote key id advances when the config genuinely changes).
-	previousPreflight, err := ReadKMSPreflightForOperator(ctx, e, GetClients(e), scenario.OperatorNamespace)
+	previousPreflightStatus, err := ReadKMSPreflightForOperator(ctx, e, GetClients(e), scenario.OperatorNamespace)
 	require.NoError(e, err)
+	// Capture the preflight pod as the operator creates it; on success the operator reaps it,
+	// so it cannot be fetched live afterwards for the PodSpec drift check below.
+	captureCtx, cancelCapture := context.WithCancel(ctx)
+	defer cancelCapture()
+	capturedPreflightPod := StartCapturingLatestPreflightPod(captureCtx, e, GetClients(e), scenario.Namespace)
 	clientSet := SetAndWaitForEncryptionType(ctx, e, provider, scenario.TargetGRs, scenario.Namespace, scenario.LabelSelector)
+	cancelCapture() // preflight has run and its pod is captured; stop the watch
 	scenario.AssertFunc(e, clientSet, provider.Type, scenario.Namespace, scenario.LabelSelector)
 	AssertEncryptionConfig(e, clientSet, scenario.EncryptionConfigSecretName, scenario.EncryptionConfigSecretNamespace, scenario.TargetGRs)
-	AssertKMSPreflightSucceededForOperator(ctx, e, clientSet, scenario.OperatorNamespace, previousPreflight)
+	AssertKMSPreflight(ctx, e, clientSet, scenario.OperatorNamespace, scenario.Namespace, scenario.LabelSelector, previousPreflightStatus, capturedPreflightPod.Load())
 }
 
 func TestEncryptionType(ctx context.Context, t testing.TB, scenario BasicScenario, provider EncryptionProvider) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved KMS encryption scenario validation by capturing preflight pod information during configuration.
  - Added checks for configuration drift between the KMS preflight pod and the running operand.
  - Validation now covers operator-specific status paths, preflight status transitions, pod details, namespace, and label selection.
  - Added safeguards to ensure captured preflight information remains current and is validated consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->