### PR TITLE
NO-JIRA: kms rotation: add read/write helpers for remote key secret annotations

### DIFF
--- a/pkg/operator/encryption/secrets/remote_key.go
+++ b/pkg/operator/encryption/secrets/remote_key.go
@@ -1,0 +1,65 @@
+package secrets
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/openshift/library-go/pkg/operator/encryption/state"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// ReadRemoteKeyStateFromSecret reads remote key rotation annotations from a key secret.
+func ReadRemoteKeyStateFromSecret(s *corev1.Secret) (state.RemoteKeyState, error) {
+	if s == nil {
+		return state.RemoteKeyState{}, nil
+	}
+	annotations := s.Annotations
+	rk := state.RemoteKeyState{
+		TargetRemoteKeyID:   annotations[encryptionSecretTargetRemoteKeyID],
+		MigratedRemoteKeyID: annotations[encryptionSecretMigratedRemoteKeyID],
+		ConvergedID:         annotations[encryptionSecretRemoteKeyConvergedID],
+	}
+	if v, ok := annotations[encryptionSecretRemoteKeyConvergedAt]; ok && len(v) > 0 {
+		ts, err := time.Parse(time.RFC3339, v)
+		if err != nil {
+			return state.RemoteKeyState{}, fmt.Errorf("secret %s/%s has invalid %s annotation: %v", s.Namespace, s.Name, encryptionSecretRemoteKeyConvergedAt, err)
+		}
+		rk.ConvergedAt = ts
+	}
+
+	if err := rk.Validate(); err != nil {
+		return state.RemoteKeyState{}, fmt.Errorf("secret %s/%s is invalid %s", s.Namespace, s.Name, err)
+	}
+
+	return rk, nil
+}
+
+// applyRemoteKeyAnnotations writes remote key rotation annotations into the given map.
+// Empty values remove the corresponding annotation keys. Returns an error when the remote key state is invalid
+func applyRemoteKeyAnnotations(annotations map[string]string, rk state.RemoteKeyState) error {
+	if err := rk.Validate(); err != nil {
+		return err
+	}
+
+	delete(annotations, encryptionSecretTargetRemoteKeyID)
+	if rk.TargetRemoteKeyID != "" {
+		annotations[encryptionSecretTargetRemoteKeyID] = rk.TargetRemoteKeyID
+	}
+
+	delete(annotations, encryptionSecretMigratedRemoteKeyID)
+	if rk.MigratedRemoteKeyID != "" {
+		annotations[encryptionSecretMigratedRemoteKeyID] = rk.MigratedRemoteKeyID
+	}
+
+	delete(annotations, encryptionSecretRemoteKeyConvergedID)
+	if rk.ConvergedID != "" {
+		annotations[encryptionSecretRemoteKeyConvergedID] = rk.ConvergedID
+	}
+
+	delete(annotations, encryptionSecretRemoteKeyConvergedAt)
+	if !rk.ConvergedAt.IsZero() {
+		annotations[encryptionSecretRemoteKeyConvergedAt] = rk.ConvergedAt.Format(time.RFC3339)
+	}
+
+	return nil
+}

