### PR TITLE
NO-JIRA: Add downstream apiserver operator Dockerfiles for CI vendor testing

### DIFF
--- a/openshift-ci/downstream-kms/Dockerfile.cluster-authentication-operator
+++ b/openshift-ci/downstream-kms/Dockerfile.cluster-authentication-operator
@@ -1,0 +1,22 @@
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS builder
+WORKDIR /go/src/github.com/openshift/library-go
+COPY . .
+
+WORKDIR /go/src/github.com/openshift/cluster-authentication-operator
+RUN git clone --branch master --single-branch https://github.com/openshift/cluster-authentication-operator.git . \
+    && go mod edit -replace github.com/openshift/library-go=/go/src/github.com/openshift/library-go \
+    && go mod tidy \
+    && go mod vendor
+
+ARG TAGS=ocp
+ENV GO_PACKAGE=github.com/openshift/cluster-authentication-operator
+RUN go build -ldflags "-X $GO_PACKAGE/pkg/version.versionFromGit=$(git describe --long --tags --abbrev=7 --match 'v[0-9]*' 2>/dev/null || echo downstream-kms-test)" -tags="${TAGS}" -o authentication-operator ./cmd/authentication-operator
+RUN GO_BUILD_PACKAGES=./cmd/cluster-authentication-operator-tests-ext make build --warn-undefined-variables \
+    && gzip cluster-authentication-operator-tests-ext
+
+FROM registry.ci.openshift.org/ocp/5.0:base-rhel9
+COPY --from=builder /go/src/github.com/openshift/cluster-authentication-operator/authentication-operator /usr/bin/
+COPY --from=builder /go/src/github.com/openshift/cluster-authentication-operator/cluster-authentication-operator-tests-ext.gz /usr/bin/
+COPY --from=builder /go/src/github.com/openshift/cluster-authentication-operator/manifests /manifests
+ENTRYPOINT ["/usr/bin/authentication-operator"]
+LABEL io.openshift.release.operator=true

--- a/openshift-ci/downstream-kms/Dockerfile.cluster-kube-apiserver-operator
+++ b/openshift-ci/downstream-kms/Dockerfile.cluster-kube-apiserver-operator
@@ -1,0 +1,25 @@
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS builder
+WORKDIR /go/src/github.com/openshift/library-go
+COPY . .
+
+WORKDIR /go/src/github.com/openshift/cluster-kube-apiserver-operator
+RUN git clone --branch main --single-branch https://github.com/openshift/cluster-kube-apiserver-operator.git . \
+    && go mod edit -replace github.com/openshift/library-go=/go/src/github.com/openshift/library-go \
+    && go mod tidy \
+    && go mod vendor
+
+ENV GO_PACKAGE=github.com/openshift/cluster-kube-apiserver-operator
+RUN make build --warn-undefined-variables \
+    && gzip cluster-kube-apiserver-operator-tests-ext
+
+FROM registry.ci.openshift.org/ocp/5.0:base-rhel9
+COPY --from=builder /go/src/github.com/openshift/cluster-kube-apiserver-operator/bindata/bootkube/bootstrap-manifests /usr/share/bootkube/manifests/bootstrap-manifests/
+COPY --from=builder /go/src/github.com/openshift/cluster-kube-apiserver-operator/bindata/bootkube/config /usr/share/bootkube/manifests/config/
+COPY --from=builder /go/src/github.com/openshift/cluster-kube-apiserver-operator/bindata/bootkube/manifests /usr/share/bootkube/manifests/manifests/
+COPY --from=builder /go/src/github.com/openshift/cluster-kube-apiserver-operator/bindata/bootkube/scc-manifests /usr/share/bootkube/manifests/manifests/
+COPY --from=builder /go/src/github.com/openshift/cluster-kube-apiserver-operator/vendor/github.com/openshift/api/apiserver/v1/zz_generated.crd-manifests/kube-apiserver_apirequestcounts.crd.yaml /usr/share/bootkube/manifests/manifests/
+COPY --from=builder /go/src/github.com/openshift/cluster-kube-apiserver-operator/cluster-kube-apiserver-operator /usr/bin/
+COPY --from=builder /go/src/github.com/openshift/cluster-kube-apiserver-operator/cluster-kube-apiserver-operator-tests-ext.gz /usr/bin/
+COPY --from=builder /go/src/github.com/openshift/cluster-kube-apiserver-operator/manifests /manifests
+COPY --from=builder /go/src/github.com/openshift/cluster-kube-apiserver-operator/bindata/bootkube/scc-manifests /manifests
+LABEL io.openshift.release.operator=true

--- a/openshift-ci/downstream-kms/Dockerfile.cluster-openshift-apiserver-operator
+++ b/openshift-ci/downstream-kms/Dockerfile.cluster-openshift-apiserver-operator
@@ -1,0 +1,19 @@
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS builder
+WORKDIR /go/src/github.com/openshift/library-go
+COPY . .
+
+WORKDIR /go/src/github.com/openshift/cluster-openshift-apiserver-operator
+RUN git clone --branch main --single-branch https://github.com/openshift/cluster-openshift-apiserver-operator.git . \
+    && go mod edit -replace github.com/openshift/library-go=/go/src/github.com/openshift/library-go \
+    && go mod tidy \
+    && go mod vendor
+
+RUN GODEBUG=tls13=1 make build \
+    && make tests-ext-build \
+    && gzip cluster-openshift-apiserver-operator-tests-ext
+
+FROM registry.ci.openshift.org/ocp/5.0:base-rhel9
+COPY --from=builder /go/src/github.com/openshift/cluster-openshift-apiserver-operator/cluster-openshift-apiserver-operator /usr/bin/
+COPY --from=builder /go/src/github.com/openshift/cluster-openshift-apiserver-operator/cluster-openshift-apiserver-operator-tests-ext.gz /usr/bin/
+COPY --from=builder /go/src/github.com/openshift/cluster-openshift-apiserver-operator/manifests /manifests
+LABEL io.openshift.release.operator=true


### PR DESCRIPTION
These build cluster-authentication-operator, cluster-kube-apiserver-operator, and cluster-openshift-apiserver-operator images with the current library-go checkout vendored in via a local go.mod replace, so a library-go PR can exercise the real downstream e2e-aws-operator-encryption-kms test suites before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added container build configurations for the Cluster Authentication, Cluster Kube API Server, and Cluster OpenShift API Server Operators.
  * Built operator runtime images with their required manifests and test assets.
  * Standardized these images on a RHEL 9-based runtime and marked them as release operator images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->