### PR TITLE
NO-JIRA: add RemoteKeyState to KMSState

### DIFF
--- a/pkg/operator/encryption/secrets/types.go
+++ b/pkg/operator/encryption/secrets/types.go
@@ -67,6 +67,18 @@ const (
 	// values fetched from the referenced configmap in openshift-config. The full data key is
 	// constructed as prefix + configMapName + separator + dataKey.
 	encryptionSecretKMSConfigMapDataPrefix = "encryption.apiserver.operator.openshift.io-kms-plugin-configmap-"
+
+	// encryptionSecretTargetRemoteKeyID is the target remote KMS key ID to migrate toward.
+	encryptionSecretTargetRemoteKeyID = "encryption.apiserver.operator.openshift.io/target-remote-key-id"
+
+	// encryptionSecretMigratedRemoteKeyID is the last fully migrated remote KMS key ID.
+	encryptionSecretMigratedRemoteKeyID = "encryption.apiserver.operator.openshift.io/migrated-remote-key-id"
+
+	// encryptionSecretRemoteKeyConvergedAt records when a candidate remote key ID first achieved cluster convergence.
+	encryptionSecretRemoteKeyConvergedAt = "encryption.apiserver.operator.openshift.io/remote-key-converged-at"
+
+	// encryptionSecretRemoteKeyConvergedID is the candidate remote key ID the converged-at timestamp belongs to.
+	encryptionSecretRemoteKeyConvergedID = "encryption.apiserver.operator.openshift.io/remote-key-converged-id"
 )
 
 // MigratedGroupResources is the data structured stored in the

--- a/pkg/operator/encryption/state/types.go
+++ b/pkg/operator/encryption/state/types.go
@@ -68,6 +68,32 @@ func (k *KeyState) HasKMSConfigMapData() bool {
 	return k != nil && k.KMS != nil && len(k.KMS.PluginConfigMapData.entries) > 0
 }
 
+// RemoteKey returns the remote key rotation state. Non-KMS keys have no remote key.
+func (k *KeyState) RemoteKey() RemoteKeyState {
+	if k == nil || k.KMS == nil {
+		return RemoteKeyState{}
+	}
+	return k.KMS.RemoteKey
+}
+
+// RemoteKeyState is the in-memory view of remote key rotation annotations.
+type RemoteKeyState struct {
+	// TargetRemoteKeyID is the target remote KMS key ID to migrate toward.
+	// Will be empty before successful preflight, otherwise it is always set to what health check observes.
+	TargetRemoteKeyID string
+	// MigratedRemoteKeyID is the last fully migrated remote KMS key ID. Meaning it is empty until the first
+	// SVM ran successfully.
+	MigratedRemoteKeyID string
+	// ConvergedAt records when a candidate remote key ID first achieved cluster convergence. This is used to determine
+	// when the five-minute grace period for apiservers start. Only non-zero when a new target remote key was observed
+	// across all health reports.
+	ConvergedAt time.Time
+	// ConvergedID is the candidate remote key ID the converged-at timestamp belongs to. This is used to track what remote
+	// key triggered the convergence timer. This is used to determine whether the remote key was changed during the convergence.
+	// Only non-empty when a new target remote key was observed across all health reports.
+	ConvergedID string
+}
+
 // KMSState stores all KMS encryption mode related configurations
 type KMSState struct {
 	// Encoded EncryptionConfig that stores the KMS related fields
@@ -81,6 +107,9 @@ type KMSState struct {
 
 	// PluginConfigMapData stores data key-value pairs fetched from referenced configmaps.
 	PluginConfigMapData KMSReferenceData
+
+	// RemoteKey tracks KMS remote key rotation annotations on the backing secret.
+	RemoteKey RemoteKeyState
 }
 
 // KMSReferenceData stores data key-value pairs fetched from referenced secrets or configmaps.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added visibility into remote KMS key rotation progress, including target keys, migrated keys, convergence timestamps, and converged key identifiers.
  - Improved encryption state reporting for KMS-managed keys, making migration progress easier to monitor.
  - Non-KMS keys continue to be handled safely without exposing remote-key migration details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->