--- a/pkg/operator/encryption/secrets/remote_key_test.go
+++ b/pkg/operator/encryption/secrets/remote_key_test.go
@@ -1,0 +1,117 @@
+package secrets
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/library-go/pkg/operator/encryption/state"
+)
+
+func TestReadRemoteKeyAnnotations(t *testing.T) {
+	ts := time.Date(2026, 8, 31, 10, 0, 0, 0, time.UTC)
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "openshift-config-managed",
+			Name:      "encryption-key-test-1",
+			Annotations: map[string]string{
+				encryptionSecretTargetRemoteKeyID:    "remote-old",
+				encryptionSecretMigratedRemoteKeyID:  "remote-old",
+				encryptionSecretRemoteKeyConvergedID: "remote-new",
+				encryptionSecretRemoteKeyConvergedAt: ts.Format(time.RFC3339),
+			},
+		},
+	}
+
+	got, err := ReadRemoteKeyStateFromSecret(secret)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.TargetRemoteKeyID != "remote-old" || got.MigratedRemoteKeyID != "remote-old" {
+		t.Fatalf("unexpected ids: %#v", got)
+	}
+	if got.ConvergedID != "remote-new" || !got.ConvergedAt.Equal(ts) {
+		t.Fatalf("unexpected convergence: %#v", got)
+	}
+}
+
+func TestReadRemoteKeyAnnotationsInvalidConvergence(t *testing.T) {
+	tests := []struct {
+		name      string
+		id        string
+		at        time.Time
+		expectErr bool
+	}{
+		{name: "both default", id: "", at: time.Time{}, expectErr: false},
+		{name: "only id", id: "id", at: time.Time{}, expectErr: true},
+		{name: "only time", id: "", at: time.Now(), expectErr: true},
+		{name: "both set", id: "id", at: time.Now(), expectErr: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "openshift-config-managed",
+					Name:      "encryption-key-test-1",
+					Annotations: map[string]string{
+						encryptionSecretRemoteKeyConvergedID: tt.id,
+						encryptionSecretRemoteKeyConvergedAt: tt.at.Format(time.RFC3339),
+					},
+				},
+			}
+
+			_, err := ReadRemoteKeyStateFromSecret(secret)
+			if tt.expectErr && err == nil {
+				t.Errorf("expected error but got nil")
+			} else if !tt.expectErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestInvalidRemoteKeyAnnotationBeforeSetting(t *testing.T) {
+	err := applyRemoteKeyAnnotations(make(map[string]string), state.RemoteKeyState{
+		ConvergedAt: time.Time{},
+		ConvergedID: "1337",
+	})
+	if err == nil {
+		t.Errorf("expected error but got nil")
+	}
+}
+
+func TestApplyRemoteKeyAnnotations(t *testing.T) {
+	now := time.Now()
+	nowStr := now.Format(time.RFC3339)
+	annotations := map[string]string{
+		encryptionSecretTargetRemoteKeyID:    "remove",
+		encryptionSecretMigratedRemoteKeyID:  "keep",
+		encryptionSecretRemoteKeyConvergedID: "old",
+		encryptionSecretRemoteKeyConvergedAt: nowStr,
+	}
+	err := applyRemoteKeyAnnotations(annotations, state.RemoteKeyState{
+		TargetRemoteKeyID:   "", // should remove
+		MigratedRemoteKeyID: "keep",
+		ConvergedAt:         now,
+		// updated with a new key
+		ConvergedID: "new-key",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := annotations[encryptionSecretTargetRemoteKeyID]; ok {
+		t.Fatal("expected target annotation to be removed")
+	}
+	if annotations[encryptionSecretMigratedRemoteKeyID] != "keep" {
+		t.Fatalf("expected annotation %s to stay", encryptionSecretMigratedRemoteKeyID)
+	}
+	if annotations[encryptionSecretRemoteKeyConvergedID] != "new-key" {
+		t.Fatalf("expected annotation %s to update", encryptionSecretRemoteKeyConvergedID)
+	}
+	if annotations[encryptionSecretRemoteKeyConvergedAt] != nowStr {
+		t.Fatalf("expected annotation %s to stay", encryptionSecretRemoteKeyConvergedAt)
+	}
+}

--- a/pkg/operator/encryption/secrets/secrets.go
+++ b/pkg/operator/encryption/secrets/secrets.go
@@ -88,6 +88,13 @@ func ToKeyState(s *corev1.Secret) (state.KeyState, error) {
 			// encryption mode.
 			return state.KeyState{}, fmt.Errorf("%s can not be empty, when mode is KMS", encryptionSecretKMSPluginConfig)
 		}
+
+		remoteKey, err := ReadRemoteKeyStateFromSecret(s)
+		if err != nil {
+			return state.KeyState{}, err
+		}
+		key.KMS.RemoteKey = remoteKey
+
 		for dataKey, value := range s.Data {
 			rawKey, found := strings.CutPrefix(dataKey, encryptionSecretKMSSecretDataPrefix)
 			if !found {
@@ -176,6 +183,10 @@ func FromKeyState(component string, ks state.KeyState) (*corev1.Secret, error) {
 			return nil, err
 		}
 		s.Data[encryptionSecretKMSPluginConfig] = pluginData
+	}
+
+	if err := applyRemoteKeyAnnotations(s.Annotations, ks.RemoteKey()); err != nil {
+		return nil, err
 	}
 
 	if ks.HasKMSSecretData() {

--- a/pkg/operator/encryption/secrets/secrets_test.go
+++ b/pkg/operator/encryption/secrets/secrets_test.go
@@ -151,6 +151,10 @@ func TestRoundtrip(t *testing.T) {
 						Timeout:    &metav1.Duration{Duration: 10 * time.Second},
 					},
 					Plugin: defaultKMSPluginConfig,
+					RemoteKey: state.RemoteKeyState{
+						TargetRemoteKeyID:   "remote-new",
+						MigratedRemoteKeyID: "remote-old",
+					},
 				},
 				Migrated: state.MigrationState{
 					Timestamp: now,

--- a/pkg/operator/encryption/state/types.go
+++ b/pkg/operator/encryption/state/types.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -92,6 +93,14 @@ type RemoteKeyState struct {
 	// key triggered the convergence timer. This is used to determine whether the remote key was changed during the convergence.
 	// Only non-empty when a new target remote key was observed across all health reports.
 	ConvergedID string
+}
+
+// Validate checks whether the remote key state is coherent. Returns a descriptive error when it is not.
+func (rk RemoteKeyState) Validate() error {
+	if rk.ConvergedAt.IsZero() != (rk.ConvergedID == "") {
+		return errors.New("RemoteKeyState requires convergedAt and convergedId both set, or default")
+	}
+	return nil
 }
 
 // KMSState stores all KMS encryption mode related configurations


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Remote encryption key rotation state is now preserved with KMS secrets.
  - Remote key identifiers and convergence timestamps are restored when reading secret configuration and saved when generating secrets.

- **Bug Fixes**
  - Invalid rotation timestamps and inconsistent convergence details are now reported as errors instead of being silently ignored.
  - Empty remote key values now correctly clear previously stored rotation annotations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->