### PR TITLE
WIP: CNTRLPLANE-3237: kms preflight drift positive path

### DIFF
--- a/test/library/encryption/assertion.go
+++ b/test/library/encryption/assertion.go
@@ -464,18 +464,23 @@ func (o kmsOperatorCR) decodeKMSOperatorStatus(obj map[string]interface{}) (kmsO
 	return status, nil
 }
 
-// AssertKMSPreflightSucceededForOperator asserts KMS preflight passed for the operator owning
-// operatorNamespace. previous is the pre-apply snapshot (see ReadKMSPreflightForOperator).
-func AssertKMSPreflightSucceededForOperator(ctx context.Context, t testing.TB, clientSet ClientSet, operatorNamespace string, previous operatorv1.KMSPreflightCheck) {
+// AssertKMSPreflight asserts KMS preflight passed for the operator owning
+// operatorNamespace, then asserts capturedPreflightPod does not drift from the operand
+// PodSpec. previous is the pre-apply snapshot (see ReadKMSPreflightForOperator);
+// namespace/labelSelector locate the operand pod; capturedPreflightPod comes from
+// StartCapturingLatestPreflightPod started before the config was applied.
+func AssertKMSPreflight(ctx context.Context, t testing.TB, clientSet ClientSet, operatorNamespace, namespace, labelSelector string, previous operatorv1.KMSPreflightCheck, capturedPreflightPod *corev1.Pod) {
 	t.Helper()
 	cr := operatorCRForNamespace(t, operatorNamespace)
-	assertKMSPreflightSucceeded(ctx, t, clientSet.DynamicClient, cr, "cluster", previous)
+	observedConfigHash := assertKMSPreflightSucceeded(ctx, t, clientSet.DynamicClient, cr, "cluster", previous)
+	AssertNoPreflightConfigDriftFromCapture(ctx, t, clientSet, namespace, labelSelector, observedConfigHash, capturedPreflightPod)
 }
 
 // assertKMSPreflightSucceeded asserts preflight passed for the CR's current config: degraded is
 // False, preflight reports Succeeded for the observed config hash, remoteKeyID is set (proving a
-// live KMS check ran), and remoteKeyID advanced when the config changed since previous.
-func assertKMSPreflightSucceeded(ctx context.Context, t testing.TB, dynamicClient dynamic.Interface, cr kmsOperatorCR, name string, previous operatorv1.KMSPreflightCheck) {
+// live KMS check ran), and remoteKeyID advanced when the config changed since previous. It
+// returns the observed config hash the check passed for.
+func assertKMSPreflightSucceeded(ctx context.Context, t testing.TB, dynamicClient dynamic.Interface, cr kmsOperatorCR, name string, previous operatorv1.KMSPreflightCheck) string {
 	t.Helper()
 
 	var preflight operatorv1.KMSPreflightCheck
@@ -501,4 +506,5 @@ func assertKMSPreflightSucceeded(ctx context.Context, t testing.TB, dynamicClien
 		"KMS preflight not confirmed for %s/%s: degradedFalse=%t result.status=%q result.configHash=%q observedConfigHash=%q remoteKeyID=%q (previous observedConfigHash=%q remoteKeyID=%q)",
 		cr.gvr.Resource, name, degradedFalse, preflight.Result.Status, preflight.Result.ConfigHash, preflight.ObservedConfigHash, preflight.Result.RemoteKeyID,
 		previous.ObservedConfigHash, previous.Result.RemoteKeyID)
+	return preflight.ObservedConfigHash
 }

--- a/test/library/encryption/helpers.go
+++ b/test/library/encryption/helpers.go
@@ -784,22 +784,54 @@ func StartCapturingLatestPreflightPod(ctx context.Context, t testing.TB, clientS
 	go func() {
 		defer close(done)
 		defer w.Stop()
+
+		// snapshot renders the current capture for diagnostic logs so a CI failure
+		// ("no preflight pod captured") is self-explanatory from the log alone.
+		snapshot := func() string {
+			if p := captured.Load(); p != nil {
+				return fmt.Sprintf("uid=%s rv=%s phase=%s", p.UID, p.ResourceVersion, p.Status.Phase)
+			}
+			return "<none>"
+		}
+
+		var events, stores int
 		for {
 			select {
 			case <-ctx.Done():
+				t.Logf("preflight pod capture: watch stopped via context after %d events, %d stored (captured=%s)",
+					events, stores, snapshot())
 				return
 			case ev, ok := <-w.ResultChan():
 				if !ok {
+					// The apiserver closes watches routinely (request timeout, apiserver
+					// rollout). This watch is NOT re-established, so anything created after
+					// this point is never captured -- the likely cause of an empty capture.
+					t.Logf("preflight pod capture: WATCH CHANNEL CLOSED after %d events, %d stored (captured=%s) -- watch is not re-established",
+						events, stores, snapshot())
 					return
 				}
+				events++
+				if ev.Type == watch.Error {
+					t.Logf("preflight pod capture: watch ERROR event (#%d): %#v", events, ev.Object)
+					continue
+				}
 				pod, isPod := ev.Object.(*corev1.Pod)
-				if !isPod || (ev.Type != watch.Added && ev.Type != watch.Modified) {
+				if !isPod {
+					t.Logf("preflight pod capture: skipping %s event (#%d) with non-pod object %T", ev.Type, events, ev.Object)
+					continue
+				}
+				if ev.Type != watch.Added && ev.Type != watch.Modified {
+					t.Logf("preflight pod capture: skipping %s event (#%d) for %s/%s (uid=%s, phase=%s)",
+						ev.Type, events, pod.Namespace, pod.Name, pod.UID, pod.Status.Phase)
 					continue
 				}
 				if prev := captured.Load(); prev != nil && ev.Type == watch.Modified && prev.UID != pod.UID {
+					t.Logf("preflight pod capture: ignoring MODIFIED event (#%d) for stale uid=%s (captured uid=%s)",
+						events, pod.UID, prev.UID)
 					continue
 				}
 				captured.Store(pod)
+				stores++
 				t.Logf("captured preflight pod %s/%s (%s, uid=%s, rv=%s, phase=%s)",
 					pod.Namespace, pod.Name, ev.Type, pod.UID, pod.ResourceVersion, pod.Status.Phase)
 			}

--- a/test/library/encryption/helpers.go
+++ b/test/library/encryption/helpers.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -21,12 +22,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	"github.com/openshift/library-go/pkg/operator/encryption/kms/preflight"
 
 	oauthapiv1 "github.com/openshift/api/oauth/v1"
 	routev1 "github.com/openshift/api/route/v1"
@@ -169,7 +172,7 @@ func GetClients(t testing.TB) ClientSet {
 }
 
 // ReadKMSPreflightForOperator returns the operator's current preflight snapshot (zero when unset).
-// Snapshot it before applying a new KMS config and pass it to AssertKMSPreflightSucceededForOperator
+// Snapshot it before applying a new KMS config and pass it to AssertKMSPreflight
 // to confirm a fresh preflight ran for that config.
 func ReadKMSPreflightForOperator(ctx context.Context, t testing.TB, clientSet ClientSet, operatorNamespace string) (operatorv1.KMSPreflightCheck, error) {
 	t.Helper()
@@ -758,4 +761,54 @@ func allTargetGRsMigrated(keyMeta EncryptionKeyMeta, targetGRs []schema.GroupRes
 		}
 	}
 	return true
+}
+
+// StartCapturingLatestPreflightPod watches the preflight pod by name and keeps the
+// latest ADDED/MODIFIED version (UID-locked so a stale pod reusing the name cannot
+// pollute the capture) in an atomic.Pointer. The operator reaps the pod on success,
+// so start this before applying the KMS config. stop cancels the watch and blocks
+// until the goroutine exits, so the pointer can be read without racing a Store; it
+// is idempotent.
+func StartCapturingLatestPreflightPod(ctx context.Context, t testing.TB, clientSet ClientSet, namespace string) (*atomic.Pointer[corev1.Pod], func()) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(ctx)
+	w, err := clientSet.Kube.CoreV1().Pods(namespace).Watch(ctx, metav1.ListOptions{FieldSelector: "metadata.name=" + preflight.PodName})
+	if err != nil {
+		cancel()
+		require.NoError(t, err)
+	}
+	t.Logf("capturing preflight pod %s/%s", namespace, preflight.PodName)
+
+	captured := &atomic.Pointer[corev1.Pod]{}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer w.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case ev, ok := <-w.ResultChan():
+				if !ok {
+					return
+				}
+				pod, isPod := ev.Object.(*corev1.Pod)
+				if !isPod || (ev.Type != watch.Added && ev.Type != watch.Modified) {
+					continue
+				}
+				if prev := captured.Load(); prev != nil && ev.Type == watch.Modified && prev.UID != pod.UID {
+					continue
+				}
+				captured.Store(pod)
+				t.Logf("captured preflight pod %s/%s (%s, uid=%s, rv=%s, phase=%s)",
+					pod.Namespace, pod.Name, ev.Type, pod.UID, pod.ResourceVersion, pod.Status.Phase)
+			}
+		}
+	}()
+
+	stop := func() {
+		cancel()
+		<-done
+	}
+	return captured, stop
 }

--- a/test/library/encryption/preflight_drift.go
+++ b/test/library/encryption/preflight_drift.go
@@ -13,6 +13,11 @@ import (
 	"github.com/openshift/library-go/pkg/operator/encryption/kms/preflight"
 )
 
+// preflightConfigHashAnnotation mirrors the unexported annotation the preflight
+// deployer stamps on the pod. Annotation keys are a stable contract, so the test
+// duplicates it rather than exporting it from the production package.
+const preflightConfigHashAnnotation = "encryption.apiserver.operator.openshift.io/kms-preflight-config-hash"
+
 // DefaultPreflightPodSpecDriftIgnore lists PodSpec field names skipped by
 // AssertNoPreflightConfigDrift via cmpopts.IgnoreFields. Unknown diffs outside
 // this list fail the drift check.
@@ -72,12 +77,34 @@ func AssertNoPreflightConfigDrift(ctx context.Context, t testing.TB, clientSet C
 	targetPod := findAnyOperandPod(ctx, t, clientSet, namespace, labelSelector)
 	require.NotNil(t, targetPod, "no Running pod in %s matching %q", namespace, labelSelector)
 
-	diff := cmp.Diff(&targetPod.Spec, &preflightPod.Spec,
-		cmpopts.IgnoreFields(corev1.PodSpec{}, DefaultPreflightPodSpecDriftIgnore...),
+	assertNoPodSpecDrift(t, targetPod, preflightPod, DefaultPreflightPodSpecDriftIgnore...)
+}
+
+// AssertNoPreflightConfigDriftFromCapture runs the PodSpec drift check against a
+// pod recorded by StartCapturingLatestPreflightPod, for use on the positive path where
+// the operator reaps the pod on success. preflightPod must carry expectedConfigHash,
+// proving the diff is against the pod deployed for the config under test.
+func AssertNoPreflightConfigDriftFromCapture(ctx context.Context, t testing.TB, clientSet ClientSet, namespace, labelSelector, expectedConfigHash string, preflightPod *corev1.Pod) {
+	t.Helper()
+	require.NotNil(t, preflightPod, "no preflight pod captured")
+	require.Equal(t, expectedConfigHash, preflightPod.Annotations[preflightConfigHashAnnotation], "captured preflight pod config-hash annotation")
+
+	targetPod := findAnyOperandPod(ctx, t, clientSet, namespace, labelSelector)
+	require.NotNil(t, targetPod, "no Running pod in %s matching %q", namespace, labelSelector)
+
+	assertNoPodSpecDrift(t, targetPod, preflightPod, DefaultPreflightPodSpecDriftIgnore...)
+}
+
+// assertNoPodSpecDrift fails if cmp.Diff reports PodSpec drift between operand and
+// preflightPod outside ignoreFields.
+func assertNoPodSpecDrift(t testing.TB, operand, preflightPod *corev1.Pod, ignoreFields ...string) {
+	t.Helper()
+	diff := cmp.Diff(&operand.Spec, &preflightPod.Spec,
+		cmpopts.IgnoreFields(corev1.PodSpec{}, ignoreFields...),
 		cmpopts.EquateEmpty(),
 	)
 	require.Empty(t, diff, "preflight pod %s/%s drifted from target %s/%s:\n%s",
-		preflightPod.Namespace, preflightPod.Name, targetPod.Namespace, targetPod.Name, diff)
+		preflightPod.Namespace, preflightPod.Name, operand.Namespace, operand.Name, diff)
 }
 
 // findAnyOperandPod returns any Running pod matching labelSelector.

--- a/test/library/encryption/scenarios.go
+++ b/test/library/encryption/scenarios.go
@@ -77,12 +77,17 @@ func TestEncryptionTypeKMS(ctx context.Context, t testing.TB, scenario BasicScen
 	e := NewE(t, PrintEventsOnFailure(scenario.OperatorNamespace))
 	// Snapshot preflight before applying the new config so the assertion can confirm a fresh
 	// preflight ran for it (the remote key id advances when the config genuinely changes).
-	previousPreflight, err := ReadKMSPreflightForOperator(ctx, e, GetClients(e), scenario.OperatorNamespace)
+	previousPreflightStatus, err := ReadKMSPreflightForOperator(ctx, e, GetClients(e), scenario.OperatorNamespace)
 	require.NoError(e, err)
+	// Capture the preflight pod as the operator creates it; on success the operator reaps it,
+	// so it cannot be fetched live afterwards for the PodSpec drift check below.
+	capturedPreflightPod, stopCapture := StartCapturingLatestPreflightPod(ctx, e, GetClients(e), scenario.Namespace)
+	defer stopCapture()
 	clientSet := SetAndWaitForEncryptionType(ctx, e, provider, scenario.TargetGRs, scenario.Namespace, scenario.LabelSelector)
+	stopCapture() // preflight has run; join the watch before reading the capture
 	scenario.AssertFunc(e, clientSet, provider.Type, scenario.Namespace, scenario.LabelSelector)
 	AssertEncryptionConfig(e, clientSet, scenario.EncryptionConfigSecretName, scenario.EncryptionConfigSecretNamespace, scenario.TargetGRs)
-	AssertKMSPreflightSucceededForOperator(ctx, e, clientSet, scenario.OperatorNamespace, previousPreflight)
+	AssertKMSPreflight(ctx, e, clientSet, scenario.OperatorNamespace, scenario.Namespace, scenario.LabelSelector, previousPreflightStatus, capturedPreflightPod.Load())
 }
 
 func TestEncryptionType(ctx context.Context, t testing.TB, scenario BasicScenario, provider EncryptionProvider) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded KMS encryption validation to verify both preflight status and runtime pod configuration.
  * Added coverage for detecting configuration drift between preflight and running operand pods.
  * Improved monitoring of preflight pod execution to ensure the latest valid configuration is evaluated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->